### PR TITLE
docs: document the post-transfer holder check in the incoming transfe…

### DIFF
--- a/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domainnamen zu OVHcloud transferieren
 description: Erfahren Sie hier, wie Sie Ihren Domainnamen zu OVHcloud transferieren
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -190,24 +190,24 @@ OVHcloud startet dann automatisch die Aktualisierung des Inhabers bei der Regist
 
 #### Die Inhaber unterscheiden sich bei der Identität des Inhabers
 
-Dies betrifft die Angaben, die bestimmen, **wer** der Inhaber ist: Name, Vorname, Organisation, Rechtsform. Die meisten Registries erlauben es nicht, diese Angaben über eine einfache Aktualisierung zu ändern. Nur ein **Inhaberwechsel** (auch „Trade“ genannt) kann sie korrigieren.
+Dies betrifft die Angaben, die bestimmen, **wer** der Inhaber ist: Name, Vorname, Organisation, Rechtsform. Die meisten Registries erlauben es nicht, diese Angaben über eine einfache Aktualisierung zu ändern. Nur ein **Inhaberwechsel** (auch "Trade" genannt) kann sie korrigieren.
 
 Was OVHcloud dann tut, hängt von der Endung Ihres Domainnamens ab:
 
 |Situation|Was passiert|
 |---|---|
