### PR TITLE
docs: translate the HTTP/2 Rapid Reset guide into all 7 locales

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: So entschärfen Sie die HTTP/2-Rapid-Reset-Sicherheitslücke (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: So entschärfen Sie die HTTP/2-Rapid-Reset-Sicherheitslücke
+description: Erfahren Sie, wie Sie die HTTP/2-Rapid-Reset-Sicherheitslücke entschärfen
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
-## Introduction
+## Einleitung
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+Am 10. Oktober 2023 haben Forscher und Hersteller ein Verhalten des HTTP/2-Protokolls offengelegt, das einen Denial-of-Service-Angriff (DoS) auf Layer 7 ermöglicht.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Die unter CVE-2023-44487 geführte Schwachstelle erlaubt es einem Angreifer, über das HTTP/2-Protokoll zusätzliche Last auf Webservern zu erzeugen, was zu einem Denial of Service führen kann.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Ein Angreifer kann die Sicherheitslücke ausnutzen, indem er über eine bestehende Verbindung sehr schnell eine große Anzahl von HTTP/2-Streams öffnet und wieder abbricht. Dies verursacht einen übermäßigen Ressourcenverbrauch auf Serverseite bei minimalen Kosten auf Clientseite. Technisch umgeht dieses Vorgehen die Obergrenze für gleichzeitige Streams des Servers, da die eingehenden Streams schneller zurückgesetzt werden, als nachfolgende Streams eintreffen.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+Aus dem zuerst identifizierten Verhalten sind mehrere Varianten mit unterschiedlicher Reihenfolge der Anfragen entstanden. Sie ermöglichen es, Gegenmaßnahmen zu umgehen, die auf der Rate der eingehenden zurückgesetzten Streams beruhen.
 
-## Impacts on OVHcloud products
+## Auswirkungen auf OVHcloud Produkte
 
-|Range of products|Products|Impact|
+|Produktpalette|Produkte|Auswirkung|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Webhosting|CDN|Nicht betroffen|
+|Web Cloud|Webhosting - Cloud Web|Nicht betroffen|
+|Bare Metal Cloud|Netzwerk - Load Balancer|Nicht betroffen|
 
-## How to mitigate the vulnerability
+## So entschärfen Sie die Sicherheitslücke
 
-### OVHcloud-initiated mitigation
+### Von OVHcloud durchgeführte Maßnahmen
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Wenn Sie einen der oben genannten Dienste nutzen, hat OVHcloud die erforderlichen Maßnahmen zur Entschärfung der Sicherheitslücke ergriffen und Sie sind nicht betroffen.
 
-### Customer-initiated mitigation
+### Vom Kunden durchzuführende Maßnahmen
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Wenn Ihre Website auf einer Cloud-Instanz (Public Cloud oder Hosted Private Cloud) oder auf einem Bare Metal Server gehostet wird, auf dem HTTP/2 aktiviert und im Internet exponiert ist, empfehlen wir Ihnen, die neuesten Updates zu installieren, um Ihre Resilienz zu verbessern.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Die wichtigsten Hersteller haben Sicherheitshinweise und Stellungnahmen veröffentlicht, um Sie zu unterstützen und weitere Informationen bereitzustellen.
 
-## External references
+## Externe Referenzen
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - Details zu CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Qualys Community - HTTP/2-Rapid-Reset-Angriff (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/en/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -7,20 +7,20 @@ availableIn: [eu, ca, apac]
 
 ## Introduction
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behaviour that enables a Layer 7 denial-of-service (DoS) attack.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Tracked as CVE-2023-44487, the issue lets an attacker create additional load on web servers over the HTTP/2 protocol, which could lead to a denial of service.
 
 An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+Several variants of this first behaviour have emerged, each using a different request order, which lets them bypass mitigations based on the rate of inbound reset streams.
 
 ## Impacts on OVHcloud products
 
 |Range of products|Products|Impact|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
+|Web Hosting|CDN|Not impacted|
+|Web Cloud|Web Hosting - Cloud Web|Not impacted|
 |Bare Metal Cloud|Network - Load Balancer|Not impacted|
 
 ## How to mitigate the vulnerability
@@ -31,14 +31,14 @@ If you are using any of the services above, OVHcloud took the appropriate action
 
 ### Customer-initiated mitigation
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+If your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend applying the latest updates to improve your resiliency.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Major vendors have released advisories and statements to guide you and provide more information.
 
 ## External references
 
 [National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
 [Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/es/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: Cómo mitigar la vulnerabilidad de reinicio rápido HTTP/2 (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: Cómo mitigar la vulnerabilidad HTTP/2 Rapid Reset
+description: Descubra cómo mitigar la vulnerabilidad HTTP/2 Rapid Reset
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
-## Introduction
+## Introducción
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+El 10 de octubre de 2023, investigadores y proveedores revelaron un comportamiento del protocolo HTTP/2 que permite llevar a cabo un ataque de denegación de servicio (DoS) en la capa 7.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Registrada con el identificador CVE-2023-44487, esta vulnerabilidad permite a un atacante generar una carga adicional en los servidores web a través del protocolo HTTP/2, lo que puede provocar una denegación de servicio.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Un atacante puede explotar esta vulnerabilidad abriendo y cancelando muy rápidamente un gran número de flujos HTTP/2 en una conexión ya establecida, lo que provoca un consumo excesivo de recursos en el servidor con un coste mínimo para el cliente. Esta técnica elude el límite de flujos simultáneos del servidor, ya que los flujos entrantes se reinician más rápido de lo que llegan los siguientes.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+A raíz de este primer comportamiento identificado han surgido varias variantes, que utilizan órdenes de peticiones diferentes. Permiten eludir las medidas de mitigación basadas en la tasa de flujos reiniciados entrantes.
 
-## Impacts on OVHcloud products
+## Impacto en los productos de OVHcloud
 
-|Range of products|Products|Impact|
+|Gama de productos|Productos|Impacto|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Hosting|CDN|No afectado|
+|Web Cloud|Hosting - Cloud Web|No afectado|
+|Bare Metal Cloud|Red - Load Balancer|No afectado|
 
-## How to mitigate the vulnerability
+## Cómo mitigar la vulnerabilidad
 
-### OVHcloud-initiated mitigation
+### Medidas adoptadas por OVHcloud
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Si utiliza alguno de los servicios mencionados anteriormente, OVHcloud ha tomado las medidas necesarias para mitigar la vulnerabilidad y usted no está afectado.
 
-### Customer-initiated mitigation
+### Medidas que debe adoptar el cliente
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Si su sitio web está alojado en una instancia Cloud (Public Cloud o Hosted Private Cloud) o en un servidor Bare Metal con el protocolo HTTP/2 activado y expuesto a Internet, le recomendamos aplicar las últimas actualizaciones para mejorar su resiliencia.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Los principales proveedores han publicado boletines de seguridad y comunicados para orientarle y proporcionarle más información.
 
-## External references
+## Referencias externas
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - detalles de CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Comunidad de Qualys - ataque HTTP/2 Rapid Reset (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/fr/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: Comment gérer la vulnérabilité HTTP/2 Rapid Reset (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: Comment atténuer la vulnérabilité HTTP/2 Rapid Reset
+description: Découvrez comment atténuer la vulnérabilité HTTP/2 Rapid Reset
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
 ## Introduction
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+Le 10 octobre 2023, des chercheurs et des éditeurs ont révélé un comportement du protocole HTTP/2 permettant de mener une attaque par déni de service (DoS) au niveau de la couche 7.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Référencée CVE-2023-44487, cette faille permet à un attaquant de générer une charge supplémentaire sur les serveurs web via le protocole HTTP/2, ce qui peut conduire à un déni de service.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Un attaquant peut exploiter cette vulnérabilité en ouvrant puis en annulant très rapidement un grand nombre de flux HTTP/2 sur une connexion déjà établie, ce qui provoque une consommation excessive de ressources côté serveur pour un coût minime côté client. Cette technique contourne la limite de flux simultanés du serveur, car les flux entrants sont réinitialisés plus vite que les flux suivants n'arrivent.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+Ce premier comportement a donné lieu à plusieurs variantes, qui utilisent des ordres de requêtes différents. Elles permettent de contourner les mesures d'atténuation fondées sur le taux de flux réinitialisés entrants.
 
-## Impacts on OVHcloud products
+## Impacts sur les produits OVHcloud
 
-|Range of products|Products|Impact|
+|Gamme de produits|Produits|Impact|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Hébergements web|CDN|Non impacté|
+|Web Cloud|Hébergements web - Cloud Web|Non impacté|
+|Bare Metal Cloud|Réseau - Load Balancer|Non impacté|
 
-## How to mitigate the vulnerability
+## Comment atténuer la vulnérabilité
 
-### OVHcloud-initiated mitigation
+### Atténuation mise en œuvre par OVHcloud
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Si vous utilisez l'un des services mentionnés ci-dessus, OVHcloud a pris les mesures nécessaires pour atténuer la vulnérabilité et vous n'êtes pas impacté.
 
-### Customer-initiated mitigation
+### Atténuation à mettre en œuvre par le client
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Si votre site web est hébergé sur une instance Cloud (Public Cloud ou Hosted Private Cloud) ou sur un serveur Bare Metal dont le protocole HTTP/2 est activé et exposé sur Internet, nous vous recommandons d'appliquer les dernières mises à jour pour améliorer votre résilience.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Les principaux éditeurs ont publié des bulletins de sécurité et des communiqués pour vous guider et vous fournir plus d'informations.
 
-## External references
+## Références externes
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - détail de la CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Communauté Qualys - attaque HTTP/2 Rapid Reset (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/it/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: Come mitigare la vulnerabilità HTTP/2 Rapid Reset (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: Come mitigare la vulnerabilità HTTP/2 Rapid Reset
+description: Scopri come mitigare la vulnerabilità HTTP/2 Rapid Reset
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
-## Introduction
+## Introduzione
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+Il 10 ottobre 2023, ricercatori e fornitori hanno divulgato un comportamento del protocollo HTTP/2 che permette di condurre un attacco di negazione del servizio (DoS) a livello 7.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Registrata con l'identificativo CVE-2023-44487, questa vulnerabilità permette a un attaccante di generare un carico aggiuntivo sui server web tramite il protocollo HTTP/2, con il rischio di provocare una negazione del servizio.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Un attaccante può sfruttare questa vulnerabilità aprendo e annullando molto rapidamente un gran numero di flussi HTTP/2 su una connessione già stabilita, provocando un consumo eccessivo di risorse lato server a fronte di un costo minimo lato client. Questa tecnica aggira il limite di flussi simultanei del server, poiché i flussi in entrata vengono reimpostati più rapidamente di quanto arrivino quelli successivi.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+A seguito di questo primo comportamento identificato sono emerse diverse varianti, che utilizzano ordini di richieste differenti. Permettono di aggirare le misure di mitigazione basate sul tasso di flussi reimpostati in entrata.
 
-## Impacts on OVHcloud products
+## Impatti sui prodotti OVHcloud
 
-|Range of products|Products|Impact|
+|Gamma di prodotti|Prodotti|Impatto|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Hosting Web|CDN|Non impattato|
+|Web Cloud|Hosting Web - Cloud Web|Non impattato|
+|Bare Metal Cloud|Rete - Load Balancer|Non impattato|
 
-## How to mitigate the vulnerability
+## Come mitigare la vulnerabilità
 
-### OVHcloud-initiated mitigation
+### Misure adottate da OVHcloud
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Se utilizzi uno dei servizi indicati sopra, OVHcloud ha adottato le misure necessarie per mitigare la vulnerabilità e non sei impattato.
 
-### Customer-initiated mitigation
+### Misure da adottare da parte del cliente
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Se il tuo sito web è ospitato su un'istanza Cloud (Public Cloud o Hosted Private Cloud) o su un server Bare Metal con il protocollo HTTP/2 attivato ed esposto su Internet, ti consigliamo di applicare gli ultimi aggiornamenti per migliorare la tua resilienza.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+I principali fornitori hanno pubblicato bollettini di sicurezza e comunicati per guidarti e fornirti maggiori informazioni.
 
-## External references
+## Riferimenti esterni
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - dettagli della CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Community Qualys - attacco HTTP/2 Rapid Reset (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/pl/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: Jak złagodzić lukę w zabezpieczeniach HTTP/2 Rapid Reset (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: Jak złagodzić lukę w zabezpieczeniach HTTP/2 Rapid Reset
+description: Dowiedz się, jak złagodzić lukę w zabezpieczeniach HTTP/2 Rapid Reset
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
-## Introduction
+## Wprowadzenie
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+10 października 2023 roku badacze i producenci ujawnili zachowanie protokołu HTTP/2 umożliwiające przeprowadzenie ataku typu odmowa usługi (DoS) w warstwie 7.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Luka oznaczona identyfikatorem CVE-2023-44487 pozwala atakującemu wygenerować dodatkowe obciążenie serwerów WWW za pośrednictwem protokołu HTTP/2, co może doprowadzić do odmowy usługi.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Atakujący może wykorzystać tę lukę, otwierając i anulując bardzo szybko dużą liczbę strumieni HTTP/2 w ramach już ustanowionego połączenia. Powoduje to nadmierne zużycie zasobów po stronie serwera przy minimalnym koszcie po stronie klienta. Technika ta omija limit jednoczesnych strumieni serwera, ponieważ strumienie przychodzące są resetowane szybciej, niż pojawiają się kolejne.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+Na podstawie pierwszego zidentyfikowanego zachowania powstało kilka wariantów wykorzystujących inną kolejność zapytań. Pozwalają one obejść mechanizmy ochronne oparte na częstotliwości przychodzących zresetowanych strumieni.
 
-## Impacts on OVHcloud products
+## Wpływ na produkty OVHcloud
 
-|Range of products|Products|Impact|
+|Gama produktów|Produkty|Wpływ|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Hosting|CDN|Brak wpływu|
+|Web Cloud|Hosting - Cloud Web|Brak wpływu|
+|Bare Metal Cloud|Sieć - Load Balancer|Brak wpływu|
 
-## How to mitigate the vulnerability
+## Jak złagodzić lukę w zabezpieczeniach
 
-### OVHcloud-initiated mitigation
+### Działania podjęte przez OVHcloud
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Jeśli korzystasz z jednej z wymienionych powyżej usług, nie jesteś narażony: OVHcloud wdrożyło odpowiednie działania w celu złagodzenia luki.
 
-### Customer-initiated mitigation
+### Działania po stronie klienta
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Jeśli Twoja witryna internetowa jest hostowana na instancji Cloud (Public Cloud lub Hosted Private Cloud) albo na serwerze Bare Metal z włączonym protokołem HTTP/2 udostępnionym w Internecie, zalecamy zainstalowanie najnowszych aktualizacji, aby zwiększyć odporność infrastruktury.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Główni producenci opublikowali biuletyny bezpieczeństwa i komunikaty, aby pomóc Ci w tym zadaniu i przekazać więcej informacji.
 
-## External references
+## Źródła zewnętrzne
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - szczegóły CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Społeczność Qualys - atak HTTP/2 Rapid Reset (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)

--- a/docs/pt/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/info-http2-rapidreset.mdx
@@ -1,44 +1,44 @@
 ---
-title: Como mitigar a vulnerabilidade do HTTP/2 Rapid Reset (EN)
-description: Find out how to manage the HTTP/2 Rapid Reset vulnerability
+title: Como mitigar a vulnerabilidade HTTP/2 Rapid Reset
+description: Descubra como mitigar a vulnerabilidade HTTP/2 Rapid Reset
 lastUpdated: 2023-10-13
 availableIn: [eu, ca, apac]
 ---
 
-## Introduction
+## Introdução
 
-On October 10th 2023, researchers and vendors disclosed an HTTP/2 protocol behavior allowing to perform a denial-of-service (DoS) using Layer 7.
+A 10 de outubro de 2023, investigadores e fornecedores divulgaram um comportamento do protocolo HTTP/2 que permite realizar um ataque de negação de serviço (DoS) na camada 7.
 
-Labelled CVE-2023-44487, an attacker can leverage this issue to create additional load on web servers which could lead to denial of service by using HTTP/2 protocol.
+Registada com o identificador CVE-2023-44487, esta vulnerabilidade permite a um atacante gerar uma carga adicional nos servidores web através do protocolo HTTP/2, o que pode conduzir a uma negação de serviço.
 
-An attacker can exploit the vulnerability by quickly initiating and cancelling a large number of HTTP/2 streams over an established connection causing excessive resource consumption server-side with minimal client-side attacker cost. This technically circumvents the server's concurrent stream maximum limit because incoming streams are reset faster than subsequent streams arrive.
+Um atacante pode explorar esta vulnerabilidade abrindo e cancelando muito rapidamente um grande número de fluxos HTTP/2 numa ligação já estabelecida, o que provoca um consumo excessivo de recursos do lado do servidor com um custo mínimo do lado do cliente. Esta técnica contorna o limite de fluxos simultâneos do servidor, uma vez que os fluxos recebidos são reiniciados mais rapidamente do que chegam os seguintes.
 
-Several variations using different query orders resulted from the first behaviour identified, allowing to bypass mitigations based on the rate of inbound reset streams.
+A partir deste primeiro comportamento identificado surgiram várias variantes, que utilizam ordens de pedidos diferentes. Permitem contornar as medidas de mitigação baseadas na taxa de fluxos reiniciados recebidos.
 
-## Impacts on OVHcloud products
+## Impactos nos produtos OVHcloud
 
-|Range of products|Products|Impact|
+|Gama de produtos|Produtos|Impacto|
 |---|---|---|
-|Web hosting|CDN|Not impacted|
-|Web Cloud|Web hosting - Cloud hosting|Not impacted|
-|Bare Metal Cloud|Network - Load Balancer|Not impacted|
+|Alojamentos web|CDN|Não afetado|
+|Web Cloud|Alojamentos web - Cloud Web|Não afetado|
+|Bare Metal Cloud|Rede - Load Balancer|Não afetado|
 
-## How to mitigate the vulnerability
+## Como mitigar a vulnerabilidade
 
-### OVHcloud-initiated mitigation
+### Medidas aplicadas pela OVHcloud
 
-If you are using any of the services above, OVHcloud took the appropriate actions to mitigate the vulnerability and you are not impacted.
+Se utiliza um dos serviços mencionados acima, a OVHcloud tomou as medidas necessárias para mitigar a vulnerabilidade e não é afetado.
 
-### Customer-initiated mitigation
+### Medidas a aplicar pelo cliente
 
-In the case your website is hosted on a Cloud Instance (Public Cloud or Hosted Private Cloud) or on a Bare Metal Server having HTTP/2 enabled and exposed on the Internet, we recommend you to apply the latest upgrades to improve your resiliency.
+Se o seu site web está alojado numa instância Cloud (Public Cloud ou Hosted Private Cloud) ou num servidor Bare Metal com o protocolo HTTP/2 ativado e exposto na Internet, recomendamos que aplique as últimas atualizações para melhorar a sua resiliência.
 
-The main vendors released advisories and statements in order to guide you and provide more information.
+Os principais fornecedores publicaram boletins de segurança e comunicados para o orientar e fornecer mais informações.
 
-## External references
+## Referências externas
 
-[National vulnerability database - CVE-2023-44487 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+[National Vulnerability Database - detalhes da CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
 
-[CVE Numbering Authorities - CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+[CVE Numbering Authorities - CVE-2023-44487](https://www.cve.org/CVERecord?id=CVE-2023-44487)
 
-[Qualys community - CVE-2023-44487 HTTP/2 Rapid Reset Attack](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)
+[Comunidade Qualys - ataque HTTP/2 Rapid Reset (CVE-2023-44487)](https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack)


### PR DESCRIPTION
## What

`web-cloud/web-hosting/info-http2-rapidreset` existed in all 7 locale trees, but
every single file — including `docs/fr/` — carried the English body. The only
signal was an `(EN)` marker appended to each translated `title:`.

This PR translates the guide for real in `fr`, `de`, `es`, `it`, `pl` and `pt`,
and cleans up the English source along the way.

## Why

The guide was the only one of its kind in `databases`, `domains` and
`web-hosting`: an audit of those three products (211 guides × 7 locales) found
209 guides fully translated, one partial missing in FR, and this one guide
served in English to readers of all 6 non-English locales.

## Translation routing

Source language follows the documentation convention — `de`/`pl` from English,
`es`/`it`/`pt` from French:

| Target | Source | Register used (matches the locale's existing guides) |
|---|---|---|
| `fr` | `en` | — |
| `de` | `en` | formal *Sie* |
| `pl` | `en` | 2nd person singular |
| `es` | `fr` | formal *usted* |
| `it` | `fr` | informal *tu* |
| `pt` | `fr` | formal, European Portuguese (pt-PT) |

Product names come from the terminology reference, per locale:
`Web Hosting` / `Webhosting` / `Hosting` / `Hosting Web` / `Hébergements web` /
`Alojamentos web`. `Web Cloud`, `Bare Metal Cloud`, `Cloud Web`, `CDN` and
`Load Balancer` are identical across locales and stay untranslated.

The `(EN)` marker is removed from all 7 titles.

## Changes to the English source

The English text carried a few defects that surfaced while translating:

- **Spelling consistency** — the file mixed `behavior` (US) and `behaviour` (GB);
  harmonised on `behaviour`, matching the file's other markers (`Labelled`).
- **Product names** — `Web hosting` → `Web Hosting` and `Cloud hosting` →
  `Cloud Web`, aligning the impact table with the terminology reference and with
  the rest of `docs/en/guides/web-cloud/` (`Cloud Web` 121 uses vs
  `Cloud hosting` 5).
- **Dangling modifier** — "Labelled CVE-2023-44487, **an attacker** can leverage
  this issue…" attached the CVE label to the attacker. Rewritten as "Tracked as
  CVE-2023-44487, **the issue** lets an attacker…".
- **Calques** — `allowing to perform` / `allowing to bypass` (no object),
  `In the case your website is hosted`, `we recommend you to apply`,
  `in order to guide you`, `The main vendors released`, and a missing article in
  `by using HTTP/2 protocol`.

## Link freshness

`cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487` has been serving a 301
to CVE.org; replaced with the canonical `https://www.cve.org/CVERecord?id=CVE-2023-44487`
in all 7 files. The record was confirmed `PUBLISHED` via the CVE Services API —
fetching the page directly only returns the client-rendered shell, so a plain
content check is inconclusive there.

The other two references (`nvd.nist.gov`, `blog.qualys.com`) return 200 and have
no localised variants, so they stay in English in every locale.

## Verification

- Structural parity across the 7 locales: 6 headings, 5 table rows (3 cells
  each), 3 external links — identical everywhere.
- No untranslated residue: no English left in `de`/`pl`, no French left in
  `es`/`it`/`pt`, beyond proper nouns (`National Vulnerability Database`,
  `CVE Numbering Authorities`, `Qualys`) and product names.
- Guide contains no action buttons, no CP navigation blocks, no `<Api>` tags, no
  text-fragment tokens, no images and no code blocks — nothing to validate
  against the Manager repo or the API schema snapshot.
- `availableIn: [eu, ca, apac]` but no zoned URL, DNS entry or zoned product in
  the content, so no `<Region>` gating is needed.
- All 7 files remain regular files (mode `100644`), not symlinks — they are
  genuine translations now, so the English-fallback symlink pattern does not
  apply.
- Lint passes.

## Known follow-ups (not in this PR)

- `lastUpdated` is still `2023-10-13` in all 7 files, although 6 of them now
  carry entirely new content. Worth deciding before merge.
- No community link on any of the 7 files, whereas 115 of the 130 French
  `web-hosting` guides have one. Adding it is a content addition, left out
  deliberately.
- Impact table, first row: the "Range of products" cell reads `Web Hosting`, but
  CDN is a **Web Cloud** product — which is exactly the range given on the second
  row. The defect is symmetric across all 7 locales.
- `config/sidebar/index.md` labels this guide
  `Information - HTTP2 rapid reset vulnerability`, which no longer matches the
  English `title:`. Pre-existing drift, untouched here.
- `description` is close to a duplicate of `title` and well under the SEO
  window in all 7 locales — inherited from the original English file.
