### PR TITLE
docs(domains): restore the French o2switch incoming transfer guide dropped by the new-docs seed

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -1726,6 +1726,7 @@
                     + [Transferring a domain name from GoDaddy to OVHcloud](web-cloud/domains/transfer-incoming-godaddy)
                     + [Transferring a domain name from Home.pl to OVHcloud](web-cloud/domains/transfer-incoming-homepl)
                     + [Transferring a domain name from Ionos to OVHcloud](web-cloud/domains/transfer-incoming-ionos)
+                    + [Transferring a domain name from o2switch to OVHcloud](web-cloud/domains/transfer-incoming-o2switch)
                     + [Transferring a domain name from Gandi to OVHcloud](web-cloud/domains/transfer-incoming-gandi)
                     + [Transferring a domain name from Wix to OVHcloud](web-cloud/domains/transfer-incoming-wix)
                 + [Outgoing transfer from OVHcloud](web-cloud-domains-domain-names-outgoing-transfer-from-ovhcloud)

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-o2switch.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-o2switch.mdx
@@ -1,0 +1,81 @@
+---
+title: Transférer un nom de domaine de o2switch vers OVHcloud
+description: Découvrez les démarches spécifiques pour transférer un nom de domaine depuis o2switch vers OVHcloud
+lastUpdated: 2026-02-10
+availableIn: [eu, ca, apac]
+---
+
+## Objectif
+
+Le transfert d’un nom de domaine enregistré chez o2switch nécessite une démarche spécifique.
+
+**Découvrez comment transférer un nom de domaine enregistré chez o2switch vers OVHcloud**
+
+:::warning
+Le [bureau d’enregistrement](/links/web/domains-what-is-registrar) d’un nom de domaine représente l’organisation/fournisseur agréé auprès duquel le nom de domaine est enregistré/souscrit par un particulier, une association ou une organisation. C’est auprès de ce même bureau d’enregistrement que vous renouvelez la souscription de votre nom de domaine (généralement une fois par an).
+
+Si OVHcloud est déjà le bureau d’enregistrement de votre nom de domaine **avant** de démarrer la procédure qui va suivre, le transfert entrant de domaine n’est pas la procédure appropriée. La procédure de transfert entrant de domaine s’applique **uniquement** aux noms de domaine enregistrés dans un autre bureau d’enregistrement qu’OVHcloud.
+
+Pour transférer la gestion de votre nom de domaine vers un autre compte client OVHcloud, la méthode adéquate est un **changement de contacts**. La procédure est décrite dans le guide « [Gérer les contacts de ses services](/guides/account-and-service-management/account-information/managing-contacts) ».
+Si vous devez également changer le **titulaire** du nom de domaine, vous devez le faire **avant** de changer les contacts du nom de domaine. Pour cela, suivez les instructions décrites dans notre documentation sur le [changement de titulaire des noms de domaine](/guides/web-cloud/domains/trade-domain).
+:::
+
+## Prérequis
+
+- Le nom de domaine est enregistré chez o2switch.
+- Le nom de domaine existe depuis plus de 60 jours.
+- Le nom de domaine n’a pas été transféré ou n’a pas changé de titulaire au cours des 60 derniers jours.
+- L’état du nom de domaine est « OK » ou « Transférable ».
+- Le nom de domaine n’a pas expiré et sa date d’expiration laisse le temps de terminer le transfert (recommandé : plus de 60 jours).
+
+Vous devez aussi :
+
+- Pouvoir déverrouiller le nom de domaine.
+- Posséder le code de transfert ou pouvoir le récupérer.
+- Être habilité à demander le transfert du nom de domaine.
+- Avoir prévenu le titulaire du nom de domaine et/ou ses administrateurs de la demande de transfert.
+
+[[fragment:support-scope]]
+
+## En pratique
+
+:::info
+La zone DNS active d’un nom de domaine contient la configuration DNS appliquée à votre nom de domaine. C’est elle qui lie votre nom de domaine à vos services tels que vos adresses e-mails ou votre site web.
+
+Si, en complément de votre nom de domaine, vous disposez aussi d’une zone DNS active pour celui-ci chez votre bureau d’enregistrement actuel, vérifiez auprès de ses services que la zone DNS appliquée à votre nom de domaine ne va pas être supprimée une fois le transfert effectué.
+
+En effet, certains bureaux d’enregistrement suppriment la zone DNS présente chez eux dès que le transfert de votre nom de domaine est terminé. Si tel est le cas, recréez à l’identique votre zone DNS chez OVHcloud avant de démarrer les actions liées au transfert de votre nom de domaine.
+
+Pour cela, consultez les guides suivants :
+
+- [Créer une zone DNS chez OVHcloud](/guides/web-cloud/domains/dns-zone-create)
+- [Éditer une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit)
+
+Vérifiez également que votre bureau d’enregistrement actuel ne va pas fermer d’autres services comme, par exemple, les adresses e-mails associées à votre nom de domaine.
+
+Si, en plus du transfert de votre nom de domaine, vous souhaitez migrer les services qui lui sont associés (site web, e-mail, etc.), consultez d’abord notre guide « [Migrer son site web et ses services associés vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh) » avant de poursuivre.
+Ce guide explique en détail comment migrer l’ensemble de vos services sans coupures.
+
+Si vous réalisez uniquement le transfert de votre nom de domaine sans déménager vos autres services, veillez à bien récupérer les serveurs DNS actifs pour votre nom de domaine auprès de votre **bureau d’enregistrement** actuel pour les renseigner directement lors de l’étape 3 du guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ».
+Cela vous évitera d’interrompre l’association entre votre nom de domaine et vos services externes associés.
+:::
+
+### Déverrouiller le nom de domaine et récupérer le code de transfert
+
+Suivez les étapes décrites dans la [documentation dédiée de o2switch](https://faq.o2switch.fr/nom-de-domaine/code-transfert/o2switch/).
+
+### Initier le transfert de nom de domaine chez OVHcloud
+
+Une fois le code de transfert obtenu, transférez votre nom de domaine en suivant les étapes de notre guide « [Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain) ».
+
+## Aller plus loin <a name="go-further"></a>
+
+[Transférer son nom de domaine vers OVHcloud](/guides/web-cloud/domains/transfer-incoming-generic-domain)
+
+[Migrer son site web et ses e-mails vers OVHcloud](/guides/web-cloud/web-hosting/hosting-migrating-to-ovh)
+
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
+
+Si vous souhaitez bénéficier d’une assistance à l’usage et à la configuration de vos solutions OVHcloud, consultez nos différentes [offres de support](/links/support).
+
+Échangez avec notre [communauté d’utilisateurs](/links/community).


### PR DESCRIPTION

## What

Ports the French version of the o2switch incoming domain transfer guide from
`ovh/docs@develop` (`pages/web_cloud/domains/transfer_incoming_o2switch/guide.fr-fr.md`)
into `docs/fr/guides/web-cloud/domains/transfer-incoming-o2switch.mdx`, and registers it
in the sidebar.

## Why

This guide was live in production and was dropped during the migration to new-docs.

In legacy, `flag: hidden` was applied to 13 locale files — every locale **except French**.
That matches the editorial intent: o2switch is a French host, so the guide was surfaced
only in the French market.

Unlike the home.pl case, the migration itself was correct here: commit `8c8ab25757`
produced a full set of routable, up-to-date `.mdx` files for all seven locales, including
`docs/fr/.../transfer-incoming-o2switch.mdx`. The new-docs seed then kept only the
`_`-prefixed (masked, stale) variants. French had no masked variant, so the only publicly
listed version of this guide was discarded.

Evidence it was published: the Wayback Machine holds HTTP 200 captures of
`help.ovhcloud.com/csm/fr-domain-names-transfer-from-o2switch` (KB0062654) from
2024-05-25 through 2024-08-22, plus `fr-ca` (KB0062656). The page now returns a 404 with
no targeted redirect — o2switch is absent from `scripts/slug-mapping.json` entirely,
because that table was built from the FR tree and the FR file no longer existed.

## Scope

- **FR only.** Content is taken from the current legacy `develop`, i.e. **after** PR
  ovh/docs#8799 (`propriétaire` → `titulaire`), not from the stale snapshot the
  `_`-prefixed files still carry.
- The six `_transfer-incoming-o2switch.mdx` files (`de`, `en`, `es`, `it`, `pl`, `pt`)
  are **left masked and untouched** — verified file by file, all still carry
  `flag: hidden`.
- `availableIn: [eu, ca, apac]` is correct here: o2switch had 15 locale files in legacy,
  including `en-ca` and `fr-ca`, so it was genuinely distributed to CA/APAC. (Contrast
  with the home.pl guide, which was EU-only and shipped as `[eu]`.)

## Conversions applied

| Legacy | New |
|---|---|
| `excerpt:` | `description:` |
| `updated:` | `lastUpdated:` |
| `> [!warning]` ×2 | `:::warning` |
| `> [!primary]` | `:::info` |
| Hand-written support disclaimer | `[[fragment:support-scope]]` |
| `/pages/x_y/z_w` ×6 | `/guides/x-y/z-w` |
| Straight apostrophes | Typographic `’` (35) |

Three fixes already applied to the new-docs sibling (`transfer-incoming-godaddy`) by PR
ovh/ovhcloud-docs#500 were never backported to legacy, so the raw port would have
reintroduced them. Aligned on the corrected form: `bureaux d’enregistrements` →
`d’enregistrement`, `en détails` → `en détail`, `serveur DNS` → `serveurs DNS`.

## Corrections on top of the port

**Brand name** — the company spells itself **`o2switch`**, all lowercase (verified on
their own site: page title, headings and body text). Corrected in the guide (6
occurrences) and in the sidebar entry.

**Stale external link** — `faq.o2switch.fr/espace-client/recuperer-code-de-transfert`
returns a **301**. Replaced with the canonical target
`faq.o2switch.fr/nom-de-domaine/code-transfert/o2switch/` (HTTP 200, French, correct
topic).

**Proofread** (FR is a reference locale, so the full four-phase pass including rewording
was run):

- Vague link text `[ce guide]` → `« [Gérer les contacts de ses services](…) »`, matching
  the target guide's actual `title:`.
- Terminology unified: the guide called the same object `code de transfert` three times
  and `code d’autorisation` once.
- `site Web` → `site web` (the file already used lowercase twice; corpus is 95 lowercase
  vs 15 uppercase).
- Missing sentence-final period after a `»` citation.
- Nine rewordings: circumlocutions (`être en mesure de` → `pouvoir`), nominalisations
  (`procéder au transfert de` → `transférez`), tautologies (`enregistré auprès du bureau
  d’enregistrement` → `enregistré chez`), and a subordinate clause that repeated its own
  `###` heading verbatim.

Callout bodies were left untouched, per the proofread rule that admonitions are
intentionally emphatic and out of rewording scope.

## Verification

- `pnpm sidebar:validate` — pass, no false positive (unlike the home.pl PR, the file
  exists in `docs/fr`, the validator's reference locale).
- The sidebar entry resolves **only in FR**: the parser drops entries for locales where
  the file is absent (`config/sidebar/parser.ts:429`).
- Proofread pre-pass: **0 ERROR**. The 3 remaining `missing-NBSP` warnings are dismissed —
  all six sibling FR transfer guides emit exactly the same three, and the FR `domains`
  corpus is 682 regular spaces vs 177 NBSP before `:`.
- 9/9 internal `/guides/` targets resolve in `docs/fr`; link labels were checked against
  each target's real `title:`, not just for existence.
- 4/4 `/links/` keys exist in `config/links.ts`.
- `[[fragment:support-scope]]` — key present, FR body present, correctly placed.
- Zone check (§12): `availableIn` spans three zones, but the body contains no
  zone-dependent content — no `<Region>`, no `mail.ovh.net`/`.ca`, no `dnsNN`, no
  `eu`/`ca.api`, no EU-only product.
- YAML parses; no straight apostrophes; trailing newline present.

## Note for reviewers

The six masked locale files are now stale relative to this FR version, both for the brand
casing and for the reworded passages. They are intentionally out of scope for this PR:
they are not routed, not displayed, and were explicitly frozen. Refreshing them is a
`/translate` task if these guides are ever unmasked.

The four sibling FR transfer guides still carry the defects fixed here (`[ce guide]`,
`site Web`, the missing final period, and the same verbose phrasings). A corpus-wide sweep
is deliberately left out of this PR.