-|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers und der Vorgang ist für diese Endung kostenlos|OVHcloud leitet den Inhaberwechsel automatisch ein, **er wird jedoch nicht ohne Ihre Bestätigung abgeschlossen**: siehe „[Bestätigung des Inhaberwechsels](#step5-foa)“ weiter unten.|
+|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers und der Vorgang ist für diese Endung kostenlos|OVHcloud leitet den Inhaberwechsel automatisch ein, **er wird jedoch nicht ohne Ihre Bestätigung abgeschlossen**: siehe "[Bestätigung des Inhaberwechsels](#step5-foa)" weiter unten.|
 |Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers, der Vorgang ist für diese Endung jedoch kostenpflichtig|OVHcloud führt den Vorgang **nicht** durch. Sie erhalten eine Benachrichtigung, dass der bei der Registry der Domainendung eingetragene Inhaber nicht der bestellte ist. Sie können den Inhaberwechsel dann jederzeit selbst beauftragen.|
 |Die Domainendung erlaubt keinen Inhaberwechsel während eines Transfers|Es wird kein automatischer Vorgang ausgelöst. Der Domainname behält den bei der Registry der Domainendung eingetragenen Inhaber.|
 
 :::warning
-Ein kostenpflichtiger Inhaberwechsel wird **niemals** automatisch ausgelöst: Dieser Vorgang wird abgerechnet und verlängert die Laufzeit je nach Endung um ein Jahr. Er erfordert daher Ihre Zustimmung. Um ihn selbst durchzuführen, folgen Sie unserer Anleitung „[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)“.
+Ein kostenpflichtiger Inhaberwechsel wird **niemals** automatisch ausgelöst: Dieser Vorgang wird abgerechnet und verlängert die Laufzeit je nach Endung um ein Jahr. Er erfordert daher Ihre Zustimmung. Um ihn selbst durchzuführen, folgen Sie unserer Anleitung "[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
 ##### Bestätigung des Inhaberwechsels <a name="step5-foa"></a>
 
-Ein Inhaberwechsel wird **niemals** allein auf Initiative von OVHcloud durchgeführt, auch dann nicht, wenn er kostenlos ist und automatisch eingeleitet wurde. Bei den meisten Domainendungen wird eine Bestätigungsanfrage (Form of Authorization, kurz „FOA“) per E-Mail versandt:
+Ein Inhaberwechsel wird **niemals** allein auf Initiative von OVHcloud durchgeführt, auch dann nicht, wenn er kostenlos ist und automatisch eingeleitet wurde. Bei den meisten Domainendungen wird eine Bestätigungsanfrage (Form of Authorization, kurz "FOA") per E-Mail versandt:
 
 - an den **vorherigen Inhaber**, also denjenigen, der zum Zeitpunkt des Transfers bei der Registry der Domainendung eingetragen war;
 - an den **neuen Inhaber**, also denjenigen, den Sie bei OVHcloud bestellt haben.
@@ -230,7 +230,7 @@ Den Fortschritt der Anfrage und die Erinnerungen können Sie auf der Seite <Mana
 :::
 
 :::info
-Nicht alle Domainendungen erfordern diese Bestätigung per E-Mail: Manche Registries führen den Inhaberwechsel ohne Bestätigungsanfrage durch. Das genaue Vorgehen beim Inhaberwechsel ist in unserer Anleitung „[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)“ beschrieben.
+Nicht alle Domainendungen erfordern diese Bestätigung per E-Mail: Manche Registries führen den Inhaberwechsel ohne Bestätigungsanfrage durch. Das genaue Vorgehen beim Inhaberwechsel ist in unserer Anleitung "[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)" beschrieben.
 
 :::
 
@@ -242,7 +242,7 @@ Gibt die Registry der Domainendung die Inhaberdaten nicht heraus, bleibt der Ver
 
 Manche Registries verlangen Angaben, die Ihr Inhaberkontakt nicht zwingend enthält. So lehnt die Registry der Endung `.pl` beispielsweise einen Inhaber ohne Telefonnummer ab.
 
-In diesem Fall weist der Vorgang auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> auf die fehlende Angabe hin. Vervollständigen Sie den betreffenden Kontakt gemäß unserer Anleitung „[Kontakte eines Service verwalten](/guides/account-and-service-management/account-information/managing-contacts)“ und starten Sie den Vorgang anschließend auf derselben Seite neu.
+In diesem Fall weist der Vorgang auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> auf die fehlende Angabe hin. Vervollständigen Sie den betreffenden Kontakt gemäß unserer Anleitung "[Kontakte eines Service verwalten](/guides/account-and-service-management/account-information/managing-contacts)" und starten Sie den Vorgang anschließend auf derselben Seite neu.
 
 #### Besonderheiten je Domainendung
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -71,6 +71,7 @@ Der Transferprozess umfasst mehrere Schritte. Diese erfordern die Kontaktaufnahm
 |[2](#step2)|[Domainname entsperren und Transfer-Code beantragen](#step2)|Der Administrator des Domainnamens mit Genehmigung des Inhabers|Beim aktuellen Registrar|Entsprechend Ihrem Vorgehen|
 |[3](#step3)|[Domaintransfer beantragen](#step3)|Jede Person, die den Transfer-Code sowie die Genehmigung des Inhabers hat|Beim neuen Registrar (OVHcloud)|Entsprechend Ihrem Vorgehen|
 |[4](#step4)|[Transfer bestätigen](#step4)|Ihr aktueller Registrar|Via Anfrage der Organisation, die Ihre Domainendung verwaltet|Maximal fünf Tage|
+|[5](#step5)|[Überprüfung des Inhabers nach dem Transfer](#step5)|OVHcloud, automatisch|Bei der Registry der Domainendung|Automatisch, direkt nach dem Transfer|
 
 :::warning
 Das genaue Verfahren für den Domaintransfer kann variieren, insbesondere bei bestimmten Ländercode-**TLD**s (**ccTLD**, z.B. .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi) und einigen speziellen **TLD**s (.am, .fm. etc.). Je nach Endung Ihres Domainnamens können zusätzliche Voraussetzungen notwendig sein. Wir empfehlen Ihnen, zunächst die für die betreffende Endung verfügbaren Informationen auf unserer Website zu überprüfen: [https://www.ovhcloud.com/de/domains/tld/](/links/web/domains-tld).
@@ -166,7 +167,107 @@ Anschließend beträgt die Gesamtfrist für den **Transfer eines ".fr" Domainnam
 Im Fall einer **Ablehnung des Transfers seitens des aktuellen Registrars** wird der Transfer **trotzdem durchgeführt**, benötigt jedoch **mindestens 22 nicht reduzierbare Tage**, bis er abgeschlossen ist.
 :::
 
-### Schritt 5: Domainnamen bei OVHcloud verwalten
+### Schritt 5: Überprüfung des Inhabers nach dem Transfer <a name="step5"></a>
+
+Der Transfer ist nun abgeschlossen und Ihr Domainname ist bei OVHcloud registriert. Zu diesem Zeitpunkt vergleicht OVHcloud automatisch zwei Angaben:
+
+- den **bei der Registry der Domainendung eingetragenen Inhaber**, so wie er sich nach dem Transfer darstellt;
+- den **von Ihnen angegebenen Inhaber** bei Ihrer Bestellung bei OVHcloud.
+
+Dieser Vergleich soll sicherstellen, dass der bei der Registry eingetragene Inhaber tatsächlich derjenige ist, den Sie bestellt haben. Er erfolgt vollständig automatisch und **blockiert den Transfer niemals**: Ihr Domainname bleibt transferiert, unabhängig vom Ergebnis.
+
+Drei Ergebnisse sind möglich.
+
+#### Beide Inhaber stimmen überein
+
+Es ist keine Aktion erforderlich: Der bei der Registry eingetragene Inhaber ist bereits derjenige, den Sie bestellt haben.
+
+#### Die Inhaber unterscheiden sich bei änderbaren Angaben
+
+Dies betrifft die Angaben, deren Korrektur die Registry über eine einfache Aktualisierung zulässt: Postanschrift, Ort, Postleitzahl, Land, E-Mail-Adresse, Telefonnummer usw.
+
+OVHcloud startet dann automatisch die Aktualisierung des Inhabers bei der Registry, ohne Zutun Ihrerseits. Dieser Vorgang ist vom Transfer getrennt: Er läuft direkt danach ab und Sie können ihn auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> verfolgen.
+
+#### Die Inhaber unterscheiden sich bei der Identität des Inhabers
+
+Dies betrifft die Angaben, die bestimmen, **wer** der Inhaber ist: Name, Vorname, Organisation, Rechtsform. Die meisten Registries erlauben es nicht, diese Angaben über eine einfache Aktualisierung zu ändern. Nur ein **Inhaberwechsel** (auch „Trade“ genannt) kann sie korrigieren.
+
+Was OVHcloud dann tut, hängt von der Endung Ihres Domainnamens ab:
+
+|Situation|Was passiert|
+|---|---|
+|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers und der Vorgang ist für diese Endung kostenlos|OVHcloud leitet den Inhaberwechsel automatisch ein, **er wird jedoch nicht ohne Ihre Bestätigung abgeschlossen**: siehe „[Bestätigung des Inhaberwechsels](#step5-foa)“ weiter unten.|
+|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers, der Vorgang ist für diese Endung jedoch kostenpflichtig|OVHcloud führt den Vorgang **nicht** durch. Sie erhalten eine Benachrichtigung, dass der bei der Registry eingetragene Inhaber nicht der bestellte ist. Sie können den Inhaberwechsel dann jederzeit selbst beauftragen.|
+|Die Domainendung erlaubt keinen Inhaberwechsel während eines Transfers|Es wird kein automatischer Vorgang ausgelöst. Der Domainname behält den bei der Registry eingetragenen Inhaber.|
+
+:::warning
+Ein kostenpflichtiger Inhaberwechsel wird **niemals** automatisch ausgelöst: Dieser Vorgang wird abgerechnet und verlängert die Laufzeit je nach Endung um ein Jahr. Er erfordert daher Ihre Zustimmung. Um ihn selbst durchzuführen, folgen Sie unserer Anleitung „[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)“.
+
+:::
+
+##### Bestätigung des Inhaberwechsels <a name="step5-foa"></a>
+
+Ein Inhaberwechsel wird **niemals** allein auf Initiative von OVHcloud durchgeführt, auch dann nicht, wenn er kostenlos ist und automatisch eingeleitet wurde. Bei den meisten Domainendungen wird eine Bestätigungsanfrage (Form of Authorization, kurz „FOA“) per E-Mail versandt:
+
+- an den **vorherigen Inhaber**, also denjenigen, der zum Zeitpunkt des Transfers bei der Registry eingetragen war;
+- an den **neuen Inhaber**, also denjenigen, den Sie bei OVHcloud bestellt haben.
+
+**Beide Empfänger müssen zustimmen**, damit der Inhaberwechsel zustande kommt. Drei Ergebnisse sind möglich:
+
+|Antwort auf die Bestätigungsanfragen|Ergebnis|
+|---|---|
+|Beide Inhaber stimmen zu|Der Inhaberwechsel wird bei der Registry durchgeführt.|
+|Einer der beiden Inhaber lehnt ab|Der Vorgang wird sofort **abgebrochen**. Der Domainname behält den bei der Registry eingetragenen Inhaber.|
+|Keine Antwort innerhalb der Frist|Der Vorgang **läuft ab** und der Inhaber wird nicht angeglichen. Die Frist wird von der Registry der Domainendung festgelegt.|
+
+:::warning
+Stellen Sie sicher, dass die E-Mail-Adresse des **vorherigen Inhabers** erreichbar ist. Kann niemand die an diese Adresse gesendete Anfrage bestätigen, läuft der Inhaberwechsel ab und Ihr Domainname bleibt auf den Namen des vorherigen Inhabers eingetragen.
+
+Den Fortschritt der Anfrage und die Erinnerungen können Sie auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> verfolgen.
+
+:::
+
+:::info
+Nicht alle Domainendungen erfordern diese Bestätigung per E-Mail: Manche Registries führen den Inhaberwechsel ohne Bestätigungsanfrage durch. Das genaue Vorgehen beim Inhaberwechsel ist in unserer Anleitung „[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)“ beschrieben.
+
+:::
+
+#### Wenn der Vergleich zu keinem Ergebnis führt
+
+Gibt die Registry die Inhaberdaten nicht heraus, bleibt der Vergleich ohne Ergebnis und es wird kein automatischer Vorgang ausgelöst. Eine Überprüfung der Kontakte erfolgt später durch OVHcloud. Ihr Domainname bleibt transferiert und nutzbar.
+
+#### Wenn bei Ihrem Inhaberkontakt eine Pflichtangabe fehlt
+
+Manche Registries verlangen Angaben, die Ihr Inhaberkontakt nicht zwingend enthält. So lehnt die Registry der Endung `.pl` beispielsweise einen Inhaber ohne Telefonnummer ab.
+
+In diesem Fall weist der Vorgang auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> auf die fehlende Angabe hin. Vervollständigen Sie den betreffenden Kontakt gemäß unserer Anleitung „[Kontakte eines Service verwalten](/guides/account-and-service-management/account-information/managing-contacts)“ und starten Sie den Vorgang anschließend auf derselben Seite neu.
+
+#### Besonderheiten je Domainendung
+
+Die Überprüfung des Inhabers gilt für **alle** Domainendungen. Die folgende Tabelle gibt für jede Endung an, was von dem oben beschriebenen Verhalten abweicht.
+
+|Domainendungen|Besonderheit bei der Überprüfung des Inhabers|
+|---|---|
+|Generische Endungen (**gTLD**)|Generisches Verhalten|
+|`.com`, `.net`, `.cn`, `.ws`|Generisches Verhalten|
+|`.ca`|Die von der Registry CIRA verlangte Kategorie der Rechtsform des Inhabers wird von der Registry übernommen, wenn beide Inhaber übereinstimmen. Diese Angabe ist für alle späteren Vorgänge an einer `.ca` unerlässlich.|
+|`.hk`|Die Registry HKDNR gibt weder die Organisation noch die E-Mail-Adresse des Inhabers heraus. Ein automatischer Inhaberwechsel kann daher nicht verfügbar sein.|
+|`.pl`|Die Registry NASK lehnt einen Inhaber ohne Telefonnummer ab: Der Vorgang weist dann auf die zu ergänzende Angabe hin.|
+|`.fr` und weitere von AFNIC verwaltete Endungen|Generisches Verhalten. Der allgemeine Ablauf eines `.fr`-Transfers bleibt derjenige aus [Schritt 4](#step4).|
+|`.eu` und die Entsprechung in kyrillischer Schrift|Generisches Verhalten|
+|`.uk`|Generisches Verhalten|
+|`.ac.uk`, `.gov.uk`|Generisches Verhalten|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Generisches Verhalten|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Generisches Verhalten|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Generisches Verhalten|
+|Weitere von einer spezifischen Registry verwaltete Endungen|Generisches Verhalten|
+
+:::info
+Ob ein Inhaberwechsel während eines Transfers zulässig ist und ob er kostenlos oder kostenpflichtig ist, wird **je Domainendung** festgelegt. Um die für Ihre Endung geltenden Bedingungen zu erfahren, geben Sie Ihren Domainnamen auf der Seite [www.ovhcloud.com/de/domains/tld/](/links/web/domains-tld) ein.
+
+:::
+
+### Schritt 6: Domainnamen bei OVHcloud verwalten
 
 Sobald der Transfer abgeschlossen ist, können Sie Ihren Domainnamen über die Seite <ManagerLink to="/#/web-domains/domain">Domainnamen</ManagerLink> verwalten.
 

--- a/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -65,12 +65,12 @@ Um die Transferkosten anzuzeigen, geben Sie den Domainnamen, den Sie transferier
 
 Der Transferprozess umfasst mehrere Schritte. Diese erfordern die Kontaktaufnahme mit Ihrem aktuellen Registrar und OVHcloud. Die folgende Tabelle enthält die zu kontaktierenden Stellen sowie die Dauer der verschiedenen Schritte des Transfervorgangs.
 
-|Schritt|Beschreibung|Wer ist betroffen?|Wo?|Dauer|
+|Schritt|Beschreibung|Wer ist betroffen?|Bei wem?|Dauer|
 |---|---|---|---|---|
-|[1](#step1)|[Domaininformationen überprüfen](#step1)|Administrator des Domainnamens|Beim aktuellen Registrar|Entsprechend Ihrem Vorgehen|
-|[2](#step2)|[Domainname entsperren und Transfer-Code beantragen](#step2)|Der Administrator des Domainnamens mit Genehmigung des Inhabers|Beim aktuellen Registrar|Entsprechend Ihrem Vorgehen|
-|[3](#step3)|[Domaintransfer beantragen](#step3)|Jede Person, die den Transfer-Code sowie die Genehmigung des Inhabers hat|Beim neuen Registrar (OVHcloud)|Entsprechend Ihrem Vorgehen|
-|[4](#step4)|[Transfer bestätigen](#step4)|Ihr aktueller Registrar|Via Anfrage der Organisation, die Ihre Domainendung verwaltet|Maximal fünf Tage|
+|[1](#step1)|[Domaininformationen überprüfen](#step1)|Der Inhaber des Domainnamens oder die Person, die ihn verwaltet|Beim aktuellen Registrar|Entsprechend Ihrem Vorgehen|
+|[2](#step2)|[Domainname entsperren und Transfer-Code beantragen](#step2)|Der Inhaber des Domainnamens oder die Person, die ihn verwaltet|Beim aktuellen Registrar|Entsprechend Ihrem Vorgehen|
+|[3](#step3)|[Domaintransfer beantragen](#step3)|Jede Person, die den Transfer-Code hat|Beim neuen Registrar (OVHcloud)|Entsprechend Ihrem Vorgehen|
+|[4](#step4)|[Transfer bestätigen](#step4)|Ihr aktueller Registrar|Bei der Registry der Domainendung|Maximal fünf Tage|
 |[5](#step5)|[Überprüfung des Inhabers nach dem Transfer](#step5)|OVHcloud, automatisch|Bei der Registry der Domainendung|Automatisch, direkt nach dem Transfer|
 
 :::warning
@@ -174,19 +174,19 @@ Der Transfer ist nun abgeschlossen und Ihr Domainname ist bei OVHcloud registrie
 - den **bei der Registry der Domainendung eingetragenen Inhaber**, so wie er sich nach dem Transfer darstellt;
 - den **von Ihnen angegebenen Inhaber** bei Ihrer Bestellung bei OVHcloud.
 
-Dieser Vergleich soll sicherstellen, dass der bei der Registry eingetragene Inhaber tatsächlich derjenige ist, den Sie bestellt haben. Er erfolgt vollständig automatisch und **blockiert den Transfer niemals**: Ihr Domainname bleibt transferiert, unabhängig vom Ergebnis.
+Dieser Vergleich soll sicherstellen, dass der bei der Registry der Domainendung eingetragene Inhaber tatsächlich derjenige ist, den Sie bestellt haben. Er erfolgt vollständig automatisch und **blockiert den Transfer niemals**: Ihr Domainname bleibt transferiert, unabhängig vom Ergebnis.
 
 Drei Ergebnisse sind möglich.
 
 #### Beide Inhaber stimmen überein
 
-Es ist keine Aktion erforderlich: Der bei der Registry eingetragene Inhaber ist bereits derjenige, den Sie bestellt haben.
+Es ist keine Aktion erforderlich: Der bei der Registry der Domainendung eingetragene Inhaber ist bereits derjenige, den Sie bestellt haben.
 
 #### Die Inhaber unterscheiden sich bei änderbaren Angaben
 
-Dies betrifft die Angaben, deren Korrektur die Registry über eine einfache Aktualisierung zulässt: Postanschrift, Ort, Postleitzahl, Land, E-Mail-Adresse, Telefonnummer usw.
+Dies betrifft die Angaben, deren Korrektur die Registry der Domainendung über eine einfache Aktualisierung zulässt: Postanschrift, Ort, Postleitzahl, Land, E-Mail-Adresse, Telefonnummer usw.
 
-OVHcloud startet dann automatisch die Aktualisierung des Inhabers bei der Registry, ohne Zutun Ihrerseits. Dieser Vorgang ist vom Transfer getrennt: Er läuft direkt danach ab und Sie können ihn auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> verfolgen.
+OVHcloud startet dann automatisch die Aktualisierung des Inhabers bei der Registry der Domainendung, ohne Zutun Ihrerseits. Dieser Vorgang ist vom Transfer getrennt: Er läuft direkt danach ab und Sie können ihn auf der Seite <ManagerLink to="/#/web/ongoing-operations">Laufende Vorgänge</ManagerLink> verfolgen.
 
 #### Die Inhaber unterscheiden sich bei der Identität des Inhabers
 
@@ -197,8 +197,8 @@ Was OVHcloud dann tut, hängt von der Endung Ihres Domainnamens ab:
 |Situation|Was passiert|
 |---|---|
 |Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers und der Vorgang ist für diese Endung kostenlos|OVHcloud leitet den Inhaberwechsel automatisch ein, **er wird jedoch nicht ohne Ihre Bestätigung abgeschlossen**: siehe „[Bestätigung des Inhaberwechsels](#step5-foa)“ weiter unten.|
-|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers, der Vorgang ist für diese Endung jedoch kostenpflichtig|OVHcloud führt den Vorgang **nicht** durch. Sie erhalten eine Benachrichtigung, dass der bei der Registry eingetragene Inhaber nicht der bestellte ist. Sie können den Inhaberwechsel dann jederzeit selbst beauftragen.|
-|Die Domainendung erlaubt keinen Inhaberwechsel während eines Transfers|Es wird kein automatischer Vorgang ausgelöst. Der Domainname behält den bei der Registry eingetragenen Inhaber.|
+|Die Domainendung erlaubt einen Inhaberwechsel während eines Transfers, der Vorgang ist für diese Endung jedoch kostenpflichtig|OVHcloud führt den Vorgang **nicht** durch. Sie erhalten eine Benachrichtigung, dass der bei der Registry der Domainendung eingetragene Inhaber nicht der bestellte ist. Sie können den Inhaberwechsel dann jederzeit selbst beauftragen.|
+|Die Domainendung erlaubt keinen Inhaberwechsel während eines Transfers|Es wird kein automatischer Vorgang ausgelöst. Der Domainname behält den bei der Registry der Domainendung eingetragenen Inhaber.|
 
 :::warning
 Ein kostenpflichtiger Inhaberwechsel wird **niemals** automatisch ausgelöst: Dieser Vorgang wird abgerechnet und verlängert die Laufzeit je nach Endung um ein Jahr. Er erfordert daher Ihre Zustimmung. Um ihn selbst durchzuführen, folgen Sie unserer Anleitung „[Inhaber eines Domainnamens ändern](/guides/web-cloud/domains/trade-domain)“.
@@ -209,16 +209,18 @@ Ein kostenpflichtiger Inhaberwechsel wird **niemals** automatisch ausgelöst: Di
 
 Ein Inhaberwechsel wird **niemals** allein auf Initiative von OVHcloud durchgeführt, auch dann nicht, wenn er kostenlos ist und automatisch eingeleitet wurde. Bei den meisten Domainendungen wird eine Bestätigungsanfrage (Form of Authorization, kurz „FOA“) per E-Mail versandt:
 
-- an den **vorherigen Inhaber**, also denjenigen, der zum Zeitpunkt des Transfers bei der Registry eingetragen war;
+- an den **vorherigen Inhaber**, also denjenigen, der zum Zeitpunkt des Transfers bei der Registry der Domainendung eingetragen war;
 - an den **neuen Inhaber**, also denjenigen, den Sie bei OVHcloud bestellt haben.
 
 **Beide Empfänger müssen zustimmen**, damit der Inhaberwechsel zustande kommt. Drei Ergebnisse sind möglich:
 
 |Antwort auf die Bestätigungsanfragen|Ergebnis|
 |---|---|
-|Beide Inhaber stimmen zu|Der Inhaberwechsel wird bei der Registry durchgeführt.|
-|Einer der beiden Inhaber lehnt ab|Der Vorgang wird sofort **abgebrochen**. Der Domainname behält den bei der Registry eingetragenen Inhaber.|
+|Beide Inhaber stimmen zu|Der Inhaberwechsel wird bei der Registry der Domainendung durchgeführt.|
+|Einer der beiden Inhaber lehnt ab|Der Vorgang wird sofort **abgebrochen**. Der Domainname behält den bei der Registry der Domainendung eingetragenen Inhaber.|
 |Keine Antwort innerhalb der Frist|Der Vorgang **läuft ab** und der Inhaber wird nicht angeglichen. Die Frist wird von der Registry der Domainendung festgelegt.|
+
+Unabhängig vom Ergebnis dieser Bestätigungsanfrage **bleibt der Transfer Ihres Domainnamens bestehen**: Eine Ablehnung, ein Ablauf der Frist oder eine Blockierung des Inhaberwechsels führt nicht zur Annullierung des Transfers. Lediglich die Angleichung des Inhabers findet nicht statt und Ihr Domainname bleibt bei OVHcloud registriert.
 
 :::warning
 Stellen Sie sicher, dass die E-Mail-Adresse des **vorherigen Inhabers** erreichbar ist. Kann niemand die an diese Adresse gesendete Anfrage bestätigen, läuft der Inhaberwechsel ab und Ihr Domainname bleibt auf den Namen des vorherigen Inhabers eingetragen.
@@ -234,7 +236,7 @@ Nicht alle Domainendungen erfordern diese Bestätigung per E-Mail: Manche Regist
 
 #### Wenn der Vergleich zu keinem Ergebnis führt
 
-Gibt die Registry die Inhaberdaten nicht heraus, bleibt der Vergleich ohne Ergebnis und es wird kein automatischer Vorgang ausgelöst. Eine Überprüfung der Kontakte erfolgt später durch OVHcloud. Ihr Domainname bleibt transferiert und nutzbar.
+Gibt die Registry der Domainendung die Inhaberdaten nicht heraus, bleibt der Vergleich ohne Ergebnis und es wird kein automatischer Vorgang ausgelöst. Eine Überprüfung der Kontakte erfolgt später durch OVHcloud. Ihr Domainname bleibt transferiert und nutzbar.
 
 #### Wenn bei Ihrem Inhaberkontakt eine Pflichtangabe fehlt
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -71,6 +71,7 @@ The transfer procedure has several steps. These steps will involve various entit
 |[2](#step2)|[Unlocking the domain and retrieving the transfer code](#step2)|The domain administrator, with the holder's permission|With the current registrar|Depends on your actions|
 |[3](#step3)|[Requesting the domain name transfer](#step3)|Whoever has the transfer code and the holder's permission|With the new registrar|Depends on your actions|
 |[4](#step4)|[Transfer confirmation](#step4)|With the current registrar|At the request of the organisation managing the domain name extension|Five days maximum|
+|[5](#step5)|[Holder check after the transfer](#step5)|OVHcloud, automatically|With the registry of the extension|Automatic, right after the transfer|
 
 :::warning
 The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: [https://www.ovhcloud.com/en-gb/domains/tld/](/links/web/domains-tld).
@@ -167,7 +168,107 @@ In case of **opposition to the transfer by the current registrar**, the transfer
 
 :::
 
-### Step 5: Manage your domain at OVHcloud
+### Step 5: Holder check after the transfer <a name="step5"></a>
+
+The transfer is now effective and your domain name is registered at OVHcloud. At this point, OVHcloud automatically compares two pieces of information:
+
+- the **holder registered with the registry** of the extension, as it stands after the transfer;
+- the **holder you entered** when placing your order at OVHcloud.
+
+The purpose of this comparison is to ensure that the holder declared with the registry is indeed the one you ordered. It is fully automatic and **never blocks the transfer**: your domain name remains transferred, whatever the outcome.
+
+Three outcomes are possible.
+
+#### Both holders match
+
+No action is required: the holder registered with the registry is already the one you ordered.
+
+#### The holders differ on editable information
+
+This covers the information the registry allows to be corrected by a simple update: postal address, city, postcode, country, email address, phone number, etc.
+
+OVHcloud then automatically starts the holder update with the registry, with no action on your part. This operation is separate from the transfer: it takes place right after it, and you can track it from the <ManagerLink to="/#/web/ongoing-operations">Ongoing operations</ManagerLink> page.
+
+#### The holders differ on the holder's identity
+
+This covers the information that designates **who** the holder is: surname, first name, organisation, legal form. Most registries do not allow this information to be changed by a simple update. Only a **change of holder** (also called a "trade") can correct it.
+
+What OVHcloud does then depends on your domain name extension:
+
+|Situation|What happens|
+|---|---|
+|The extension allows a change of holder during a transfer, and the operation is free for this extension|OVHcloud automatically initiates the change of holder, but **it does not complete without your validation**: see "[Validating the change of holder](#step5-foa)" below.|
+|The extension allows a change of holder during a transfer, but the operation is chargeable for this extension|OVHcloud **does not carry out** the operation. You receive a notification informing you that the holder registered with the registry is not the one you ordered. You can then order the change of holder yourself, whenever you wish.|
+|The extension does not allow a change of holder during a transfer|No automatic operation is triggered. The domain name keeps the holder registered with the registry.|
+
+:::warning
+A chargeable change of holder is **never** triggered automatically: this operation is billed and, depending on the extension, adds a year of subscription. It therefore requires your consent. To carry it out yourself, follow our guide "[Changing the holder of a domain name](/guides/web-cloud/domains/trade-domain)".
+
+:::
+
+##### Validating the change of holder <a name="step5-foa"></a>
+
+A change of holder is **never** applied on OVHcloud's initiative alone, even when it is free and initiated automatically. For most extensions, a validation request (Form of Authorization, or "FOA") is sent by email:
+
+- to the **previous holder**, that is, the one registered with the registry at the time of the transfer;
+- to the **new holder**, that is, the one you ordered at OVHcloud.
+
+**Both recipients must accept** for the change of holder to go through. Three outcomes are possible:
+
+|Response to the validation requests|Result|
+|---|---|
+|Both holders accept|The change of holder is applied with the registry.|
+|One of the two holders refuses|The operation is **cancelled** immediately. The domain name keeps the holder registered with the registry.|
+|No response within the allotted time|The operation **expires** and the holder is not realigned. The time allowed is set by the registry of the extension.|
+
+:::warning
+Make sure the email address of the **previous holder** is reachable. If nobody can validate the request sent to that address, the change of holder will expire and your domain name will remain registered under the previous holder's name.
+
+You can track the progress of the request and its reminders from the <ManagerLink to="/#/web/ongoing-operations">Ongoing operations</ManagerLink> page.
+
+:::
+
+:::info
+Not all extensions require this email validation: some registries apply the change of holder without a confirmation request. The full change of holder procedure is described in our guide "[Changing the holder of a domain name](/guides/web-cloud/domains/trade-domain)".
+
+:::
+
+#### If the comparison is inconclusive
+
+If the registry does not disclose the holder's information, the comparison remains inconclusive and no automatic operation is triggered. A contact check is carried out later by OVHcloud. Your domain name remains transferred and usable.
+
+#### If mandatory information is missing from your holder contact
+
+Some registries require information that your holder contact does not necessarily include. For example, the registry of the `.pl` extension refuses a holder without a phone number.
+
+In this case, the operation reports the missing information on the <ManagerLink to="/#/web/ongoing-operations">Ongoing operations</ManagerLink> page. Complete the contact concerned by following our guide "[Managing the contacts of a service](/guides/account-and-service-management/account-information/managing-contacts)", then restart the operation from that same page.
+
+#### Specifics per extension
+
+The holder check applies to **all** extensions. The table below states, extension by extension, what departs from the behaviour described above.
+
+|Extensions|Specifics of the holder check|
+|---|---|
+|Generic extensions (**gTLD**)|Generic behaviour|
+|`.com`, `.net`, `.cn`, `.ws`|Generic behaviour|
+|`.ca`|The holder's legal form category, required by the CIRA registry, is taken from the registry when both holders match. This information is essential for any subsequent operation on a `.ca`.|
+|`.hk`|The HKDNR registry discloses neither the organisation nor the email address of the holder. An automatic change of holder may therefore be unavailable.|
+|`.pl`|The NASK registry refuses a holder without a phone number: the operation then reports the information to be completed.|
+|`.fr` and other extensions managed by AFNIC|Generic behaviour. The general course of a `.fr` transfer remains the one described in [step 4](#step4).|
+|`.eu` and its Cyrillic-script equivalent|Generic behaviour|
+|`.uk`|Generic behaviour|
+|`.ac.uk`, `.gov.uk`|Generic behaviour|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Generic behaviour|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Generic behaviour|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Generic behaviour|
+|Other extensions managed by a specific registry|Generic behaviour|
+
+:::info
+Whether a change of holder is allowed during a transfer, and whether it is free or chargeable, are defined **per extension**. To find out the conditions that apply to yours, enter your domain name on the [www.ovhcloud.com/en-gb/domains/tld/](/links/web/domains-tld) page.
+
+:::
+
+### Step 6: Manage your domain at OVHcloud
 
 Once the transfer procedure is complete, you can manage your domain name from the <ManagerLink to="/#/web-domains/domain">Domain names</ManagerLink> page.
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferring a domain name to OVHcloud
 description: Find out how to transfer a generic domain name to OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -65,13 +65,13 @@ To find out the pricing conditions for transferring a domain name depending on i
 
 The transfer procedure has several steps. These steps will involve various entities being contacted, including your current domain name registrar, OVHcloud, and other parties. The table below provides a breakdown of who is contacted, and how long each step will take to complete.
 
-|Steps|Description|Who is involved?|Where?|Time taken|
+|Steps|Description|Who is involved?|With whom?|Time taken|
 |---|---|---|---|---|
-|[1](#step1)|[Checking the information associated with the domain](#step1)|The domain administrator|With the current registrar|Depends on your actions|
-|[2](#step2)|[Unlocking the domain and retrieving the transfer code](#step2)|The domain administrator, with the holder's permission|With the current registrar|Depends on your actions|
-|[3](#step3)|[Requesting the domain name transfer](#step3)|Whoever has the transfer code and the holder's permission|With the new registrar|Depends on your actions|
-|[4](#step4)|[Transfer confirmation](#step4)|With the current registrar|At the request of the organisation managing the domain name extension|Five days maximum|
-|[5](#step5)|[Holder check after the transfer](#step5)|OVHcloud, automatically|With the registry of the extension|Automatic, right after the transfer|
+|[1](#step1)|[Checking the information associated with the domain](#step1)|The domain name holder, or whoever administers it|The current registrar|Depends on your actions|
+|[2](#step2)|[Unlocking the domain and retrieving the transfer code](#step2)|The domain name holder, or whoever administers it|The current registrar|Depends on your actions|
+|[3](#step3)|[Requesting the domain name transfer](#step3)|Whoever has the transfer code|The new registrar (for example, OVHcloud)|Depends on your actions|
+|[4](#step4)|[Transfer confirmation](#step4)|The current registrar|The registry of the extension|Five days maximum|
+|[5](#step5)|[Holder check after the transfer](#step5)|OVHcloud, automatically|The registry of the extension|Automatic, right after the transfer|
 
 :::warning
 The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: [https://www.ovhcloud.com/en-gb/domains/tld/](/links/web/domains-tld).
@@ -172,22 +172,22 @@ In case of **opposition to the transfer by the current registrar**, the transfer
 
 The transfer is now effective and your domain name is registered at OVHcloud. At this point, OVHcloud automatically compares two pieces of information:
 
-- the **holder registered with the registry** of the extension, as it stands after the transfer;
+- the **holder registered with the registry of the extension**, as it stands after the transfer;
 - the **holder you entered** when placing your order at OVHcloud.
 
-The purpose of this comparison is to ensure that the holder declared with the registry is indeed the one you ordered. It is fully automatic and **never blocks the transfer**: your domain name remains transferred, whatever the outcome.
+The purpose of this comparison is to ensure that the holder declared with the registry of the extension is indeed the one you ordered. It is fully automatic and **never blocks the transfer**: your domain name remains transferred, whatever the outcome.
 
 Three outcomes are possible.
 
 #### Both holders match
 
-No action is required: the holder registered with the registry is already the one you ordered.
+No action is required: the holder registered with the registry of the extension is already the one you ordered.
 
 #### The holders differ on editable information
 
-This covers the information the registry allows to be corrected by a simple update: postal address, city, postcode, country, email address, phone number, etc.
+This covers the information the registry of the extension allows to be corrected by a simple update: postal address, city, postcode, country, email address, phone number, etc.
 
-OVHcloud then automatically starts the holder update with the registry, with no action on your part. This operation is separate from the transfer: it takes place right after it, and you can track it from the <ManagerLink to="/#/web/ongoing-operations">Ongoing operations</ManagerLink> page.
+OVHcloud then automatically starts the holder update with the registry of the extension, with no action on your part. This operation is separate from the transfer: it takes place right after it, and you can track it from the <ManagerLink to="/#/web/ongoing-operations">Ongoing operations</ManagerLink> page.
 
 #### The holders differ on the holder's identity
 
@@ -198,8 +198,8 @@ What OVHcloud does then depends on your domain name extension:
 |Situation|What happens|
 |---|---|
 |The extension allows a change of holder during a transfer, and the operation is free for this extension|OVHcloud automatically initiates the change of holder, but **it does not complete without your validation**: see "[Validating the change of holder](#step5-foa)" below.|
-|The extension allows a change of holder during a transfer, but the operation is chargeable for this extension|OVHcloud **does not carry out** the operation. You receive a notification informing you that the holder registered with the registry is not the one you ordered. You can then order the change of holder yourself, whenever you wish.|
-|The extension does not allow a change of holder during a transfer|No automatic operation is triggered. The domain name keeps the holder registered with the registry.|
+|The extension allows a change of holder during a transfer, but the operation is chargeable for this extension|OVHcloud **does not carry out** the operation. You receive a notification informing you that the holder registered with the registry of the extension is not the one you ordered. You can then order the change of holder yourself, whenever you wish.|
+|The extension does not allow a change of holder during a transfer|No automatic operation is triggered. The domain name keeps the holder registered with the registry of the extension.|
 
 :::warning
 A chargeable change of holder is **never** triggered automatically: this operation is billed and, depending on the extension, adds a year of subscription. It therefore requires your consent. To carry it out yourself, follow our guide "[Changing the holder of a domain name](/guides/web-cloud/domains/trade-domain)".
@@ -210,16 +210,18 @@ A chargeable change of holder is **never** triggered automatically: this operati
 
 A change of holder is **never** applied on OVHcloud's initiative alone, even when it is free and initiated automatically. For most extensions, a validation request (Form of Authorization, or "FOA") is sent by email:
 
-- to the **previous holder**, that is, the one registered with the registry at the time of the transfer;
+- to the **previous holder**, that is, the one registered with the registry of the extension at the time of the transfer;
 - to the **new holder**, that is, the one you ordered at OVHcloud.
 
 **Both recipients must accept** for the change of holder to go through. Three outcomes are possible:
 
 |Response to the validation requests|Result|
 |---|---|
-|Both holders accept|The change of holder is applied with the registry.|
-|One of the two holders refuses|The operation is **cancelled** immediately. The domain name keeps the holder registered with the registry.|
+|Both holders accept|The change of holder is applied with the registry of the extension.|
+|One of the two holders refuses|The operation is **cancelled** immediately. The domain name keeps the holder registered with the registry of the extension.|
 |No response within the allotted time|The operation **expires** and the holder is not realigned. The time allowed is set by the registry of the extension.|
+
+Whatever the outcome of this validation request, **the transfer of your domain name stands**: a refusal, an expiry or a block on the change of holder does not cancel the transfer. Only the realignment of the holder does not take place, and your domain name remains registered at OVHcloud.
 
 :::warning
 Make sure the email address of the **previous holder** is reachable. If nobody can validate the request sent to that address, the change of holder will expire and your domain name will remain registered under the previous holder's name.
@@ -235,7 +237,7 @@ Not all extensions require this email validation: some registries apply the chan
 
 #### If the comparison is inconclusive
 
-If the registry does not disclose the holder's information, the comparison remains inconclusive and no automatic operation is triggered. A contact check is carried out later by OVHcloud. Your domain name remains transferred and usable.
+If the registry of the extension does not disclose the holder's information, the comparison remains inconclusive and no automatic operation is triggered. A contact check is carried out later by OVHcloud. Your domain name remains transferred and usable.
 
 #### If mandatory information is missing from your holder contact
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir un nombre de dominio a OVHcloud
 description: Descubra cómo realizar la transferencia de un nombre de dominio a OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -193,24 +193,24 @@ OVHcloud inicia entonces automáticamente la actualización del titular en el re
 
 #### Los titulares difieren en la identidad del titular
 
-Se trata aquí de los datos que designan **quién** es el titular: apellidos, nombre, organización, forma jurídica. La mayoría de los registros no permiten modificar estos datos mediante una simple actualización. Solo un **cambio de titular** (también llamado «trade») permite corregirlos.
+Se trata aquí de los datos que designan **quién** es el titular: apellidos, nombre, organización, forma jurídica. La mayoría de los registros no permiten modificar estos datos mediante una simple actualización. Solo un **cambio de titular** (también llamado "trade") permite corregirlos.
 
 Lo que hace OVHcloud depende entonces de la extensión de su nombre de dominio:
 
 |Situación|Qué ocurre|
 |---|---|
-|La extensión permite el cambio de titular durante una transferencia y la operación es gratuita para esa extensión|OVHcloud inicia automáticamente el cambio de titular, pero **este no se completa sin su validación**: consulte «[Validación del cambio de titular](#step5-foa)» más abajo.|
+|La extensión permite el cambio de titular durante una transferencia y la operación es gratuita para esa extensión|OVHcloud inicia automáticamente el cambio de titular, pero **este no se completa sin su validación**: consulte "[Validación del cambio de titular](#step5-foa)" más abajo.|
 |La extensión permite el cambio de titular durante una transferencia, pero la operación es de pago para esa extensión|OVHcloud **no realiza** la operación. Recibirá una notificación indicándole que el titular registrado en el registro de la extensión no es el solicitado. Podrá entonces solicitar usted mismo el cambio de titular cuando lo desee.|
 |La extensión no permite el cambio de titular durante una transferencia|No se activa ninguna operación automática. El nombre de dominio conserva el titular registrado en el registro de la extensión.|
 
 :::warning
-Un cambio de titular de pago **nunca** se activa automáticamente: esta operación se factura y, según la extensión, añade un año de suscripción. Por tanto, requiere su consentimiento. Para realizarlo usted mismo, siga nuestra guía «[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)».
+Un cambio de titular de pago **nunca** se activa automáticamente: esta operación se factura y, según la extensión, añade un año de suscripción. Por tanto, requiere su consentimiento. Para realizarlo usted mismo, siga nuestra guía "[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
 ##### Validación del cambio de titular <a name="step5-foa"></a>
 
-Un cambio de titular **nunca** se aplica por iniciativa exclusiva de OVHcloud, incluso cuando es gratuito y se ha iniciado automáticamente. En la mayoría de las extensiones, se envía por correo electrónico una solicitud de validación (formulario de autorización o «FOA»):
+Un cambio de titular **nunca** se aplica por iniciativa exclusiva de OVHcloud, incluso cuando es gratuito y se ha iniciado automáticamente. En la mayoría de las extensiones, se envía por correo electrónico una solicitud de validación (formulario de autorización o "FOA"):
 
 - al **titular anterior**, es decir, el registrado en el registro de la extensión en el momento de la transferencia;
 - al **nuevo titular**, es decir, el que ha solicitado en OVHcloud.
@@ -233,7 +233,7 @@ Puede seguir el avance de la solicitud y sus recordatorios desde la página <Man
 :::
 
 :::info
-No todas las extensiones exigen esta validación por correo electrónico: algunos registros aplican el cambio de titular sin solicitud de confirmación. El detalle del procedimiento de cambio de titular se describe en nuestra guía «[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)».
+No todas las extensiones exigen esta validación por correo electrónico: algunos registros aplican el cambio de titular sin solicitud de confirmación. El detalle del procedimiento de cambio de titular se describe en nuestra guía "[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
@@ -245,7 +245,7 @@ Si el registro de la extensión no facilita los datos del titular, la comparaci�
 
 Algunos registros exigen datos que su contacto titular no incluye necesariamente. Por ejemplo, el registro de la extensión `.pl` rechaza un titular sin número de teléfono.
 
-En ese caso, la operación indica el dato que falta en la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>. Complete el contacto correspondiente siguiendo nuestra guía «[Gestionar los contactos de un servicio](/guides/account-and-service-management/account-information/managing-contacts)» y reinicie la operación desde esa misma página.
+En ese caso, la operación indica el dato que falta en la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>. Complete el contacto correspondiente siguiendo nuestra guía "[Gestionar los contactos de un servicio](/guides/account-and-service-management/account-information/managing-contacts)" y reinicie la operación desde esa misma página.
 
 #### Particularidades por extensión
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -73,6 +73,7 @@ El procedimiento de transferencia se desarrolla en varias etapas e involucra a v
 |[2](#step2)|[Desbloquear el nombre de dominio y obtener el código de transferencia](#step2)|El administrador del nombre de dominio, con la autorización del titular|En el actual agente registrador|Depende de sus acciones|
 |[3](#step3)|[Solicitar la transferencia del nombre de dominio](#step3)|Cualquiera que posea el código de transferencia, también con el permiso del titular|Con el nuevo agente registrador (por ejemplo, OVHcloud)|Depende de sus acciones|
 |[4](#step4)|[Validación de la transferencia](#step4)|El actual agente registrador|A través de una solicitud enviada por la entidad que gestiona la extensión del nombre de dominio|Máximo 5 días|
+|[5](#step5)|[Comprobación del titular tras la transferencia](#step5)|OVHcloud, automáticamente|Con el registro de la extensión|Automático, justo después de la transferencia|
 
 :::warning
 El procedimiento exacto de transferencia de nombre de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del nombre de dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: [https://www.ovhcloud.com/es-es/domains/tld/](/links/web/domains-tld).
@@ -169,7 +170,107 @@ En caso de **oposición a la transferencia por el actual agente registrador**, l
 
 :::
 
-### 5. Gestionar su nombre de dominio con OVHcloud
+### 5. Comprobación del titular tras la transferencia <a name="step5"></a>
+
+La transferencia ya es efectiva y su nombre de dominio está registrado en OVHcloud. En ese momento, OVHcloud compara automáticamente dos datos:
+
+- el **titular registrado en el registro** de la extensión, tal como queda tras la transferencia;
+- el **titular que ha indicado** al realizar su pedido en OVHcloud.
+
+El objetivo de esta comparación es garantizar que el titular declarado en el registro sea realmente el que ha solicitado. Es totalmente automática y **nunca bloquea la transferencia**: su nombre de dominio permanece transferido, sea cual sea el resultado.
+
+Existen tres resultados posibles.
+
+#### Ambos titulares coinciden
+
+No es necesaria ninguna acción: el titular registrado en el registro ya es el que ha solicitado.
+
+#### Los titulares difieren en datos modificables
+
+Se trata de los datos que el registro permite corregir mediante una simple actualización: dirección postal, ciudad, código postal, país, dirección de correo electrónico, número de teléfono, etc.
+
+OVHcloud inicia entonces automáticamente la actualización del titular en el registro, sin ninguna acción por su parte. Esta operación es independiente de la transferencia: se realiza justo después de esta y puede seguirla desde la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>.
+
+#### Los titulares difieren en la identidad del titular
+
+Se trata aquí de los datos que designan **quién** es el titular: apellidos, nombre, organización, forma jurídica. La mayoría de los registros no permiten modificar estos datos mediante una simple actualización. Solo un **cambio de titular** (también llamado «trade») permite corregirlos.
+
+Lo que hace OVHcloud depende entonces de la extensión de su nombre de dominio:
+
+|Situación|Qué ocurre|
+|---|---|
+|La extensión permite el cambio de titular durante una transferencia y la operación es gratuita para esa extensión|OVHcloud inicia automáticamente el cambio de titular, pero **este no se completa sin su validación**: consulte «[Validación del cambio de titular](#step5-foa)» más abajo.|
+|La extensión permite el cambio de titular durante una transferencia, pero la operación es de pago para esa extensión|OVHcloud **no realiza** la operación. Recibirá una notificación indicándole que el titular registrado en el registro no es el solicitado. Podrá entonces solicitar usted mismo el cambio de titular cuando lo desee.|
+|La extensión no permite el cambio de titular durante una transferencia|No se activa ninguna operación automática. El nombre de dominio conserva el titular registrado en el registro.|
+
+:::warning
+Un cambio de titular de pago **nunca** se activa automáticamente: esta operación se factura y, según la extensión, añade un año de suscripción. Por tanto, requiere su consentimiento. Para realizarlo usted mismo, siga nuestra guía «[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+##### Validación del cambio de titular <a name="step5-foa"></a>
+
+Un cambio de titular **nunca** se aplica por iniciativa exclusiva de OVHcloud, incluso cuando es gratuito y se ha iniciado automáticamente. En la mayoría de las extensiones, se envía por correo electrónico una solicitud de validación (formulario de autorización o «FOA»):
+
+- al **titular anterior**, es decir, el registrado en el registro en el momento de la transferencia;
+- al **nuevo titular**, es decir, el que ha solicitado en OVHcloud.
+
+**Ambos destinatarios deben aceptar** para que el cambio de titular se lleve a cabo. Existen tres resultados posibles:
+
+|Respuesta a las solicitudes de validación|Resultado|
+|---|---|
+|Ambos titulares aceptan|El cambio de titular se aplica en el registro.|
+|Uno de los dos titulares rechaza|La operación se **cancela** de inmediato. El nombre de dominio conserva el titular registrado en el registro.|
+|Ninguna respuesta en el plazo establecido|La operación **caduca** y el titular no se corrige. El plazo lo fija el registro de la extensión.|
+
+:::warning
+Asegúrese de que la dirección de correo electrónico del **titular anterior** sea accesible. Si nadie puede validar la solicitud enviada a esa dirección, el cambio de titular caducará y su nombre de dominio seguirá registrado a nombre del titular anterior.
+
+Puede seguir el avance de la solicitud y sus recordatorios desde la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>.
+
+:::
+
+:::info
+No todas las extensiones exigen esta validación por correo electrónico: algunos registros aplican el cambio de titular sin solicitud de confirmación. El detalle del procedimiento de cambio de titular se describe en nuestra guía «[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+#### Si la comparación no es concluyente
+
+Si el registro no facilita los datos del titular, la comparación no es concluyente y no se activa ninguna operación automática. OVHcloud realiza posteriormente una comprobación de los contactos. Su nombre de dominio sigue transferido y operativo.
+
+#### Si falta un dato obligatorio en su contacto titular
+
+Algunos registros exigen datos que su contacto titular no incluye necesariamente. Por ejemplo, el registro de la extensión `.pl` rechaza un titular sin número de teléfono.
+
+En ese caso, la operación indica el dato que falta en la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>. Complete el contacto correspondiente siguiendo nuestra guía «[Gestionar los contactos de un servicio](/guides/account-and-service-management/account-information/managing-contacts)» y reinicie la operación desde esa misma página.
+
+#### Particularidades por extensión
+
+La comprobación del titular se aplica a **todas** las extensiones. La siguiente tabla precisa, extensión por extensión, lo que se desvía del comportamiento descrito anteriormente.
+
+|Extensiones|Particularidad de la comprobación del titular|
+|---|---|
+|Extensiones genéricas (**gTLD**)|Comportamiento genérico|
+|`.com`, `.net`, `.cn`, `.ws`|Comportamiento genérico|
+|`.ca`|La categoría de forma jurídica del titular, exigida por el registro CIRA, se toma del registro cuando ambos titulares coinciden. Este dato es imprescindible para cualquier operación posterior sobre un `.ca`.|
+|`.hk`|El registro HKDNR no facilita ni la organización ni la dirección de correo electrónico del titular. Por tanto, el cambio de titular automático puede no estar disponible.|
+|`.pl`|El registro NASK rechaza un titular sin número de teléfono: la operación indica entonces el dato que debe completarse.|
+|`.fr` y otras extensiones gestionadas por AFNIC|Comportamiento genérico. El desarrollo general de la transferencia de un `.fr` sigue siendo el descrito en la [etapa 4](#step4).|
+|`.eu` y su equivalente en alfabeto cirílico|Comportamiento genérico|
+|`.uk`|Comportamiento genérico|
+|`.ac.uk`, `.gov.uk`|Comportamiento genérico|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Comportamiento genérico|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Comportamiento genérico|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Comportamiento genérico|
+|Otras extensiones gestionadas por un registro específico|Comportamiento genérico|
+
+:::info
+La autorización del cambio de titular durante una transferencia, así como su carácter gratuito o de pago, se definen **por extensión**. Para conocer las condiciones aplicables a la suya, introduzca su nombre de dominio en la página [www.ovhcloud.com/es-es/domains/tld/](/links/web/domains-tld).
+
+:::
+
+### 6. Gestionar su nombre de dominio con OVHcloud
 
 Una vez finalizado el procedimiento de transferencia, podrá administrar su nombre de dominio desde la página <ManagerLink to="/#/web-domains/domain">Dominios</ManagerLink>.
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -67,13 +67,13 @@ Para conocer las condiciones tarifarias para la transferencia de un nombre de do
 
 El procedimiento de transferencia se desarrolla en varias etapas e involucra a varias entidades, entre ellas su actual agente registrador, OVHcloud y otras partes. La siguiente tabla resume las etapas de una transferencia.
 
-|Etapa|Descripción|Quién realiza la acción|Dónde|Plazo|
+|Etapa|Descripción|Quién realiza la acción|Ante quién|Plazo|
 |---|---|---|---|---|
-|[1](#step1)|[Comprobar la información relativa al nombre de dominio](#step1)|El administrador del nombre de dominio|En el actual agente registrador|Depende de sus acciones|
-|[2](#step2)|[Desbloquear el nombre de dominio y obtener el código de transferencia](#step2)|El administrador del nombre de dominio, con la autorización del titular|En el actual agente registrador|Depende de sus acciones|
-|[3](#step3)|[Solicitar la transferencia del nombre de dominio](#step3)|Cualquiera que posea el código de transferencia, también con el permiso del titular|Con el nuevo agente registrador (por ejemplo, OVHcloud)|Depende de sus acciones|
-|[4](#step4)|[Validación de la transferencia](#step4)|El actual agente registrador|A través de una solicitud enviada por la entidad que gestiona la extensión del nombre de dominio|Máximo 5 días|
-|[5](#step5)|[Comprobación del titular tras la transferencia](#step5)|OVHcloud, automáticamente|Con el registro de la extensión|Automático, justo después de la transferencia|
+|[1](#step1)|[Comprobar la información relativa al nombre de dominio](#step1)|El titular del nombre de dominio, o la persona que lo administra|El actual agente registrador|Depende de sus acciones|
+|[2](#step2)|[Desbloquear el nombre de dominio y obtener el código de transferencia](#step2)|El titular del nombre de dominio, o la persona que lo administra|El actual agente registrador|Depende de sus acciones|
+|[3](#step3)|[Solicitar la transferencia del nombre de dominio](#step3)|Cualquiera que posea el código de transferencia|El nuevo agente registrador (por ejemplo, OVHcloud)|Depende de sus acciones|
+|[4](#step4)|[Validación de la transferencia](#step4)|El actual agente registrador|El registro de la extensión|Máximo 5 días|
+|[5](#step5)|[Comprobación del titular tras la transferencia](#step5)|OVHcloud, automáticamente|El registro de la extensión|Automático, justo después de la transferencia|
 
 :::warning
 El procedimiento exacto de transferencia de nombre de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del nombre de dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: [https://www.ovhcloud.com/es-es/domains/tld/](/links/web/domains-tld).
@@ -174,22 +174,22 @@ En caso de **oposición a la transferencia por el actual agente registrador**, l
 
 La transferencia ya es efectiva y su nombre de dominio está registrado en OVHcloud. En ese momento, OVHcloud compara automáticamente dos datos:
 
-- el **titular registrado en el registro** de la extensión, tal como queda tras la transferencia;
+- el **titular registrado en el registro de la extensión**, tal como queda tras la transferencia;
 - el **titular que ha indicado** al realizar su pedido en OVHcloud.
 
-El objetivo de esta comparación es garantizar que el titular declarado en el registro sea realmente el que ha solicitado. Es totalmente automática y **nunca bloquea la transferencia**: su nombre de dominio permanece transferido, sea cual sea el resultado.
+El objetivo de esta comparación es garantizar que el titular declarado en el registro de la extensión sea realmente el que ha solicitado. Es totalmente automática y **nunca bloquea la transferencia**: su nombre de dominio permanece transferido, sea cual sea el resultado.
 
 Existen tres resultados posibles.
 
 #### Ambos titulares coinciden
 
-No es necesaria ninguna acción: el titular registrado en el registro ya es el que ha solicitado.
+No es necesaria ninguna acción: el titular registrado en el registro de la extensión ya es el que ha solicitado.
 
 #### Los titulares difieren en datos modificables
 
-Se trata de los datos que el registro permite corregir mediante una simple actualización: dirección postal, ciudad, código postal, país, dirección de correo electrónico, número de teléfono, etc.
+Se trata de los datos que el registro de la extensión permite corregir mediante una simple actualización: dirección postal, ciudad, código postal, país, dirección de correo electrónico, número de teléfono, etc.
 
-OVHcloud inicia entonces automáticamente la actualización del titular en el registro, sin ninguna acción por su parte. Esta operación es independiente de la transferencia: se realiza justo después de esta y puede seguirla desde la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>.
+OVHcloud inicia entonces automáticamente la actualización del titular en el registro de la extensión, sin ninguna acción por su parte. Esta operación es independiente de la transferencia: se realiza justo después de esta y puede seguirla desde la página <ManagerLink to="/#/web/ongoing-operations">Operaciones en curso</ManagerLink>.
 
 #### Los titulares difieren en la identidad del titular
 
@@ -200,8 +200,8 @@ Lo que hace OVHcloud depende entonces de la extensión de su nombre de dominio:
 |Situación|Qué ocurre|
 |---|---|
 |La extensión permite el cambio de titular durante una transferencia y la operación es gratuita para esa extensión|OVHcloud inicia automáticamente el cambio de titular, pero **este no se completa sin su validación**: consulte «[Validación del cambio de titular](#step5-foa)» más abajo.|
-|La extensión permite el cambio de titular durante una transferencia, pero la operación es de pago para esa extensión|OVHcloud **no realiza** la operación. Recibirá una notificación indicándole que el titular registrado en el registro no es el solicitado. Podrá entonces solicitar usted mismo el cambio de titular cuando lo desee.|
-|La extensión no permite el cambio de titular durante una transferencia|No se activa ninguna operación automática. El nombre de dominio conserva el titular registrado en el registro.|
+|La extensión permite el cambio de titular durante una transferencia, pero la operación es de pago para esa extensión|OVHcloud **no realiza** la operación. Recibirá una notificación indicándole que el titular registrado en el registro de la extensión no es el solicitado. Podrá entonces solicitar usted mismo el cambio de titular cuando lo desee.|
+|La extensión no permite el cambio de titular durante una transferencia|No se activa ninguna operación automática. El nombre de dominio conserva el titular registrado en el registro de la extensión.|
 
 :::warning
 Un cambio de titular de pago **nunca** se activa automáticamente: esta operación se factura y, según la extensión, añade un año de suscripción. Por tanto, requiere su consentimiento. Para realizarlo usted mismo, siga nuestra guía «[Cambiar el titular de un nombre de dominio](/guides/web-cloud/domains/trade-domain)».
@@ -212,16 +212,18 @@ Un cambio de titular de pago **nunca** se activa automáticamente: esta operaci�
 
 Un cambio de titular **nunca** se aplica por iniciativa exclusiva de OVHcloud, incluso cuando es gratuito y se ha iniciado automáticamente. En la mayoría de las extensiones, se envía por correo electrónico una solicitud de validación (formulario de autorización o «FOA»):
 
-- al **titular anterior**, es decir, el registrado en el registro en el momento de la transferencia;
+- al **titular anterior**, es decir, el registrado en el registro de la extensión en el momento de la transferencia;
 - al **nuevo titular**, es decir, el que ha solicitado en OVHcloud.
 
 **Ambos destinatarios deben aceptar** para que el cambio de titular se lleve a cabo. Existen tres resultados posibles:
 
 |Respuesta a las solicitudes de validación|Resultado|
 |---|---|
-|Ambos titulares aceptan|El cambio de titular se aplica en el registro.|
-|Uno de los dos titulares rechaza|La operación se **cancela** de inmediato. El nombre de dominio conserva el titular registrado en el registro.|
+|Ambos titulares aceptan|El cambio de titular se aplica en el registro de la extensión.|
+|Uno de los dos titulares rechaza|La operación se **cancela** de inmediato. El nombre de dominio conserva el titular registrado en el registro de la extensión.|
 |Ninguna respuesta en el plazo establecido|La operación **caduca** y el titular no se corrige. El plazo lo fija el registro de la extensión.|
+
+Sea cual sea el resultado de esta solicitud de validación, **la transferencia de su nombre de dominio se mantiene**: un rechazo, una caducidad o un bloqueo del cambio de titular no anula la transferencia. Únicamente no se produce la corrección del titular, y su nombre de dominio sigue registrado en OVHcloud.
 
 :::warning
 Asegúrese de que la dirección de correo electrónico del **titular anterior** sea accesible. Si nadie puede validar la solicitud enviada a esa dirección, el cambio de titular caducará y su nombre de dominio seguirá registrado a nombre del titular anterior.
@@ -237,7 +239,7 @@ No todas las extensiones exigen esta validación por correo electrónico: alguno
 
 #### Si la comparación no es concluyente
 
-Si el registro no facilita los datos del titular, la comparación no es concluyente y no se activa ninguna operación automática. OVHcloud realiza posteriormente una comprobación de los contactos. Su nombre de dominio sigue transferido y operativo.
+Si el registro de la extensión no facilita los datos del titular, la comparación no es concluyente y no se activa ninguna operación automática. OVHcloud realiza posteriormente una comprobación de los contactos. Su nombre de dominio sigue transferido y operativo.
 
 #### Si falta un dato obligatorio en su contacto titular
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transférer son nom de domaine vers OVHcloud
 description: "Découvrez comment réaliser le transfert d’un nom de domaine vers OVHcloud"
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -72,6 +72,7 @@ La procédure de transfert comporte plusieurs étapes, impliquant la prise de co
 |[2](#step2)|[Déverrouillage du nom de domaine et récupération du code de transfert](#step2)|L’administrateur du nom de domaine, avec l’autorisation du titulaire|Avec le bureau d’enregistrement actuel|Dépend de vos actions|
 |[3](#step3)|[Demande de transfert de nom de domaine](#step3)|Toute personne possédant le code de transfert, également avec la permission du titulaire|Avec le nouveau bureau d’enregistrement (par exemple OVHcloud)|Dépend de vos actions|
 |[4](#step4)|[Validation du transfert](#step4)|Le bureau d’enregistrement actuel|À la demande de l’organisation gérant l’extension de nom de domaine|Cinq jours maximum|
+|[5](#step5)|[Vérification du titulaire après le transfert](#step5)|OVHcloud, automatiquement|Avec le registre de l’extension|Automatique, juste après le transfert|
 
 :::warning
 La procédure exacte de transfert de nom de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l’extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d’abord les informations affichées pour l’extension concernée, sur notre site Web : [https://www.ovhcloud.com/fr/domains/tld/](/links/web/domains-tld).
@@ -168,7 +169,107 @@ En cas d’**opposition au transfert par le bureau d’enregistrement actuel**, 
 
 :::
 
-### Étape 5 : gérer son nom de domaine avec OVHcloud
+### Étape 5 : vérification du titulaire après le transfert <a name="step5"></a>
+
+Le transfert est désormais effectif et votre nom de domaine est enregistré chez OVHcloud. À ce moment, OVHcloud compare automatiquement deux informations :
+
+- le **titulaire enregistré auprès du registre** de l’extension, tel qu’il ressort du transfert ;
+- le **titulaire que vous avez renseigné** lors de votre commande chez OVHcloud.
+
+Cette comparaison a pour but de garantir que le titulaire déclaré auprès du registre est bien celui que vous avez commandé. Elle est entièrement automatique et **ne bloque jamais le transfert** : votre nom de domaine reste transféré, quelle que soit son issue.
+
+Trois issues sont possibles.
+
+#### Les deux titulaires correspondent
+
+Aucune action n’est nécessaire : le titulaire enregistré auprès du registre est déjà celui que vous avez commandé.
+
+#### Les titulaires diffèrent sur des informations modifiables
+
+Il s’agit des informations que le registre autorise à corriger par une simple mise à jour : adresse postale, ville, code postal, pays, adresse e-mail, numéro de téléphone, etc.
+
+OVHcloud lance alors automatiquement la mise à jour du titulaire auprès du registre, sans action de votre part. Cette opération est distincte du transfert : elle se déroule juste après celui-ci et vous pouvez la suivre depuis la page <ManagerLink to="/#/web/ongoing-operations">Opérations en cours</ManagerLink>.
+
+#### Les titulaires diffèrent sur l’identité du titulaire
+
+Il s’agit ici des informations qui désignent **qui** est le titulaire : nom, prénom, organisation, forme juridique. La plupart des registres interdisent de modifier ces informations par une simple mise à jour. Seul un **changement de titulaire** (aussi appelé « trade ») permet de les corriger.
+
+Ce que fait OVHcloud dépend alors de l’extension de votre nom de domaine :
+
+|Situation|Ce qui se passe|
+|---|---|
+|L’extension autorise le changement de titulaire pendant un transfert, et l’opération est gratuite pour cette extension|OVHcloud engage automatiquement le changement de titulaire, mais **celui-ci ne se termine pas sans votre validation** : voir « [Validation du changement de titulaire](#step5-foa) » ci-dessous.|
+|L’extension autorise le changement de titulaire pendant un transfert, mais l’opération est payante pour cette extension|OVHcloud **ne réalise pas** l’opération. Vous recevez une notification vous signalant que le titulaire enregistré auprès du registre n’est pas celui commandé. Vous pouvez alors commander vous-même le changement de titulaire, quand vous le souhaitez.|
+|L’extension n’autorise pas le changement de titulaire pendant un transfert|Aucune opération automatique n’est déclenchée. Le nom de domaine conserve le titulaire enregistré auprès du registre.|
+
+:::warning
+Un changement de titulaire payant n’est **jamais** déclenché automatiquement : cette opération est facturée et, selon l’extension, ajoute une année de souscription. Elle nécessite donc votre accord. Pour la réaliser vous-même, suivez notre guide « [Changer le titulaire d’un nom de domaine](/guides/web-cloud/domains/trade-domain) ».
+
+:::
+
+##### Validation du changement de titulaire <a name="step5-foa"></a>
+
+Un changement de titulaire n’est **jamais** appliqué sur la seule initiative d’OVHcloud, même lorsqu’il est gratuit et engagé automatiquement. Pour la plupart des extensions, une demande de validation (formulaire d’autorisation, ou « FOA ») est envoyée par e-mail :
+
+- au **titulaire précédent**, c’est-à-dire celui enregistré auprès du registre au moment du transfert ;
+- au **nouveau titulaire**, c’est-à-dire celui que vous avez commandé chez OVHcloud.
+
+**Les deux destinataires doivent accepter** pour que le changement de titulaire aboutisse. Trois issues sont possibles :
+
+|Réponse aux demandes de validation|Résultat|
+|---|---|
+|Les deux titulaires acceptent|Le changement de titulaire est appliqué auprès du registre.|
+|L’un des deux titulaires refuse|L’opération est **annulée** immédiatement. Le nom de domaine conserve le titulaire enregistré auprès du registre.|
+|Aucune réponse dans le délai imparti|L’opération **expire** et le titulaire n’est pas réaligné. Le délai est fixé par le registre de l’extension.|
+
+:::warning
+Veillez à ce que l’adresse e-mail du **titulaire précédent** soit accessible. Si personne ne peut valider la demande envoyée à cette adresse, le changement de titulaire expirera et votre nom de domaine restera enregistré au nom du titulaire précédent.
+
+Vous pouvez suivre l’avancement de la demande et les relances depuis la page <ManagerLink to="/#/web/ongoing-operations">Opérations en cours</ManagerLink>.
+
+:::
+
+:::info
+Toutes les extensions n’exigent pas cette validation par e-mail : certains registres appliquent le changement de titulaire sans demande de confirmation. Le détail de la procédure de changement de titulaire est décrit dans notre guide « [Changer le titulaire d’un nom de domaine](/guides/web-cloud/domains/trade-domain) ».
+
+:::
+
+#### Si la comparaison n’aboutit pas
+
+Si le registre ne communique pas les informations du titulaire, la comparaison reste sans conclusion et aucune opération automatique n’est déclenchée. Une vérification des contacts est réalisée ultérieurement par OVHcloud. Votre nom de domaine reste transféré et utilisable.
+
+#### Si une information obligatoire manque sur votre contact titulaire
+
+Certains registres exigent des informations que votre contact titulaire ne comporte pas nécessairement. Par exemple, le registre de l’extension `.pl` refuse un titulaire dépourvu de numéro de téléphone.
+
+Dans ce cas, l’opération signale l’information manquante depuis la page <ManagerLink to="/#/web/ongoing-operations">Opérations en cours</ManagerLink>. Complétez le contact concerné en suivant notre guide « [Gérer les contacts associés à un service](/guides/account-and-service-management/account-information/managing-contacts) », puis relancez l’opération depuis cette même page.
+
+#### Spécificités par extension
+
+La vérification du titulaire s’applique à **toutes** les extensions. Le tableau ci-dessous précise, extension par extension, ce qui s’écarte du comportement décrit ci-dessus.
+
+|Extensions|Spécificité de la vérification du titulaire|
+|---|---|
+|Extensions génériques (**gTLD**)|Comportement générique|
+|`.com`, `.net`, `.cn`, `.ws`|Comportement générique|
+|`.ca`|La catégorie de forme juridique du titulaire, exigée par le registre CIRA, est reprise depuis le registre lorsque les deux titulaires correspondent. Cette information est indispensable aux opérations ultérieures sur un `.ca`.|
+|`.hk`|Le registre HKDNR ne communique ni l’organisation ni l’adresse e-mail du titulaire. Un changement de titulaire automatique peut donc être indisponible.|
+|`.pl`|Le registre NASK refuse un titulaire dépourvu de numéro de téléphone : l’opération signale alors l’information à compléter.|
+|`.fr` et autres extensions gérées par l’AFNIC|Comportement générique. Le déroulé général du transfert `.fr` reste celui décrit à l’[étape 4](#step4).|
+|`.eu` et son équivalent en alphabet cyrillique|Comportement générique|
+|`.uk`|Comportement générique|
+|`.ac.uk`, `.gov.uk`|Comportement générique|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Comportement générique|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Comportement générique|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Comportement générique|
+|Autres extensions gérées par un registre spécifique|Comportement générique|
+
+:::info
+L’autorisation du changement de titulaire pendant un transfert, ainsi que son caractère gratuit ou payant, sont définis **par extension**. Pour connaître les conditions applicables à la vôtre, renseignez votre nom de domaine sur la page [www.ovhcloud.com/fr/domains/tld/](/links/web/domains-tld).
+
+:::
+
+### Étape 6 : gérer son nom de domaine avec OVHcloud
 
 Une fois la procédure de transfert terminée, vous pouvez gérer votre nom de domaine depuis la page <ManagerLink to="/#/web-domains/domain">Noms de domaine</ManagerLink>.
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -11,7 +11,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
-Votre nom de domaine est actuellement déposé dans un **bureau d’enregistrement** et vous souhaitez le confier à OVHcloud ? C’est possible, via une procédure de transfert.
+Votre nom de domaine est actuellement enregistré auprès d’un **bureau d’enregistrement** et vous souhaitez le confier à OVHcloud ? C’est possible, via une procédure de transfert.
 
 En transférant votre nom de domaine, vous changerez de **bureau d’enregistrement** pour celui-ci. Vous pouvez transférer votre nom de domaine vers OVHcloud en créant une commande. Ce processus prend généralement entre un et dix jours.
 
@@ -64,15 +64,15 @@ Pour connaître les conditions tarifaires pour le transfert d’un nom de domain
 
 :::
 
-La procédure de transfert comporte plusieurs étapes, impliquant la prise de contact avec votre registre actuel et OVHcloud. Le tableau ci-dessous vous indique les personnes contactées et la durée estimée de chaque étape.
+La procédure de transfert comporte plusieurs étapes, impliquant la prise de contact avec votre bureau d’enregistrement actuel et OVHcloud. Le tableau ci-dessous vous indique les personnes contactées et la durée estimée de chaque étape.
 
-|Étapes|Description|Qui est impliqué ?|Où ?|Temps requis|
+|Étapes|Description|Qui est impliqué ?|Auprès de qui ?|Temps requis|
 |---|---|---|---|---|
-|[1](#step1)|[Vérification des informations associées au nom de domaine](#step1)|L’administrateur du nom de domaine|Avec le bureau d’enregistrement actuel|Dépend de vos actions|
-|[2](#step2)|[Déverrouillage du nom de domaine et récupération du code de transfert](#step2)|L’administrateur du nom de domaine, avec l’autorisation du titulaire|Avec le bureau d’enregistrement actuel|Dépend de vos actions|
-|[3](#step3)|[Demande de transfert de nom de domaine](#step3)|Toute personne possédant le code de transfert, également avec la permission du titulaire|Avec le nouveau bureau d’enregistrement (par exemple OVHcloud)|Dépend de vos actions|
-|[4](#step4)|[Validation du transfert](#step4)|Le bureau d’enregistrement actuel|À la demande de l’organisation gérant l’extension de nom de domaine|Cinq jours maximum|
-|[5](#step5)|[Vérification du titulaire après le transfert](#step5)|OVHcloud, automatiquement|Avec le registre de l’extension|Automatique, juste après le transfert|
+|[1](#step1)|[Vérification des informations associées au nom de domaine](#step1)|Le titulaire du nom de domaine, ou la personne qui l’administre|Le bureau d’enregistrement actuel|Dépend de vos actions|
+|[2](#step2)|[Déverrouillage du nom de domaine et récupération du code de transfert](#step2)|Le titulaire du nom de domaine, ou la personne qui l’administre|Le bureau d’enregistrement actuel|Dépend de vos actions|
+|[3](#step3)|[Demande de transfert de nom de domaine](#step3)|Toute personne possédant le code de transfert|Le nouveau bureau d’enregistrement (par exemple OVHcloud)|Dépend de vos actions|
+|[4](#step4)|[Validation du transfert](#step4)|Le bureau d’enregistrement actuel|Le registre de l’extension|Cinq jours maximum|
+|[5](#step5)|[Vérification du titulaire après le transfert](#step5)|OVHcloud, automatiquement|Le registre de l’extension|Automatique, juste après le transfert|
 
 :::warning
 La procédure exacte de transfert de nom de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l’extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d’abord les informations affichées pour l’extension concernée, sur notre site Web : [https://www.ovhcloud.com/fr/domains/tld/](/links/web/domains-tld).
@@ -173,22 +173,22 @@ En cas d’**opposition au transfert par le bureau d’enregistrement actuel**, 
 
 Le transfert est désormais effectif et votre nom de domaine est enregistré chez OVHcloud. À ce moment, OVHcloud compare automatiquement deux informations :
 
-- le **titulaire enregistré auprès du registre** de l’extension, tel qu’il ressort du transfert ;
+- le **titulaire enregistré auprès du registre de l’extension**, tel qu’il ressort du transfert ;
 - le **titulaire que vous avez renseigné** lors de votre commande chez OVHcloud.
 
-Cette comparaison a pour but de garantir que le titulaire déclaré auprès du registre est bien celui que vous avez commandé. Elle est entièrement automatique et **ne bloque jamais le transfert** : votre nom de domaine reste transféré, quelle que soit son issue.
+Cette comparaison a pour but de garantir que le titulaire déclaré auprès du registre de l’extension est bien celui que vous avez commandé. Elle est entièrement automatique et **ne bloque jamais le transfert** : votre nom de domaine reste transféré, quelle que soit son issue.
 
 Trois issues sont possibles.
 
 #### Les deux titulaires correspondent
 
-Aucune action n’est nécessaire : le titulaire enregistré auprès du registre est déjà celui que vous avez commandé.
+Aucune action n’est nécessaire : le titulaire enregistré auprès du registre de l’extension est déjà celui que vous avez commandé.
 
 #### Les titulaires diffèrent sur des informations modifiables
 
-Il s’agit des informations que le registre autorise à corriger par une simple mise à jour : adresse postale, ville, code postal, pays, adresse e-mail, numéro de téléphone, etc.
+Il s’agit des informations que le registre de l’extension autorise à corriger par une simple mise à jour : adresse postale, ville, code postal, pays, adresse e-mail, numéro de téléphone, etc.
 
-OVHcloud lance alors automatiquement la mise à jour du titulaire auprès du registre, sans action de votre part. Cette opération est distincte du transfert : elle se déroule juste après celui-ci et vous pouvez la suivre depuis la page <ManagerLink to="/#/web/ongoing-operations">Opérations en cours</ManagerLink>.
+OVHcloud lance alors automatiquement la mise à jour du titulaire auprès du registre de l’extension, sans action de votre part. Cette opération est distincte du transfert : elle se déroule juste après celui-ci et vous pouvez la suivre depuis la page <ManagerLink to="/#/web/ongoing-operations">Opérations en cours</ManagerLink>.
 
 #### Les titulaires diffèrent sur l’identité du titulaire
 
@@ -199,8 +199,8 @@ Ce que fait OVHcloud dépend alors de l’extension de votre nom de domaine :
 |Situation|Ce qui se passe|
 |---|---|
 |L’extension autorise le changement de titulaire pendant un transfert, et l’opération est gratuite pour cette extension|OVHcloud engage automatiquement le changement de titulaire, mais **celui-ci ne se termine pas sans votre validation** : voir « [Validation du changement de titulaire](#step5-foa) » ci-dessous.|
-|L’extension autorise le changement de titulaire pendant un transfert, mais l’opération est payante pour cette extension|OVHcloud **ne réalise pas** l’opération. Vous recevez une notification vous signalant que le titulaire enregistré auprès du registre n’est pas celui commandé. Vous pouvez alors commander vous-même le changement de titulaire, quand vous le souhaitez.|
-|L’extension n’autorise pas le changement de titulaire pendant un transfert|Aucune opération automatique n’est déclenchée. Le nom de domaine conserve le titulaire enregistré auprès du registre.|
+|L’extension autorise le changement de titulaire pendant un transfert, mais l’opération est payante pour cette extension|OVHcloud **ne réalise pas** l’opération. Vous recevez une notification vous signalant que le titulaire enregistré auprès du registre de l’extension n’est pas celui commandé. Vous pouvez alors commander vous-même le changement de titulaire, quand vous le souhaitez.|
+|L’extension n’autorise pas le changement de titulaire pendant un transfert|Aucune opération automatique n’est déclenchée. Le nom de domaine conserve le titulaire enregistré auprès du registre de l’extension.|
 
 :::warning
 Un changement de titulaire payant n’est **jamais** déclenché automatiquement : cette opération est facturée et, selon l’extension, ajoute une année de souscription. Elle nécessite donc votre accord. Pour la réaliser vous-même, suivez notre guide « [Changer le titulaire d’un nom de domaine](/guides/web-cloud/domains/trade-domain) ».
@@ -211,16 +211,18 @@ Un changement de titulaire payant n’est **jamais** déclenché automatiquement
 
 Un changement de titulaire n’est **jamais** appliqué sur la seule initiative d’OVHcloud, même lorsqu’il est gratuit et engagé automatiquement. Pour la plupart des extensions, une demande de validation (formulaire d’autorisation, ou « FOA ») est envoyée par e-mail :
 
-- au **titulaire précédent**, c’est-à-dire celui enregistré auprès du registre au moment du transfert ;
+- au **titulaire précédent**, c’est-à-dire celui enregistré auprès du registre de l’extension au moment du transfert ;
 - au **nouveau titulaire**, c’est-à-dire celui que vous avez commandé chez OVHcloud.
 
 **Les deux destinataires doivent accepter** pour que le changement de titulaire aboutisse. Trois issues sont possibles :
 
 |Réponse aux demandes de validation|Résultat|
 |---|---|
-|Les deux titulaires acceptent|Le changement de titulaire est appliqué auprès du registre.|
-|L’un des deux titulaires refuse|L’opération est **annulée** immédiatement. Le nom de domaine conserve le titulaire enregistré auprès du registre.|
+|Les deux titulaires acceptent|Le changement de titulaire est appliqué auprès du registre de l’extension.|
+|L’un des deux titulaires refuse|L’opération est **annulée** immédiatement. Le nom de domaine conserve le titulaire enregistré auprès du registre de l’extension.|
 |Aucune réponse dans le délai imparti|L’opération **expire** et le titulaire n’est pas réaligné. Le délai est fixé par le registre de l’extension.|
+
+Quelle que soit l’issue de cette demande de validation, **le transfert de votre nom de domaine reste acquis** : un refus, une expiration ou un blocage du changement de titulaire n’entraîne pas l’annulation du transfert. Seul le réalignement du titulaire n’a pas lieu et votre nom de domaine reste enregistré chez OVHcloud.
 
 :::warning
 Veillez à ce que l’adresse e-mail du **titulaire précédent** soit accessible. Si personne ne peut valider la demande envoyée à cette adresse, le changement de titulaire expirera et votre nom de domaine restera enregistré au nom du titulaire précédent.
@@ -236,7 +238,7 @@ Toutes les extensions n’exigent pas cette validation par e-mail : certains reg
 
 #### Si la comparaison n’aboutit pas
 
-Si le registre ne communique pas les informations du titulaire, la comparaison reste sans conclusion et aucune opération automatique n’est déclenchée. Une vérification des contacts est réalisée ultérieurement par OVHcloud. Votre nom de domaine reste transféré et utilisable.
+Si le registre de l’extension ne communique pas les informations du titulaire, la comparaison reste sans conclusion et aucune opération automatique n’est déclenchée. Une vérification des contacts est réalisée ultérieurement par OVHcloud. Votre nom de domaine reste transféré et utilisable.
 
 #### Si une information obligatoire manque sur votre contact titulaire
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Trasferire un nome di dominio in OVHcloud
 description: Questa guida ti mostra come avviare la procedura di trasferimento di un nome di dominio generico verso OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -192,24 +192,24 @@ OVHcloud avvia allora automaticamente l’aggiornamento dell’intestatario pres
 
 #### Gli intestatari differiscono sull’identità dell’intestatario
 
-Si tratta qui delle informazioni che indicano **chi** è l’intestatario: cognome, nome, organizzazione, forma giuridica. La maggior parte dei Registri non consente di modificare queste informazioni con un semplice aggiornamento. Solo un **cambio di intestatario** (detto anche «trade») permette di correggerle.
+Si tratta qui delle informazioni che indicano **chi** è l’intestatario: cognome, nome, organizzazione, forma giuridica. La maggior parte dei Registri non consente di modificare queste informazioni con un semplice aggiornamento. Solo un **cambio di intestatario** (detto anche "trade") permette di correggerle.
 
 Ciò che fa OVHcloud dipende allora dall’estensione del tuo nome di dominio:
 
 |Situazione|Cosa accade|
 |---|---|
-|L’estensione consente il cambio di intestatario durante un trasferimento e l’operazione è gratuita per questa estensione|OVHcloud avvia automaticamente il cambio di intestatario, ma **questo non si conclude senza la tua convalida**: consulta «[Convalida del cambio di intestatario](#step5-foa)» di seguito.|
+|L’estensione consente il cambio di intestatario durante un trasferimento e l’operazione è gratuita per questa estensione|OVHcloud avvia automaticamente il cambio di intestatario, ma **questo non si conclude senza la tua convalida**: consulta "[Convalida del cambio di intestatario](#step5-foa)" di seguito.|
 |L’estensione consente il cambio di intestatario durante un trasferimento, ma l’operazione è a pagamento per questa estensione|OVHcloud **non effettua** l’operazione. Riceverai una notifica che segnala che l’intestatario registrato presso il Registro dell’estensione non è quello ordinato. Potrai quindi ordinare tu stesso il cambio di intestatario, quando lo desideri.|
 |L’estensione non consente il cambio di intestatario durante un trasferimento|Non viene avviata alcuna operazione automatica. Il nome di dominio conserva l’intestatario registrato presso il Registro dell’estensione.|
 
 :::warning
-Un cambio di intestatario a pagamento non viene **mai** avviato automaticamente: questa operazione è fatturata e, in base all’estensione, aggiunge un anno di sottoscrizione. Richiede quindi il tuo consenso. Per effettuarlo tu stesso, segui la nostra guida «[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)».
+Un cambio di intestatario a pagamento non viene **mai** avviato automaticamente: questa operazione è fatturata e, in base all’estensione, aggiunge un anno di sottoscrizione. Richiede quindi il tuo consenso. Per effettuarlo tu stesso, segui la nostra guida "[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
 ##### Convalida del cambio di intestatario <a name="step5-foa"></a>
 
-Un cambio di intestatario non viene **mai** applicato per sola iniziativa di OVHcloud, nemmeno quando è gratuito e avviato automaticamente. Per la maggior parte delle estensioni, viene inviata per email una richiesta di convalida (modulo di autorizzazione, o «FOA»):
+Un cambio di intestatario non viene **mai** applicato per sola iniziativa di OVHcloud, nemmeno quando è gratuito e avviato automaticamente. Per la maggior parte delle estensioni, viene inviata per email una richiesta di convalida (modulo di autorizzazione, o "FOA"):
 
 - all’**intestatario precedente**, ovvero quello registrato presso il Registro dell’estensione al momento del trasferimento;
 - al **nuovo intestatario**, ovvero quello che hai ordinato presso OVHcloud.
@@ -232,7 +232,7 @@ Puoi seguire l’avanzamento della richiesta e i solleciti dalla pagina <Manager
 :::
 
 :::info
-Non tutte le estensioni richiedono questa convalida via email: alcuni Registri applicano il cambio di intestatario senza richiesta di conferma. Il dettaglio della procedura di cambio di intestatario è descritto nella nostra guida «[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)».
+Non tutte le estensioni richiedono questa convalida via email: alcuni Registri applicano il cambio di intestatario senza richiesta di conferma. Il dettaglio della procedura di cambio di intestatario è descritto nella nostra guida "[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
@@ -244,7 +244,7 @@ Se il Registro dell’estensione non comunica le informazioni dell’intestatari
 
 Alcuni Registri richiedono informazioni che il tuo contatto intestatario non contiene necessariamente. Ad esempio, il Registro dell’estensione `.pl` rifiuta un intestatario privo di numero di telefono.
 
-In questo caso, l’operazione segnala l’informazione mancante dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>. Completa il contatto interessato seguendo la nostra guida «[Gestire i contatti di un servizio](/guides/account-and-service-management/account-information/managing-contacts)», quindi riavvia l’operazione dalla stessa pagina.
+In questo caso, l’operazione segnala l’informazione mancante dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>. Completa il contatto interessato seguendo la nostra guida "[Gestire i contatti di un servizio](/guides/account-and-service-management/account-information/managing-contacts)", quindi riavvia l’operazione dalla stessa pagina.
 
 #### Specificità per estensione
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -72,6 +72,7 @@ La procedura di trasferimento prevede diversi step, tra cui l'avvio di contatti 
 |[2](#step2)|[Sblocco del nome di dominio e recupero del codice di trasferimento](#step2)|L'amministratore del nome di dominio, con l'autorizzazione dell'intestatario|Il Registrar attuale|In base alle azioni effettuate|
 |[3](#step3)|[Trasferimento di un nome di dominio](#step3)|Chiunque sia in possesso del codice di trasferimento, anche con il permesso dell'intestatario|Con il nuovo Registrar (ad esempio, OVHcloud)|In base alle azioni effettuate|
 |[4](#step4)|[Conferma del trasferimento](#step4)|Il Registrar attuale|Tramite una richiesta da parte del Registro che gestisce l'estensione del nome di dominio|Massimo cinque giorni|
+|[5](#step5)|[Verifica dell’intestatario dopo il trasferimento](#step5)|OVHcloud, automaticamente|Con il Registro dell’estensione|Automatica, subito dopo il trasferimento|
 
 :::warning
 La procedura esatta di trasferimento del nome di dominio può variare, in particolare per alcune **TLD** del codice del paese (**ccTLD**, quali .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, ecc.) e per alcune **TLD** speciali (.am, .fm, ecc.). In base all'estensione del tuo nome di dominio, potrebbero essere necessari requisiti aggiuntivi. Ti consigliamo di verificare le informazioni mostrate per l'estensione in questione dal nostro sito Web: [https://www.ovhcloud.com/it/domains/tld/](/links/web/domains-tld).
@@ -168,7 +169,107 @@ In caso di **opposizione al trasferimento da parte dell'attuale Registrar**, il 
 
 :::
 
-### Step 5: gestire il nome di dominio con OVHcloud
+### Step 5: verifica dell’intestatario dopo il trasferimento <a name="step5"></a>
+
+Il trasferimento è ora effettivo e il tuo nome di dominio è registrato presso OVHcloud. In questo momento, OVHcloud confronta automaticamente due informazioni:
+
+- l’**intestatario registrato presso il Registro** dell’estensione, come risulta dal trasferimento;
+- l’**intestatario che hai indicato** al momento dell’ordine presso OVHcloud.
+
+Questo confronto ha lo scopo di garantire che l’intestatario dichiarato presso il Registro sia effettivamente quello che hai ordinato. È completamente automatico e **non blocca mai il trasferimento**: il tuo nome di dominio resta trasferito, qualunque sia l’esito.
+
+Sono possibili tre esiti.
+
+#### I due intestatari corrispondono
+
+Non è necessaria alcuna azione: l’intestatario registrato presso il Registro è già quello che hai ordinato.
+
+#### Gli intestatari differiscono su informazioni modificabili
+
+Si tratta delle informazioni che il Registro consente di correggere con un semplice aggiornamento: indirizzo postale, città, codice postale, Paese, indirizzo email, numero di telefono, ecc.
+
+OVHcloud avvia allora automaticamente l’aggiornamento dell’intestatario presso il Registro, senza alcuna azione da parte tua. Questa operazione è distinta dal trasferimento: si svolge subito dopo e puoi seguirla dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>.
+
+#### Gli intestatari differiscono sull’identità dell’intestatario
+
+Si tratta qui delle informazioni che indicano **chi** è l’intestatario: cognome, nome, organizzazione, forma giuridica. La maggior parte dei Registri non consente di modificare queste informazioni con un semplice aggiornamento. Solo un **cambio di intestatario** (detto anche «trade») permette di correggerle.
+
+Ciò che fa OVHcloud dipende allora dall’estensione del tuo nome di dominio:
+
+|Situazione|Cosa accade|
+|---|---|
+|L’estensione consente il cambio di intestatario durante un trasferimento e l’operazione è gratuita per questa estensione|OVHcloud avvia automaticamente il cambio di intestatario, ma **questo non si conclude senza la tua convalida**: consulta «[Convalida del cambio di intestatario](#step5-foa)» di seguito.|
+|L’estensione consente il cambio di intestatario durante un trasferimento, ma l’operazione è a pagamento per questa estensione|OVHcloud **non effettua** l’operazione. Riceverai una notifica che segnala che l’intestatario registrato presso il Registro non è quello ordinato. Potrai quindi ordinare tu stesso il cambio di intestatario, quando lo desideri.|
+|L’estensione non consente il cambio di intestatario durante un trasferimento|Non viene avviata alcuna operazione automatica. Il nome di dominio conserva l’intestatario registrato presso il Registro.|
+
+:::warning
+Un cambio di intestatario a pagamento non viene **mai** avviato automaticamente: questa operazione è fatturata e, in base all’estensione, aggiunge un anno di sottoscrizione. Richiede quindi il tuo consenso. Per effettuarlo tu stesso, segui la nostra guida «[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+##### Convalida del cambio di intestatario <a name="step5-foa"></a>
+
+Un cambio di intestatario non viene **mai** applicato per sola iniziativa di OVHcloud, nemmeno quando è gratuito e avviato automaticamente. Per la maggior parte delle estensioni, viene inviata per email una richiesta di convalida (modulo di autorizzazione, o «FOA»):
+
+- all’**intestatario precedente**, ovvero quello registrato presso il Registro al momento del trasferimento;
+- al **nuovo intestatario**, ovvero quello che hai ordinato presso OVHcloud.
+
+**Entrambi i destinatari devono accettare** perché il cambio di intestatario vada a buon fine. Sono possibili tre esiti:
+
+|Risposta alle richieste di convalida|Risultato|
+|---|---|
+|Entrambi gli intestatari accettano|Il cambio di intestatario viene applicato presso il Registro.|
+|Uno dei due intestatari rifiuta|L’operazione viene **annullata** immediatamente. Il nome di dominio conserva l’intestatario registrato presso il Registro.|
+|Nessuna risposta entro il termine previsto|L’operazione **scade** e l’intestatario non viene allineato. Il termine è stabilito dal Registro dell’estensione.|
+
+:::warning
+Assicurati che l’indirizzo email dell’**intestatario precedente** sia raggiungibile. Se nessuno può convalidare la richiesta inviata a tale indirizzo, il cambio di intestatario scadrà e il tuo nome di dominio resterà registrato a nome dell’intestatario precedente.
+
+Puoi seguire l’avanzamento della richiesta e i solleciti dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>.
+
+:::
+
+:::info
+Non tutte le estensioni richiedono questa convalida via email: alcuni Registri applicano il cambio di intestatario senza richiesta di conferma. Il dettaglio della procedura di cambio di intestatario è descritto nella nostra guida «[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+#### Se il confronto non è conclusivo
+
+Se il Registro non comunica le informazioni dell’intestatario, il confronto resta senza esito e non viene avviata alcuna operazione automatica. Una verifica dei contatti viene effettuata successivamente da OVHcloud. Il tuo nome di dominio resta trasferito e utilizzabile.
+
+#### Se manca un’informazione obbligatoria sul tuo contatto intestatario
+
+Alcuni Registri richiedono informazioni che il tuo contatto intestatario non contiene necessariamente. Ad esempio, il Registro dell’estensione `.pl` rifiuta un intestatario privo di numero di telefono.
+
+In questo caso, l’operazione segnala l’informazione mancante dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>. Completa il contatto interessato seguendo la nostra guida «[Gestire i contatti di un servizio](/guides/account-and-service-management/account-information/managing-contacts)», quindi riavvia l’operazione dalla stessa pagina.
+
+#### Specificità per estensione
+
+La verifica dell’intestatario si applica a **tutte** le estensioni. La tabella seguente precisa, estensione per estensione, ciò che si discosta dal comportamento descritto sopra.
+
+|Estensioni|Specificità della verifica dell’intestatario|
+|---|---|
+|Estensioni generiche (**gTLD**)|Comportamento generico|
+|`.com`, `.net`, `.cn`, `.ws`|Comportamento generico|
+|`.ca`|La categoria di forma giuridica dell’intestatario, richiesta dal Registro CIRA, viene ripresa dal Registro quando i due intestatari corrispondono. Questa informazione è indispensabile per le operazioni successive su un `.ca`.|
+|`.hk`|Il Registro HKDNR non comunica né l’organizzazione né l’indirizzo email dell’intestatario. Un cambio di intestatario automatico può quindi non essere disponibile.|
+|`.pl`|Il Registro NASK rifiuta un intestatario privo di numero di telefono: l’operazione segnala allora l’informazione da completare.|
+|`.fr` e altre estensioni gestite da AFNIC|Comportamento generico. Lo svolgimento generale del trasferimento di un `.fr` resta quello descritto allo [step 4](#step4).|
+|`.eu` e il suo equivalente in alfabeto cirillico|Comportamento generico|
+|`.uk`|Comportamento generico|
+|`.ac.uk`, `.gov.uk`|Comportamento generico|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Comportamento generico|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Comportamento generico|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Comportamento generico|
+|Altre estensioni gestite da un Registro specifico|Comportamento generico|
+
+:::info
+L’autorizzazione del cambio di intestatario durante un trasferimento, così come il suo carattere gratuito o a pagamento, sono definiti **per estensione**. Per conoscere le condizioni applicabili alla tua, inserisci il tuo nome di dominio nella pagina [www.ovhcloud.com/it/domains/tld/](/links/web/domains-tld).
+
+:::
+
+### Step 6: gestire il nome di dominio con OVHcloud
 
 Una volta completata la procedura, è possibile gestire il nome di dominio dalla pagina <ManagerLink to="/#/web-domains/domain">Domini</ManagerLink>.
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -66,13 +66,13 @@ Per conoscere le condizioni tariffarie per il trasferimento di un nome di domini
 
 La procedura di trasferimento prevede diversi step, tra cui l'avvio di contatti con diverse entità. Il tuo attuale Registrar, OVHcloud e altre parti. La tabella qui sotto riassume le diverse fasi del processo:
 
-|Step|Descrizione|Soggetti coinvolti|Dove|Campo obbligatorio|
+|Step|Descrizione|Soggetti coinvolti|Presso chi|Tempo necessario|
 |---|---|---|---|---|
-|[1](#step1)|[Verifica delle informazioni associate al nome di dominio](#step1)|L'amministratore del nome di dominio|Il Registrar attuale|In base alle azioni effettuate|
-|[2](#step2)|[Sblocco del nome di dominio e recupero del codice di trasferimento](#step2)|L'amministratore del nome di dominio, con l'autorizzazione dell'intestatario|Il Registrar attuale|In base alle azioni effettuate|
-|[3](#step3)|[Trasferimento di un nome di dominio](#step3)|Chiunque sia in possesso del codice di trasferimento, anche con il permesso dell'intestatario|Con il nuovo Registrar (ad esempio, OVHcloud)|In base alle azioni effettuate|
-|[4](#step4)|[Conferma del trasferimento](#step4)|Il Registrar attuale|Tramite una richiesta da parte del Registro che gestisce l'estensione del nome di dominio|Massimo cinque giorni|
-|[5](#step5)|[Verifica dell’intestatario dopo il trasferimento](#step5)|OVHcloud, automaticamente|Con il Registro dell’estensione|Automatica, subito dopo il trasferimento|
+|[1](#step1)|[Verifica delle informazioni associate al nome di dominio](#step1)|L’intestatario del nome di dominio o la persona che lo amministra|Il Registrar attuale|In base alle azioni effettuate|
+|[2](#step2)|[Sblocco del nome di dominio e recupero del codice di trasferimento](#step2)|L’intestatario del nome di dominio o la persona che lo amministra|Il Registrar attuale|In base alle azioni effettuate|
+|[3](#step3)|[Trasferimento di un nome di dominio](#step3)|Chiunque sia in possesso del codice di trasferimento|Il nuovo Registrar (ad esempio, OVHcloud)|In base alle azioni effettuate|
+|[4](#step4)|[Conferma del trasferimento](#step4)|Il Registrar attuale|Il Registro dell’estensione|Massimo cinque giorni|
+|[5](#step5)|[Verifica dell’intestatario dopo il trasferimento](#step5)|OVHcloud, automaticamente|Il Registro dell’estensione|Automatica, subito dopo il trasferimento|
 
 :::warning
 La procedura esatta di trasferimento del nome di dominio può variare, in particolare per alcune **TLD** del codice del paese (**ccTLD**, quali .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, ecc.) e per alcune **TLD** speciali (.am, .fm, ecc.). In base all'estensione del tuo nome di dominio, potrebbero essere necessari requisiti aggiuntivi. Ti consigliamo di verificare le informazioni mostrate per l'estensione in questione dal nostro sito Web: [https://www.ovhcloud.com/it/domains/tld/](/links/web/domains-tld).
@@ -173,22 +173,22 @@ In caso di **opposizione al trasferimento da parte dell'attuale Registrar**, il 
 
 Il trasferimento è ora effettivo e il tuo nome di dominio è registrato presso OVHcloud. In questo momento, OVHcloud confronta automaticamente due informazioni:
 
-- l’**intestatario registrato presso il Registro** dell’estensione, come risulta dal trasferimento;
+- l’**intestatario registrato presso il Registro dell’estensione**, come risulta dal trasferimento;
 - l’**intestatario che hai indicato** al momento dell’ordine presso OVHcloud.
 
-Questo confronto ha lo scopo di garantire che l’intestatario dichiarato presso il Registro sia effettivamente quello che hai ordinato. È completamente automatico e **non blocca mai il trasferimento**: il tuo nome di dominio resta trasferito, qualunque sia l’esito.
+Questo confronto ha lo scopo di garantire che l’intestatario dichiarato presso il Registro dell’estensione sia effettivamente quello che hai ordinato. È completamente automatico e **non blocca mai il trasferimento**: il tuo nome di dominio resta trasferito, qualunque sia l’esito.
 
 Sono possibili tre esiti.
 
 #### I due intestatari corrispondono
 
-Non è necessaria alcuna azione: l’intestatario registrato presso il Registro è già quello che hai ordinato.
+Non è necessaria alcuna azione: l’intestatario registrato presso il Registro dell’estensione è già quello che hai ordinato.
 
 #### Gli intestatari differiscono su informazioni modificabili
 
-Si tratta delle informazioni che il Registro consente di correggere con un semplice aggiornamento: indirizzo postale, città, codice postale, Paese, indirizzo email, numero di telefono, ecc.
+Si tratta delle informazioni che il Registro dell’estensione consente di correggere con un semplice aggiornamento: indirizzo postale, città, codice postale, Paese, indirizzo email, numero di telefono, ecc.
 
-OVHcloud avvia allora automaticamente l’aggiornamento dell’intestatario presso il Registro, senza alcuna azione da parte tua. Questa operazione è distinta dal trasferimento: si svolge subito dopo e puoi seguirla dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>.
+OVHcloud avvia allora automaticamente l’aggiornamento dell’intestatario presso il Registro dell’estensione, senza alcuna azione da parte tua. Questa operazione è distinta dal trasferimento: si svolge subito dopo e puoi seguirla dalla pagina <ManagerLink to="/#/web/ongoing-operations">Operazioni in corso</ManagerLink>.
 
 #### Gli intestatari differiscono sull’identità dell’intestatario
 
@@ -199,8 +199,8 @@ Ciò che fa OVHcloud dipende allora dall’estensione del tuo nome di dominio:
 |Situazione|Cosa accade|
 |---|---|
 |L’estensione consente il cambio di intestatario durante un trasferimento e l’operazione è gratuita per questa estensione|OVHcloud avvia automaticamente il cambio di intestatario, ma **questo non si conclude senza la tua convalida**: consulta «[Convalida del cambio di intestatario](#step5-foa)» di seguito.|
-|L’estensione consente il cambio di intestatario durante un trasferimento, ma l’operazione è a pagamento per questa estensione|OVHcloud **non effettua** l’operazione. Riceverai una notifica che segnala che l’intestatario registrato presso il Registro non è quello ordinato. Potrai quindi ordinare tu stesso il cambio di intestatario, quando lo desideri.|
-|L’estensione non consente il cambio di intestatario durante un trasferimento|Non viene avviata alcuna operazione automatica. Il nome di dominio conserva l’intestatario registrato presso il Registro.|
+|L’estensione consente il cambio di intestatario durante un trasferimento, ma l’operazione è a pagamento per questa estensione|OVHcloud **non effettua** l’operazione. Riceverai una notifica che segnala che l’intestatario registrato presso il Registro dell’estensione non è quello ordinato. Potrai quindi ordinare tu stesso il cambio di intestatario, quando lo desideri.|
+|L’estensione non consente il cambio di intestatario durante un trasferimento|Non viene avviata alcuna operazione automatica. Il nome di dominio conserva l’intestatario registrato presso il Registro dell’estensione.|
 
 :::warning
 Un cambio di intestatario a pagamento non viene **mai** avviato automaticamente: questa operazione è fatturata e, in base all’estensione, aggiunge un anno di sottoscrizione. Richiede quindi il tuo consenso. Per effettuarlo tu stesso, segui la nostra guida «[Modificare l’intestatario di un nome di dominio](/guides/web-cloud/domains/trade-domain)».
@@ -211,16 +211,18 @@ Un cambio di intestatario a pagamento non viene **mai** avviato automaticamente:
 
 Un cambio di intestatario non viene **mai** applicato per sola iniziativa di OVHcloud, nemmeno quando è gratuito e avviato automaticamente. Per la maggior parte delle estensioni, viene inviata per email una richiesta di convalida (modulo di autorizzazione, o «FOA»):
 
-- all’**intestatario precedente**, ovvero quello registrato presso il Registro al momento del trasferimento;
+- all’**intestatario precedente**, ovvero quello registrato presso il Registro dell’estensione al momento del trasferimento;
 - al **nuovo intestatario**, ovvero quello che hai ordinato presso OVHcloud.
 
 **Entrambi i destinatari devono accettare** perché il cambio di intestatario vada a buon fine. Sono possibili tre esiti:
 
 |Risposta alle richieste di convalida|Risultato|
 |---|---|
-|Entrambi gli intestatari accettano|Il cambio di intestatario viene applicato presso il Registro.|
-|Uno dei due intestatari rifiuta|L’operazione viene **annullata** immediatamente. Il nome di dominio conserva l’intestatario registrato presso il Registro.|
+|Entrambi gli intestatari accettano|Il cambio di intestatario viene applicato presso il Registro dell’estensione.|
+|Uno dei due intestatari rifiuta|L’operazione viene **annullata** immediatamente. Il nome di dominio conserva l’intestatario registrato presso il Registro dell’estensione.|
 |Nessuna risposta entro il termine previsto|L’operazione **scade** e l’intestatario non viene allineato. Il termine è stabilito dal Registro dell’estensione.|
+
+Qualunque sia l’esito di questa richiesta di convalida, **il trasferimento del tuo nome di dominio resta acquisito**: un rifiuto, una scadenza o un blocco del cambio di intestatario non comporta l’annullamento del trasferimento. Non avviene soltanto l’allineamento dell’intestatario e il tuo nome di dominio resta registrato presso OVHcloud.
 
 :::warning
 Assicurati che l’indirizzo email dell’**intestatario precedente** sia raggiungibile. Se nessuno può convalidare la richiesta inviata a tale indirizzo, il cambio di intestatario scadrà e il tuo nome di dominio resterà registrato a nome dell’intestatario precedente.
@@ -236,7 +238,7 @@ Non tutte le estensioni richiedono questa convalida via email: alcuni Registri a
 
 #### Se il confronto non è conclusivo
 
-Se il Registro non comunica le informazioni dell’intestatario, il confronto resta senza esito e non viene avviata alcuna operazione automatica. Una verifica dei contatti viene effettuata successivamente da OVHcloud. Il tuo nome di dominio resta trasferito e utilizzabile.
+Se il Registro dell’estensione non comunica le informazioni dell’intestatario, il confronto resta senza esito e non viene avviata alcuna operazione automatica. Una verifica dei contatti viene effettuata successivamente da OVHcloud. Il tuo nome di dominio resta trasferito e utilizzabile.
 
 #### Se manca un’informazione obbligatoria sul tuo contatto intestatario
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -64,15 +64,15 @@ Aby uzyskać informacje na temat cennika transferu nazwy domeny w zależności o
 
 :::
 
-Procedura transferu składa się z kilku etapów, w które włączone są różne podmioty, w tym obecny rejestr, OVHcloud i inne strony. Poniższa tabela wskazuje osoby, z którymi należy się kontaktować oraz szacowany czas trwania każdego etapu.
+Procedura transferu składa się z kilku etapów, w które włączone są różne podmioty, w tym obecny operator nazwy domeny, OVHcloud i inne strony. Poniższa tabela wskazuje osoby, z którymi należy się kontaktować oraz szacowany czas trwania każdego etapu.
 
-|Etapy|Opis|Kto wykonuje działanie?|Gdzie?/Jak?|Czas realizacji|
+|Etapy|Opis|Kto wykonuje działanie?|U kogo?|Czas realizacji|
 |---|---|---|---|---|
-|[1](#step1)|[Weryfikacja informacji związanych z nazwą domeny](#step1)|Administrator nazwy domeny|U obecnego operatora nazwy domeny|W zależności od podjętych przez Ciebie działań|
-|[2](#step2)|[Odblokowanie nazwy domeny i pobranie kodu transferu](#step2)|Administrator nazwy domeny, za zgodą abonenta|U obecnego operatora nazwy domeny|W zależności od podjętych przez Ciebie działań|
-|[3](#step3)|[Wniosek o transfer nazwy domeny](#step3)|Każda osoba posiadająca kod transferu, za zgodą abonenta|U nowego operatora (np. OVHcloud)|W zależności od podjętych przez Ciebie działań|
-|[4](#step4)|[Zatwierdzenie transferu](#step4)|U obecnego operatora nazwy domeny|Na prośbę organizacji zarządzającej rozszerzeniem Twojej nazwy domeny|Maksymalnie 5 dni|
-|[5](#step5)|[Weryfikacja abonenta po transferze](#step5)|OVHcloud, automatycznie|W rejestrze rozszerzenia|Automatycznie, bezpośrednio po transferze|
+|[1](#step1)|[Weryfikacja informacji związanych z nazwą domeny](#step1)|Abonent nazwy domeny lub osoba nią administrująca|Obecny operator nazwy domeny|W zależności od podjętych przez Ciebie działań|
+|[2](#step2)|[Odblokowanie nazwy domeny i pobranie kodu transferu](#step2)|Abonent nazwy domeny lub osoba nią administrująca|Obecny operator nazwy domeny|W zależności od podjętych przez Ciebie działań|
+|[3](#step3)|[Wniosek o transfer nazwy domeny](#step3)|Każda osoba posiadająca kod transferu|Nowy operator (np. OVHcloud)|W zależności od podjętych przez Ciebie działań|
+|[4](#step4)|[Zatwierdzenie transferu](#step4)|Obecny operator nazwy domeny|Rejestr rozszerzenia|Maksymalnie 5 dni|
+|[5](#step5)|[Weryfikacja abonenta po transferze](#step5)|OVHcloud, automatycznie|Rejestr rozszerzenia|Automatycznie, bezpośrednio po transferze|
 
 :::warning
 Dokładna procedura transferu nazwy domeny może się różnić, w szczególności w przypadku niektórych **TLD** kodu kraju (**ccTLD**, takich jak .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, itp.) oraz niektórych specjalnych **TLD** (.am, .fm, itp.). W zależności od rozszerzenia Twojej nazwy domeny, mogą być konieczne dodatkowe wymagania. Zalecamy sprawdzenie w pierwszej kolejności informacji wyświetlanych dla danego rozszerzenia na naszej stronie internetowej: [https://www.ovhcloud.com/pl/domains/tld/](/links/web/domains-tld).
@@ -173,22 +173,22 @@ W przypadku **sprzeciwu wobec transferu ze strony aktualnego rejestratora**, prz
 
 Transfer został zakończony i Twoja nazwa domeny jest zarejestrowana w OVHcloud. W tym momencie OVHcloud automatycznie porównuje dwie informacje:
 
-- **abonenta zarejestrowanego w rejestrze** rozszerzenia, w postaci wynikającej z transferu;
+- **abonenta zarejestrowanego w rejestrze rozszerzenia**, w postaci wynikającej z transferu;
 - **abonenta, którego wskazałeś** podczas składania zamówienia w OVHcloud.
 
-Celem tego porównania jest zapewnienie, że abonent zgłoszony w rejestrze jest rzeczywiście tym, którego zamówiłeś. Porównanie jest w pełni automatyczne i **nigdy nie blokuje transferu**: Twoja nazwa domeny pozostaje przeniesiona, niezależnie od wyniku.
+Celem tego porównania jest zapewnienie, że abonent zgłoszony w rejestrze rozszerzenia jest rzeczywiście tym, którego zamówiłeś. Porównanie jest w pełni automatyczne i **nigdy nie blokuje transferu**: Twoja nazwa domeny pozostaje przeniesiona, niezależnie od wyniku.
 
 Możliwe są trzy wyniki.
 
 #### Obaj abonenci są zgodni
 
-Nie jest wymagane żadne działanie: abonent zarejestrowany w rejestrze jest już tym, którego zamówiłeś.
+Nie jest wymagane żadne działanie: abonent zarejestrowany w rejestrze rozszerzenia jest już tym, którego zamówiłeś.
 
 #### Abonenci różnią się w zakresie danych modyfikowalnych
 
-Chodzi o dane, których korektę rejestr dopuszcza w ramach zwykłej aktualizacji: adres pocztowy, miejscowość, kod pocztowy, kraj, adres e-mail, numer telefonu itp.
+Chodzi o dane, których korektę rejestr rozszerzenia dopuszcza w ramach zwykłej aktualizacji: adres pocztowy, miejscowość, kod pocztowy, kraj, adres e-mail, numer telefonu itp.
 
-OVHcloud automatycznie rozpoczyna wówczas aktualizację abonenta w rejestrze, bez żadnego działania z Twojej strony. Operacja ta jest niezależna od transferu: przebiega bezpośrednio po nim i możesz ją śledzić na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>.
+OVHcloud automatycznie rozpoczyna wówczas aktualizację abonenta w rejestrze rozszerzenia, bez żadnego działania z Twojej strony. Operacja ta jest niezależna od transferu: przebiega bezpośrednio po nim i możesz ją śledzić na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>.
 
 #### Abonenci różnią się w zakresie tożsamości abonenta
 
@@ -199,8 +199,8 @@ Dalsze działanie OVHcloud zależy od rozszerzenia Twojej nazwy domeny:
 |Sytuacja|Co się dzieje|
 |---|---|
 |Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, a operacja jest dla tego rozszerzenia bezpłatna|OVHcloud automatycznie inicjuje zmianę abonenta, ale **nie zostanie ona zakończona bez Twojego zatwierdzenia**: patrz „[Zatwierdzenie zmiany abonenta](#step5-foa)” poniżej.|
-|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, ale operacja jest dla tego rozszerzenia płatna|OVHcloud **nie wykonuje** tej operacji. Otrzymasz powiadomienie informujące, że abonent zarejestrowany w rejestrze nie jest tym, którego zamówiłeś. Możesz wtedy samodzielnie zlecić zmianę abonenta w dowolnym momencie.|
-|Rozszerzenie nie dopuszcza zmiany abonenta w trakcie transferu|Nie jest uruchamiana żadna automatyczna operacja. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze.|
+|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, ale operacja jest dla tego rozszerzenia płatna|OVHcloud **nie wykonuje** tej operacji. Otrzymasz powiadomienie informujące, że abonent zarejestrowany w rejestrze rozszerzenia nie jest tym, którego zamówiłeś. Możesz wtedy samodzielnie zlecić zmianę abonenta w dowolnym momencie.|
+|Rozszerzenie nie dopuszcza zmiany abonenta w trakcie transferu|Nie jest uruchamiana żadna automatyczna operacja. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze rozszerzenia.|
 
 :::warning
 Płatna zmiana abonenta **nigdy** nie jest uruchamiana automatycznie: operacja ta jest fakturowana i, w zależności od rozszerzenia, wydłuża subskrypcję o rok. Wymaga zatem Twojej zgody. Aby wykonać ją samodzielnie, skorzystaj z naszego przewodnika „[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)”.
@@ -211,16 +211,18 @@ Płatna zmiana abonenta **nigdy** nie jest uruchamiana automatycznie: operacja t
 
 Zmiana abonenta **nigdy** nie jest wykonywana wyłącznie z inicjatywy OVHcloud, również wtedy, gdy jest bezpłatna i została uruchomiona automatycznie. W przypadku większości rozszerzeń wniosek o zatwierdzenie (formularz upoważnienia, tzw. „FOA”) jest wysyłany e-mailem:
 
-- do **poprzedniego abonenta**, czyli tego zarejestrowanego w rejestrze w chwili transferu;
+- do **poprzedniego abonenta**, czyli tego zarejestrowanego w rejestrze rozszerzenia w chwili transferu;
 - do **nowego abonenta**, czyli tego, którego zamówiłeś w OVHcloud.
 
 **Obaj odbiorcy muszą wyrazić zgodę**, aby zmiana abonenta została zrealizowana. Możliwe są trzy wyniki:
 
 |Odpowiedź na wnioski o zatwierdzenie|Rezultat|
 |---|---|
-|Obaj abonenci wyrażają zgodę|Zmiana abonenta zostaje wprowadzona w rejestrze.|
-|Jeden z dwóch abonentów odmawia|Operacja zostaje natychmiast **anulowana**. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze.|
+|Obaj abonenci wyrażają zgodę|Zmiana abonenta zostaje wprowadzona w rejestrze rozszerzenia.|
+|Jeden z dwóch abonentów odmawia|Operacja zostaje natychmiast **anulowana**. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze rozszerzenia.|
 |Brak odpowiedzi w wyznaczonym terminie|Operacja **wygasa** i abonent nie zostaje skorygowany. Termin jest ustalany przez rejestr rozszerzenia.|
+
+Niezależnie od wyniku tego wniosku o zatwierdzenie **transfer Twojej nazwy domeny pozostaje w mocy**: odmowa, wygaśnięcie lub zablokowanie zmiany abonenta nie powoduje anulowania transferu. Nie dochodzi jedynie do skorygowania abonenta, a Twoja nazwa domeny pozostaje zarejestrowana w OVHcloud.
 
 :::warning
 Upewnij się, że adres e-mail **poprzedniego abonenta** jest dostępny. Jeśli nikt nie może zatwierdzić wniosku wysłanego na ten adres, zmiana abonenta wygaśnie, a Twoja nazwa domeny pozostanie zarejestrowana na poprzedniego abonenta.
@@ -236,7 +238,7 @@ Nie wszystkie rozszerzenia wymagają tego zatwierdzenia e-mailem: niektóre reje
 
 #### Jeśli porównanie nie daje rozstrzygnięcia
 
-Jeśli rejestr nie udostępnia danych abonenta, porównanie pozostaje nierozstrzygnięte i nie jest uruchamiana żadna automatyczna operacja. Weryfikacja kontaktów jest przeprowadzana później przez OVHcloud. Twoja nazwa domeny pozostaje przeniesiona i gotowa do użytku.
+Jeśli rejestr rozszerzenia nie udostępnia danych abonenta, porównanie pozostaje nierozstrzygnięte i nie jest uruchamiana żadna automatyczna operacja. Weryfikacja kontaktów jest przeprowadzana później przez OVHcloud. Twoja nazwa domeny pozostaje przeniesiona i gotowa do użytku.
 
 #### Jeśli w kontakcie abonenta brakuje obowiązkowej informacji
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -72,6 +72,7 @@ Procedura transferu składa się z kilku etapów, w które włączone są różn
 |[2](#step2)|[Odblokowanie nazwy domeny i pobranie kodu transferu](#step2)|Administrator nazwy domeny, za zgodą abonenta|U obecnego operatora nazwy domeny|W zależności od podjętych przez Ciebie działań|
 |[3](#step3)|[Wniosek o transfer nazwy domeny](#step3)|Każda osoba posiadająca kod transferu, za zgodą abonenta|U nowego operatora (np. OVHcloud)|W zależności od podjętych przez Ciebie działań|
 |[4](#step4)|[Zatwierdzenie transferu](#step4)|U obecnego operatora nazwy domeny|Na prośbę organizacji zarządzającej rozszerzeniem Twojej nazwy domeny|Maksymalnie 5 dni|
+|[5](#step5)|[Weryfikacja abonenta po transferze](#step5)|OVHcloud, automatycznie|W rejestrze rozszerzenia|Automatycznie, bezpośrednio po transferze|
 
 :::warning
 Dokładna procedura transferu nazwy domeny może się różnić, w szczególności w przypadku niektórych **TLD** kodu kraju (**ccTLD**, takich jak .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, itp.) oraz niektórych specjalnych **TLD** (.am, .fm, itp.). W zależności od rozszerzenia Twojej nazwy domeny, mogą być konieczne dodatkowe wymagania. Zalecamy sprawdzenie w pierwszej kolejności informacji wyświetlanych dla danego rozszerzenia na naszej stronie internetowej: [https://www.ovhcloud.com/pl/domains/tld/](/links/web/domains-tld).
@@ -168,7 +169,107 @@ W przypadku **sprzeciwu wobec transferu ze strony aktualnego rejestratora**, prz
 
 :::
 
-### Etap 5: zarządzaj nazwą domeny za pomocą OVHcloud
+### Etap 5: weryfikacja abonenta po transferze <a name="step5"></a>
+
+Transfer został zakończony i Twoja nazwa domeny jest zarejestrowana w OVHcloud. W tym momencie OVHcloud automatycznie porównuje dwie informacje:
+
+- **abonenta zarejestrowanego w rejestrze** rozszerzenia, w postaci wynikającej z transferu;
+- **abonenta, którego wskazałeś** podczas składania zamówienia w OVHcloud.
+
+Celem tego porównania jest zapewnienie, że abonent zgłoszony w rejestrze jest rzeczywiście tym, którego zamówiłeś. Porównanie jest w pełni automatyczne i **nigdy nie blokuje transferu**: Twoja nazwa domeny pozostaje przeniesiona, niezależnie od wyniku.
+
+Możliwe są trzy wyniki.
+
+#### Obaj abonenci są zgodni
+
+Nie jest wymagane żadne działanie: abonent zarejestrowany w rejestrze jest już tym, którego zamówiłeś.
+
+#### Abonenci różnią się w zakresie danych modyfikowalnych
+
+Chodzi o dane, których korektę rejestr dopuszcza w ramach zwykłej aktualizacji: adres pocztowy, miejscowość, kod pocztowy, kraj, adres e-mail, numer telefonu itp.
+
+OVHcloud automatycznie rozpoczyna wówczas aktualizację abonenta w rejestrze, bez żadnego działania z Twojej strony. Operacja ta jest niezależna od transferu: przebiega bezpośrednio po nim i możesz ją śledzić na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>.
+
+#### Abonenci różnią się w zakresie tożsamości abonenta
+
+Chodzi tutaj o dane wskazujące, **kim** jest abonent: nazwisko, imię, organizacja, forma prawna. Większość rejestrów nie pozwala na zmianę tych danych w ramach zwykłej aktualizacji. Tylko **zmiana abonenta** (nazywana również „trade”) umożliwia ich korektę.
+
+Dalsze działanie OVHcloud zależy od rozszerzenia Twojej nazwy domeny:
+
+|Sytuacja|Co się dzieje|
+|---|---|
+|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, a operacja jest dla tego rozszerzenia bezpłatna|OVHcloud automatycznie inicjuje zmianę abonenta, ale **nie zostanie ona zakończona bez Twojego zatwierdzenia**: patrz „[Zatwierdzenie zmiany abonenta](#step5-foa)” poniżej.|
+|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, ale operacja jest dla tego rozszerzenia płatna|OVHcloud **nie wykonuje** tej operacji. Otrzymasz powiadomienie informujące, że abonent zarejestrowany w rejestrze nie jest tym, którego zamówiłeś. Możesz wtedy samodzielnie zlecić zmianę abonenta w dowolnym momencie.|
+|Rozszerzenie nie dopuszcza zmiany abonenta w trakcie transferu|Nie jest uruchamiana żadna automatyczna operacja. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze.|
+
+:::warning
+Płatna zmiana abonenta **nigdy** nie jest uruchamiana automatycznie: operacja ta jest fakturowana i, w zależności od rozszerzenia, wydłuża subskrypcję o rok. Wymaga zatem Twojej zgody. Aby wykonać ją samodzielnie, skorzystaj z naszego przewodnika „[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)”.
+
+:::
+
+##### Zatwierdzenie zmiany abonenta <a name="step5-foa"></a>
+
+Zmiana abonenta **nigdy** nie jest wykonywana wyłącznie z inicjatywy OVHcloud, również wtedy, gdy jest bezpłatna i została uruchomiona automatycznie. W przypadku większości rozszerzeń wniosek o zatwierdzenie (formularz upoważnienia, tzw. „FOA”) jest wysyłany e-mailem:
+
+- do **poprzedniego abonenta**, czyli tego zarejestrowanego w rejestrze w chwili transferu;
+- do **nowego abonenta**, czyli tego, którego zamówiłeś w OVHcloud.
+
+**Obaj odbiorcy muszą wyrazić zgodę**, aby zmiana abonenta została zrealizowana. Możliwe są trzy wyniki:
+
+|Odpowiedź na wnioski o zatwierdzenie|Rezultat|
+|---|---|
+|Obaj abonenci wyrażają zgodę|Zmiana abonenta zostaje wprowadzona w rejestrze.|
+|Jeden z dwóch abonentów odmawia|Operacja zostaje natychmiast **anulowana**. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze.|
+|Brak odpowiedzi w wyznaczonym terminie|Operacja **wygasa** i abonent nie zostaje skorygowany. Termin jest ustalany przez rejestr rozszerzenia.|
+
+:::warning
+Upewnij się, że adres e-mail **poprzedniego abonenta** jest dostępny. Jeśli nikt nie może zatwierdzić wniosku wysłanego na ten adres, zmiana abonenta wygaśnie, a Twoja nazwa domeny pozostanie zarejestrowana na poprzedniego abonenta.
+
+Postęp wniosku oraz przypomnienia możesz śledzić na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>.
+
+:::
+
+:::info
+Nie wszystkie rozszerzenia wymagają tego zatwierdzenia e-mailem: niektóre rejestry wprowadzają zmianę abonenta bez wniosku o potwierdzenie. Szczegóły procedury zmiany abonenta opisano w naszym przewodniku „[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)”.
+
+:::
+
+#### Jeśli porównanie nie daje rozstrzygnięcia
+
+Jeśli rejestr nie udostępnia danych abonenta, porównanie pozostaje nierozstrzygnięte i nie jest uruchamiana żadna automatyczna operacja. Weryfikacja kontaktów jest przeprowadzana później przez OVHcloud. Twoja nazwa domeny pozostaje przeniesiona i gotowa do użytku.
+
+#### Jeśli w kontakcie abonenta brakuje obowiązkowej informacji
+
+Niektóre rejestry wymagają danych, których Twój kontakt abonenta niekoniecznie zawiera. Na przykład rejestr rozszerzenia `.pl` odrzuca abonenta bez numeru telefonu.
+
+W takim przypadku operacja wskazuje brakującą informację na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>. Uzupełnij dany kontakt, korzystając z naszego przewodnika „[Zarządzanie kontaktami usługi](/guides/account-and-service-management/account-information/managing-contacts)”, a następnie ponownie uruchom operację na tej samej stronie.
+
+#### Specyfika poszczególnych rozszerzeń
+
+Weryfikacja abonenta dotyczy **wszystkich** rozszerzeń. Poniższa tabela precyzuje, rozszerzenie po rozszerzeniu, co odbiega od opisanego powyżej zachowania.
+
+|Rozszerzenia|Specyfika weryfikacji abonenta|
+|---|---|
+|Rozszerzenia generyczne (**gTLD**)|Zachowanie generyczne|
+|`.com`, `.net`, `.cn`, `.ws`|Zachowanie generyczne|
+|`.ca`|Kategoria formy prawnej abonenta, wymagana przez rejestr CIRA, jest przejmowana z rejestru, gdy obaj abonenci są zgodni. Informacja ta jest niezbędna do późniejszych operacji na domenie `.ca`.|
+|`.hk`|Rejestr HKDNR nie udostępnia ani organizacji, ani adresu e-mail abonenta. Automatyczna zmiana abonenta może więc być niedostępna.|
+|`.pl`|Rejestr NASK odrzuca abonenta bez numeru telefonu: operacja wskazuje wówczas informację do uzupełnienia.|
+|`.fr` i inne rozszerzenia zarządzane przez AFNIC|Zachowanie generyczne. Ogólny przebieg transferu domeny `.fr` pozostaje taki, jak opisano w [etapie 4](#step4).|
+|`.eu` i jego odpowiednik w cyrylicy|Zachowanie generyczne|
+|`.uk`|Zachowanie generyczne|
+|`.ac.uk`, `.gov.uk`|Zachowanie generyczne|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Zachowanie generyczne|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Zachowanie generyczne|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Zachowanie generyczne|
+|Inne rozszerzenia zarządzane przez określony rejestr|Zachowanie generyczne|
+
+:::info
+Dopuszczalność zmiany abonenta w trakcie transferu, a także jej bezpłatny lub płatny charakter, są określane **dla każdego rozszerzenia**. Aby poznać warunki obowiązujące dla Twojego rozszerzenia, wpisz swoją nazwę domeny na stronie [www.ovhcloud.com/pl/domains/tld/](/links/web/domains-tld).
+
+:::
+
+### Etap 6: zarządzaj nazwą domeny za pomocą OVHcloud
 
 Po zakończeniu operacji transferu możesz zarządzać nazwą domeny na stronie <ManagerLink to="/#/web-domains/domain">Domeny</ManagerLink>.
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transfer nazwy domeny do OVHcloud
 description: Dowiedz się, jak wykonać transfer nazwy domeny do OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -192,24 +192,24 @@ OVHcloud automatycznie rozpoczyna wówczas aktualizację abonenta w rejestrze ro
 
 #### Abonenci różnią się w zakresie tożsamości abonenta
 
-Chodzi tutaj o dane wskazujące, **kim** jest abonent: nazwisko, imię, organizacja, forma prawna. Większość rejestrów nie pozwala na zmianę tych danych w ramach zwykłej aktualizacji. Tylko **zmiana abonenta** (nazywana również „trade”) umożliwia ich korektę.
+Chodzi tutaj o dane wskazujące, **kim** jest abonent: nazwisko, imię, organizacja, forma prawna. Większość rejestrów nie pozwala na zmianę tych danych w ramach zwykłej aktualizacji. Tylko **zmiana abonenta** (nazywana również "trade") umożliwia ich korektę.
 
 Dalsze działanie OVHcloud zależy od rozszerzenia Twojej nazwy domeny:
 
 |Sytuacja|Co się dzieje|
 |---|---|
-|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, a operacja jest dla tego rozszerzenia bezpłatna|OVHcloud automatycznie inicjuje zmianę abonenta, ale **nie zostanie ona zakończona bez Twojego zatwierdzenia**: patrz „[Zatwierdzenie zmiany abonenta](#step5-foa)” poniżej.|
+|Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, a operacja jest dla tego rozszerzenia bezpłatna|OVHcloud automatycznie inicjuje zmianę abonenta, ale **nie zostanie ona zakończona bez Twojego zatwierdzenia**: patrz "[Zatwierdzenie zmiany abonenta](#step5-foa)" poniżej.|
 |Rozszerzenie dopuszcza zmianę abonenta w trakcie transferu, ale operacja jest dla tego rozszerzenia płatna|OVHcloud **nie wykonuje** tej operacji. Otrzymasz powiadomienie informujące, że abonent zarejestrowany w rejestrze rozszerzenia nie jest tym, którego zamówiłeś. Możesz wtedy samodzielnie zlecić zmianę abonenta w dowolnym momencie.|
 |Rozszerzenie nie dopuszcza zmiany abonenta w trakcie transferu|Nie jest uruchamiana żadna automatyczna operacja. Nazwa domeny zachowuje abonenta zarejestrowanego w rejestrze rozszerzenia.|
 
 :::warning
-Płatna zmiana abonenta **nigdy** nie jest uruchamiana automatycznie: operacja ta jest fakturowana i, w zależności od rozszerzenia, wydłuża subskrypcję o rok. Wymaga zatem Twojej zgody. Aby wykonać ją samodzielnie, skorzystaj z naszego przewodnika „[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)”.
+Płatna zmiana abonenta **nigdy** nie jest uruchamiana automatycznie: operacja ta jest fakturowana i, w zależności od rozszerzenia, wydłuża subskrypcję o rok. Wymaga zatem Twojej zgody. Aby wykonać ją samodzielnie, skorzystaj z naszego przewodnika "[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
 ##### Zatwierdzenie zmiany abonenta <a name="step5-foa"></a>
 
-Zmiana abonenta **nigdy** nie jest wykonywana wyłącznie z inicjatywy OVHcloud, również wtedy, gdy jest bezpłatna i została uruchomiona automatycznie. W przypadku większości rozszerzeń wniosek o zatwierdzenie (formularz upoważnienia, tzw. „FOA”) jest wysyłany e-mailem:
+Zmiana abonenta **nigdy** nie jest wykonywana wyłącznie z inicjatywy OVHcloud, również wtedy, gdy jest bezpłatna i została uruchomiona automatycznie. W przypadku większości rozszerzeń wniosek o zatwierdzenie (formularz upoważnienia, tzw. "FOA") jest wysyłany e-mailem:
 
 - do **poprzedniego abonenta**, czyli tego zarejestrowanego w rejestrze rozszerzenia w chwili transferu;
 - do **nowego abonenta**, czyli tego, którego zamówiłeś w OVHcloud.
@@ -232,7 +232,7 @@ Postęp wniosku oraz przypomnienia możesz śledzić na stronie <ManagerLink to=
 :::
 
 :::info
-Nie wszystkie rozszerzenia wymagają tego zatwierdzenia e-mailem: niektóre rejestry wprowadzają zmianę abonenta bez wniosku o potwierdzenie. Szczegóły procedury zmiany abonenta opisano w naszym przewodniku „[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)”.
+Nie wszystkie rozszerzenia wymagają tego zatwierdzenia e-mailem: niektóre rejestry wprowadzają zmianę abonenta bez wniosku o potwierdzenie. Szczegóły procedury zmiany abonenta opisano w naszym przewodniku "[Zmiana abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
@@ -244,7 +244,7 @@ Jeśli rejestr rozszerzenia nie udostępnia danych abonenta, porównanie pozosta
 
 Niektóre rejestry wymagają danych, których Twój kontakt abonenta niekoniecznie zawiera. Na przykład rejestr rozszerzenia `.pl` odrzuca abonenta bez numeru telefonu.
 
-W takim przypadku operacja wskazuje brakującą informację na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>. Uzupełnij dany kontakt, korzystając z naszego przewodnika „[Zarządzanie kontaktami usługi](/guides/account-and-service-management/account-information/managing-contacts)”, a następnie ponownie uruchom operację na tej samej stronie.
+W takim przypadku operacja wskazuje brakującą informację na stronie <ManagerLink to="/#/web/ongoing-operations">Operacje w toku</ManagerLink>. Uzupełnij dany kontakt, korzystając z naszego przewodnika "[Zarządzanie kontaktami usługi](/guides/account-and-service-management/account-information/managing-contacts)", a następnie ponownie uruchom operację na tej samej stronie.
 
 #### Specyfika poszczególnych rozszerzeń
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -64,15 +64,15 @@ Para conhecer as condições tarifárias para a transferência de um nome de dom
 
 :::
 
-O procedimento de transferência compreende várias etapas, implicando o contacto com várias entidades, entre as quais o seu registo atual, a OVHcloud e outras partes. A tabela abaixo indica as etapas de uma transferência.
+O procedimento de transferência compreende várias etapas, implicando o contacto com várias entidades, entre as quais o seu agente registador atual, a OVHcloud e outras partes. A tabela abaixo indica as etapas de uma transferência.
 
-|Etapa|Descrição|Quem está envolvido?|Onde?|Prazo|
+|Etapa|Descrição|Quem está envolvido?|Junto de quem?|Prazo|
 |---|---|---|---|---|
-|[1](#step1)|[Verificar a informação relativa ao nome de domínio](#step1)|O administrador do nome de domínio|O agente registador atual|Depende das suas ações|
-|[2](#step2)|[Desbloquear o nome de domínio e obter o código de transferência](#step2)|O administrador do nome de domínio, com a autorização do titular|O agente registador atual|Depende das suas ações|
-|[3](#step3)|[Solicitar a transferência do nome de domínio](#step3)|Qualquer pessoa que possua o código de transferência, com a autorização do titular|Com o novo agente de registo (por exemplo, a OVHcloud)|Depende das suas ações|
-|[4](#step4)|[Validação da transferência](#step4)|O agente registador atual|Através de um pedido enviado pela entidade que gere a extensão do nome de domínio|5 dias, no máximo|
-|[5](#step5)|[Verificação do titular após a transferência](#step5)|A OVHcloud, automaticamente|Com o registo da extensão|Automática, imediatamente após a transferência|
+|[1](#step1)|[Verificar a informação relativa ao nome de domínio](#step1)|O titular do nome de domínio, ou a pessoa que o administra|O agente registador atual|Depende das suas ações|
+|[2](#step2)|[Desbloquear o nome de domínio e obter o código de transferência](#step2)|O titular do nome de domínio, ou a pessoa que o administra|O agente registador atual|Depende das suas ações|
+|[3](#step3)|[Solicitar a transferência do nome de domínio](#step3)|Qualquer pessoa que possua o código de transferência|O novo agente de registo (por exemplo, a OVHcloud)|Depende das suas ações|
+|[4](#step4)|[Validação da transferência](#step4)|O agente registador atual|O registo da extensão|5 dias, no máximo|
+|[5](#step5)|[Verificação do titular após a transferência](#step5)|A OVHcloud, automaticamente|O registo da extensão|Automática, imediatamente após a transferência|
 
 :::warning
 O procedimento exato de transferência de nome de domínio pode variar, especialmente no caso de certos **TLD** de código de país (**ccTLD**, tais como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) e de alguns **TLD** especiais (.am, .fm, etc.). Em função da extensão do nome de domínio, poderá ser necessário realizar requisitos adicionais. Recomendamos que comece por verificar as informações apresentadas para a extensão em causa no nosso website: [https://www.ovhcloud.com/pt/domains/tld/](/links/web/domains-tld).
@@ -173,22 +173,22 @@ Em caso de **oposição à transferência pelo agente de registo atual**, a tran
 
 A transferência já está concluída e o seu nome de domínio está registado na OVHcloud. Nesse momento, a OVHcloud compara automaticamente duas informações:
 
-- o **titular registado junto do registo** da extensão, tal como resulta da transferência;
+- o **titular registado junto do registo da extensão**, tal como resulta da transferência;
 - o **titular que indicou** ao efetuar a sua encomenda na OVHcloud.
 
-Esta comparação tem por objetivo garantir que o titular declarado junto do registo é efetivamente aquele que encomendou. É totalmente automática e **nunca bloqueia a transferência**: o seu nome de domínio permanece transferido, qualquer que seja o resultado.
+Esta comparação tem por objetivo garantir que o titular declarado junto do registo da extensão é efetivamente aquele que encomendou. É totalmente automática e **nunca bloqueia a transferência**: o seu nome de domínio permanece transferido, qualquer que seja o resultado.
 
 São possíveis três resultados.
 
 #### Os dois titulares correspondem
 
-Não é necessária qualquer ação: o titular registado junto do registo já é aquele que encomendou.
+Não é necessária qualquer ação: o titular registado junto do registo da extensão já é aquele que encomendou.
 
 #### Os titulares diferem em informações modificáveis
 
-Trata-se das informações que o registo permite corrigir através de uma simples atualização: endereço postal, cidade, código postal, país, endereço de e-mail, número de telefone, etc.
+Trata-se das informações que o registo da extensão permite corrigir através de uma simples atualização: endereço postal, cidade, código postal, país, endereço de e-mail, número de telefone, etc.
 
-A OVHcloud inicia então automaticamente a atualização do titular junto do registo, sem qualquer ação da sua parte. Esta operação é distinta da transferência: decorre imediatamente após esta e pode acompanhá-la na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>.
+A OVHcloud inicia então automaticamente a atualização do titular junto do registo da extensão, sem qualquer ação da sua parte. Esta operação é distinta da transferência: decorre imediatamente após esta e pode acompanhá-la na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>.
 
 #### Os titulares diferem na identidade do titular
 
@@ -199,8 +199,8 @@ O que a OVHcloud faz depende então da extensão do seu nome de domínio:
 |Situação|O que acontece|
 |---|---|
 |A extensão permite a mudança de titular durante uma transferência e a operação é gratuita para essa extensão|A OVHcloud inicia automaticamente a mudança de titular, mas **esta não é concluída sem a sua validação**: consulte «[Validação da mudança de titular](#step5-foa)» abaixo.|
-|A extensão permite a mudança de titular durante uma transferência, mas a operação é paga para essa extensão|A OVHcloud **não realiza** a operação. Receberá uma notificação a informar que o titular registado junto do registo não é aquele que encomendou. Poderá então encomendar você mesmo a mudança de titular, quando o desejar.|
-|A extensão não permite a mudança de titular durante uma transferência|Não é acionada qualquer operação automática. O nome de domínio conserva o titular registado junto do registo.|
+|A extensão permite a mudança de titular durante uma transferência, mas a operação é paga para essa extensão|A OVHcloud **não realiza** a operação. Receberá uma notificação a informar que o titular registado junto do registo da extensão não é aquele que encomendou. Poderá então encomendar você mesmo a mudança de titular, quando o desejar.|
+|A extensão não permite a mudança de titular durante uma transferência|Não é acionada qualquer operação automática. O nome de domínio conserva o titular registado junto do registo da extensão.|
 
 :::warning
 Uma mudança de titular paga **nunca** é acionada automaticamente: esta operação é faturada e, conforme a extensão, acrescenta um ano de subscrição. Requer, por isso, o seu consentimento. Para a realizar você mesmo, siga o nosso guia «[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)».
@@ -211,16 +211,18 @@ Uma mudança de titular paga **nunca** é acionada automaticamente: esta operaç
 
 Uma mudança de titular **nunca** é aplicada por iniciativa exclusiva da OVHcloud, mesmo quando é gratuita e iniciada automaticamente. Para a maioria das extensões, é enviado por e-mail um pedido de validação (formulário de autorização, ou «FOA»):
 
-- ao **titular anterior**, ou seja, aquele que estava registado junto do registo no momento da transferência;
+- ao **titular anterior**, ou seja, aquele que estava registado junto do registo da extensão no momento da transferência;
 - ao **novo titular**, ou seja, aquele que encomendou na OVHcloud.
 
 **Ambos os destinatários têm de aceitar** para que a mudança de titular se concretize. São possíveis três resultados:
 
 |Resposta aos pedidos de validação|Resultado|
 |---|---|
-|Ambos os titulares aceitam|A mudança de titular é aplicada junto do registo.|
-|Um dos dois titulares recusa|A operação é **anulada** imediatamente. O nome de domínio conserva o titular registado junto do registo.|
+|Ambos os titulares aceitam|A mudança de titular é aplicada junto do registo da extensão.|
+|Um dos dois titulares recusa|A operação é **anulada** imediatamente. O nome de domínio conserva o titular registado junto do registo da extensão.|
 |Nenhuma resposta no prazo previsto|A operação **expira** e o titular não é corrigido. O prazo é fixado pelo registo da extensão.|
+
+Qualquer que seja o resultado deste pedido de validação, **a transferência do seu nome de domínio mantém-se**: uma recusa, uma expiração ou um bloqueio da mudança de titular não anula a transferência. Apenas não se realiza a correção do titular, e o seu nome de domínio permanece registado na OVHcloud.
 
 :::warning
 Certifique-se de que o endereço de e-mail do **titular anterior** está acessível. Se ninguém puder validar o pedido enviado para esse endereço, a mudança de titular expirará e o seu nome de domínio permanecerá registado em nome do titular anterior.
@@ -236,7 +238,7 @@ Nem todas as extensões exigem esta validação por e-mail: alguns registos apli
 
 #### Se a comparação não for conclusiva
 
-Se o registo não comunicar as informações do titular, a comparação permanece inconclusiva e não é acionada qualquer operação automática. Uma verificação dos contactos é efetuada posteriormente pela OVHcloud. O seu nome de domínio permanece transferido e utilizável.
+Se o registo da extensão não comunicar as informações do titular, a comparação permanece inconclusiva e não é acionada qualquer operação automática. Uma verificação dos contactos é efetuada posteriormente pela OVHcloud. O seu nome de domínio permanece transferido e utilizável.
 
 #### Se faltar uma informação obrigatória no seu contacto de titular
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -72,6 +72,7 @@ O procedimento de transferência compreende várias etapas, implicando o contact
 |[2](#step2)|[Desbloquear o nome de domínio e obter o código de transferência](#step2)|O administrador do nome de domínio, com a autorização do titular|O agente registador atual|Depende das suas ações|
 |[3](#step3)|[Solicitar a transferência do nome de domínio](#step3)|Qualquer pessoa que possua o código de transferência, com a autorização do titular|Com o novo agente de registo (por exemplo, a OVHcloud)|Depende das suas ações|
 |[4](#step4)|[Validação da transferência](#step4)|O agente registador atual|Através de um pedido enviado pela entidade que gere a extensão do nome de domínio|5 dias, no máximo|
+|[5](#step5)|[Verificação do titular após a transferência](#step5)|A OVHcloud, automaticamente|Com o registo da extensão|Automática, imediatamente após a transferência|
 
 :::warning
 O procedimento exato de transferência de nome de domínio pode variar, especialmente no caso de certos **TLD** de código de país (**ccTLD**, tais como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) e de alguns **TLD** especiais (.am, .fm, etc.). Em função da extensão do nome de domínio, poderá ser necessário realizar requisitos adicionais. Recomendamos que comece por verificar as informações apresentadas para a extensão em causa no nosso website: [https://www.ovhcloud.com/pt/domains/tld/](/links/web/domains-tld).
@@ -168,7 +169,107 @@ Em caso de **oposição à transferência pelo agente de registo atual**, a tran
 
 :::
 
-### Etapa 5: gerir o seu nome de domínio com a OVHcloud
+### Etapa 5: verificação do titular após a transferência <a name="step5"></a>
+
+A transferência já está concluída e o seu nome de domínio está registado na OVHcloud. Nesse momento, a OVHcloud compara automaticamente duas informações:
+
+- o **titular registado junto do registo** da extensão, tal como resulta da transferência;
+- o **titular que indicou** ao efetuar a sua encomenda na OVHcloud.
+
+Esta comparação tem por objetivo garantir que o titular declarado junto do registo é efetivamente aquele que encomendou. É totalmente automática e **nunca bloqueia a transferência**: o seu nome de domínio permanece transferido, qualquer que seja o resultado.
+
+São possíveis três resultados.
+
+#### Os dois titulares correspondem
+
+Não é necessária qualquer ação: o titular registado junto do registo já é aquele que encomendou.
+
+#### Os titulares diferem em informações modificáveis
+
+Trata-se das informações que o registo permite corrigir através de uma simples atualização: endereço postal, cidade, código postal, país, endereço de e-mail, número de telefone, etc.
+
+A OVHcloud inicia então automaticamente a atualização do titular junto do registo, sem qualquer ação da sua parte. Esta operação é distinta da transferência: decorre imediatamente após esta e pode acompanhá-la na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>.
+
+#### Os titulares diferem na identidade do titular
+
+Trata-se aqui das informações que designam **quem** é o titular: apelido, nome, organização, forma jurídica. A maioria dos registos não permite alterar estas informações através de uma simples atualização. Apenas uma **mudança de titular** (também designada por «trade») permite corrigi-las.
+
+O que a OVHcloud faz depende então da extensão do seu nome de domínio:
+
+|Situação|O que acontece|
+|---|---|
+|A extensão permite a mudança de titular durante uma transferência e a operação é gratuita para essa extensão|A OVHcloud inicia automaticamente a mudança de titular, mas **esta não é concluída sem a sua validação**: consulte «[Validação da mudança de titular](#step5-foa)» abaixo.|
+|A extensão permite a mudança de titular durante uma transferência, mas a operação é paga para essa extensão|A OVHcloud **não realiza** a operação. Receberá uma notificação a informar que o titular registado junto do registo não é aquele que encomendou. Poderá então encomendar você mesmo a mudança de titular, quando o desejar.|
+|A extensão não permite a mudança de titular durante uma transferência|Não é acionada qualquer operação automática. O nome de domínio conserva o titular registado junto do registo.|
+
+:::warning
+Uma mudança de titular paga **nunca** é acionada automaticamente: esta operação é faturada e, conforme a extensão, acrescenta um ano de subscrição. Requer, por isso, o seu consentimento. Para a realizar você mesmo, siga o nosso guia «[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+##### Validação da mudança de titular <a name="step5-foa"></a>
+
+Uma mudança de titular **nunca** é aplicada por iniciativa exclusiva da OVHcloud, mesmo quando é gratuita e iniciada automaticamente. Para a maioria das extensões, é enviado por e-mail um pedido de validação (formulário de autorização, ou «FOA»):
+
+- ao **titular anterior**, ou seja, aquele que estava registado junto do registo no momento da transferência;
+- ao **novo titular**, ou seja, aquele que encomendou na OVHcloud.
+
+**Ambos os destinatários têm de aceitar** para que a mudança de titular se concretize. São possíveis três resultados:
+
+|Resposta aos pedidos de validação|Resultado|
+|---|---|
+|Ambos os titulares aceitam|A mudança de titular é aplicada junto do registo.|
+|Um dos dois titulares recusa|A operação é **anulada** imediatamente. O nome de domínio conserva o titular registado junto do registo.|
+|Nenhuma resposta no prazo previsto|A operação **expira** e o titular não é corrigido. O prazo é fixado pelo registo da extensão.|
+
+:::warning
+Certifique-se de que o endereço de e-mail do **titular anterior** está acessível. Se ninguém puder validar o pedido enviado para esse endereço, a mudança de titular expirará e o seu nome de domínio permanecerá registado em nome do titular anterior.
+
+Pode acompanhar o progresso do pedido e os avisos de lembrete na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>.
+
+:::
+
+:::info
+Nem todas as extensões exigem esta validação por e-mail: alguns registos aplicam a mudança de titular sem pedido de confirmação. O detalhe do procedimento de mudança de titular está descrito no nosso guia «[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)».
+
+:::
+
+#### Se a comparação não for conclusiva
+
+Se o registo não comunicar as informações do titular, a comparação permanece inconclusiva e não é acionada qualquer operação automática. Uma verificação dos contactos é efetuada posteriormente pela OVHcloud. O seu nome de domínio permanece transferido e utilizável.
+
+#### Se faltar uma informação obrigatória no seu contacto de titular
+
+Alguns registos exigem informações que o seu contacto de titular não contém necessariamente. Por exemplo, o registo da extensão `.pl` recusa um titular sem número de telefone.
+
+Nesse caso, a operação indica a informação que falta na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>. Complete o contacto em questão seguindo o nosso guia «[Gerir os contactos de um serviço](/guides/account-and-service-management/account-information/managing-contacts)» e, em seguida, reinicie a operação nessa mesma página.
+
+#### Especificidades por extensão
+
+A verificação do titular aplica-se a **todas** as extensões. A tabela abaixo precisa, extensão por extensão, o que se desvia do comportamento descrito acima.
+
+|Extensões|Especificidade da verificação do titular|
+|---|---|
+|Extensões genéricas (**gTLD**)|Comportamento genérico|
+|`.com`, `.net`, `.cn`, `.ws`|Comportamento genérico|
+|`.ca`|A categoria de forma jurídica do titular, exigida pelo registo CIRA, é obtida a partir do registo quando os dois titulares correspondem. Esta informação é indispensável para as operações posteriores num `.ca`.|
+|`.hk`|O registo HKDNR não comunica nem a organização nem o endereço de e-mail do titular. Uma mudança de titular automática pode, por isso, não estar disponível.|
+|`.pl`|O registo NASK recusa um titular sem número de telefone: a operação indica então a informação a completar.|
+|`.fr` e outras extensões geridas pela AFNIC|Comportamento genérico. O desenrolar geral da transferência de um `.fr` continua a ser o descrito na [etapa 4](#step4).|
+|`.eu` e o seu equivalente em alfabeto cirílico|Comportamento genérico|
+|`.uk`|Comportamento genérico|
+|`.ac.uk`, `.gov.uk`|Comportamento genérico|
+|`.at`, `.be`, `.ch`, `.li`, `.cz`, `.de`, `.dk`, `.es`, `.fi`|Comportamento genérico|
+|`.gg`, `.je`, `.hr`, `.com.hr`, `.im`, `.it`, `.lt`, `.lu`, `.mx`|Comportamento genérico|
+|`.nl`, `.pt`, `.ro`, `.se`, `.so`, `.tn`, `.tw`, `.com.tw`|Comportamento genérico|
+|Outras extensões geridas por um registo específico|Comportamento genérico|
+
+:::info
+A autorização da mudança de titular durante uma transferência, bem como o seu caráter gratuito ou pago, são definidos **por extensão**. Para conhecer as condições aplicáveis à sua, introduza o seu nome de domínio na página [www.ovhcloud.com/pt/domains/tld/](/links/web/domains-tld).
+
+:::
+
+### Etapa 6: gerir o seu nome de domínio com a OVHcloud
 
 Uma vez terminado o processo de transferência, pode gerir o seu nome de domínio a partir da página <ManagerLink to="/#/web-domains/domain">Nomes de domínio</ManagerLink>.
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir o nome de domínio para a OVHcloud
 description: Descubra como transferir um nome de domínio para a OVHcloud
-lastUpdated: 2026-03-27
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -192,24 +192,24 @@ A OVHcloud inicia então automaticamente a atualização do titular junto do reg
 
 #### Os titulares diferem na identidade do titular
 
-Trata-se aqui das informações que designam **quem** é o titular: apelido, nome, organização, forma jurídica. A maioria dos registos não permite alterar estas informações através de uma simples atualização. Apenas uma **mudança de titular** (também designada por «trade») permite corrigi-las.
+Trata-se aqui das informações que designam **quem** é o titular: apelido, nome, organização, forma jurídica. A maioria dos registos não permite alterar estas informações através de uma simples atualização. Apenas uma **mudança de titular** (também designada por "trade") permite corrigi-las.
 
 O que a OVHcloud faz depende então da extensão do seu nome de domínio:
 
 |Situação|O que acontece|
 |---|---|
-|A extensão permite a mudança de titular durante uma transferência e a operação é gratuita para essa extensão|A OVHcloud inicia automaticamente a mudança de titular, mas **esta não é concluída sem a sua validação**: consulte «[Validação da mudança de titular](#step5-foa)» abaixo.|
+|A extensão permite a mudança de titular durante uma transferência e a operação é gratuita para essa extensão|A OVHcloud inicia automaticamente a mudança de titular, mas **esta não é concluída sem a sua validação**: consulte "[Validação da mudança de titular](#step5-foa)" abaixo.|
 |A extensão permite a mudança de titular durante uma transferência, mas a operação é paga para essa extensão|A OVHcloud **não realiza** a operação. Receberá uma notificação a informar que o titular registado junto do registo da extensão não é aquele que encomendou. Poderá então encomendar você mesmo a mudança de titular, quando o desejar.|
 |A extensão não permite a mudança de titular durante uma transferência|Não é acionada qualquer operação automática. O nome de domínio conserva o titular registado junto do registo da extensão.|
 
 :::warning
-Uma mudança de titular paga **nunca** é acionada automaticamente: esta operação é faturada e, conforme a extensão, acrescenta um ano de subscrição. Requer, por isso, o seu consentimento. Para a realizar você mesmo, siga o nosso guia «[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)».
+Uma mudança de titular paga **nunca** é acionada automaticamente: esta operação é faturada e, conforme a extensão, acrescenta um ano de subscrição. Requer, por isso, o seu consentimento. Para a realizar por si, siga o nosso guia "[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
 ##### Validação da mudança de titular <a name="step5-foa"></a>
 
-Uma mudança de titular **nunca** é aplicada por iniciativa exclusiva da OVHcloud, mesmo quando é gratuita e iniciada automaticamente. Para a maioria das extensões, é enviado por e-mail um pedido de validação (formulário de autorização, ou «FOA»):
+Uma mudança de titular **nunca** é aplicada por iniciativa exclusiva da OVHcloud, mesmo quando é gratuita e iniciada automaticamente. Para a maioria das extensões, é enviado por e-mail um pedido de validação (formulário de autorização, ou "FOA"):
 
 - ao **titular anterior**, ou seja, aquele que estava registado junto do registo da extensão no momento da transferência;
 - ao **novo titular**, ou seja, aquele que encomendou na OVHcloud.
@@ -232,7 +232,7 @@ Pode acompanhar o progresso do pedido e os avisos de lembrete na página <Manage
 :::
 
 :::info
-Nem todas as extensões exigem esta validação por e-mail: alguns registos aplicam a mudança de titular sem pedido de confirmação. O detalhe do procedimento de mudança de titular está descrito no nosso guia «[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)».
+Nem todas as extensões exigem esta validação por e-mail: alguns registos aplicam a mudança de titular sem pedido de confirmação. O detalhe do procedimento de mudança de titular está descrito no nosso guia "[Alterar o titular de um nome de domínio](/guides/web-cloud/domains/trade-domain)".
 
 :::
 
@@ -244,7 +244,7 @@ Se o registo da extensão não comunicar as informações do titular, a compara�
 
 Alguns registos exigem informações que o seu contacto de titular não contém necessariamente. Por exemplo, o registo da extensão `.pl` recusa um titular sem número de telefone.
 
-Nesse caso, a operação indica a informação que falta na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>. Complete o contacto em questão seguindo o nosso guia «[Gerir os contactos de um serviço](/guides/account-and-service-management/account-information/managing-contacts)» e, em seguida, reinicie a operação nessa mesma página.
+Nesse caso, a operação indica a informação que falta na página <ManagerLink to="/#/web/ongoing-operations">Operações em curso</ManagerLink>. Complete o contacto em questão seguindo o nosso guia "[Gerir os contactos de um serviço](/guides/account-and-service-management/account-information/managing-contacts)" e, em seguida, reinicie a operação nessa mesma página.
 
 #### Especificidades por extensão
 


### PR DESCRIPTION
…r guide

Add a "holder check after the transfer" step to the generic incoming transfer guide, in the 7 locales. It covers the three outcomes of the comparison between the holder registered at the registry and the one ordered at OVHcloud: aligned, update of the editable fields, or change of holder. The change of holder is not silent: a FOA is sent to both the previous and the new holder, and a single refusal or a timeout cancels it. Per-extension specifics are listed for .ca, .hk and .pl.

The former step 5 becomes step 6. Anchors step1 to step4 are unchanged, so the inbound links from the dns-zone-import guides keep working.

Also document the orphan rspress dev servers and the rspack persistent cache failure in the README, which account for most local dev slowdowns.

D2I-6271