### PR TITLE
docs: remove AlmaLinux 10, Rocky Linux 10, Fedora from the LACP list

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Link Aggregation auf Dedicated Servern verstehen
 description: Erfahren Sie, wie Link Aggregation auf Ihrem Dedicated Server funktioniert, was OVHcloud Link Aggregation (OLA) verändert und welcher Anleitung Sie je nach Betriebssystem folgen
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Ziel
@@ -66,11 +66,10 @@ Die Aggregate werden **immer** konfiguriert und die Option wird **nicht angebote
 
 Die Option wird angeboten und ist **standardmäßig deaktiviert** bei:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 und 9
 - **Debian**, außer Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** und **Proxmox Backup Server**
-- **Rocky Linux**, außer Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 und 24.04
 - **Windows Server**, außer den Hyper-V Images
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) und [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Understanding link aggregation on dedicated servers
 description: Find out how link aggregation works on your dedicated server, what OVHcloud Link Aggregation (OLA) changes, and which guide to follow for your operating system
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Objective

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -66,11 +66,10 @@ The bonds are **always** configured, and the option is **not offered**, on:
 
 The option is offered, and **disabled by default**, on:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 and 9
 - **Debian**, except Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** and **Proxmox Backup Server**
-- **Rocky Linux**, except Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 and 24.04
 - **Windows Server**, except the Hyper-V images
 - [Bring Your Own Image](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) and [Bring Your Own Linux](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comprender la agregación de enlaces en los servidores dedicados
 description: Descubra cómo funciona la agregación de enlaces en su servidor dedicado, qué cambia OVHcloud Link Aggregation (OLA) y qué guía seguir según su sistema operativo
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Objetivo
@@ -66,11 +66,10 @@ Los agregados se configuran **siempre**, y la opción **no se ofrece**, en:
 
 La opción se ofrece y está **desactivada por defecto** en:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 y 9
 - **Debian**, excepto Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** y **Proxmox Backup Server**
-- **Rocky Linux**, excepto Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 y 24.04
 - **Windows Server**, excepto las imágenes Hyper-V
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) y [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comprendre l'agrégation de liens sur les serveurs dédiés
 description: Découvrez comment fonctionne l'agrégation de liens sur votre serveur dédié, ce que change OVHcloud Link Aggregation (OLA) et quel guide suivre selon votre système d'exploitation
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Objectif
@@ -66,11 +66,10 @@ Les agrégats sont **toujours** configurés, et l'option n'est **pas proposée**
 
 L'option est proposée, et **désactivée par défaut**, sur :
 
-- **AlmaLinux**
+- **AlmaLinux** 8 et 9
 - **Debian**, sauf Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** et **Proxmox Backup Server**
-- **Rocky Linux**, sauf Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 et 24.04
 - **Windows Server**, sauf les images Hyper-V
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) et [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Capire l'aggregazione dei collegamenti sui server dedicati
 description: Scopri come funziona l'aggregazione dei collegamenti sul tuo server dedicato, cosa cambia OVHcloud Link Aggregation (OLA) e quale guida seguire in base al tuo sistema operativo
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Obiettivo
@@ -66,11 +66,10 @@ Gli aggregati vengono **sempre** configurati, e l'opzione **non viene proposta**
 
 L'opzione viene proposta ed è **disattivata per impostazione predefinita** su:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 e 9
 - **Debian**, tranne Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** e **Proxmox Backup Server**
-- **Rocky Linux**, tranne Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 e 24.04
 - **Windows Server**, tranne le immagini Hyper-V
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) e [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Agregacja łączy na serwerach dedykowanych
 description: Dowiedz się, jak działa agregacja łączy na Twoim serwerze dedykowanym, co zmienia OVHcloud Link Aggregation (OLA) i który przewodnik wybrać w zależności od systemu operacyjnego
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Wprowadzenie
@@ -66,11 +66,10 @@ Agregaty są **zawsze** konfigurowane, a opcja **nie jest proponowana**, w przyp
 
 Opcja jest proponowana i **domyślnie wyłączona** w przypadku:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 i 9
 - **Debian**, z wyjątkiem Debiana 11
-- **Fedora**
 - **Proxmox Virtual Environment** i **Proxmox Backup Server**
-- **Rocky Linux**, z wyjątkiem Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 i 24.04
 - **Windows Server**, z wyjątkiem obrazów Hyper-V
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) i [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/link-aggregation-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Compreender a agregação de ligações nos servidores dedicados
 description: Saiba como funciona a agregação de ligações no seu servidor dedicado, o que altera o OVHcloud Link Aggregation (OLA) e que guia seguir em função do seu sistema operativo
-lastUpdated: 2026-08-06
+lastUpdated: 2026-08-17
 ---
 
 ## Objetivo
@@ -66,11 +66,10 @@ Os agregados são **sempre** configurados, e a opção **não é proposta**, em:
 
 A opção é proposta e está **desativada por defeito** em:
 
-- **AlmaLinux**
+- **AlmaLinux** 8 e 9
 - **Debian**, exceto Debian 11
-- **Fedora**
 - **Proxmox Virtual Environment** e **Proxmox Backup Server**
-- **Rocky Linux**, exceto Rocky Linux 8
+- **Rocky Linux** 9
 - **Ubuntu Server** 22.04 e 24.04
 - **Windows Server**, exceto as imagens Hyper-V
 - [Bring Your Own Image (BYOI)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-image) e [Bring Your Own Linux (BYOLinux)](/guides/bare-metal-cloud/dedicated-servers/bring-your-own-linux)


### PR DESCRIPTION
These use cloud-init's NetworkManager renderer, and that renderer never writes the bond's MAC, so the bond doesn't always come up with its fallback MAC and DHCP fails, leaving the server unreachable. The option is being withdrawn from those templates until cloud-init is fixed.

Fedora disappears from the list entirely: Fedora 43 was the only release still offering the option. AlmaLinux 8 and 9 and Rocky Linux 9 keep it, they render ifcfg, which does write the MAC.

Ref: PUBM-55091