### PR TITLE
fix(docs): correct EN source defects in Public Cloud Analytics guides

### DIFF
--- a/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/de/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/de/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/de/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/de/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -69,7 +69,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -68,7 +68,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -76,7 +76,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -55,7 +55,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/en-gb/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/en-gb/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
@@ -29,9 +29,9 @@ When your service storage begins to fill up and reaches a high mark, the Analyti
 
 When the disk usage increases even more and reaches a critical level (depending on the engine, ranging from 90% to 95%), you will receive another email notification and the service will turn to a "disk full" mode, where it will start to refuse writes.
 
-### How to handle a disk full situation ?
+### How to handle a disk full situation?
 
-Different engines react in different ways, thus Analyticss services react differently when facing disk full conditions:
+Different engines react in different ways, thus Analytics services react differently when facing disk full conditions:
 
 - `Kafka MirrorMaker`, `Dashboards` and `Kafka Connect` do not store any user data on disk. Thus they will not fill up the underlying disk storage.
 - `Kafka` and `OpenSearch` turn to read-only.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -73,7 +73,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -70,7 +70,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -78,7 +78,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/pricing.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/pricing.mdx
@@ -180,7 +180,7 @@ The complete billing report for this example would therefore contain the followi
 
 This example shows how usage from multiple services is aggregated by billing reference before being reported on the invoice.
 
-## We want your feedback
+## We want your feedback!
 
 We would love to help answer questions and appreciate any feedback you may have.
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -62,7 +62,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/es/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/es/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/es/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/es/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -69,7 +69,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -68,7 +68,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -76,7 +76,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -55,7 +55,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/it/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/it/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/it/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/it/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -69,7 +69,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -68,7 +68,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -76,7 +76,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -55,7 +55,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/pl/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/pl/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -69,7 +69,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -68,7 +68,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -76,7 +76,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -55,7 +55,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -50,7 +50,7 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 3-AZ Regions are particularly suited to mission-critical and availability-sensitive applications, where data governance requires continuous availability. This includes sectors such as e-commerce, healthcare platforms, financial services or live streaming applications.
 
-## Go Further
+## Go further
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -61,7 +61,7 @@ You can upgrade the node template of your cluster to scale your hardware resourc
 
 #### Disk type
 
