### PR TITLE
fix(components): stop the doc column clipping tooltip popups

### DIFF
--- a/components/Tooltip/Tooltip.css
+++ b/components/Tooltip/Tooltip.css
@@ -18,14 +18,13 @@
 }
 
 .tooltip-popup {
-  position: absolute;
+  /* `fixed`, not `absolute`: the popup is portalled to <body> so it escapes the
+     doc column's `overflow-x: auto` clip (which no z-index can defeat). left/top
+     are written by the positioning effect in viewport coordinates. */
+  position: fixed;
   left: 0;
-  /* Horizontal clamp set by the positioning effect; folded into every
-     transform below so the show/hide animation and the edge-clamp coexist
-     instead of overwriting each other. */
-  --tooltip-shift: 0px;
-  transform: translateX(var(--tooltip-shift)) translateY(4px);
-  z-index: 200;
+  top: 0;
+  z-index: 1200;
   /* Never wider than the viewport (minus the 8px edge gutter the clamp
      targets), so the popup stays readable on phones where a fixed 320px
      min-width plus an indented trigger would overflow. */
@@ -47,26 +46,25 @@
     transform 0.15s ease;
 }
 
-/* Placement: top (default) */
+/* Placement no longer sets top/bottom: the popup is portalled and `fixed`, so
+   the positioning effect writes both left and top in viewport coordinates.
+   A `top: auto` / `bottom: calc(100% + …)` here would fight (and win against)
+   the inline top, leaving the popup detached from its trigger.
+   These rules now only carry the entry animation's direction. */
 .tooltip-popup[data-placement="top"] {
-  bottom: calc(100% + 8px);
-  top: auto;
-  transform: translateX(var(--tooltip-shift)) translateY(4px);
+  transform: translateY(4px);
 }
 
 .tooltip-popup[data-placement="top"].tooltip-popup--visible {
-  transform: translateX(var(--tooltip-shift)) translateY(0);
+  transform: translateY(0);
 }
 
-/* Placement: bottom */
 .tooltip-popup[data-placement="bottom"] {
-  top: calc(100% + 8px);
-  bottom: auto;
-  transform: translateX(var(--tooltip-shift)) translateY(-4px);
+  transform: translateY(-4px);
 }
 
 .tooltip-popup[data-placement="bottom"].tooltip-popup--visible {
-  transform: translateX(var(--tooltip-shift)) translateY(0);
+  transform: translateY(0);
 }
 
 .tooltip-popup--visible {

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useGlossary } from 'theme/hooks/useGlossary';
 import { useLocalizeHref } from 'theme/hooks/useLocalizedHref';
 import './Tooltip.css';
