### PR TITLE
docs(domains): restore the Polish home.pl incoming transfer guide lost during the new-docs migration

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1724,6 +1724,7 @@
                     + [Transferring a .pl domain name to OVHcloud](web-cloud/domains/transfer-pl)
                     + [Transferring a domain name from Hostinger to OVHcloud](web-cloud/domains/transfer-incoming-hostinger)
                     + [Transferring a domain name from GoDaddy to OVHcloud](web-cloud/domains/transfer-incoming-godaddy)
+                    + [Transferring a domain name from Home.pl to OVHcloud](web-cloud/domains/transfer-incoming-homepl)
                     + [Transferring a domain name from Ionos to OVHcloud](web-cloud/domains/transfer-incoming-ionos)
                     + [Transferring a domain name from Gandi to OVHcloud](web-cloud/domains/transfer-incoming-gandi)
                     + [Transferring a domain name from Wix to OVHcloud](web-cloud/domains/transfer-incoming-wix)

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-homepl.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-homepl.mdx
@@ -1,0 +1,81 @@
+---
+title: Transfer nazwy domeny home.pl do OVHcloud
+description: Poznaj procedurę transferu nazwy domeny z home.pl do OVHcloud, od wymagań początkowych po odblokowanie domeny i pobranie kodu autoryzacyjnego
+lastUpdated: 2026-02-10
+availableIn: [eu]
+---
+
+## Wprowadzenie
+
+Transfer nazwy domeny home.pl wymaga zastosowania określonej procedury.
+
+**Dowiedz się, jak wykonać transfer nazwy domeny home.pl do OVHcloud**
+
+:::warning
+[Rejestrator](/links/web/domains-what-is-registrar) nazwy domeny reprezentuje organizację/autoryzowanego dostawcę, w którym nazwa domeny jest zarejestrowana/zarejestrowana przez osobę prywatną, stowarzyszenie lub organizację. To u tego samego rejestratora odnawiasz rejestrację nazwy domeny (zazwyczaj raz w roku).
+
+Jeśli OVHcloud jest już rejestratorem Twojej nazwy domeny **przed** rozpoczęciem odpowiedniej procedury, przychodzący transfer nazwy domeny nie jest właściwą procedurą. Procedura transferu nazwy domeny ma zastosowanie **tylko** do nazw domen zarejestrowanych u innego operatora niż OVHcloud.
+
+Aby przenieść zarządzanie nazwą domeny na inne konto klienta OVHcloud, odpowiednią metodą jest **zmiana kontaktów**. Procedura opisana jest w [tym przewodniku](/guides/account-and-service-management/account-information/managing-contacts).
+Jeśli musisz również zmienić **abonenta** nazwy domeny, musisz zmienić **przed** zmianą kontaktów nazwy domeny. W tym celu postępuj zgodnie z instrukcjami zawartymi w przewodniku dotyczącym [zmiany abonenta nazwy domeny](/guides/web-cloud/domains/trade-domain).
+:::
+
+## Wymagania początkowe
+
+- Nazwa domeny jest zarejestrowana u operatora home.pl.
+- Nazwa domeny istnieje od ponad 60 dni.
+- W ciągu ostatnich 60 dni nazwa domeny nie została przeniesiona ani nie zmienił się abonent.
+- Nazwa domeny ma status "OK" lub "możliwy do przeniesienia".
+- Nazwa domeny nie wygasła i ma datę wygaśnięcia umożliwiającą zakończenie procesu transferu w odpowiednim czasie (zalecane: ponad 60 dni).
+
+Musisz również:
+
+- Posiadać możliwość odblokowania nazwy domeny.
+- Posiadać kod transferu lub możliwość jego uzyskania.
+- Posiadać uprawnienia do złożenia wniosku o transfer nazwy domeny.
+- Abonent i/lub administratorzy nazwy domeny zostali poinformowani o wszczęciu procedury transferu nazwy domeny.
+
+[[fragment:support-scope]]
+
+## W praktyce
+
+:::info
+Aktywna strefa DNS nazwy domeny zawiera konfigurację DNS zastosowaną do Twojej nazwy domeny. Dzięki niemu możesz powiązać nazwę domeny z Twoimi usługami, takimi jak konta e-mail lub strona WWW.
+
+Jeśli oprócz nazwy domeny posiadasz również aktywną strefę DNS dla nazwy domeny u dotychczasowego operatora, sprawdź u jego służb, czy strefa DNS zastosowana do Twojej nazwy domeny nie zostanie usunięta po zakończeniu transferu.
+
+Niektórzy rejestratorzy usuwają strefę DNS obecną u nich w momencie zakończenia transferu Twojej nazwy domeny. W takim przypadku przed rozpoczęciem operacji związanych z transferem nazwy domeny utwórz ponownie strefę DNS w OVHcloud.
+
+Aby to zrobić, zapoznaj się z następującymi przewodnikami:
+
+- [Utwórz strefę DNS w OVHcloud](/guides/web-cloud/domains/dns-zone-create)
+- [Edycja strefy DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+Upewnij się również, że dotychczasowy operator nie zamknie dodatkowych usług, takich jak na przykład adresy e-mail powiązane z Twoją nazwą domeny.
+
+Jeśli oprócz transferu Twojej nazwy domeny chcesz przenieść usługi z nią powiązane (strona WWW, konto e-mail, etc.), zapoznaj się z naszym przewodnikiem "[Przeniesienie strony WWW i powiązanych z nią usług do OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)".
+Ten przewodnik wyjaśnia, jak migrować wszystkie usługi bez przerw w ciągłości usług.
+
+Jeśli wykonujesz wyłącznie transfer Twojej nazwy domeny bez przenoszenia innych usług, upewnij się, że pobrałeś serwery DNS aktywne dla Twojej nazwy domeny od aktualnego **operatora** i wypełnisz ten przewodnik podczas etapu 3 "[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)"
+Dzięki temu nie będziesz musiał przerywać przypisywania nazwy domeny do przypisanych usług zewnętrznych.
+:::
+
+### Odblokowanie nazwy domeny i pobranie kodu transferu
+
+Aby odblokować nazwę domeny i uzyskać kod transferu, wykonaj kroki opisane w [dedykowanej dokumentacji home.pl](https://pomoc.home.pl/baza-wiedzy/request-for-authinfo-code-form).
+
+### Rozpocznij transfer nazwy domeny do OVHcloud
+
+Po uzyskaniu kodu autoryzacyjnego możesz przenieść nazwę domeny zgodnie z instrukcjami zawartymi w przewodniku "[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)".
+
+## Sprawdź również <a name="go-further"></a>
+
+[Transfer nazwy domeny do OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Przeniesienie strony WWW i kont e-mail do OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](/links/partner).
+
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
+
+Dołącz do [grona naszych użytkowników](/links/community).


### PR DESCRIPTION
## What

Ports the Polish version of the home.pl incoming domain transfer guide from
`ovh/docs@develop` (`pages/web_cloud/domains/transfer_incoming_homepl/guide.pl-pl.md`)
into `docs/pl/guides/web-cloud/domains/transfer-incoming-homepl.mdx`, and registers it
in the sidebar.

## Why

This guide was live in production and was lost during the migration to new-docs.

In legacy, `flag: hidden` was applied to the FR and EN versions only — **PL was the sole
publicly listed locale**, which matches the editorial intent (home.pl is a Polish
registrar, so the guide was surfaced only in the Polish market).

The migration commit produced two variants per locale: a masked `_`-prefixed copy built
from a stale 2024 snapshot, and an up-to-date routable copy. The new-docs seed kept only
the `_`-prefixed files. Since PL had no masked variant, the Polish guide disappeared
entirely, and the FR/EN files that survived are the outdated ones.

The page was reachable in production until the migration
(`help.ovhcloud.com/csm/pl-domain-names-transfer-from-homepl`, HTTP 200 in the Wayback
Machine, KB0062651). It currently returns a 404 with no targeted redirect: the entry in
`scripts/slug-mapping.json` carries the leaked `_transfer-incoming-homepl` slug and no
`basePath`.

## Scope

- **PL only.** Content is taken from the current legacy `develop`, i.e. **after** PR
  ovh/docs#8799 (`właściciel` → `abonent` terminology alignment), not from the stale
  snapshot the `_`-prefixed files still carry.
- `docs/fr` and `docs/en` `_transfer-incoming-homepl.mdx` are **left masked and
  untouched**, as intended.
- No other locale is added: the guide was never distributed outside the Polish market.

## Conversions applied

| Legacy | New |
|---|---|
| `excerpt:` | `description:` |
| `updated:` | `lastUpdated:` |
| `> [!warning]` ×2 | `:::warning` |
| `> [!primary]` | `:::info` |
| Hand-written support disclaimer | `[[fragment:support-scope]]` |
| `/pages/x_y/z_w` ×6 | `/guides/x-y/z-w` |

## Proofread fixes on top of the raw port

- `availableIn: [eu]` — home.pl is the only `transfer_incoming_*` guide with no regional
  variants in legacy (3 locales vs 15 for every sibling); all 5 `domains` guides carrying
  `[eu]` show the same pattern.
- Sentence-initial capitalisation (`[rejestrator]` → `[Rejestrator]`).
- Mistranslation fixed: `Rekordy usuwają strefę DNS` ("records delete the DNS zone") →
  `Niektórzy rejestratorzy usuwają…`, matching the source ("some registrars delete…").
- `Musisz również:` list switched from nominal to infinitive forms, with correct
  accusative endings.
- Missing reflexive pronoun (`ani nie zmienił się abonent`).
- `description` expanded from 76 to 144 characters for SERP.

## Verification

- `pnpm sidebar:validate` — pass (1790 links).
- The sidebar entry resolves **only** in PL: the parser drops entries for locales where
  the file is absent (`config/sidebar/parser.ts:429`).
- 9/9 internal `/guides/` targets resolve in `docs/pl`; 4/4 `/links/` keys exist in
  `config/links.ts`.
- External link fetched: HTTP 200, Polish content, correct topic.
- `[[fragment:support-scope]]` — key present, PL body present, correctly placed.
- Proofread pre-pass: 0 candidates.

## Note for reviewers

`DEV_LOCALES=fr,en,pl pnpm sidebar:validate` reports this link as dead. That is a **false
positive**: the validator resolves every locale's links against `docs/fr` only, and this
is the repo's first guide that exists in a non-FR locale alone (current single-locale
guides are FR-only, handled by `FR_ONLY_GUIDE_PATTERNS`). The default invocation passes,
and neither CI nor the pre-commit hook runs this script. Making the validator
locale-aware is left out of this PR as a shared-tooling change.

Known pre-existing defects **not** addressed here: the same mistranslation, nominal-list
and reflexive-pronoun issues are present identically in 6–7 sibling PL transfer guides
(`godaddy`, `hostinger`, `ionos`, `gandi`, `wix`, `_o2switch`). Fixing them is a separate
corpus-wide sweep.