-The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](https://www.ovhcloud.com/pt/public-cloud/regions-availability/)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
+The type of storage available may vary according to the region your cluster lives in: see our page "[Availability of Public Cloud products](/links/public-cloud/regions-pci)" for more information about block storage type availability depending on region. Thus, your cluster may be backed by e.g. *High Speed* or *High Speed Gen2* block storage.
 
 Also, the performance characteristics of the various storage offerings may vary depending on e.g. the storage size your cluster uses: *High Speed* may offer better iops than *High Speed Gen2* for some disk sizes. See the [Block Storage page](https://www.ovhcloud.com/pt/public-cloud/block-storage/) for more information about those performance characteristics.
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -20,7 +20,7 @@ In addition to [the responsibility model for Analytics services](/guides/public-
 - CSA type 1
 - C5 type 1
 
-## 2.Best pratices to be deployed on the service
+## 2.Best practices to be deployed on the service
 
 ### 2.1 Recommendations once the service is delivered
 
@@ -109,7 +109,7 @@ For a MongoDB engine:
 - **Nodes:** service instances and the underlying VMs use full volume encryption using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup) with a randomly generated ephemeral key for each instance and each volume. 
 The key is never re-used and will be trashed at the destruction of the instance, so there’s a natural key rotation with roll-forward upgrades. 
 We use the LUKS2 mode aes-cbc-essiv:sha256 with a 512-bit key.
-- **Backups:** backups are encrypted with a randomly generated key. This key is Asymetric RSA4096.
+- **Backups:** backups are encrypted with a randomly generated key. This key is asymmetric RSA4096.
 
 For all the Analytics engines such as Kafka, OpenSearch and so on, at-rest data encryption covers both active service instances as well as service backups in cloud object storage:
 
@@ -153,7 +153,7 @@ You can import and export your data following recommendations provided by editor
 
 ### 9.1 Erasure of customer data
 
-Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are relased automtically, including used encryption keys.<br/>
+Once you destroy your Public Cloud project (your Analytics project) in the OVHcloud Control Panel, all allocated resources are released automatically, including used encryption keys.<br/>
 As the encryption keys are unique for each project, they will be deleted after service decommissioning. Data can not be retrieved after.
 
 ## Go further

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -118,7 +118,7 @@ kubectl apply -f cr.yaml
 You can check it has been properly created using this command:
 
 ```bash
-kubectl kubectl -n ovhcloud get database
+kubectl -n ovhcloud get database
 NAME                              AGE
 public-cloud-databases-operator   59m
 ```

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/kafka-connect-cluster-cli.mdx
@@ -69,7 +69,7 @@ ssl.certificate.location=/home/user/kafkacat/service.cert
 
 In our example, the cluster address and port are **kafka-f411d2ae-f411d2ae.database.cloud.ovh.net:20186** and the previously downloaded CA certificates are in the **/home/user/kafkacat/** folder.
 
-Change theses values according to your own configuration.
+Change these values according to your own configuration.
 
 ##### **Kafka producer**
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/kafka-create-cluster.mdx
@@ -68,7 +68,7 @@ A summary of your order is display to help you review your service configuration
 
 ![Review order](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.1.v2.png)
 
-The components of the price is also summarized with a monthly estimation.
+The components of the price are also summarized with a monthly estimation.
 
 ![Review pricing](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.2.v2.png)
 
@@ -76,7 +76,7 @@ Click the `API and Terraform equivalent` button to open the following window:
 
 ![API and Terraform equivalent](/images/guides/public-cloud/data-analytics/analytics/kafka-create-cluster/kafka_configuration.3.v2.png)
 
-The informations displayed in this window could help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
+The information displayed in this window can help you automate your service creation with the [OVHcloud API](/guides/manage-and-operate/api/first-steps) or the OVHcloud Terraform Provider.
 
 When you are ready click the `Order` button to create your service.
 In a matter of minutes, your new Apache Kafka service will be deployed.

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -55,7 +55,7 @@ You will find a reminder of all these options in the order summary.
 
 You can choose a different region for your new service.
 
-<img className="thumbnail" alt="selec tRegion" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
+<img className="thumbnail" alt="Select region" src="/images/public-cloud/data-analytics/analytics/analytics-restore-backup/select-region.png" loading="lazy" />
 
 #### Restore point
 


### PR DESCRIPTION
Nine defect classes found while translating the data-analytics family into French. Fixes the English source and the locale trees that still carry English bodies.

Content and correctness:
- database-operator: "kubectl kubectl -n ovhcloud get database" repeated the command word, so the block failed when copy-pasted.
- clickhouse-capabilities-limitations: a hardcoded en-gb URL for the Public Cloud availability page sent every non-English locale to the English site. Now uses the /links/public-cloud/regions-pci key, which resolves per locale. Note the key is named regions-pci, not regions-availability.

Spelling and grammar:
- concepts-security-overview: "Best pratices", "Asymetric", "relased automtically".
- handling-disk-full: "Analyticss services".
- kafka-connect-cluster-cli: "Change theses values".
- kafka-create-cluster: "The components of the price is also summarized"; "The informations displayed ... could help".
- restore-backup: alt="selec tRegion" on a screenshot.

Heading variants normalised to the family standard:
- "## Go Further" -> "## Go further" (analytics-regions-comparison)
- "## We want your feedback" -> "... feedback!" (pricing)
- "disk full situation ?" -> "situation?" (handling-disk-full) No guide links to these anchors, so no slug references break.

Scope: docs/en plus the de/es/it/pl/pt real files. FR is deliberately untouched - those guides are translated on i18n/fr-analytics, and the defects only survive in FR as untranslated English bodies that the translation replaces. The two branches share no files and merge clean in either order.

Symlinked locale pages are not in this changeset: they resolve to the EN file, which is fixed here, so they inherit the correction.

Verified: 44/44 compile via @mdx-js/mdx.