@@ -52,6 +53,9 @@ export function Tooltip({
 }: TooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [actualPlacement, setActualPlacement] = useState(placement);
+  // The popup portals into document.body, which does not exist during the
+  // static render — mount-gate it so SSR output and first client render match.
+  const [mounted, setMounted] = useState(false);
   const glossary = useGlossary();
   const localizeHref = useLocalizeHref();
   // An unknown key renders the trigger as plain text (see the `!resolved`
@@ -65,6 +69,8 @@ export function Tooltip({
   const isTouch = useRef(false);
   const tooltipId = `tooltip-${id}`;
 
+  useEffect(() => setMounted(true), []);
+
   // Never leave a pending close behind on unmount (SPA route changes).
   useEffect(
     () => () => {
@@ -73,38 +79,62 @@ export function Tooltip({
     [],
   );
 
-  // Position the popup and flip if overflowing viewport.
+  // Position the popup in VIEWPORT coordinates.
   //
-  // The horizontal clamp is applied as a CSS variable, NOT by writing
-  // `style.transform` directly: the visible/hidden transition is itself a
-  // `transform`, so an inline transform overrides the stylesheet and pins the
-  // popup to its "visible" offset permanently. That produced a popup which
-  // appeared and then snapped away with the cursor completely still, on
-  // whichever tooltips happened to sit near the right edge.
+  // The popup is portalled to <body> and positioned `fixed`, because the
+  // Rspress doc column ships `overflow-x: auto` — a scroll container, which
+  // CLIPS any descendant regardless of z-index. That is why a tooltip near the
+  // right edge was cut off / overlapped by the on-this-page outline. Rendering
+  // outside the column is the only fix that does not fight the framework's own
+  // horizontal-overflow handling (see styles/index.css, `.rp-doc-layout__doc`).
+  //
+  // Because the popup is no longer a child of the trigger, its position must be
+  // computed rather than inherited: left/top come from the trigger's rect and
+  // are clamped to the real viewport.
   useEffect(() => {
     if (!isOpen || !popupRef.current || !triggerRef.current) return;
 
     const popup = popupRef.current;
     const trigger = triggerRef.current;
-    const triggerRect = trigger.getBoundingClientRect();
-    const popupRect = popup.getBoundingClientRect();
 
-    // Flip vertically if overflowing viewport. Only set state when the value
-    // actually changes — an unconditional set re-renders every open and can
-    // re-run this effect against a mid-transition rect.
-    const next: 'top' | 'bottom' =
-      placement === 'top' && triggerRect.top - popupRect.height - 8 < 0
-        ? 'bottom'
-        : placement === 'bottom' &&
-            triggerRect.bottom + popupRect.height + 8 > window.innerHeight
-          ? 'top'
-          : placement;
-    setActualPlacement((prev) => (prev === next ? prev : next));
+    const place = () => {
+      const triggerRect = trigger.getBoundingClientRect();
+      const popupRect = popup.getBoundingClientRect();
 
-    // Clamp: if popup overflows right edge, shift it left.
-    const popupRight = triggerRect.left + popupRect.width;
-    const offset = Math.max(0, popupRight - (window.innerWidth - 8));
-    popup.style.setProperty('--tooltip-shift', `-${offset}px`);
+      // Flip vertically when the preferred side has no room.
+      const next: 'top' | 'bottom' =
+        placement === 'top' && triggerRect.top - popupRect.height - 8 < 0
+          ? 'bottom'
+          : placement === 'bottom' &&
+              triggerRect.bottom + popupRect.height + 8 > window.innerHeight
+            ? 'top'
+            : placement;
+      setActualPlacement((prev) => (prev === next ? prev : next));
+
+      // Clamp horizontally to the viewport, with an 8px gutter on both sides.
+      const left = Math.max(
+        8,
+        Math.min(triggerRect.left, window.innerWidth - popupRect.width - 8),
+      );
+      const top =
+        next === 'top'
+          ? triggerRect.top - popupRect.height - 8
+          : triggerRect.bottom + 8;
+
+      popup.style.left = `${left}px`;
+      popup.style.top = `${top}px`;
+    };
+
+    place();
+
+    // A fixed popup does not travel with the page, so re-place it while it is
+    // open rather than leaving it stranded mid-scroll.
+    window.addEventListener('scroll', place, true);
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('scroll', place, true);
+      window.removeEventListener('resize', place);
+    };
   }, [isOpen, placement]);
 
   // Close on outside interaction. `pointerdown` rather than `mousedown` so a
@@ -188,8 +218,14 @@ export function Tooltip({
       onFocus={handleMouseEnter}
       // Keyboard users must be able to Tab INTO the popup's links, so only
       // close when focus leaves the trigger/popup subtree entirely.
+      // The popup is portalled, so it is NOT inside currentTarget any more —
+      // check it explicitly or tabbing into its links would close the popup.
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(next && popupRef.current?.contains(next))
+        ) {
           setIsOpen(false);
         }
       }}
@@ -202,19 +238,27 @@ export function Tooltip({
       onKeyDown={handleKeyDown}
     >
       {children}
-      <span
-        ref={popupRef}
-        id={tooltipId}
-        role="tooltip"
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        className={`tooltip-popup${isOpen ? ' tooltip-popup--visible' : ''}`}
-        data-placement={actualPlacement}
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: content comes from MDX files and the committed glossary, not user input
-        dangerouslySetInnerHTML={{
-          __html: parseSimpleMarkdown(resolved, localizeHref),
-        }}
-      />
+      {/* Portalled to <body>: see the positioning effect above — the doc
+          column is a scroll container and would clip the popup. Only mounted
+          while open, and only in the browser (SSR has no document). */}
+      {mounted &&
+        isOpen &&
+        createPortal(
+          <span
+            ref={popupRef}
+            id={tooltipId}
+            role="tooltip"
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            className="tooltip-popup tooltip-popup--visible"
+            data-placement={actualPlacement}
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: content comes from MDX files and the committed glossary, not user input
+            dangerouslySetInnerHTML={{
+              __html: parseSimpleMarkdown(resolved, localizeHref),
+            }}
+          />,
+          document.body,
+        )}
     </span>
   );
 }


### PR DESCRIPTION
A tooltip near the right edge of the text column was cut off and overlapped by the on-this-page outline. It was not a z-index race: Rspress ships `overflow-x: auto` on `.rp-doc-layout__doc`, which makes it a scroll container, and a scroll container clips its descendants whatever their z-index. Raising 200 would have changed nothing.

The popup is now portalled to <body> and positioned `fixed`, so no ancestor can clip it. left/top are computed from the trigger's rect and clamped to the real viewport with an 8px gutter; a scroll/resize listener re-places it while it is open, since a fixed element no longer travels with the page.

styles/index.css already documents this trap for sticky tab headers, but that workaround is scoped `:has(.rp-tabs)` and most guides have no tab block, so it never applied here.

Knock-on changes the portal required:

- The [data-placement] rules kept `top: auto` and `bottom: calc(100% + 8px)` from the absolute-positioned era. Once the popup was fixed, those resolved against <body> and beat the inline top, leaving the popup detached from its trigger. They now carry only the entry animation.
- onBlur tested DOM containment, which the portal breaks — tabbing into a popup link would have closed it. It now also checks the popup.
- The popup mounts client-side only, so SSR output and the first client render match.