### PR TITLE
docs: translate the missing Domains/DNS guides into de, es, it, pl and pt

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-ips-update.mdx
@@ -1,64 +1,64 @@
 ---
-title: "List of IP addresses of OVHcloud DNS servers"
-description: "Find out the updated IP addresses for OVHcloud DNS servers"
+title: Liste der IP-Adressen der OVHcloud DNS-Server
+description: Erfahren Sie, welche neuen IP-Adressen für die OVHcloud DNS-Server gelten
 lastUpdated: 2025-08-07
 availableIn: [eu, ca, apac]
 ---
 
 import { Region } from '@components/Zone';
 
-## Objective
+## Ziel
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+Dieser Leitfaden erläutert die Änderungen der IP-Adressen, die einen Teil unserer in Europa gehosteten DNS-Server betreffen und ab **August 2025** gelten.
 
-**Discover the list of new IP addresses for OVHcloud DNS servers.**
+**Entdecken Sie die Liste der neuen IP-Adressen der OVHcloud DNS-Server.**
 
-## Requirements
+## Voraussetzungen
 
-- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
+- Sie haben Zugriff auf Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink>, um den betreffenden Domainnamen zu verwalten.
 
-## Instructions
+## In der praktischen Anwendung
 
-### Who is concerned?
+### Wer ist betroffen?
 
-This change can impact customers who:
+Diese Änderung kann Kunden betreffen, die:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
-- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
+- in den DNS-Einträgen vom Typ `NS` ihrer DNS-Zone einen individuellen DNS-Servernamen definiert und diesem Namen über einen DNS-Eintrag vom Typ `A` die IP-Adresse eines OVHcloud DNS-Servers zugewiesen haben.
+- zusätzlich einen `GLUE`-Eintrag für diesen individuellen Namen konfiguriert haben, um ihn in der Konfiguration der DNS-Server des Domainnamens mit der IP-Adresse eines OVHcloud DNS-Servers zu verknüpfen.
+- diesen individuellen Namen derzeit als DNS-Server ihres Domainnamens verwenden (definiert in ihrem Kundencenter oder bei ihrer Registrierungsstelle).
 
-For more information, please read our guide on [Customizing a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+Weitere Informationen hierzu finden Sie in unserer Anleitung "[DNS-Server eines Domainnamens individualisieren (Glue Records)](/guides/web-cloud/domains/glue-registry)".
 
 :::warning
-If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
+Wenn Sie keine manuellen Änderungen an der DNS-Konfiguration vorgenommen haben (Standardeinstellung), sind Sie von dieser Änderung nicht betroffen.
 :::
 
-### Schedule
+### Zeitplan
 
-| Step                                | Estimated date           |
+| Schritt | Voraussichtliches Datum |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
-| Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
-| Deletion of IPv4 traffic          | Early October 2025 |
+| Löschung des IPv6-Traffics auf den alten IP-Adressen | Erfolgt am 5. August 2025 |
+| Inbetriebnahme der neuen IP-Adressen | Ab dem 5. August 2025 |
+| Versand der ersten Informations-E-Mail an die identifizierten Kunden | Mitte August 2025 |
+| Versand der zweiten Erinnerungs-E-Mail | 15. September 2025 |
+| Löschung des IPv4-Traffics | Anfang Oktober 2025 |
 
 :::warning
-Using old IP addresses after this date will cause DNS resolution failure for domain names whose configuration has not been updated.
+Die Verwendung der alten IP-Adressen nach diesem Datum führt zum Fehlschlagen der DNS-Auflösung für die Domainnamen, deren Konfiguration nicht aktualisiert wurde.
 :::
 
-### What can I do if I am concerned?
+### Was kann ich tun, wenn ich betroffen bin?
 
-1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+1. Prüfen Sie, ob Sie in Ihrer DNS-Zone noch eine alte IP-Adresse verwenden.
+2. **Ersetzen Sie diese** durch die neue IP-Adresse (siehe Tabelle unten).
+3. [Aktualisieren Sie Ihre GLUE Records](/guides/web-cloud/domains/glue-registry), falls Sie in Ihrem OVHcloud Kundencenter einen solchen Eintrag konfiguriert haben.
 
-### IP address mapping table
+### Zuordnungstabelle der IP-Adressen
 
-| Hostname     | Old IPv4   | New IPv4   | Old IPv6       | New IPv6         |
-|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 <Region zones={['eu']}>
 
+| Hostname     | Alte IPv4   | Neue IPv4   | Alte IPv6       | Neue IPv6         |
+|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |
@@ -123,10 +123,10 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 </Region>
 
-## Go further
+## Weiterführende Informationen
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
 
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,1 +1,86 @@
-../../../../en/guides/web-cloud/domains/dns-zonemaster.mdx
+---
+title: Tutorial - Zonemaster verwenden
+description: Erfahren Sie, wie Sie die DNS-Konfiguration eines Domainnamens mit Zonemaster analysieren und verbesserungswürdige Elemente identifizieren
+lastUpdated: 2026-02-10
+availableIn: [eu, ca, apac]
+---
+
+[[fragment:support-scope]]
+
+## Ziel
+
+[Zonemaster](https://zonemaster.net/en/) ist ein Tool, das in Zusammenarbeit zwischen [AFNIC](https://www.afnic.fr/) (der französischen Registry) und [The Swedish Internet Foundation](https://internetstiftelsen.se/en/) (der schwedischen Registry) entstanden ist. Damit können Sie die DNS-Konfiguration (Domain Name System) eines Domainnamens analysieren und die Elemente identifizieren, die verbessert oder korrigiert werden können.
+
+:::info
+Um das Konzept des DNS besser zu verstehen, lesen Sie bitte unsere Anleitung "[Alle Informationen zur DNS-Zone](/guides/web-cloud/domains/dns-zone-general-information)".
+:::
+
+## Voraussetzungen
+
+- Sie verfügen über einen [Domainnamen](/links/web/domains).
+
+## In der praktischen Anwendung
+
+### Eingabefeld
+
+Mit dem Tool Zonemaster können Sie eine bereits für einen Domainnamen bestehende DNS-Konfiguration prüfen oder eine auf zukünftigen DNS-Servern vorkonfigurierte DNS-Zone testen.
+
+Um die aktuelle Konfiguration eines Domainnamens zu prüfen, geben Sie Ihren Domainnamen ein und klicken Sie auf <code className="action">Run test</code>
+
+<img className="thumbnail" alt="Screenshot des Zonemaster-Formulars. Der Domainname &quot;domain.tld&quot; wurde eingegeben und kann getestet werden." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+
+Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf den betreffenden Domainnamen angewendet haben, aktivieren Sie das Kästchen <code className="action">Options</code> und geben Sie die folgenden Informationen ein:
+
+- **Name servers**: Geben Sie die Daten des Nameservers ein, der einem Domainnamen zugeordnet ist. Klicken Sie auf <code className="action">+</code>, um einen weiteren Nameserver hinzuzufügen. Die Eingabe einer IP-Adresse ist optional.
+- **Delegation Signer (DS record)**: Geben Sie im Rahmen des DNSSEC-Schutzes die Daten des DS-Eintrags ein. Klicken Sie auf <code className="action">+</code>, um einen weiteren DS-Eintrag hinzuzufügen. Wenn die DNS-Server das DNSSEC-Protokoll nicht verwenden, können Sie diese Felder leer lassen. Bei einer mit DNSSEC signierten Zone können Sie mit dieser Funktion vor der Veröffentlichung prüfen, ob die Zone mit einem validierenden Resolver und den DS-Einträgen, die Sie veröffentlichen möchten, korrekt funktioniert.
+
+Über die Kästchen `Disable IPv6` und `Disable IPv4` können Sie die Prüfungen zudem auf ein bestimmtes IP-Protokoll beschränken
+
+> **Beispiel**:
+>
+> Sie sind Inhaber des Domainnamens "domain.tld", der derzeit die DNS-Server "dnsXX.ovh.net" und "nsXX.ovh.net" verwendet.
+>
+> Sie haben für diesen Domainnamen eine DNS-Zone auf den DNS-Servern "dns1.test.tld" und "dns2.test.tld" konfiguriert.
+>
+> Vor dem Wechsel der DNS-Server können Sie über das Kästchen <code className="action">Options</code> eine erweiterte Suche durchführen, indem Sie "dns1.test.tld" und "dns2.test.tld" in die Felder `Name servers` eintragen.
+>
+> Zonemaster führt dann einen Test durch, als würden Sie die Server "dns1.test.tld" und "dns2.test.tld" für "domain.tld" verwenden.
+>
+> <img className="thumbnail" alt="Screenshot der erweiterten Optionen des Zonemaster-Formulars. Die beiden Nameserver &quot;dns1.test.tld&quot; und &quot;dns2.test.tld&quot; wurden im Bereich &quot;Name servers&quot; des Formulars eingetragen." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+
+:::info
+Wenn Sie einen Domainnamen eingeben und auf die Schaltflächen <code className="action">Fetch NS from parent zone</code> und <code className="action">Fetch DS from parent zone</code> klicken, werden die dem Domainnamen zugeordneten DNS-Server angezeigt sowie die Daten des DS-Eintrags (DNSSEC), sofern einer konfiguriert wurde.
+
+<img className="thumbnail" alt="Screenshot der Zonemaster-Ergebnisseite für den Domainnamen &quot;domain.tld&quot;. Der Bereich &quot;Addresses&quot; ist aufgeklappt." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+:::
+
+### Ergebnis
+
+Nach dem Absenden des Formulars werden die Ergebnisse nach Testgruppen angezeigt. Die Tests sind nach Schweregrad sortiert.
+
+- **Error**: Dieser Bereich zeigt Fehler oder fehlende Elemente an, die zu einer Fehlfunktion führen können.
+- **Warning**: Dieser Bereich ist funktionsfähig, verdient jedoch besondere Aufmerksamkeit. Das Tool hat festgestellt, dass ein Parameter nicht dem Standard seiner Kategorie entspricht, ohne dass dies den Betrieb blockiert.
+- **Notice**: Hierbei handelt es sich um eine reine Information ohne besondere Auswirkungen auf die Funktion des Domainnamens.
+- **Info**: Dieser Bereich ist funktionsfähig und erfüllt die Standardkriterien seiner Kategorie.
+
+Für jeden Test können weitere Details abgerufen werden, zum Beispiel um im Fall einer Fehlfunktion den Fehler nachzuvollziehen oder einfach zur Information.
+
+<img className="thumbnail" alt="Screenshot der Zonemaster-Ergebnisseite mit den nach Schweregrad sortierten Testgruppen." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+
+### Nützliche Informationen
+
+Wenn Sie weitere Fragen zu Zonemaster haben, lesen Sie den Bereich [FAQ](https://zonemaster.net/en/faq) auf [https://zonemaster.net/](https://zonemaster.net/).
+
+## Weiterführende Informationen <a name="go-further"></a>
+
+[Alle Informationen zu DNS-Servern](/guides/web-cloud/domains/dns-server-general-information).
+
+[Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit).
+
+[Domainnamen mit DNSSEC gegen Cache Poisoning schützen](/links/web/domains-dnssec).
+
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
+
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
+
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Zonemaster verwenden
 description: Erfahren Sie, wie Sie die DNS-Konfiguration eines Domainnamens mit Zonemaster analysieren und verbesserungswürdige Elemente identifizieren
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ Mit dem Tool Zonemaster können Sie eine bereits für einen Domainnamen bestehen
 
 Um die aktuelle Konfiguration eines Domainnamens zu prüfen, geben Sie Ihren Domainnamen ein und klicken Sie auf <code className="action">Run test</code>
 
-<img className="thumbnail" alt="Screenshot des Zonemaster-Formulars. Der Domainname &quot;domain.tld&quot; wurde eingegeben und kann getestet werden." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster-Formular mit eingegebenem Domainnamen, bereit zum Testen." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf den betreffenden Domainnamen angewendet haben, aktivieren Sie das Kästchen <code className="action">Options</code> und geben Sie die folgenden Informationen ein:
 
@@ -46,12 +46,12 @@ Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf d
 >
 > Zonemaster führt dann einen Test durch, als würden Sie die Server "dns1.test.tld" und "dns2.test.tld" für "domain.tld" verwenden.
 >
-> <img className="thumbnail" alt="Screenshot der erweiterten Optionen des Zonemaster-Formulars. Die beiden Nameserver &quot;dns1.test.tld&quot; und &quot;dns2.test.tld&quot; wurden im Bereich &quot;Name servers&quot; des Formulars eingetragen." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Erweiterte Optionen des Zonemaster-Formulars mit zwei eingetragenen Nameservern." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Wenn Sie einen Domainnamen eingeben und auf die Schaltflächen <code className="action">Fetch NS from parent zone</code> und <code className="action">Fetch DS from parent zone</code> klicken, werden die dem Domainnamen zugeordneten DNS-Server angezeigt sowie die Daten des DS-Eintrags (DNSSEC), sofern einer konfiguriert wurde.
 
-<img className="thumbnail" alt="Screenshot der Zonemaster-Ergebnisseite für den Domainnamen &quot;domain.tld&quot;. Der Bereich &quot;Addresses&quot; ist aufgeklappt." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster-Ergebnisseite für den Domainnamen mit aufgeklapptem Bereich Addresses." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Ergebnis
@@ -65,7 +65,7 @@ Nach dem Absenden des Formulars werden die Ergebnisse nach Testgruppen angezeigt
 
 Für jeden Test können weitere Details abgerufen werden, zum Beispiel um im Fall einer Fehlfunktion den Fehler nachzuvollziehen oder einfach zur Information.
 
-<img className="thumbnail" alt="Screenshot der Zonemaster-Ergebnisseite mit den nach Schweregrad sortierten Testgruppen." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster-Ergebnisseite mit den nach Schweregrad sortierten Testgruppen." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Nützliche Informationen
 

--- a/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -29,12 +29,12 @@ Um die aktuelle Konfiguration eines Domainnamens zu prüfen, geben Sie Ihren Dom
 
 <img className="thumbnail" alt="Zonemaster-Formular mit eingegebenem Domainnamen, bereit zum Testen." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf den betreffenden Domainnamen angewendet haben, aktivieren Sie das Kästchen <code className="action">Options</code> und geben Sie die folgenden Informationen ein:
+Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf den betreffenden Domainnamen angewendet haben, aktivieren Sie das Kästchen <code className="action">Show options</code> und geben Sie die folgenden Informationen ein:
 
-- **Name servers**: Geben Sie die Daten des Nameservers ein, der einem Domainnamen zugeordnet ist. Klicken Sie auf <code className="action">+</code>, um einen weiteren Nameserver hinzuzufügen. Die Eingabe einer IP-Adresse ist optional.
-- **Delegation Signer (DS record)**: Geben Sie im Rahmen des DNSSEC-Schutzes die Daten des DS-Eintrags ein. Klicken Sie auf <code className="action">+</code>, um einen weiteren DS-Eintrag hinzuzufügen. Wenn die DNS-Server das DNSSEC-Protokoll nicht verwenden, können Sie diese Felder leer lassen. Bei einer mit DNSSEC signierten Zone können Sie mit dieser Funktion vor der Veröffentlichung prüfen, ob die Zone mit einem validierenden Resolver und den DS-Einträgen, die Sie veröffentlichen möchten, korrekt funktioniert.
+- **Nameservers**: Geben Sie die Daten des Nameservers ein, der einem Domainnamen zugeordnet ist. Sobald der vorherige Block ausgefüllt ist, erscheint automatisch ein neuer Block `Nameserver`, sodass Sie mehrere angeben können. Die Eingabe einer IP-Adresse ist optional.
+- **DS records**: Geben Sie im Rahmen des DNSSEC-Schutzes die Daten des DS-Eintrags ein. Sobald der vorherige Block ausgefüllt ist, erscheint automatisch ein neuer Block `DS record`. Wenn die DNS-Server das DNSSEC-Protokoll nicht verwenden, können Sie diese Felder leer lassen. Bei einer mit DNSSEC signierten Zone können Sie mit dieser Funktion vor der Veröffentlichung prüfen, ob die Zone mit einem validierenden Resolver und den DS-Einträgen, die Sie veröffentlichen möchten, korrekt funktioniert.
 
-Über die Kästchen `Disable IPv6` und `Disable IPv4` können Sie die Prüfungen zudem auf ein bestimmtes IP-Protokoll beschränken
+Über die Optionen `IPv4 and IPv6`, `IPv4 only` und `IPv6 only` können Sie die Prüfungen zudem auf ein bestimmtes IP-Protokoll beschränken
 
 > **Beispiel**:
 >
@@ -42,14 +42,14 @@ Um eine DNS-Konfiguration zu prüfen, die Sie vorbereitet, aber noch nicht auf d
 >
 > Sie haben für diesen Domainnamen eine DNS-Zone auf den DNS-Servern "dns1.test.tld" und "dns2.test.tld" konfiguriert.
 >
-> Vor dem Wechsel der DNS-Server können Sie über das Kästchen <code className="action">Options</code> eine erweiterte Suche durchführen, indem Sie "dns1.test.tld" und "dns2.test.tld" in die Felder `Name servers` eintragen.
+> Vor dem Wechsel der DNS-Server können Sie über das Kästchen <code className="action">Show options</code> eine erweiterte Suche durchführen, indem Sie "dns1.test.tld" und "dns2.test.tld" in die Felder `Nameservers` eintragen.
 >
 > Zonemaster führt dann einen Test durch, als würden Sie die Server "dns1.test.tld" und "dns2.test.tld" für "domain.tld" verwenden.
 >
 > <img className="thumbnail" alt="Erweiterte Optionen des Zonemaster-Formulars mit zwei eingetragenen Nameservern." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Wenn Sie einen Domainnamen eingeben und auf die Schaltflächen <code className="action">Fetch NS from parent zone</code> und <code className="action">Fetch DS from parent zone</code> klicken, werden die dem Domainnamen zugeordneten DNS-Server angezeigt sowie die Daten des DS-Eintrags (DNSSEC), sofern einer konfiguriert wurde.
+Wenn Sie einen Domainnamen eingeben und auf die Schaltflächen <code className="action">Fetch nameservers from parent zone</code> und <code className="action">Fetch DS from parent zone</code> klicken, werden die dem Domainnamen zugeordneten DNS-Server angezeigt sowie die Daten des DS-Eintrags (DNSSEC), sofern einer konfiguriert wurde.
 
 <img className="thumbnail" alt="Zonemaster-Ergebnisseite für den Domainnamen mit aufgeklapptem Bereich Addresses." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
@@ -77,7 +77,7 @@ Wenn Sie weitere Fragen zu Zonemaster haben, lesen Sie den Bereich [FAQ](https:/
 
 [Bearbeiten der OVHcloud DNS-Zone](/guides/web-cloud/domains/dns-zone-edit).
 
-[Domainnamen mit DNSSEC gegen Cache Poisoning schützen](/links/web/domains-dnssec).
+[Domainnamen mit DNSSEC gegen Cache Poisoning schützen](/guides/web-cloud/domains/dns-dnssec).
 
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 

--- a/docs/de/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-icloud.mdx
@@ -1,97 +1,116 @@
 ---
-title: "How to use an OVHcloud domain with iCloud Mail"
-description: "Find out how to configure your OVHcloud domain name with iCloud to create custom email addresses"
-lastUpdated: 2025-08-27
+title: Einen OVHcloud Domainnamen mit iCloud Mail verwenden
+description: Erfahren Sie, wie Sie Ihren OVHcloud Domainnamen mit iCloud konfigurieren, um personalisierte E-Mail-Adressen zu erstellen
+lastUpdated: 2026-03-27
 availableIn: [eu, ca, apac]
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 [[fragment:support-scope]]
 
-## Objective
+## Ziel
 
-This guide explains how to use an OVHcloud-registered domain name with the Apple iCloud Mail service. You can then create custom email addresses (`firstname@mydomain.com`), which are fully managed and hosted by Apple.
+Diese Anleitung erklärt Ihnen, wie Sie einen bei OVHcloud registrierten Domainnamen mit dem Dienst iCloud Mail von Apple verwenden. So können Sie personalisierte E-Mail-Adressen (`vorname@meinedomain.de`) erstellen, die vollständig von Apple verwaltet und gehostet werden.
 
-## Requirements
+## Voraussetzungen
 
-- A [domain name](/links/web/domains) registered with OVHcloud.
-- You have access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- You have the rights to manage the DNS zone for the domain name concerned via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- An Apple ID with an **iCloud+** subscription.
+- Sie verfügen über einen bei OVHcloud registrierten [Domainnamen](/links/web/domains).
+- Sie verfügen über eine Apple-ID mit einem **iCloud+** Abonnement.
 
-## Instructions
+{/* CP-NAV-START:web-dns-zone */}
+---
 
-### Step 1: Activate the domain name in iCloud <a id="step1"></a>
+### Zugriff auf das OVHcloud Kundencenter
 
-To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section, to find the DNS records to add to your OVHcloud DNS zone.
+- **Direkter Link:** <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink>
+- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">DNS-Zone</code> > Wählen Sie Ihren Domainnamen aus
 
-At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
+---
+{/* CP-NAV-END:web-dns-zone */}
 
-### Step 2: Configure the DNS records in your OVHcloud Control Panel
+## In der praktischen Anwendung
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-2. Go to the `Web Cloud` section.
-3. Click `DNS zones`, then choose the domain name concerned.
-4. Add or edit the records mentioned below.
+### 1 - Den Domainnamen in iCloud aktivieren <a name="step1"></a>
 
-To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+Um Ihren Domainnamen in iCloud zu aktivieren, folgen Sie den Anweisungen auf der Seite "Add a domain you own to iCloud Mail on iCloud.com" der [offiziellen Apple Dokumentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Konzentrieren Sie sich auf den Abschnitt "Step 3: Update the records with your domain registrar", um die DNS-Einträge zu ermitteln, die Sie Ihrer OVHcloud DNS-Zone hinzufügen müssen.
 
-Using the DNS records you previously retrieved ([Step 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
+Am Ende dieses Schritts sendet Ihnen Apple eine Liste der DNS-Einträge (MX, CNAME, TXT), die Sie in Ihrer OVHcloud DNS-Zone konfigurieren müssen. Bewahren Sie diese für den nächsten Schritt auf.
 
-- **MX** : for receiving emails.
-- **CNAME**: for DKIM keys (`sig1._domainkey...`, `sig2._domainkey...`).
-- **TXT**: for SPF (merge if an SPF record already exists).
-- **TXT DMARC**: Optional but recommended ([Step 3](#step3)).
+### 2 - Die DNS-Einträge in Ihrem OVHcloud Kundencenter konfigurieren
+
+Klicken Sie auf die untenstehenden Tabs, um die **2** Schritte nacheinander anzuzeigen.
+
+<Tabs>
+  <Tab label="Schritt 1">
+    Gehen Sie auf die Seite <ManagerLink to="/#/web/zone">DNS-Zone</ManagerLink> und wählen Sie den betreffenden Domainnamen aus.
+
+    <img className="thumbnail" alt="Screenshot des OVHcloud Kundencenters mit der Liste der DNS-Zonen." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+  </Tab>
+  <Tab label="Schritt 2">
+    Wie Sie die einzelnen Typen von DNS-Einträgen (MX, CNAME, TXT etc.) hinzufügen, ändern oder löschen, erfahren Sie in unserer Anleitung "[Alle Informationen zu DNS-Einträgen](/guides/web-cloud/domains/dns-zone-records)".
+
+    Erstellen oder aktualisieren Sie anhand der zuvor ermittelten DNS-Einträge ([Teil 1](#step1)) die entsprechenden Felder in Ihrer OVHcloud DNS-Zone:
+
+    - **MX**: für den Empfang von E-Mails.
+    - **CNAME**: für die DKIM-Schlüssel (`sig1._domainkey...`, `sig2._domainkey...`).
+    - **TXT**: für SPF (zusammenführen, falls bereits ein SPF-Eintrag vorhanden ist).
+    - **TXT DMARC**: optional, aber empfohlen ([Teil 3](#step3)).
+
+    :::warning
+    Verwenden Sie ausschließlich die geraden Anführungszeichen `”`, wie sie in der technischen Dokumentation von Apple erscheinen (in der Regel auf Englisch). Die in manchen Übersetzungen angezeigten typografischen Anführungszeichen « » oder “ “ dürfen in der DNS-Konfiguration nicht verwendet werden.
+
+    :::
+
+  </Tab>
+</Tabs>
+
+### 3 - Einen DMARC-Eintrag hinzufügen (optional) <a name="step3"></a>
+
+Um die Zustellbarkeit Ihrer E-Mails zu verbessern und zu vermeiden, dass Ihre Nachrichten als Spam eingestuft werden, fügen Sie einen **DMARC**-Eintrag hinzu.
+
+Wie Sie einen DMARC-Eintrag im OVHcloud Kundencenter erstellen, erfahren Sie in unserer Anleitung "[E-Mail-Sicherheit durch DMARC-Eintrag verbessern](/guides/web-cloud/domains/dns-zone-dmarc)".
+
+### 4 - Die Domain in iCloud überprüfen und aktivieren
+
+Sobald die DNS-Einträge (MX, CNAME, TXT, DMARC) korrekt in Ihrer OVHcloud DNS-Zone hinzugefügt wurden, kehren Sie zu [iCloud.com](https://www.icloud.com) zurück.
+
+Folgen Sie den Anweisungen auf der Seite "Add a domain you own to iCloud Mail on iCloud.com" der [offiziellen Apple Dokumentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Konzentrieren Sie sich auf den Abschnitt "Step 4: Finish setting up the domain".
+
+Nach Abschluss dieses Schritts ist Ihr personalisierter Domainname vollständig aktiviert und Sie können bis zu 3 Adressen pro Person innerhalb Ihrer Familie erstellen.
 
 :::warning
-Use only the quotation marks `"` as they appear in Apple's technical documentation (usually in English). The quotation marks « » or " " displayed in some translations should not be used in DNS configuration.
+Die Überprüfung kann fehlschlagen, wenn Ihre DNS-Einträge noch nicht propagiert wurden. Diese Propagation kann mehrere Stunden dauern.
+
 :::
 
-### Step 3: Add a DMARC record (optional) <a id="step3"></a>
+### Häufige Fehlerbehebungen
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+#### Prüfen, wo die DNS-Zone verwaltet wird
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, please refer to our guide on [Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+Wenn Ihr Domainname mit DNS-Servern außerhalb von OVHcloud verknüpft ist (Wix, Squarespace, Cloudflare etc.), muss die Konfiguration in der Verwaltungsoberfläche dieser DNS-Server vorgenommen werden, also außerhalb des OVHcloud Kundencenters.
 
-### Step 4: Verify and activate the domain in iCloud
+#### CNAME bereits vorhanden
 
-Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
+- Ein **CNAME**-Eintrag kann nicht zusammen mit einem **A-, AAAA- oder TXT**-Eintrag bestehen, der für dieselbe Domain oder Subdomain konfiguriert ist.
+- Löschen Sie den alten Eintrag, bevor Sie den von Apple angeforderten CNAME erstellen.
 
-Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
+#### Doppelter SPF
 
-Once this step is complete, your custom domain is fully activated and you can create up to 3 addresses per person within your family.
+- Pro Domainname darf es nur **einen einzigen SPF-Eintrag** geben. Wenn bereits ein OVHcloud SPF-Eintrag vorhanden ist (z. B.: `v=spf1 include:mx.ovh.com ~all`), führen Sie ihn mit dem von Apple bereitgestellten Eintrag zusammen (z. B.: `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
-:::warning
-Validation may fail if your DNS records have not yet been propagated. This propagation may take several hours.
-:::
+#### Unvollständiges DKIM
 
-### Common troubleshooting
+- Apple fordert Sie auf, mehrere DKIM-Schlüssel (`sig1`, `sig2` etc.) in Ihrer DNS-Zone zu speichern.
 
-#### Check where the DNS zone is managed
+#### Propagationsdauer
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc. ), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+- DNS-Änderungen können mehrere Stunden (bis zu 24 Stunden) dauern, bis sie von Apple erkannt werden.
 
-#### CNAME already exists
+## Weiterführende Informationen
 
-- A **CNAME** record cannot coexist with a **A, AAAA, or TXT** record configured on the same domain or subdomain.
-- Delete the old record before creating the CNAME requested by Apple.
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-#### Duplicate SPF
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
 
-- There can only be **one SPF record** per domain name. If an OVHcloud SPF record already exists (e.g.: `v=spf1 include:mx.ovh.com ~all`), merge it with the one provided by Apple (e.g.:
-`v=spf1 include:mx.ovh.com include:icloud.com ~all`).
-
-#### Incomplete DKIM
-
-- Apple invites you to save several DKIM keys (`sig1`, `sig2`, etc.) in your DNS zone.
-
-#### Propagation time
-
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
-
-## Go further
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner) .
-
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
-
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/domains/overview.mdx
+++ b/docs/de/guides/web-cloud/domains/overview.mdx
@@ -2,33 +2,33 @@
 pageType: overview
 title: Domains
 description: "Domainnamen bei OVHcloud registrieren, transferieren und verwalten - DNS-Konfiguration, DNSSEC, Inhaberwechsel, Verlängerung und Domains API."
-text: "Manage your domain names and DNS configuration with OVHcloud."
-essentialsTitle: "Essential guides to get started"
+text: "Verwalten Sie Ihre Domainnamen und Ihre DNS-Konfiguration mit OVHcloud."
+essentialsTitle: "Die wichtigsten Anleitungen für den Einstieg"
 essentials:
-  - title: "FAQ Domain names and DNS"
+  - title: "FAQ zu Domainnamen & DNS"
     link: /guides/web-cloud/domains/faq-domain-dns
-  - title: "Editing an OVHcloud DNS zone"
+  - title: "Bearbeiten der OVHcloud DNS-Zone"
     link: /guides/web-cloud/domains/dns-zone-edit
-  - title: "Transferring a domain name to OVHcloud"
+  - title: "Domainnamen zu OVHcloud transferieren"
     link: /guides/web-cloud/domains/transfer-incoming-generic-domain
-  - title: "Changing the owner of a domain name"
+  - title: "Inhaber eines Domainnamens ändern"
     link: /guides/web-cloud/domains/trade-domain
-  - title: "How to renew OVHcloud domain names"
+  - title: "OVHcloud Domainnamen verlängern"
     link: /guides/web-cloud/domains/autorenew-domain-name
 goFurther:
-  title: Go further
+  title: Weiterführende Informationen
   items:
-    - title: Visit the OVHcloud community
+    - title: OVHcloud Community besuchen
       link: https://community.ovhcloud.com/
-    - title: View the roadmap & changelog
+    - title: "Roadmap & Changelog einsehen"
       link: https://www.ovhcloud.com/de/roadmap-changelog/
-    - title: Join Discord
+    - title: Discord beitreten
       link: https://discord.gg/ovhcloud
 cta:
-  title: Questions? Access OVHcloud support
-  description: "Find the answer to your questions in our help centre."
+  title: "Fragen? OVHcloud Support kontaktieren"
+  description: "Finden Sie die Antworten auf Ihre Fragen im Hilfe-Center."
   actions:
-    - text: Access support
+    - text: Zum Support
       link: https://help.ovhcloud.com/
       theme: brand
 availableIn: [eu, ca, apac]

--- a/docs/en/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-ips-update.mdx
@@ -9,11 +9,13 @@ import { Region } from '@components/Zone';
 
 ## Objective
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+This guide explains the IP address changes affecting part of our DNS servers hosted in Europe, which have applied since **August 2025**.
 
 **Discover the list of new IP addresses for OVHcloud DNS servers.**
 
 ## Requirements
+
+- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
 
 ## Instructions
 
@@ -21,11 +23,11 @@ This guide explains the IP addresses changes affecting part of our DNS servers h
 
 This change can impact customers who:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name’s DNS servers.
-- Are currently using this custom name as their domain name’s DNS server (defined in their Control Panel or at their registrar).
+- Have defined a custom DNS server name in the `NS` records of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
+- Have also configured a `GLUE` record for this custom name, to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
+- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
 
-For more information, please read our guide on [Customizing a domain name’s DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+For more information, see our guide [Customising a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
 
 :::warning
 If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
@@ -35,10 +37,10 @@ If you have not made any manual changes to the DNS configuration (default settin
 
 | Step                                | Estimated date           |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
+| Delete IPv6 traffic on old IPs         | Completed on 5 August 2025 |
+| Commissioning of new IPs   | Since 5 August 2025 |
 | Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
+| Send second reminder email         | 15 September 2025 |
 | Deletion of IPv4 traffic          | Early October 2025 |
 
 :::warning
@@ -48,8 +50,8 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 ### What can I do if I am concerned?
 
 1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+2. **Replace it** with the new IP address (see the table below).
+3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured any in your OVHcloud Control Panel.
 
 ### IP address mapping table
 
@@ -123,8 +125,8 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 ## Go further
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tutorial - Using Zonemaster
+description: Learn how to analyse the DNS configuration of a domain name with Zonemaster and identify the elements to correct or improve
 lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
@@ -11,7 +12,7 @@ availableIn: [eu, ca, apac]
 [Zonemaster](https://zonemaster.net/en/) is a tool created through the collaboration between [AFNIC](https://www.afnic.fr/) (the French registry) and [The Swedish Internet Foundation](https://internetstiftelsen.se/en/) (the Swedish registry). It lets you analyse the DNS (Domain Name System) configuration of a domain name and identify the elements that can be improved or corrected.
 
 :::info
-For a better understanding of the DNS concept, please refer to our guide “[Everything you need to know about DNS zone](/guides/web-cloud/domains/dns-zone-general-information)”.
+For a better understanding of the DNS concept, please refer to our guide "[Everything you need to know about DNS zone](/guides/web-cloud/domains/dns-zone-general-information)".
 :::
 
 ## Requirements
@@ -26,7 +27,7 @@ The Zonemaster tool lets you check a DNS configuration already in place on a dom
 
 To check the current configuration of a domain name, enter your domain name then click <code className="action">Run test</code>
 
-<img className="thumbnail" alt="Screenshot of the Zonemaster form. The domain “domain.tld” has been entered and is ready to be tested." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Screenshot of the Zonemaster form. The domain "domain.tld" has been entered and is ready to be tested." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 To check a DNS configuration that you have prepared but not yet applied to the domain name concerned, tick the <code className="action">Options</code> box, then enter the following information:
 
@@ -35,17 +36,22 @@ To check a DNS configuration that you have prepared but not yet applied to the d
 
 You can also force the checks on a specific IP protocol, via the `Disable IPv6` and `Disable IPv4` boxes
 
-> **Example**:<br/><br/> You are the holder of the domain name “domain.tld”, which currently uses the DNS servers “dnsXX.ovh.net” and “nsXX.ovh.net”.
+> **Example**:
 >
->You have configured a DNS zone for this domain name on the DNS servers “dns1.test.tld” and “dns2.test.tld”.<br/>
-> Before changing the DNS servers, you can perform an advanced search using the <code className="action">Options</code> box by entering “dns1.test.tld” and “dns2.test.tld” in the `Name servers` boxes.<br/>
-> Zonemaster will run a test as if you were using the servers “dns1.test.tld” and “dns2.test.tld” on “domain.tld”.<br/>
-> <img className="thumbnail" alt="Screenshot of the advanced options of the Zonemaster form. The two name servers “dns1.test.tld” and “dns2.test.tld” have been entered in the “Name servers” section of the form." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> You are the holder of the domain name "domain.tld", which currently uses the DNS servers "dnsXX.ovh.net" and "nsXX.ovh.net".
+>
+> You have configured a DNS zone for this domain name on the DNS servers "dns1.test.tld" and "dns2.test.tld".
+>
+> Before changing the DNS servers, you can perform an advanced search using the <code className="action">Options</code> box by entering "dns1.test.tld" and "dns2.test.tld" in the `Name servers` boxes.
+>
+> Zonemaster will run a test as if you were using the servers "dns1.test.tld" and "dns2.test.tld" on "domain.tld".
+>
+> <img className="thumbnail" alt="Screenshot of the advanced options of the Zonemaster form. The two name servers "dns1.test.tld" and "dns2.test.tld" have been entered in the "Name servers" section of the form." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 When you enter a domain name and click the <code className="action">Fetch NS from parent zone</code> and <code className="action">Fetch DS from parent zone</code> buttons, the DNS servers associated with the domain name will appear, along with the details of the DS record (DNSSEC) if one has been configured.
 
-<img className="thumbnail" alt="Screenshot of the Zonemaster results page for the domain “domain.tld”. The “Addresses” section is expanded." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Screenshot of the Zonemaster results page for the domain "domain.tld". The "Addresses" section is expanded." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Result
@@ -59,7 +65,7 @@ Once the form has been submitted, the results are displayed in groups of tests. 
 
 For each test, it is possible to obtain more details, for example to understand the error in the event of a malfunction, or simply for information.
 
-<img className="thumbnail" alt="domains" src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Screenshot of the Zonemaster results page with the test groups sorted by severity." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Useful information
 

--- a/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ The Zonemaster tool lets you check a DNS configuration already in place on a dom
 
 To check the current configuration of a domain name, enter your domain name then click <code className="action">Run test</code>
 
-<img className="thumbnail" alt="Screenshot of the Zonemaster form. The domain "domain.tld" has been entered and is ready to be tested." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster form with a domain name entered and ready to be tested." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 To check a DNS configuration that you have prepared but not yet applied to the domain name concerned, tick the <code className="action">Options</code> box, then enter the following information:
 
@@ -46,12 +46,12 @@ You can also force the checks on a specific IP protocol, via the `Disable IPv6` 
 >
 > Zonemaster will run a test as if you were using the servers "dns1.test.tld" and "dns2.test.tld" on "domain.tld".
 >
-> <img className="thumbnail" alt="Screenshot of the advanced options of the Zonemaster form. The two name servers "dns1.test.tld" and "dns2.test.tld" have been entered in the "Name servers" section of the form." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Advanced options of the Zonemaster form with two name servers entered." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 When you enter a domain name and click the <code className="action">Fetch NS from parent zone</code> and <code className="action">Fetch DS from parent zone</code> buttons, the DNS servers associated with the domain name will appear, along with the details of the DS record (DNSSEC) if one has been configured.
 
-<img className="thumbnail" alt="Screenshot of the Zonemaster results page for the domain "domain.tld". The "Addresses" section is expanded." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster results page with the Addresses section expanded." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Result
@@ -65,7 +65,7 @@ Once the form has been submitted, the results are displayed in groups of tests. 
 
 For each test, it is possible to obtain more details, for example to understand the error in the event of a malfunction, or simply for information.
 
-<img className="thumbnail" alt="Screenshot of the Zonemaster results page with the test groups sorted by severity." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Zonemaster results page with the test groups sorted by severity." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Useful information
 

--- a/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -29,12 +29,12 @@ To check the current configuration of a domain name, enter your domain name then
 
 <img className="thumbnail" alt="Zonemaster form with a domain name entered and ready to be tested." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-To check a DNS configuration that you have prepared but not yet applied to the domain name concerned, tick the <code className="action">Options</code> box, then enter the following information:
+To check a DNS configuration that you have prepared but not yet applied to the domain name concerned, tick the <code className="action">Show options</code> box, then enter the following information:
 
-- **Name servers**: enter the details of the name server associated with a domain name. Click the <code className="action">+</code> to add an additional name server. Entering an IP address is optional.
-- **Delegation Signer (DS record)**: as part of DNSSEC protection, enter the details of the DS record. Click the <code className="action">+</code> to add an additional DS record. If the DNS servers do not use the DNSSEC protocol, you can leave these fields empty. In the case of a zone signed with DNSSEC, this function lets you check that the zone works correctly with a validating resolver, using the DS records you are about to publish, prior to their publication.
+- **Nameservers**: enter the details of the name server associated with a domain name. A new `Nameserver` block appears automatically as soon as the previous one is filled in, so you can declare several. Entering an IP address is optional.
+- **DS records**: as part of DNSSEC protection, enter the details of the DS record. A new `DS record` block appears automatically as soon as the previous one is filled in. If the DNS servers do not use the DNSSEC protocol, you can leave these fields empty. In the case of a zone signed with DNSSEC, this function lets you check that the zone works correctly with a validating resolver, using the DS records you are about to publish, prior to their publication.
 
-You can also force the checks on a specific IP protocol, via the `Disable IPv6` and `Disable IPv4` boxes
+You can also force the checks on a specific IP protocol with the `IPv4 and IPv6`, `IPv4 only` and `IPv6 only` options
 
 > **Example**:
 >
@@ -42,14 +42,14 @@ You can also force the checks on a specific IP protocol, via the `Disable IPv6` 
 >
 > You have configured a DNS zone for this domain name on the DNS servers "dns1.test.tld" and "dns2.test.tld".
 >
-> Before changing the DNS servers, you can perform an advanced search using the <code className="action">Options</code> box by entering "dns1.test.tld" and "dns2.test.tld" in the `Name servers` boxes.
+> Before changing the DNS servers, you can perform an advanced search using the <code className="action">Show options</code> box by entering "dns1.test.tld" and "dns2.test.tld" in the `Nameservers` boxes.
 >
 > Zonemaster will run a test as if you were using the servers "dns1.test.tld" and "dns2.test.tld" on "domain.tld".
 >
 > <img className="thumbnail" alt="Advanced options of the Zonemaster form with two name servers entered." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-When you enter a domain name and click the <code className="action">Fetch NS from parent zone</code> and <code className="action">Fetch DS from parent zone</code> buttons, the DNS servers associated with the domain name will appear, along with the details of the DS record (DNSSEC) if one has been configured.
+When you enter a domain name and click the <code className="action">Fetch nameservers from parent zone</code> and <code className="action">Fetch DS from parent zone</code> buttons, the DNS servers associated with the domain name will appear, along with the details of the DS record (DNSSEC) if one has been configured.
 
 <img className="thumbnail" alt="Zonemaster results page with the Addresses section expanded." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
@@ -77,7 +77,7 @@ If you have any further questions about Zonemaster, refer to the [FAQ](https://z
 
 [Edit an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit).
 
-[Protect your domain name against Cache Poisoning with DNSSEC](/links/web/domains-dnssec).
+[Protect your domain name against Cache Poisoning with DNSSEC](/guides/web-cloud/domains/dns-dnssec).
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Using Zonemaster
 description: Learn how to analyse the DNS configuration of a domain name with Zonemaster and identify the elements to correct or improve
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/en/guides/web-cloud/domains/domain-icloud.mdx
@@ -33,7 +33,7 @@ This guide explains how to use an OVHcloud-registered domain name with the Apple
 
 ### 1 - Activate the domain name in iCloud <a name="step1"></a>
 
-To activate your domain name in iCloud, follow the instructions from the “Add a domain you own to iCloud Mail on iCloud.com” page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the “Step 3: Update the records with your domain registrar” section, to find the DNS records to add to your OVHcloud DNS zone.
+To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section to find the DNS records to add to your OVHcloud DNS zone.
 
 At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
 
@@ -45,10 +45,10 @@ Click on the tabs below to view each of the **2** steps.
   <Tab label="Step 1">
     Go to the <ManagerLink to="/#/web/zone">DNS zones</ManagerLink> page, then choose the domain name concerned.
 
-    <img className="thumbnail" alt="DNS zones" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+    <img className="thumbnail" alt="Screenshot of the OVHcloud Control Panel showing the list of DNS zones." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
   </Tab>
   <Tab label="Step 2">
-    To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide “[Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records)”.
+    To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide "[Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records)".
 
     Using the DNS records you previously retrieved ([Part 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
 
@@ -67,15 +67,15 @@ Click on the tabs below to view each of the **2** steps.
 
 ### 3 - Add a DMARC record (optional) <a name="step3"></a>
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+To improve the deliverability of your emails and prevent them from being delivered as spam, add a **DMARC** record.
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, refer to our guide "[Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc)".
+To find out how to create a DMARC record in the OVHcloud Control Panel, refer to our guide "[How to improve email security with a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc)".
 
 ### 4 - Verify and activate the domain in iCloud
 
 Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
 
-Follow the instructions from the “Add a domain you own to iCloud Mail on iCloud.com” page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the “Step 4: Finish setting up the domain” section.
+Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
 
 Once this step is complete, your custom domain name is fully activated and you can create up to 3 addresses per person within your family.
 
@@ -88,7 +88,7 @@ Validation may fail if your DNS records have not yet been propagated. This propa
 
 #### Check where the DNS zone is managed
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc.), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc.), you must configure the records in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
 
 #### CNAME already exists
 
@@ -106,7 +106,7 @@ If your domain name is associated with DNS servers external to OVHcloud (Wix, Sq
 
 #### Propagation time
 
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
+- DNS changes can take several hours (up to 24 hours) to be recognised by Apple.
 
 ## Go further
 

--- a/docs/es/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-ips-update.mdx
@@ -1,64 +1,64 @@
 ---
-title: "List of IP addresses of OVHcloud DNS servers"
-description: "Find out the updated IP addresses for OVHcloud DNS servers"
+title: Cambio de las direcciones IP de los servidores DNS de OVHcloud
+description: Descubra la lista de las nuevas direcciones IP de los servidores DNS de OVHcloud
 lastUpdated: 2025-08-07
 availableIn: [eu, ca, apac]
 ---
 
 import { Region } from '@components/Zone';
 
-## Objective
+## Objetivo
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+Esta guía presenta los cambios de direcciones IP que afectan a una parte de nuestros servidores DNS alojados en Europa, aplicables a partir de **agosto de 2025**.
 
-**Discover the list of new IP addresses for OVHcloud DNS servers.**
+**Descubra la lista de las nuevas direcciones IP de los servidores DNS.**
 
-## Requirements
+## Requisitos
 
-- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
+- Tener acceso al <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> para gestionar el nombre de dominio en cuestión.
 
-## Instructions
+## Procedimiento
 
-### Who is concerned?
+### ¿A quién afecta?
 
-This change can impact customers who:
+Este cambio puede afectar a los clientes que:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
-- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
+- Hayan definido un nombre de servidor DNS personalizado en los registros DNS de tipo `NS` de su zona DNS y hayan asociado la dirección IP de un servidor DNS de OVHcloud a dicho nombre mediante un registro DNS de tipo `A`.
+- Hayan configurado además un registro `GLUE` para ese nombre personalizado, con el fin de asociarlo a la dirección IP de un servidor DNS de OVHcloud, en la configuración de los servidores DNS del dominio.
+- Utilicen actualmente ese nombre personalizado como servidor DNS de su dominio (definido en su área de cliente o en su agente registrador).
 
-For more information, please read our guide on [Customizing a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+Para más información, consulte nuestra guía "[Personalizar los servidores DNS de un dominio (Glue Records)](/guides/web-cloud/domains/glue-registry)".
 
 :::warning
-If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
+Si no ha realizado ninguna modificación manual de la configuración DNS (configuración por defecto), este cambio no le afecta.
 :::
 
-### Schedule
+### Calendario
 
-| Step                                | Estimated date           |
+| Etapa | Fecha prevista |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
-| Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
-| Deletion of IPv4 traffic          | Early October 2025 |
+| Eliminación del tráfico IPv6 en las antiguas direcciones IP | Realizada el 5 de agosto de 2025 |
+| Puesta en servicio de las nuevas direcciones IP | A partir del 5 de agosto de 2025 |
+| Envío del primer correo electrónico informativo a los clientes identificados | Mediados de agosto de 2025 |
+| Envío del segundo correo electrónico recordatorio | 15 de septiembre de 2025 |
+| Eliminación del tráfico IPv4 | Principios de octubre de 2025 |
 
 :::warning
-Using old IP addresses after this date will cause DNS resolution failure for domain names whose configuration has not been updated.
+El uso de las antiguas direcciones IP después de esa fecha provocará el fallo de la resolución DNS de los dominios cuya configuración no se haya actualizado.
 :::
 
-### What can I do if I am concerned?
+### ¿Qué hacer si me afecta?
 
-1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+1. Compruebe si sigue utilizando una antigua dirección IP en su zona DNS.
+2. **Sustitúyala** por la nueva dirección IP (consulte la tabla siguiente).
+3. [Actualice sus registros GLUE](/guides/web-cloud/domains/glue-registry) si los ha configurado en su área de cliente.
 
-### IP address mapping table
+### Tabla de correspondencia de las direcciones IP
 
-| Hostname     | Old IPv4   | New IPv4   | Old IPv6       | New IPv6         |
-|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 <Region zones={['eu']}>
 
+| Nombre de host     | Antigua IPv4   | Nueva IPv4   | Antigua IPv6       | Nueva IPv6         |
+|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |
@@ -116,17 +116,17 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 <Region zones={['ca', 'apac']}>
 
-| Server | IP |
+| Servidor | IP |
 |---|---|
 | dns10.ovh.ca | 192.99.60.247 |
 | ns10.ovh.ca | 167.114.154.30 |
 
 </Region>
 
-## Go further
+## Más información
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+Si quiere disfrutar de ayuda en el uso y la configuración de sus soluciones de OVHcloud, consulte nuestros distintos [planes de soporte](/links/support).
 
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Uso de Zonemaster
 description: Descubra cómo analizar la configuración DNS de un dominio con Zonemaster e identificar los elementos que deben corregirse o mejorarse
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ La herramienta Zonemaster permite comprobar una configuración DNS en un nombre 
 
 Para comprobar la configuración actual de un nombre de dominio, introduzca el nombre de dominio y haga clic en <code className="action">Ejecutar</code>.
 
-<img className="thumbnail" alt="Captura de pantalla del formulario de Zonemaster. El nombre de dominio &quot;domain.tld&quot; se ha introducido y está listo para ser probado." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Formulario de Zonemaster con un nombre de dominio introducido, listo para probar." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Para comprobar que la configuración DNS se haya preparado, pero todavía no se haya aplicado al nombre de dominio, marque la casilla <code className="action">Opciones</code> e introduzca la siguiente información:
 
@@ -46,12 +46,12 @@ También puede forzar la verificación de un protocolo IP específico mediante l
 >
 > Zonemaster realizará una prueba como si utilizara los servidores "dns1.test.tld" y "dns2.test.tld" en "domain.tld".
 >
-> <img className="thumbnail" alt="Captura de pantalla de las opciones avanzadas del formulario de Zonemaster. Los dos servidores de nombres &quot;dns1.test.tld&quot; y &quot;dns2.test.tld&quot; se han introducido en la sección &quot;Servidores de nombres&quot; del formulario." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Opciones avanzadas del formulario de Zonemaster con dos servidores de nombres introducidos." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Cuando introduzca un nombre de dominio y haga clic en los botones <code className="action">Obtener datos desde la zona padre</code> y <code className="action">Obtener DS desde la zona padre</code>, aparecerán los servidores DNS asociados al nombre de dominio, así como la información del registro DS (DNSSEC), en caso de que haya sido configurado.
 
-<img className="thumbnail" alt="Captura de pantalla de la página de resultados de Zonemaster para el nombre de dominio &quot;domain.tld&quot;. Se desarrolla la sección &quot;Direcciones&quot;." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Página de resultados de Zonemaster con la sección Addresses desplegada." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Resultado

--- a/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tutorial - Uso de Zonemaster
+description: Descubra cómo analizar la configuración DNS de un dominio con Zonemaster e identificar los elementos que deben corregirse o mejorarse
 lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
@@ -35,10 +36,16 @@ Para comprobar que la configuración DNS se haya preparado, pero todavía no se 
 
 También puede forzar la verificación de un protocolo IP específico mediante las casillas `Deshabilitar IPv6` y `Deshabilitar IPv4`.
 
-> **Ejemplo**:<br/><br/> Usted es el titular del nombre de dominio "domain.tld", que utiliza actualmente los servidores DNS "dnsXX.ovh.net" y "nsXX.ovh.net". 
-> Ha configurado una zona DNS para este nombre de dominio en los servidores DNS "dns1.test.tld" y "dns2.test.tld". <br/>
-> Antes de cambiar los servidores DNS, puede realizar una búsqueda avanzada en la casilla <code className="action">Opciones</code> introduciendo "dns1.test.tld" y "dns2.test.tld" en las casillas de `servidores de nombres`.<br/>
-> Zonemaster realizará una prueba como si utilizara los servidores "dns1.test.tld" y "dns2.test.tld" en "domain.tld".<br/>
+> **Ejemplo**:
+>
+> Usted es el titular del nombre de dominio "domain.tld", que utiliza actualmente los servidores DNS "dnsXX.ovh.net" y "nsXX.ovh.net".
+>
+> Ha configurado una zona DNS para este nombre de dominio en los servidores DNS "dns1.test.tld" y "dns2.test.tld".
+>
+> Antes de cambiar los servidores DNS, puede realizar una búsqueda avanzada en la casilla <code className="action">Opciones</code> introduciendo "dns1.test.tld" y "dns2.test.tld" en las casillas de `servidores de nombres`.
+>
+> Zonemaster realizará una prueba como si utilizara los servidores "dns1.test.tld" y "dns2.test.tld" en "domain.tld".
+>
 > <img className="thumbnail" alt="Captura de pantalla de las opciones avanzadas del formulario de Zonemaster. Los dos servidores de nombres &quot;dns1.test.tld&quot; y &quot;dns2.test.tld&quot; se han introducido en la sección &quot;Servidores de nombres&quot; del formulario." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
@@ -58,7 +65,7 @@ Una vez validado el formulario, los resultados se muestran por grupo de pruebas.
 
 Para cada prueba, es posible obtener más detalles, por ejemplo, para entender el error en caso de fallo, o simplemente a título indicativo.
 
-<img className="thumbnail" alt="Captura de pantalla de la página de resultados de Zonemaster para el nombre de dominio &quot;domain.tld&quot;. La sección &quot;Address&quot; se expande." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Página de resultados de Zonemaster con los grupos de pruebas ordenados por severidad." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Información útil
 

--- a/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -25,16 +25,16 @@ Para entender mejor la noción de DNS, consulte nuestra guía "[Todo sobre la zo
 
 La herramienta Zonemaster permite comprobar una configuración DNS en un nombre de dominio o probar una zona DNS preconfigurada en futuros servidores DNS.
 
-Para comprobar la configuración actual de un nombre de dominio, introduzca el nombre de dominio y haga clic en <code className="action">Ejecutar</code>.
+Para comprobar la configuración actual de un nombre de dominio, introduzca el nombre de dominio y haga clic en <code className="action">Ejecutar prueba</code>.
 
 <img className="thumbnail" alt="Formulario de Zonemaster con un nombre de dominio introducido, listo para probar." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Para comprobar que la configuración DNS se haya preparado, pero todavía no se haya aplicado al nombre de dominio, marque la casilla <code className="action">Opciones</code> e introduzca la siguiente información:
+Para comprobar que la configuración DNS se haya preparado, pero todavía no se haya aplicado al nombre de dominio, marque la casilla <code className="action">Mostrar opciones</code> e introduzca la siguiente información:
 
-- **Servidores de nombres** : introduzca la información del servidor de nombres asociado a un nombre de dominio. Haga clic en el <code className="action">+</code> para poder añadir un servidor de nombres adicional. Es opcional introducir una dirección IP.
-- **Registros DS** : introduzca los elementos del registro DS en la protección DNSSEC. Haga clic en el <code className="action">+</code> para poder añadir un registro DS adicional. Si los servidores DNS no utilizan el protocolo DNSSEC, puede dejar estos campos libres. En el caso de una zona firmada con DNSSEC, esta función permite comprobar que la zona funciona correctamente con un servidor de resolución válido, con los registros DS que se van a publicar, antes de su publicación.
+- **Servidores de nombres** : introduzca la información del servidor de nombres asociado a un nombre de dominio. Un nuevo bloque `Servidor de nombres` aparece automáticamente en cuanto se rellena el anterior, lo que permite declarar varios. Es opcional introducir una dirección IP.
+- **Registros DS** : introduzca los elementos del registro DS en la protección DNSSEC. Un nuevo bloque `Registro DS` aparece automáticamente en cuanto se rellena el anterior. Si los servidores DNS no utilizan el protocolo DNSSEC, puede dejar estos campos libres. En el caso de una zona firmada con DNSSEC, esta función permite comprobar que la zona funciona correctamente con un servidor de resolución válido, con los registros DS que se van a publicar, antes de su publicación.
 
-También puede forzar la verificación de un protocolo IP específico mediante las casillas `Deshabilitar IPv6` y `Deshabilitar IPv4`.
+También puede forzar la verificación de un protocolo IP específico mediante las opciones `IPv4 e IPv6`, `IPv4 solo` e `IPv6 solo`.
 
 > **Ejemplo**:
 >
@@ -42,14 +42,14 @@ También puede forzar la verificación de un protocolo IP específico mediante l
 >
 > Ha configurado una zona DNS para este nombre de dominio en los servidores DNS "dns1.test.tld" y "dns2.test.tld".
 >
-> Antes de cambiar los servidores DNS, puede realizar una búsqueda avanzada en la casilla <code className="action">Opciones</code> introduciendo "dns1.test.tld" y "dns2.test.tld" en las casillas de `servidores de nombres`.
+> Antes de cambiar los servidores DNS, puede realizar una búsqueda avanzada en la casilla <code className="action">Mostrar opciones</code> introduciendo "dns1.test.tld" y "dns2.test.tld" en las casillas de `Servidores de nombres`.
 >
 > Zonemaster realizará una prueba como si utilizara los servidores "dns1.test.tld" y "dns2.test.tld" en "domain.tld".
 >
 > <img className="thumbnail" alt="Opciones avanzadas del formulario de Zonemaster con dos servidores de nombres introducidos." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Cuando introduzca un nombre de dominio y haga clic en los botones <code className="action">Obtener datos desde la zona padre</code> y <code className="action">Obtener DS desde la zona padre</code>, aparecerán los servidores DNS asociados al nombre de dominio, así como la información del registro DS (DNSSEC), en caso de que haya sido configurado.
+Cuando introduzca un nombre de dominio y haga clic en los botones <code className="action">Obtener servidores de nombres del dominio padre</code> y <code className="action">Obtener DS del dominio padre</code>, aparecerán los servidores DNS asociados al nombre de dominio, así como la información del registro DS (DNSSEC), en caso de que haya sido configurado.
 
 <img className="thumbnail" alt="Página de resultados de Zonemaster con la sección Addresses desplegada." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
@@ -77,7 +77,7 @@ Si tiene más preguntas sobre Zonemaster, consulte las [FAQ](https://zonemaster.
 
 [Modificación de una zona DNS de OVHcloud](/guides/web-cloud/domains/dns-zone-edit).
 
-[Proteja su nombre de dominio contra el «cache poisoning» con el servicio DNSSEC](/guides/web-cloud/domains/dns-dnssec)
+[Proteja su nombre de dominio contra el "cache poisoning" con el servicio DNSSEC](/guides/web-cloud/domains/dns-dnssec)
 
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 

--- a/docs/es/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-icloud.mdx
@@ -1,97 +1,116 @@
 ---
-title: "How to use an OVHcloud domain with iCloud Mail"
-description: "Find out how to configure your OVHcloud domain name with iCloud to create custom email addresses"
-lastUpdated: 2025-08-27
+title: Cómo utilizar un nombre de dominio de OVHcloud con iCloud Mail
+description: Descubra cómo configurar su nombre de dominio de OVHcloud con iCloud para crear direcciones de correo electrónico personalizadas
+lastUpdated: 2026-03-27
 availableIn: [eu, ca, apac]
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 [[fragment:support-scope]]
 
-## Objective
+## Objetivo
 
-This guide explains how to use an OVHcloud-registered domain name with the Apple iCloud Mail service. You can then create custom email addresses (`firstname@mydomain.com`), which are fully managed and hosted by Apple.
+Esta guía le explica cómo utilizar un nombre de dominio registrado en OVHcloud con el servicio iCloud Mail de Apple. De este modo, podrá crear direcciones de correo electrónico personalizadas (`nombre@midominio.es`), gestionadas y alojadas íntegramente por Apple.
 
-## Requirements
+## Requisitos
 
-- A [domain name](/links/web/domains) registered with OVHcloud.
-- You have access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- You have the rights to manage the DNS zone for the domain name concerned via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- An Apple ID with an **iCloud+** subscription.
+- Tener un [nombre de dominio](/links/web/domains) registrado en OVHcloud.
+- Un identificador de Apple con una suscripción **iCloud+**.
 
-## Instructions
+{/* CP-NAV-START:web-dns-zone */}
+---
 
-### Step 1: Activate the domain name in iCloud <a id="step1"></a>
+### Acceso al área de cliente de OVHcloud
 
-To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section, to find the DNS records to add to your OVHcloud DNS zone.
+- **Enlace directo:** <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink>
+- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Zonas DNS</code> > Seleccione su nombre de dominio
 
-At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
+---
+{/* CP-NAV-END:web-dns-zone */}
 
-### Step 2: Configure the DNS records in your OVHcloud Control Panel
+## Procedimiento
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-2. Go to the `Web Cloud` section.
-3. Click `DNS zones`, then choose the domain name concerned.
-4. Add or edit the records mentioned below.
+### 1 - Activar el nombre de dominio en iCloud <a name="step1"></a>
 
-To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+Para activar su nombre de dominio en iCloud, siga las instrucciones de la página "Add a domain you own to iCloud Mail on iCloud.com" de la [documentación oficial de Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Céntrese en la sección "Step 3: Update the records with your domain registrar" (Actualizar los registros en su agente registrador de dominios), para anotar los registros DNS que deberá añadir a su zona DNS de OVHcloud.
 
-Using the DNS records you previously retrieved ([Step 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
+Al final de esta etapa, Apple le comunicará una lista de registros DNS (MX, CNAME, TXT) que deberá configurar en su zona DNS de OVHcloud. Consérvelos para la siguiente etapa.
 
-- **MX** : for receiving emails.
-- **CNAME**: for DKIM keys (`sig1._domainkey...`, `sig2._domainkey...`).
-- **TXT**: for SPF (merge if an SPF record already exists).
-- **TXT DMARC**: Optional but recommended ([Step 3](#step3)).
+### 2 - Configurar los registros DNS en su área de cliente de OVHcloud
+
+Haga clic en las pestañas siguientes para mostrar sucesivamente cada una de las **2** etapas.
+
+<Tabs>
+  <Tab label="Paso 1">
+    Acceda a la página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> y elija el nombre de dominio correspondiente.
+
+    <img className="thumbnail" alt="Captura de pantalla del área de cliente de OVHcloud con la lista de zonas DNS." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+  </Tab>
+  <Tab label="Paso 2">
+    Para saber cómo añadir, modificar o eliminar cada tipo de registro DNS (MX, CNAME, TXT, etc.), consulte nuestra guía "[Todo sobre los registros DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+    Con los registros DNS anotados anteriormente ([Parte 1](#step1)), cree o actualice los campos correspondientes en su zona DNS de OVHcloud:
+
+    - **MX**: para la recepción de los correos electrónicos.
+    - **CNAME**: para las claves DKIM (`sig1._domainkey...`, `sig2._domainkey...`).
+    - **TXT**: para el SPF (fusiónelo si ya existe un registro SPF).
+    - **TXT DMARC**: opcional, pero recomendado ([Parte 3](#step3)).
+
+    :::warning
+    Utilice únicamente comillas rectas `”` tal y como aparecen en la documentación técnica de Apple (generalmente en su versión en inglés). Las comillas tipográficas « » o “ “ que se muestran en algunas traducciones no deben utilizarse en la configuración DNS.
+
+    :::
+
+  </Tab>
+</Tabs>
+
+### 3 - Añadir un registro DMARC (opcional) <a name="step3"></a>
+
+Para mejorar la entregabilidad de sus correos electrónicos y evitar que sus mensajes lleguen como spam, añada un registro **DMARC**.
+
+Para saber cómo crear un registro DMARC en su área de cliente de OVHcloud, consulte nuestra guía "[Mejorar la seguridad del correo electrónico mediante el registro DMARC](/guides/web-cloud/domains/dns-zone-dmarc)".
+
+### 4 - Verificar y activar el dominio en iCloud
+
+Una vez añadidos correctamente los registros DNS (MX, CNAME, TXT, DMARC) a su zona DNS de OVHcloud, vuelva a [iCloud.com](https://www.icloud.com).
+
+Siga las instrucciones de la página "Add a domain you own to iCloud Mail on iCloud.com" de la [documentación oficial de Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Céntrese en la sección "Step 4: Finish setting up the domain".
+
+Una vez finalizada esta etapa, su nombre de dominio personalizado estará totalmente activado y podrá crear hasta 3 direcciones por persona en el ámbito familiar.
 
 :::warning
-Use only the quotation marks `"` as they appear in Apple's technical documentation (usually in English). The quotation marks « » or " " displayed in some translations should not be used in DNS configuration.
+La validación puede fallar si sus registros DNS todavía no se han propagado. Esta propagación puede tardar varias horas.
+
 :::
 
-### Step 3: Add a DMARC record (optional) <a id="step3"></a>
+### Resolución de problemas frecuentes
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+#### Comprobar dónde se gestiona la zona DNS
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, please refer to our guide on [Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+Si su nombre de dominio está asociado a servidores DNS externos a OVHcloud (Wix, Squarespace, Cloudflare, etc.), la configuración debe realizarse en la interfaz de gestión de dichos servidores DNS, fuera del área de cliente de OVHcloud.
 
-### Step 4: Verify and activate the domain in iCloud
+#### CNAME ya existente
 
-Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
+- Un registro **CNAME** no puede coexistir con un registro **A, AAAA o TXT** configurado en el mismo dominio o subdominio.
+- Elimine el antiguo registro antes de crear el CNAME solicitado por Apple.
 
-Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
+#### SPF duplicado
 
-Once this step is complete, your custom domain is fully activated and you can create up to 3 addresses per person within your family.
+- Solo puede existir **un único registro SPF** por nombre de dominio. Si ya existe un registro SPF de OVHcloud (ej.: `v=spf1 include:mx.ovh.com ~all`), fusiónelo con el proporcionado por Apple (ej.: `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
-:::warning
-Validation may fail if your DNS records have not yet been propagated. This propagation may take several hours.
-:::
+#### DKIM incompleto
 
-### Common troubleshooting
+- Apple le invita a registrar varias claves DKIM (`sig1`, `sig2`, etc.) en su zona DNS.
 
-#### Check where the DNS zone is managed
+#### Plazo de propagación
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc. ), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+- Las modificaciones DNS pueden tardar varias horas (hasta 24 h) en ser reconocidas por Apple.
 
-#### CNAME already exists
+## Más información
 
-- A **CNAME** record cannot coexist with a **A, AAAA, or TXT** record configured on the same domain or subdomain.
-- Delete the old record before creating the CNAME requested by Apple.
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-#### Duplicate SPF
+Si quiere disfrutar de ayuda en el uso y la configuración de sus soluciones de OVHcloud, consulte nuestros distintos [planes de soporte](/links/support).
 
-- There can only be **one SPF record** per domain name. If an OVHcloud SPF record already exists (e.g.: `v=spf1 include:mx.ovh.com ~all`), merge it with the one provided by Apple (e.g.:
-`v=spf1 include:mx.ovh.com include:icloud.com ~all`).
-
-#### Incomplete DKIM
-
-- Apple invites you to save several DKIM keys (`sig1`, `sig2`, etc.) in your DNS zone.
-
-#### Propagation time
-
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
-
-## Go further
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner) .
-
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
-
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-ips-update.mdx
@@ -15,14 +15,16 @@ Ce guide présente les changements d’adresses IP affectant une partie de nos s
 
 ## Prérequis
 
+- Un accès à l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> pour gérer le nom de domaine concerné.
+
 ## En pratique
 
-### Qui est concerné ?
+### Qui est concerné ?
 
-Ce changement peut impacter les clients qui :
+Ce changement peut impacter les clients qui :
 
 - Ont défini un nom de serveur DNS personnalisé dans les enregistrements DNS de type `NS` de leur zone DNS, et ont associé une adresse IP d’un serveur DNS OVHcloud à ce nom via un enregistrement DNS de type `A`.
-- Ont également configuré un enregistrement `GLUE` pour ce nom personnalisé, afin de l’associer à l’adresse IP d’un serveur DNS OVHcloud, dans la configuration des serveurs DNS du nom de domaine.
+- Ont également configuré un enregistrement `GLUE` pour ce nom personnalisé, pour l’associer à l’adresse IP d’un serveur DNS OVHcloud, dans la configuration des serveurs DNS du nom de domaine.
 - Utilisent actuellement ce nom personnalisé comme serveur DNS de leur nom de domaine (défini dans leur espace client ou auprès de leur bureau d’enregistrement).
 
 Pour plus d’informations, consultez notre guide « [Personnaliser les serveurs DNS d’un nom de domaine (Glue Records)](/guides/web-cloud/domains/glue-registry) ».
@@ -35,7 +37,7 @@ Si vous n’avez effectué aucune modification manuelle de la configuration DNS 
 
 | Étape                                | Date prévue           |
 |-------------------------------------|------------------------|
-| Suppression du trafic IPv6 sur les anciennes adresses IP         | Effectuée le 05 août 2025 |
+| Suppression du trafic IPv6 sur les anciennes adresses IP         | Effectuée le 5 août 2025 |
 | Mise en service des nouvelles adresses IP   | Dès le 5 août 2025 |
 | Envoi du premier e-mail d’information aux clients identifiés | Mi-août 2025 |
 | Envoi du second e-mail de rappel         | 15 septembre 2025 |
@@ -45,18 +47,18 @@ Si vous n’avez effectué aucune modification manuelle de la configuration DNS 
 L’utilisation des anciennes adresses IP après cette date provoquera l’échec de la résolution DNS pour les noms de domaine dont la configuration n’a pas été mise à jour.
 :::
 
-### Que faire si je suis concerné ?
+### Que faire si je suis concerné ?
 
-1. Identifiez si vous utilisez encore une ancienne adresse IP dans votre zone DNS.
+1. Vérifiez si vous utilisez encore une ancienne adresse IP dans votre zone DNS.
 2. **Remplacez-la** par la nouvelle adresse IP (voir le tableau ci-dessous).
-3. [Mettez à jour vos GLUE records](/guides/web-cloud/domains/glue-registry) si vous en avez configuré dans votre interface client.
+3. [Mettez à jour vos GLUE records](/guides/web-cloud/domains/glue-registry) si vous en avez configuré dans votre espace client.
 
 ### Tableau de correspondance des adresses IP
 
-| Nom d’hôte     | Ancienne IPv4   | Nouvelle IPv4   | Ancienne IPv6       | Nouvelle IPv6         |
-|:---------------|:----------------|:----------------|:--------------------|:----------------------|
 <Region zones={['eu']}>
 
+| Nom d’hôte     | Ancienne IPv4   | Nouvelle IPv4   | Ancienne IPv6       | Nouvelle IPv6         |
+|:---------------|:----------------|:----------------|:--------------------|:----------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |

--- a/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tutoriel - Utilisation de Zonemaster
+description: Découvrez comment analyser la configuration DNS d’un nom de domaine avec Zonemaster et identifier les éléments à corriger ou améliorer
 lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
@@ -28,18 +29,23 @@ Pour vérifier la configuration actuelle d’un nom de domaine, saisissez votre 
 
 <img className="thumbnail" alt="Capture d’écran du formulaire de Zonemaster. Le domaine « domain.tld » a été saisi et est prêt à être testé." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Pour vérifier une configuration DNS que vous avez préparée mais pas encore appliquée au nom de domaine concerné, cochez la case <code className="action">Options</code>, puis saisissez les informations suivantes :
+Pour vérifier une configuration DNS que vous avez préparée mais pas encore appliquée au nom de domaine concerné, cochez la case <code className="action">Options</code>, puis saisissez les informations suivantes :
 
-- **Serveurs DNS** : saisissez les informations du serveur de nom associé à un nom de domaine. Cliquez sur le <code className="action">+</code> pour pouvoir ajouter un serveur de nom supplémentaire. La saisie d’une adresse IP est facultative.
+- **Serveurs DNS** : saisissez les informations du serveur de nom associé à un nom de domaine. Cliquez sur le <code className="action">+</code> pour pouvoir ajouter un serveur de nom supplémentaire. La saisie d’une adresse IP est facultative.
 - **Délégation du Signataire (enregistrement DS)**: dans le cadre d’une protection DNSSEC, saisissez les éléments de l’enregistrement DS. Cliquez sur le <code className="action">+</code> pour pouvoir ajouter un enregistrement DS supplémentaire. Si les serveurs DNS n’utilisent pas le protocole DNSSEC, vous pouvez laisser ces champs libres. Dans le cas d’une zone signée avec DNSSEC, cette fonction permet de vérifier que la zone fonctionne correctement avec un résolveur validant, avec les enregistrements DS qu’on est sur le point de publier, préalablement à leur publication.
 
 Vous pouvez également forcer les vérifications sur un protocole IP spécifique, via les cases `Désactiver IPv6` et `Désactiver IPv4`
 
-> **Exemple**:<br/><br/> Vous êtes titulaire du nom de domaine « domain.tld », qui utilise actuellement les serveurs DNS « dnsXX.ovh.net » et  « nsXX.ovh.net ».
+> **Exemple**:
 >
->Vous avez configuré une zone DNS pour ce nom de domaine sur les serveurs DNS « dns1.test.tld » et « dns2.test.tld ».<br/>
-> Avant de changer les serveurs DNS, vous pouvez effectuer une recherche avancée à l’aide de la case <code className="action">Options</code> en saisissant « dns1.test.tld » et « dns2.test.tld » dans les cases `Serveurs DNS`.<br/>
-> Zonemaster réalisera un test comme si vous utilisiez les serveurs « dns1.test.tld » et « dns2.test.tld » sur « domain.tld ».<br/>
+> Vous êtes titulaire du nom de domaine « domain.tld », qui utilise actuellement les serveurs DNS « dnsXX.ovh.net » et  « nsXX.ovh.net ».
+>
+> Vous avez configuré une zone DNS pour ce nom de domaine sur les serveurs DNS « dns1.test.tld » et « dns2.test.tld ».
+>
+> Avant de changer les serveurs DNS, vous pouvez effectuer une recherche avancée à l’aide de la case <code className="action">Options</code> en saisissant « dns1.test.tld » et « dns2.test.tld » dans les cases `Serveurs DNS`.
+>
+> Zonemaster réalisera un test comme si vous utilisiez les serveurs « dns1.test.tld » et « dns2.test.tld » sur « domain.tld ».
+>
 > <img className="thumbnail" alt="Capture d’écran des options avancées du formulaire de Zonemaster. Les deux serveurs de noms « dns1.test.tld » et « dns2.test.tld » ont été saisis dans la section « Serveurs de noms » du formulaire." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
@@ -52,14 +58,14 @@ Lorsque vous saisissez un nom de domaine et que vous cliquez sur les boutons <co
 
 Une fois le formulaire validé, les résultats sont affichés par groupe de tests. Les tests sont classés par niveau de sévérité.
 
-- **Erreur** : cette partie présente des erreurs ou des éléments manquants pouvant causer un dysfonctionnement.
-- **Avertissement** : cette partie est fonctionnelle mais mérite une attention particulière. L’outil a détecté qu’un paramètre ne répond pas au standard de sa catégorie, sans que cela ne bloque son fonctionnement.
-- **Note** : il s’agit d’une simple information, sans conséquence particulière sur le fonctionnement du nom de domaine.
-- **Info** : cette partie est fonctionnelle et répond aux critères standard dans sa catégorie.
+- **Erreur** : cette partie présente des erreurs ou des éléments manquants pouvant causer un dysfonctionnement.
+- **Avertissement** : cette partie est fonctionnelle mais mérite une attention particulière. L’outil a détecté qu’un paramètre ne répond pas au standard de sa catégorie, sans que cela ne bloque son fonctionnement.
+- **Note** : il s’agit d’une simple information, sans conséquence particulière sur le fonctionnement du nom de domaine.
+- **Info** : cette partie est fonctionnelle et répond aux critères standard dans sa catégorie.
 
 Pour chaque test, il est possible d’obtenir plus de détails, par exemple pour comprendre l’erreur dans le cas d’un dysfonctionnement, ou simplement à titre indicatif.
 
-<img className="thumbnail" alt="domains" src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Page de résultats de Zonemaster, avec les groupes de tests triés par sévérité." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Informations utiles
 

--- a/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -25,16 +25,16 @@ Pour mieux comprendre la notion de DNS, consultez notre guide « [Tout savoir su
 
 L’outil Zonemaster permet de vérifier une configuration DNS en place sur un nom de domaine ou de tester une zone DNS préconfigurée sur des futurs serveurs DNS.
 
-Pour vérifier la configuration actuelle d’un nom de domaine, saisissez votre nom de domaine puis cliquez sur <code className="action">Lancer</code>
+Pour vérifier la configuration actuelle d’un nom de domaine, saisissez votre nom de domaine puis cliquez sur <code className="action">Lancer un test</code>
 
 <img className="thumbnail" alt="Formulaire Zonemaster avec un nom de domaine saisi, prêt à être testé." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Pour vérifier une configuration DNS que vous avez préparée mais pas encore appliquée au nom de domaine concerné, cochez la case <code className="action">Options</code>, puis saisissez les informations suivantes :
+Pour vérifier une configuration DNS que vous avez préparée mais pas encore appliquée au nom de domaine concerné, cochez la case <code className="action">Afficher les options</code>, puis saisissez les informations suivantes :
 
-- **Serveurs DNS** : saisissez les informations du serveur de nom associé à un nom de domaine. Cliquez sur le <code className="action">+</code> pour pouvoir ajouter un serveur de nom supplémentaire. La saisie d’une adresse IP est facultative.
-- **Délégation du Signataire (enregistrement DS)**: dans le cadre d’une protection DNSSEC, saisissez les éléments de l’enregistrement DS. Cliquez sur le <code className="action">+</code> pour pouvoir ajouter un enregistrement DS supplémentaire. Si les serveurs DNS n’utilisent pas le protocole DNSSEC, vous pouvez laisser ces champs libres. Dans le cas d’une zone signée avec DNSSEC, cette fonction permet de vérifier que la zone fonctionne correctement avec un résolveur validant, avec les enregistrements DS qu’on est sur le point de publier, préalablement à leur publication.
+- **Serveurs de noms** : saisissez les informations du serveur de nom associé à un nom de domaine. Un nouveau bloc `Serveur de noms` apparaît automatiquement dès que le précédent est renseigné, ce qui permet d’en déclarer plusieurs. La saisie d’une adresse IP est facultative.
+- **Enregistrements DS**: dans le cadre d’une protection DNSSEC, saisissez les éléments de l’enregistrement DS. Un nouveau bloc `Enregistrement DS` apparaît automatiquement dès que le précédent est renseigné. Si les serveurs DNS n’utilisent pas le protocole DNSSEC, vous pouvez laisser ces champs libres. Dans le cas d’une zone signée avec DNSSEC, cette fonction permet de vérifier que la zone fonctionne correctement avec un résolveur validant, avec les enregistrements DS qu’on est sur le point de publier, préalablement à leur publication.
 
-Vous pouvez également forcer les vérifications sur un protocole IP spécifique, via les cases `Désactiver IPv6` et `Désactiver IPv4`
+Vous pouvez également forcer les vérifications sur un protocole IP spécifique grâce aux options `IPv4 et IPv6`, `IPv4 seulement` et `IPv6 seulement`
 
 > **Exemple**:
 >
@@ -42,14 +42,14 @@ Vous pouvez également forcer les vérifications sur un protocole IP spécifique
 >
 > Vous avez configuré une zone DNS pour ce nom de domaine sur les serveurs DNS « dns1.test.tld » et « dns2.test.tld ».
 >
-> Avant de changer les serveurs DNS, vous pouvez effectuer une recherche avancée à l’aide de la case <code className="action">Options</code> en saisissant « dns1.test.tld » et « dns2.test.tld » dans les cases `Serveurs DNS`.
+> Avant de changer les serveurs DNS, vous pouvez effectuer une recherche avancée à l’aide de la case <code className="action">Afficher les options</code> en saisissant « dns1.test.tld » et « dns2.test.tld » dans les cases `Serveurs de noms`.
 >
 > Zonemaster réalisera un test comme si vous utilisiez les serveurs « dns1.test.tld » et « dns2.test.tld » sur « domain.tld ».
 >
 > <img className="thumbnail" alt="Options avancées du formulaire Zonemaster avec deux serveurs de noms saisis." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Lorsque vous saisissez un nom de domaine et que vous cliquez sur les boutons <code className="action">Récupérer les NS depuis la zone parente</code> et <code className="action">Récupérer les DS depuis la zone parente</code>, les serveurs DNS associés au nom de domaine apparaitront ainsi que les informations de l’enregistrement DS (DNSSEC) si celui-ci a été configuré.
+Lorsque vous saisissez un nom de domaine et que vous cliquez sur les boutons <code className="action">Récupérer les serveurs de noms à partir de la zone parente</code> et <code className="action">Récupérer les DS à partir de la zone parent</code>, les serveurs DNS associés au nom de domaine apparaitront ainsi que les informations de l’enregistrement DS (DNSSEC) si celui-ci a été configuré.
 
 <img className="thumbnail" alt="Page de résultats de Zonemaster avec la section Adresses développée." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
@@ -77,7 +77,7 @@ Si vous avez des questions supplémentaires au sujet de Zonemaster, consultez la
 
 [Modification d’une zone DNS OVHcloud](/guides/web-cloud/domains/dns-zone-edit).
 
-[Protégez votre nom de domaine contre le Cache Poisoning avec le DNSSEC](/links/web/domains-dnssec).
+[Protégez votre nom de domaine contre le Cache Poisoning avec le DNSSEC](/guides/web-cloud/domains/dns-dnssec).
 
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
 

--- a/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ L’outil Zonemaster permet de vérifier une configuration DNS en place sur un n
 
 Pour vérifier la configuration actuelle d’un nom de domaine, saisissez votre nom de domaine puis cliquez sur <code className="action">Lancer</code>
 
-<img className="thumbnail" alt="Capture d’écran du formulaire de Zonemaster. Le domaine « domain.tld » a été saisi et est prêt à être testé." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire Zonemaster avec un nom de domaine saisi, prêt à être testé." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Pour vérifier une configuration DNS que vous avez préparée mais pas encore appliquée au nom de domaine concerné, cochez la case <code className="action">Options</code>, puis saisissez les informations suivantes :
 
@@ -46,12 +46,12 @@ Vous pouvez également forcer les vérifications sur un protocole IP spécifique
 >
 > Zonemaster réalisera un test comme si vous utilisiez les serveurs « dns1.test.tld » et « dns2.test.tld » sur « domain.tld ».
 >
-> <img className="thumbnail" alt="Capture d’écran des options avancées du formulaire de Zonemaster. Les deux serveurs de noms « dns1.test.tld » et « dns2.test.tld » ont été saisis dans la section « Serveurs de noms » du formulaire." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Options avancées du formulaire Zonemaster avec deux serveurs de noms saisis." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Lorsque vous saisissez un nom de domaine et que vous cliquez sur les boutons <code className="action">Récupérer les NS depuis la zone parente</code> et <code className="action">Récupérer les DS depuis la zone parente</code>, les serveurs DNS associés au nom de domaine apparaitront ainsi que les informations de l’enregistrement DS (DNSSEC) si celui-ci a été configuré.
 
-<img className="thumbnail" alt="Capture d’écran de la page de résultats de Zonemaster pour le domaine « domain.tld ». La section « Adresses » est développée." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Page de résultats de Zonemaster avec la section Adresses développée." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Résultat
@@ -65,7 +65,7 @@ Une fois le formulaire validé, les résultats sont affichés par groupe de test
 
 Pour chaque test, il est possible d’obtenir plus de détails, par exemple pour comprendre l’erreur dans le cas d’un dysfonctionnement, ou simplement à titre indicatif.
 
-<img className="thumbnail" alt="Page de résultats de Zonemaster, avec les groupes de tests triés par sévérité." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Page de résultats de Zonemaster avec les groupes de tests triés par sévérité." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Informations utiles
 

--- a/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutoriel - Utilisation de Zonemaster
 description: Découvrez comment analyser la configuration DNS d’un nom de domaine avec Zonemaster et identifier les éléments à corriger ou améliorer
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/fr/guides/web-cloud/domains/domain-icloud.mdx
@@ -33,7 +33,7 @@ Ce guide vous explique comment utiliser un nom de domaine enregistré chez OVHcl
 
 ### 1 - Activer le nom de domaine dans iCloud <a name="step1"></a>
 
-Pour activer votre nom de domaine dans iCloud, suivez les instructions de la page « Add a domain you own to iCloud Mail on iCloud.com » de la [documentation officielle Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentrez-vous sur la section « Step 3: Update the records with your domain registrar » (Mettre à jour les enregistrements auprès de votre registraire de domaine), pour relever les enregistrements DNS à ajouter dans votre zone DNS OVHcloud.
+Pour activer votre nom de domaine dans iCloud, suivez les instructions de la page « Add a domain you own to iCloud Mail on iCloud.com » de la [documentation officielle Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentrez-vous sur la section « Step 3: Update the records with your domain registrar » (Mettre à jour les enregistrements auprès de votre bureau d’enregistrement), pour relever les enregistrements DNS à ajouter dans votre zone DNS OVHcloud.
 
 À l’issue de cette étape, une liste d’enregistrements DNS (MX, CNAME, TXT) à configurer dans votre zone DNS OVHcloud vous sera communiquée par Apple. Conservez-les pour l’étape suivante.
 
@@ -45,7 +45,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
   <Tab label="Étape 1">
     Accédez à la page <ManagerLink to="/#/web/zone">Zones DNS</ManagerLink>, puis choisissez le nom de domaine concerné.
 
-    <img className="thumbnail" alt="Zones DNS" src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+    <img className="thumbnail" alt="Capture d’écran de l’espace client OVHcloud affichant la liste des zones DNS." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 2">
     Pour savoir comment ajouter, modifier ou supprimer chaque type d’enregistrement DNS (MX, CNAME, TXT, etc.), consultez notre guide « [Tout savoir sur les enregistrements DNS](/guides/web-cloud/domains/dns-zone-records) ».
@@ -67,7 +67,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 
 ### 3 - Ajouter un enregistrement DMARC (facultatif) <a name="step3"></a>
 
-Pour améliorer la délivrabilité de vos e-mails et éviter que vos messages arrivent en SPAM, ajoutez un enregistrement **DMARC**.
+Pour améliorer la délivrabilité de vos e-mails et éviter que vos messages arrivent en spam, ajoutez un enregistrement **DMARC**.
 
 Pour savoir comment créer un enregistrement DMARC dans votre espace client OVHcloud, consultez notre guide « [Améliorer la sécurité des e-mails via un enregistrement DMARC](/guides/web-cloud/domains/dns-zone-dmarc) ».
 
@@ -88,7 +88,7 @@ La validation peut échouer si vos enregistrements DNS n’ont pas encore été 
 
 #### Vérifier où est gérée la zone DNS
 
-Si votre nom de domaine est associé à des serveurs DNS externes à OVHcloud (Wix, Squarespace, Cloudflare, etc. ), la configuration doit être effectuée dans l’interface de gestion de ces serveurs DNS, hors de l’espace client OVHcloud.
+Si votre nom de domaine est associé à des serveurs DNS externes à OVHcloud (Wix, Squarespace, Cloudflare, etc.), la configuration doit être effectuée dans l’interface de gestion de ces serveurs DNS, hors de l’espace client OVHcloud.
 
 #### CNAME déjà existant
 
@@ -97,7 +97,7 @@ Si votre nom de domaine est associé à des serveurs DNS externes à OVHcloud (W
 
 #### SPF en doublon
 
-- Il ne peut exister qu’**un seul enregistrement SPF** par nom de domaine. Si un enregistrement SPF OVHcloud existe déjà (ex : `v=spf1 include:mx.ovh.com ~all`), fusionnez-le avec celui fourni par Apple (ex : `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
+- Il ne peut exister qu’**un seul enregistrement SPF** par nom de domaine. Si un enregistrement SPF OVHcloud existe déjà (ex : `v=spf1 include:mx.ovh.com ~all`), fusionnez-le avec celui fourni par Apple (ex : `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
 #### DKIM incomplet
 

--- a/docs/it/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-ips-update.mdx
@@ -1,64 +1,64 @@
 ---
-title: "List of IP addresses of OVHcloud DNS servers"
-description: "Find out the updated IP addresses for OVHcloud DNS servers"
+title: Modifica degli indirizzi IP dei server DNS OVHcloud
+description: Scopri la lista dei nuovi indirizzi IP dei server DNS OVHcloud
 lastUpdated: 2025-08-07
 availableIn: [eu, ca, apac]
 ---
 
 import { Region } from '@components/Zone';
 
-## Objective
+## Obiettivo
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+Questa guida presenta le modifiche degli indirizzi IP che riguardano una parte dei nostri server DNS ospitati in Europa, applicabili a partire da **agosto 2025**.
 
-**Discover the list of new IP addresses for OVHcloud DNS servers.**
+**Scopri la lista dei nuovi indirizzi IP dei server DNS.**
 
-## Requirements
+## Prerequisiti
 
-- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
+- Avere accesso allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> per gestire il nome di dominio interessato.
 
-## Instructions
+## Procedura
 
-### Who is concerned?
+### Chi è interessato?
 
-This change can impact customers who:
+Questa modifica può riguardare i clienti che:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
-- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
+- hanno definito un nome di server DNS personalizzato nei record DNS di tipo `NS` della propria zona DNS e hanno associato a questo nome l'indirizzo IP di un server DNS OVHcloud tramite un record DNS di tipo `A`;
+- hanno inoltre configurato un record `GLUE` per questo nome personalizzato, per associarlo all'indirizzo IP di un server DNS OVHcloud nella configurazione dei server DNS del dominio;
+- utilizzano attualmente questo nome personalizzato come server DNS del proprio dominio (definito nel loro Spazio Cliente o presso il proprio registrar).
 
-For more information, please read our guide on [Customizing a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+Per maggiori informazioni, consulta la nostra guida "[Personalizzare i server DNS di un dominio (Glue Records)](/guides/web-cloud/domains/glue-registry)".
 
 :::warning
-If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
+Se non hai effettuato alcuna modifica manuale della configurazione DNS (impostazione predefinita), questa modifica non ti riguarda.
 :::
 
-### Schedule
+### Calendario
 
-| Step                                | Estimated date           |
+| Fase | Data prevista |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
-| Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
-| Deletion of IPv4 traffic          | Early October 2025 |
+| Eliminazione del traffico IPv6 sui vecchi indirizzi IP | Effettuata il 5 agosto 2025 |
+| Messa in servizio dei nuovi indirizzi IP | Dal 5 agosto 2025 |
+| Invio della prima email informativa ai clienti interessati | Metà agosto 2025 |
+| Invio della seconda email di promemoria | 15 settembre 2025 |
+| Eliminazione del traffico IPv4 | Inizio ottobre 2025 |
 
 :::warning
-Using old IP addresses after this date will cause DNS resolution failure for domain names whose configuration has not been updated.
+L'utilizzo dei vecchi indirizzi IP dopo questa data causerà il fallimento della risoluzione DNS per i domini la cui configurazione non è stata aggiornata.
 :::
 
-### What can I do if I am concerned?
+### Cosa fare se sono interessato?
 
-1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+1. Verifica se utilizzi ancora un vecchio indirizzo IP nella tua zona DNS.
+2. **Sostituiscilo** con il nuovo indirizzo IP (consulta la tabella seguente).
+3. [Aggiorna i tuoi record GLUE](/guides/web-cloud/domains/glue-registry) se ne hai configurati nel tuo Spazio Cliente.
 
-### IP address mapping table
+### Tabella di corrispondenza degli indirizzi IP
 
-| Hostname     | Old IPv4   | New IPv4   | Old IPv6       | New IPv6         |
-|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 <Region zones={['eu']}>
 
+| Nome host     | Vecchio IPv4   | Nuovo IPv4   | Vecchio IPv6       | Nuovo IPv6         |
+|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |
@@ -123,10 +123,10 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 </Region>
 
-## Go further
+## Per saperne di più
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, consulta le nostre diverse [offerte di supporto](/links/support).
 
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tutorial - Utilizzo di Zonemaster
+description: Scopri come analizzare la configurazione DNS di un dominio con Zonemaster e individuare gli elementi da correggere o migliorare
 lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
@@ -35,16 +36,20 @@ Per verificare una configurazione DNS preparata ma non ancora applicata al nome 
 
 È inoltre possibile forzare le verifiche su un protocollo IP specifico tramite le caselle `Disable IPv6` e `Disable IPv4`
 
-> **Esempio**:<br/><br/> Lei è l’intestatario del nome di dominio "domain.tld", che utilizza attualmente i server DNS "dnsXX.ovh.net" e "nsXX.ovh.net". Hai configurato una zona DNS per questo nome di dominio sui server DNS "dns1.test.tld" e "dns2.test.tld".<br/>
+> **Esempio**:
 >
-> Prima di modificare i server DNS, puoi effettuare una ricerca avanzata utilizzando la casella <code className="action">Options</code> inserendo "dns1.test.tld" e "dns2.test.tld" nelle caselle `Nameservers`.<br/>
-> Zonemaster eseguirà un test come se utilizzaste i server "dns1.test.tld" e "dns2.test.tld" su "domain.tld".<br/>
+> Lei è l’intestatario del nome di dominio "domain.tld", che utilizza attualmente i server DNS "dnsXX.ovh.net" e "nsXX.ovh.net". Hai configurato una zona DNS per questo nome di dominio sui server DNS "dns1.test.tld" e "dns2.test.tld".
+>
+> Prima di modificare i server DNS, puoi effettuare una ricerca avanzata utilizzando la casella <code className="action">Options</code> inserendo "dns1.test.tld" e "dns2.test.tld" nelle caselle `Nameservers`.
+>
+> Zonemaster eseguirà un test come se utilizzaste i server "dns1.test.tld" e "dns2.test.tld" su "domain.tld".
+>
 > <img className="thumbnail" alt="Screenshot delle opzioni avanzate del modulo di Zonemaster. I due server con i nomi &quot;dns1.test.tld&quot; e &quot;dns2.test.tld&quot; sono stati inseriti nella sezione &quot;Server con i nomi&quot; del form." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Quando inserisci un nome di dominio e clicca sui pulsanti <code className="action">Fetch NS from parent zone</code> principale e <code className="action">Fetch DS from parent zone</code> principale, se configurato, i server DNS associati al nome di dominio appariranno insieme alle informazioni del record DS (DNSSEC).
 
-<img className="thumbnail" alt="Captura de pantalla de la página de resultados de Zonemaster para el dominio &quot;domain.tld&quot;. Se desarrolla la sección &quot;Address&quot;." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Screenshot della pagina dei risultati di Zonemaster per il nome di dominio &quot;domain.tld&quot;. La sezione &quot;Addresses&quot; è espansa." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### I Risultati
@@ -58,7 +63,7 @@ Una volta convalidato il modulo, i risultati sono classificati per codice colore
 
 Per ciascun test è possibile ottenere maggiori dettagli, ad esempio per comprendere l'errore nel caso di un malfunzionamento, o semplicemente a titolo indicativo.
 
-<img className="thumbnail" alt="Screenshot della pagina dei risultati di Zonemaster per il nome di dominio &quot;domain.tld&quot;. La sezione &quot;Address&quot; viene espansa." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Screenshot della pagina dei risultati di Zonemaster con i gruppi di test ordinati per severità." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Informazioni utili
 

--- a/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -25,29 +25,29 @@ Per comprendere meglio il concetto di DNS, consulta la nostra guida "[Sapere tut
 
 Il tool Zonemaster permette di verificare una configurazione DNS installata su un nome di dominio o di testare una zona DNS preconfigurata su server DNS futuri.
 
-Per verificare l'attuale configurazione di un nome di dominio, inserisci il tuo nome di dominio e clicca su <code className="action">Run</code>
+Per verificare l'attuale configurazione di un nome di dominio, inserisci il tuo nome di dominio e clicca su <code className="action">Run test</code>
 
 <img className="thumbnail" alt="Modulo di Zonemaster con un nome di dominio inserito, pronto per il test." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Per verificare una configurazione DNS preparata ma non ancora applicata al nome di dominio interessato, seleziona la casella <code className="action">Options</code> e inserisci le seguenti informazioni:
+Per verificare una configurazione DNS preparata ma non ancora applicata al nome di dominio interessato, seleziona la casella <code className="action">Show options</code> e inserisci le seguenti informazioni:
 
-- **Nameservers**: inserisci le informazioni del server del nome associato a un nome di dominio. Clicca su <code className="action">+</code> per aggiungere un server con un nome supplementare. Inserire un indirizzo IP è facoltativo.
-- **DS records**: inserisci gli elementi del record DS nell'ambito di una protezione DNSSEC. Clicca su <code className="action">+</code> per aggiungere un record DS aggiuntivo. Se i server DNS non utilizzano il protocollo DNSSEC, è possibile lasciare liberi questi campi. Nel caso di una zona firmata con DNSSEC, questa funzione permette di verificare che la zona funzioni correttamente con un resolver valido, con i record DS che stiamo per pubblicare, prima della loro pubblicazione.
+- **Nameservers**: inserisci le informazioni del server del nome associato a un nome di dominio. Un nuovo blocco `Nameserver` compare automaticamente non appena il precedente è compilato, il che permette di dichiararne diversi. Inserire un indirizzo IP è facoltativo.
+- **DS records**: inserisci gli elementi del record DS nell'ambito di una protezione DNSSEC. Un nuovo blocco `DS record` compare automaticamente non appena il precedente è compilato. Se i server DNS non utilizzano il protocollo DNSSEC, è possibile lasciare liberi questi campi. Nel caso di una zona firmata con DNSSEC, questa funzione permette di verificare che la zona funzioni correttamente con un resolver valido, con i record DS che stiamo per pubblicare, prima della loro pubblicazione.
 
-È inoltre possibile forzare le verifiche su un protocollo IP specifico tramite le caselle `Disable IPv6` e `Disable IPv4`
+È inoltre possibile forzare le verifiche su un protocollo IP specifico tramite le opzioni `IPv4 and IPv6`, `IPv4 only` e `IPv6 only`
 
 > **Esempio**:
 >
-> Lei è l’intestatario del nome di dominio "domain.tld", che utilizza attualmente i server DNS "dnsXX.ovh.net" e "nsXX.ovh.net". Hai configurato una zona DNS per questo nome di dominio sui server DNS "dns1.test.tld" e "dns2.test.tld".
+> Sei l’intestatario del nome di dominio "domain.tld", che utilizza attualmente i server DNS "dnsXX.ovh.net" e "nsXX.ovh.net". Hai configurato una zona DNS per questo nome di dominio sui server DNS "dns1.test.tld" e "dns2.test.tld".
 >
-> Prima di modificare i server DNS, puoi effettuare una ricerca avanzata utilizzando la casella <code className="action">Options</code> inserendo "dns1.test.tld" e "dns2.test.tld" nelle caselle `Nameservers`.
+> Prima di modificare i server DNS, puoi effettuare una ricerca avanzata utilizzando la casella <code className="action">Show options</code> inserendo "dns1.test.tld" e "dns2.test.tld" nelle caselle `Nameservers`.
 >
-> Zonemaster eseguirà un test come se utilizzaste i server "dns1.test.tld" e "dns2.test.tld" su "domain.tld".
+> Zonemaster eseguirà un test come se utilizzassi i server "dns1.test.tld" e "dns2.test.tld" su "domain.tld".
 >
 > <img className="thumbnail" alt="Opzioni avanzate del modulo di Zonemaster con due server dei nomi inseriti." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Quando inserisci un nome di dominio e clicca sui pulsanti <code className="action">Fetch NS from parent zone</code> principale e <code className="action">Fetch DS from parent zone</code> principale, se configurato, i server DNS associati al nome di dominio appariranno insieme alle informazioni del record DS (DNSSEC).
+Quando inserisci un nome di dominio e clicca sui pulsanti <code className="action">Fetch nameservers from parent zone</code> principale e <code className="action">Fetch DS from parent zone</code> principale, se configurato, i server DNS associati al nome di dominio appariranno insieme alle informazioni del record DS (DNSSEC).
 
 <img className="thumbnail" alt="Pagina dei risultati di Zonemaster con la sezione Addresses espansa." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::

--- a/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Utilizzo di Zonemaster
 description: Scopri come analizzare la configurazione DNS di un dominio con Zonemaster e individuare gli elementi da correggere o migliorare
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ Il tool Zonemaster permette di verificare una configurazione DNS installata su u
 
 Per verificare l'attuale configurazione di un nome di dominio, inserisci il tuo nome di dominio e clicca su <code className="action">Run</code>
 
-<img className="thumbnail" alt="Screenshot dal modulo di Zonemaster. Il nome di dominio &quot;domain.tld&quot; è stato inserito ed è pronto per essere testato." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Modulo di Zonemaster con un nome di dominio inserito, pronto per il test." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Per verificare una configurazione DNS preparata ma non ancora applicata al nome di dominio interessato, seleziona la casella <code className="action">Options</code> e inserisci le seguenti informazioni:
 
@@ -44,12 +44,12 @@ Per verificare una configurazione DNS preparata ma non ancora applicata al nome 
 >
 > Zonemaster eseguirà un test come se utilizzaste i server "dns1.test.tld" e "dns2.test.tld" su "domain.tld".
 >
-> <img className="thumbnail" alt="Screenshot delle opzioni avanzate del modulo di Zonemaster. I due server con i nomi &quot;dns1.test.tld&quot; e &quot;dns2.test.tld&quot; sono stati inseriti nella sezione &quot;Server con i nomi&quot; del form." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Opzioni avanzate del modulo di Zonemaster con due server dei nomi inseriti." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Quando inserisci un nome di dominio e clicca sui pulsanti <code className="action">Fetch NS from parent zone</code> principale e <code className="action">Fetch DS from parent zone</code> principale, se configurato, i server DNS associati al nome di dominio appariranno insieme alle informazioni del record DS (DNSSEC).
 
-<img className="thumbnail" alt="Screenshot della pagina dei risultati di Zonemaster per il nome di dominio &quot;domain.tld&quot;. La sezione &quot;Addresses&quot; è espansa." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Pagina dei risultati di Zonemaster con la sezione Addresses espansa." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### I Risultati
@@ -63,7 +63,7 @@ Una volta convalidato il modulo, i risultati sono classificati per codice colore
 
 Per ciascun test è possibile ottenere maggiori dettagli, ad esempio per comprendere l'errore nel caso di un malfunzionamento, o semplicemente a titolo indicativo.
 
-<img className="thumbnail" alt="Screenshot della pagina dei risultati di Zonemaster con i gruppi di test ordinati per severità." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Pagina dei risultati di Zonemaster con i gruppi di test ordinati per severità." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Informazioni utili
 

--- a/docs/it/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-icloud.mdx
@@ -1,97 +1,116 @@
 ---
-title: "How to use an OVHcloud domain with iCloud Mail"
-description: "Find out how to configure your OVHcloud domain name with iCloud to create custom email addresses"
-lastUpdated: 2025-08-27
+title: Come utilizzare un nome di dominio OVHcloud con iCloud Mail
+description: Scopri come configurare il tuo nome di dominio OVHcloud con iCloud per creare indirizzi e-mail personalizzati
+lastUpdated: 2026-03-27
 availableIn: [eu, ca, apac]
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 [[fragment:support-scope]]
 
-## Objective
+## Obiettivo
 
-This guide explains how to use an OVHcloud-registered domain name with the Apple iCloud Mail service. You can then create custom email addresses (`firstname@mydomain.com`), which are fully managed and hosted by Apple.
+Questa guida ti spiega come utilizzare un nome di dominio registrato presso OVHcloud con il servizio iCloud Mail di Apple. Potrai così creare indirizzi email personalizzati (`nome@miodominio.it`), interamente gestiti e ospitati da Apple.
 
-## Requirements
+## Prerequisiti
 
-- A [domain name](/links/web/domains) registered with OVHcloud.
-- You have access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- You have the rights to manage the DNS zone for the domain name concerned via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- An Apple ID with an **iCloud+** subscription.
+- Disporre di un [nome di dominio](/links/web/domains) registrato presso OVHcloud.
+- Disporre di un ID Apple con un abbonamento **iCloud+**.
 
-## Instructions
+{/* CP-NAV-START:web-dns-zone */}
+---
 
-### Step 1: Activate the domain name in iCloud <a id="step1"></a>
+### Accesso allo Spazio Cliente OVHcloud
 
-To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section, to find the DNS records to add to your OVHcloud DNS zone.
+- **Link diretto:** <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink>
+- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Zone DNS</code> > Seleziona il tuo nome di dominio
 
-At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
+---
+{/* CP-NAV-END:web-dns-zone */}
 
-### Step 2: Configure the DNS records in your OVHcloud Control Panel
+## Procedura
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-2. Go to the `Web Cloud` section.
-3. Click `DNS zones`, then choose the domain name concerned.
-4. Add or edit the records mentioned below.
+### 1 - Attivare il nome di dominio su iCloud <a name="step1"></a>
 
-To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+Per attivare il tuo nome di dominio su iCloud, segui le istruzioni della pagina "Add a domain you own to iCloud Mail on iCloud.com" della [documentazione ufficiale Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentrati sulla sezione "Step 3: Update the records with your domain registrar" (Aggiornare i record presso il tuo registrar), per individuare i record DNS da aggiungere nella tua zona DNS OVHcloud.
 
-Using the DNS records you previously retrieved ([Step 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
+Al termine di questa fase, Apple ti comunicherà una lista di record DNS (MX, CNAME, TXT) da configurare nella tua zona DNS OVHcloud. Conservali per la fase successiva.
 
-- **MX** : for receiving emails.
-- **CNAME**: for DKIM keys (`sig1._domainkey...`, `sig2._domainkey...`).
-- **TXT**: for SPF (merge if an SPF record already exists).
-- **TXT DMARC**: Optional but recommended ([Step 3](#step3)).
+### 2 - Configurare i record DNS nel tuo Spazio Cliente OVHcloud
+
+Clicca sulle tab qui sotto per visualizzare in sequenza ognuna delle **2** fasi.
+
+<Tabs>
+  <Tab label="Passaggio 1">
+    Accedi alla pagina <ManagerLink to="/#/web/zone">Zone DNS</ManagerLink> e seleziona il nome di dominio interessato.
+
+    <img className="thumbnail" alt="Screenshot dello Spazio Cliente OVHcloud con la lista delle zone DNS." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+  </Tab>
+  <Tab label="Passaggio 2">
+    Per sapere come aggiungere, modificare o eliminare ogni tipo di record DNS (MX, CNAME, TXT, ecc.), consulta la nostra guida "[Scopri tutto sui record DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+    Utilizzando i record DNS individuati in precedenza ([Parte 1](#step1)), crea o aggiorna i campi corrispondenti nella tua zona DNS OVHcloud:
+
+    - **MX**: per la ricezione delle email.
+    - **CNAME**: per le chiavi DKIM (`sig1._domainkey...`, `sig2._domainkey...`).
+    - **TXT**: per l'SPF (uniscilo se esiste già un record SPF).
+    - **TXT DMARC**: facoltativo ma consigliato ([Parte 3](#step3)).
+
+    :::warning
+    Utilizza esclusivamente le virgolette dritte `”` così come compaiono nella documentazione tecnica di Apple (generalmente in versione inglese). Le virgolette tipografiche « » o “ “ visualizzate in alcune traduzioni non devono essere utilizzate nella configurazione DNS.
+
+    :::
+
+  </Tab>
+</Tabs>
+
+### 3 - Aggiungere un record DMARC (facoltativo) <a name="step3"></a>
+
+Per migliorare la deliverability delle tue email ed evitare che i tuoi messaggi finiscano nello spam, aggiungi un record **DMARC**.
+
+Per sapere come creare un record DMARC nel tuo Spazio Cliente OVHcloud, consulta la nostra guida "[Migliora la sicurezza delle email con un record DMARC](/guides/web-cloud/domains/dns-zone-dmarc)".
+
+### 4 - Verificare e attivare il dominio su iCloud
+
+Una volta aggiunti correttamente i record DNS (MX, CNAME, TXT, DMARC) nella tua zona DNS OVHcloud, torna su [iCloud.com](https://www.icloud.com).
+
+Segui le istruzioni della pagina "Add a domain you own to iCloud Mail on iCloud.com" della [documentazione ufficiale Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentrati sulla sezione "Step 4: Finish setting up the domain".
+
+Una volta completata questa fase, il tuo nome di dominio personalizzato è pienamente attivo e puoi creare fino a 3 indirizzi per persona, nell'ambito familiare.
 
 :::warning
-Use only the quotation marks `"` as they appear in Apple's technical documentation (usually in English). The quotation marks « » or " " displayed in some translations should not be used in DNS configuration.
+La verifica può non riuscire se i tuoi record DNS non sono stati ancora propagati. Questa propagazione può richiedere diverse ore.
+
 :::
 
-### Step 3: Add a DMARC record (optional) <a id="step3"></a>
+### Risoluzione dei problemi più comuni
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+#### Verificare dove è gestita la zona DNS
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, please refer to our guide on [Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+Se il tuo nome di dominio è associato a server DNS esterni a OVHcloud (Wix, Squarespace, Cloudflare, ecc.), la configurazione deve essere effettuata nell'interfaccia di gestione di questi server DNS, al di fuori dello Spazio Cliente OVHcloud.
 
-### Step 4: Verify and activate the domain in iCloud
+#### CNAME già esistente
 
-Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
+- Un record **CNAME** non può coesistere con un record **A, AAAA o TXT** configurato sullo stesso dominio o sottodominio.
+- Elimina il vecchio record prima di creare il CNAME richiesto da Apple.
 
-Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
+#### SPF duplicato
 
-Once this step is complete, your custom domain is fully activated and you can create up to 3 addresses per person within your family.
+- Può esistere un **solo record SPF** per nome di dominio. Se esiste già un record SPF OVHcloud (es.: `v=spf1 include:mx.ovh.com ~all`), uniscilo a quello fornito da Apple (es.: `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
-:::warning
-Validation may fail if your DNS records have not yet been propagated. This propagation may take several hours.
-:::
+#### DKIM incompleto
 
-### Common troubleshooting
+- Apple ti invita a registrare più chiavi DKIM (`sig1`, `sig2`, ecc.) nella tua zona DNS.
 
-#### Check where the DNS zone is managed
+#### Tempi di propagazione
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc. ), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+- Le modifiche DNS possono richiedere diverse ore (fino a 24 ore) prima di essere riconosciute da Apple.
 
-#### CNAME already exists
+## Per saperne di più
 
-- A **CNAME** record cannot coexist with a **A, AAAA, or TXT** record configured on the same domain or subdomain.
-- Delete the old record before creating the CNAME requested by Apple.
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-#### Duplicate SPF
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, consulta le nostre diverse [offerte di supporto](/links/support).
 
-- There can only be **one SPF record** per domain name. If an OVHcloud SPF record already exists (e.g.: `v=spf1 include:mx.ovh.com ~all`), merge it with the one provided by Apple (e.g.:
-`v=spf1 include:mx.ovh.com include:icloud.com ~all`).
-
-#### Incomplete DKIM
-
-- Apple invites you to save several DKIM keys (`sig1`, `sig2`, etc.) in your DNS zone.
-
-#### Propagation time
-
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
-
-## Go further
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner) .
-
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
-
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-ips-update.mdx
@@ -1,64 +1,64 @@
 ---
-title: "List of IP addresses of OVHcloud DNS servers"
-description: "Find out the updated IP addresses for OVHcloud DNS servers"
+title: Lista adresów IP serwerów DNS OVHcloud
+description: Poznaj zaktualizowane adresy IP serwerów DNS OVHcloud
 lastUpdated: 2025-08-07
 availableIn: [eu, ca, apac]
 ---
 
 import { Region } from '@components/Zone';
 
-## Objective
+## Wprowadzenie
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+Niniejszy przewodnik przedstawia zmiany adresów IP dotyczące części naszych serwerów DNS hostowanych w Europie, które obowiązują od **sierpnia 2025 roku**.
 
-**Discover the list of new IP addresses for OVHcloud DNS servers.**
+**Poznaj listę nowych adresów IP serwerów DNS OVHcloud.**
 
-## Requirements
+## Wymagania początkowe
 
-- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
+- Dostęp do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> w celu zarządzania daną nazwą domeny.
 
-## Instructions
+## W praktyce
 
-### Who is concerned?
+### Kogo dotyczy ta zmiana?
 
-This change can impact customers who:
+Zmiana ta może dotyczyć klientów, którzy:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
-- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
+- zdefiniowali własną nazwę serwera DNS w rekordach DNS typu `NS` swojej strefy DNS i powiązali z tą nazwą adres IP serwera DNS OVHcloud za pomocą rekordu DNS typu `A`;
+- skonfigurowali dodatkowo rekord `GLUE` dla tej własnej nazwy, aby powiązać ją z adresem IP serwera DNS OVHcloud w konfiguracji serwerów DNS nazwy domeny;
+- używają obecnie tej własnej nazwy jako serwera DNS swojej nazwy domeny (zdefiniowanego w Panelu klienta lub u swojego rejestratora).
 
-For more information, please read our guide on [Customizing a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+Więcej informacji znajdziesz w przewodniku "[Personalizacja serwerów DNS nazwy domeny (Glue Records)](/guides/web-cloud/domains/glue-registry)".
 
 :::warning
-If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
+Jeśli nie wprowadziłeś żadnych ręcznych zmian w konfiguracji DNS (ustawienie domyślne), zmiana ta Cię nie dotyczy.
 :::
 
-### Schedule
+### Harmonogram
 
-| Step                                | Estimated date           |
+| Etap | Przewidywana data |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
-| Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
-| Deletion of IPv4 traffic          | Early October 2025 |
+| Usunięcie ruchu IPv6 na starych adresach IP | Zrealizowane 5 sierpnia 2025 |
+| Uruchomienie nowych adresów IP | Od 5 sierpnia 2025 |
+| Wysyłka pierwszej wiadomości informacyjnej do zidentyfikowanych klientów | Połowa sierpnia 2025 |
+| Wysyłka drugiej wiadomości przypominającej | 15 września 2025 |
+| Usunięcie ruchu IPv4 | Początek października 2025 |
 
 :::warning
-Using old IP addresses after this date will cause DNS resolution failure for domain names whose configuration has not been updated.
+Korzystanie ze starych adresów IP po tej dacie spowoduje niepowodzenie rozwiązywania nazw DNS dla nazw domen, których konfiguracja nie została zaktualizowana.
 :::
 
-### What can I do if I am concerned?
+### Co zrobić, jeśli zmiana mnie dotyczy?
 
-1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+1. Sprawdź, czy nadal używasz starego adresu IP w swojej strefie DNS.
+2. **Zastąp go** nowym adresem IP (patrz tabela poniżej).
+3. [Zaktualizuj rekordy GLUE](/guides/web-cloud/domains/glue-registry), jeśli skonfigurowałeś je w Panelu klienta OVHcloud.
 
-### IP address mapping table
+### Tabela odpowiedników adresów IP
 
-| Hostname     | Old IPv4   | New IPv4   | Old IPv6       | New IPv6         |
-|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 <Region zones={['eu']}>
 
+| Nazwa hosta     | Stary adres IPv4   | Nowy adres IPv4   | Stary adres IPv6       | Nowy adres IPv6         |
+|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |
@@ -116,17 +116,17 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 <Region zones={['ca', 'apac']}>
 
-| Server | IP |
+| Serwer | IP |
 |---|---|
 | dns10.ovh.ca | 192.99.60.247 |
 | ns10.ovh.ca | 167.114.154.30 |
 
 </Region>
 
-## Go further
+## Sprawdź również
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Korzystanie z narzędzia Zonemaster
 description: Dowiedz się, jak analizować konfigurację DNS nazwy domeny za pomocą narzędzia Zonemaster i wskazać elementy do poprawy lub korekty
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ Narzędzie Zonemaster umożliwia sprawdzenie konfiguracji DNS działającej już
 
 Aby sprawdzić aktualną konfigurację nazwy domeny, wpisz nazwę domeny, a następnie kliknij <code className="action">Run test</code>
 
-<img className="thumbnail" alt="Zrzut ekranu formularza Zonemaster. Nazwa domeny &quot;domain.tld&quot; została wpisana i jest gotowa do przetestowania." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Formularz Zonemaster z wpisaną nazwą domeny, gotowy do przetestowania." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Aby sprawdzić konfigurację DNS, która została przygotowana, ale nie została jeszcze zastosowana dla danej nazwy domeny, zaznacz pole <code className="action">Options</code>, a następnie wprowadź następujące informacje:
 
@@ -46,12 +46,12 @@ Możesz również wymusić przeprowadzenie testów na konkretnym protokole IP za
 >
 > Zonemaster przeprowadzi test tak, jakbyś używał serwerów "dns1.test.tld" i "dns2.test.tld" dla domeny "domain.tld".
 >
-> <img className="thumbnail" alt="Zrzut ekranu zaawansowanych opcji formularza Zonemaster. Dwa serwery nazw &quot;dns1.test.tld&quot; i &quot;dns2.test.tld&quot; zostały wpisane w sekcji &quot;Name servers&quot; formularza." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Zaawansowane opcje formularza Zonemaster z dwoma wpisanymi serwerami nazw." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Po wpisaniu nazwy domeny i kliknięciu przycisków <code className="action">Fetch NS from parent zone</code> oraz <code className="action">Fetch DS from parent zone</code> wyświetlą się serwery DNS powiązane z nazwą domeny, a także dane rekordu DS (DNSSEC), jeśli został skonfigurowany.
 
-<img className="thumbnail" alt="Zrzut ekranu strony wyników Zonemaster dla domeny &quot;domain.tld&quot;. Sekcja &quot;Addresses&quot; jest rozwinięta." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Strona wyników Zonemaster z rozwiniętą sekcją Addresses." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Wynik
@@ -65,7 +65,7 @@ Po zatwierdzeniu formularza wyniki wyświetlane są w grupach testów. Testy są
 
 Dla każdego testu można uzyskać więcej szczegółów, na przykład aby zrozumieć błąd w przypadku nieprawidłowego działania lub po prostu w celach informacyjnych.
 
-<img className="thumbnail" alt="Zrzut ekranu strony wyników Zonemaster z grupami testów posortowanymi według poziomu istotności." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Strona wyników Zonemaster z grupami testów posortowanymi według poziomu istotności." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Przydatne informacje
 

--- a/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,1 +1,86 @@
-../../../../en/guides/web-cloud/domains/dns-zonemaster.mdx
+---
+title: Tutorial - Korzystanie z narzędzia Zonemaster
+description: Dowiedz się, jak analizować konfigurację DNS nazwy domeny za pomocą narzędzia Zonemaster i wskazać elementy do poprawy lub korekty
+lastUpdated: 2026-02-10
+availableIn: [eu, ca, apac]
+---
+
+[[fragment:support-scope]]
+
+## Wprowadzenie
+
+[Zonemaster](https://zonemaster.net/en/) to narzędzie powstałe we współpracy [AFNIC](https://www.afnic.fr/) (francuskiego rejestru) oraz [The Swedish Internet Foundation](https://internetstiftelsen.se/en/) (szwedzkiego rejestru). Umożliwia ono analizę konfiguracji DNS (Domain Name System) nazwy domeny oraz wskazanie elementów, które można poprawić lub skorygować.
+
+:::info
+Aby lepiej zrozumieć pojęcie DNS, zapoznaj się z naszym przewodnikiem "[Wszystko o strefie DNS](/guides/web-cloud/domains/dns-zone-general-information)".
+:::
+
+## Wymagania początkowe
+
+- Posiadanie [nazwy domeny](/links/web/domains)
+
+## W praktyce
+
+### Pole wprowadzania danych
+
+Narzędzie Zonemaster umożliwia sprawdzenie konfiguracji DNS działającej już dla nazwy domeny lub przetestowanie strefy DNS wstępnie skonfigurowanej na przyszłych serwerach DNS.
+
+Aby sprawdzić aktualną konfigurację nazwy domeny, wpisz nazwę domeny, a następnie kliknij <code className="action">Run test</code>
+
+<img className="thumbnail" alt="Zrzut ekranu formularza Zonemaster. Nazwa domeny &quot;domain.tld&quot; została wpisana i jest gotowa do przetestowania." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+
+Aby sprawdzić konfigurację DNS, która została przygotowana, ale nie została jeszcze zastosowana dla danej nazwy domeny, zaznacz pole <code className="action">Options</code>, a następnie wprowadź następujące informacje:
+
+- **Name servers**: wpisz dane serwera nazw powiązanego z nazwą domeny. Kliknij <code className="action">+</code>, aby dodać kolejny serwer nazw. Podanie adresu IP jest opcjonalne.
+- **Delegation Signer (DS record)**: w ramach zabezpieczenia DNSSEC wpisz dane rekordu DS. Kliknij <code className="action">+</code>, aby dodać kolejny rekord DS. Jeśli serwery DNS nie korzystają z protokołu DNSSEC, możesz pozostawić te pola puste. W przypadku strefy podpisanej za pomocą DNSSEC funkcja ta pozwala sprawdzić, przed publikacją, czy strefa działa poprawnie z walidującym serwerem rozwiązującym nazwy przy użyciu rekordów DS, które zamierzasz opublikować.
+
+Możesz również wymusić przeprowadzenie testów na konkretnym protokole IP za pomocą pól `Disable IPv6` i `Disable IPv4`
+
+> **Przykład**:
+>
+> Jesteś właścicielem nazwy domeny "domain.tld", która korzysta obecnie z serwerów DNS "dnsXX.ovh.net" i "nsXX.ovh.net".
+>
+> Dla tej nazwy domeny skonfigurowałeś strefę DNS na serwerach DNS "dns1.test.tld" i "dns2.test.tld".
+>
+> Przed zmianą serwerów DNS możesz przeprowadzić zaawansowane wyszukiwanie za pomocą pola <code className="action">Options</code>, wpisując "dns1.test.tld" i "dns2.test.tld" w polach `Name servers`.
+>
+> Zonemaster przeprowadzi test tak, jakbyś używał serwerów "dns1.test.tld" i "dns2.test.tld" dla domeny "domain.tld".
+>
+> <img className="thumbnail" alt="Zrzut ekranu zaawansowanych opcji formularza Zonemaster. Dwa serwery nazw &quot;dns1.test.tld&quot; i &quot;dns2.test.tld&quot; zostały wpisane w sekcji &quot;Name servers&quot; formularza." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+
+:::info
+Po wpisaniu nazwy domeny i kliknięciu przycisków <code className="action">Fetch NS from parent zone</code> oraz <code className="action">Fetch DS from parent zone</code> wyświetlą się serwery DNS powiązane z nazwą domeny, a także dane rekordu DS (DNSSEC), jeśli został skonfigurowany.
+
+<img className="thumbnail" alt="Zrzut ekranu strony wyników Zonemaster dla domeny &quot;domain.tld&quot;. Sekcja &quot;Addresses&quot; jest rozwinięta." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+:::
+
+### Wynik
+
+Po zatwierdzeniu formularza wyniki wyświetlane są w grupach testów. Testy są posortowane według poziomu istotności.
+
+- **Error**: ta część przedstawia błędy lub brakujące elementy, które mogą powodować nieprawidłowe działanie.
+- **Warning**: ta część działa poprawnie, ale zasługuje na szczególną uwagę. Narzędzie wykryło, że dany parametr nie odpowiada standardowi swojej kategorii, co jednak nie blokuje jego działania.
+- **Notice**: to wyłącznie informacja, która nie ma szczególnego wpływu na działanie nazwy domeny.
+- **Info**: ta część działa poprawnie i spełnia standardowe kryteria swojej kategorii.
+
+Dla każdego testu można uzyskać więcej szczegółów, na przykład aby zrozumieć błąd w przypadku nieprawidłowego działania lub po prostu w celach informacyjnych.
+
+<img className="thumbnail" alt="Zrzut ekranu strony wyników Zonemaster z grupami testów posortowanymi według poziomu istotności." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+
+### Przydatne informacje
+
+Jeśli masz dodatkowe pytania dotyczące narzędzia Zonemaster, zapoznaj się z sekcją [FAQ](https://zonemaster.net/en/faq) na stronie [https://zonemaster.net/](https://zonemaster.net/).
+
+## Sprawdź również <a name="go-further"></a>
+
+[Wszystko o serwerach DNS](/guides/web-cloud/domains/dns-server-general-information).
+
+[Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit).
+
+[Zabezpieczenie nazwy domeny przed atakiem Cache Poisoning za pomocą DNSSEC](/links/web/domains-dnssec).
+
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
+
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
+
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -29,12 +29,12 @@ Aby sprawdzić aktualną konfigurację nazwy domeny, wpisz nazwę domeny, a nast
 
 <img className="thumbnail" alt="Formularz Zonemaster z wpisaną nazwą domeny, gotowy do przetestowania." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Aby sprawdzić konfigurację DNS, która została przygotowana, ale nie została jeszcze zastosowana dla danej nazwy domeny, zaznacz pole <code className="action">Options</code>, a następnie wprowadź następujące informacje:
+Aby sprawdzić konfigurację DNS, która została przygotowana, ale nie została jeszcze zastosowana dla danej nazwy domeny, zaznacz pole <code className="action">Show options</code>, a następnie wprowadź następujące informacje:
 
-- **Name servers**: wpisz dane serwera nazw powiązanego z nazwą domeny. Kliknij <code className="action">+</code>, aby dodać kolejny serwer nazw. Podanie adresu IP jest opcjonalne.
-- **Delegation Signer (DS record)**: w ramach zabezpieczenia DNSSEC wpisz dane rekordu DS. Kliknij <code className="action">+</code>, aby dodać kolejny rekord DS. Jeśli serwery DNS nie korzystają z protokołu DNSSEC, możesz pozostawić te pola puste. W przypadku strefy podpisanej za pomocą DNSSEC funkcja ta pozwala sprawdzić, przed publikacją, czy strefa działa poprawnie z walidującym serwerem rozwiązującym nazwy przy użyciu rekordów DS, które zamierzasz opublikować.
+- **Nameservers**: wpisz dane serwera nazw powiązanego z nazwą domeny. Nowy blok `Nameserver` pojawia się automatycznie po wypełnieniu poprzedniego, co pozwala zadeklarować ich kilka. Podanie adresu IP jest opcjonalne.
+- **DS records**: w ramach zabezpieczenia DNSSEC wpisz dane rekordu DS. Nowy blok `DS record` pojawia się automatycznie po wypełnieniu poprzedniego. Jeśli serwery DNS nie korzystają z protokołu DNSSEC, możesz pozostawić te pola puste. W przypadku strefy podpisanej za pomocą DNSSEC funkcja ta pozwala sprawdzić, przed publikacją, czy strefa działa poprawnie z walidującym serwerem rozwiązującym nazwy przy użyciu rekordów DS, które zamierzasz opublikować.
 
-Możesz również wymusić przeprowadzenie testów na konkretnym protokole IP za pomocą pól `Disable IPv6` i `Disable IPv4`
+Możesz również wymusić przeprowadzenie testów na konkretnym protokole IP za pomocą opcji `IPv4 and IPv6`, `IPv4 only` i `IPv6 only`
 
 > **Przykład**:
 >
@@ -42,14 +42,14 @@ Możesz również wymusić przeprowadzenie testów na konkretnym protokole IP za
 >
 > Dla tej nazwy domeny skonfigurowałeś strefę DNS na serwerach DNS "dns1.test.tld" i "dns2.test.tld".
 >
-> Przed zmianą serwerów DNS możesz przeprowadzić zaawansowane wyszukiwanie za pomocą pola <code className="action">Options</code>, wpisując "dns1.test.tld" i "dns2.test.tld" w polach `Name servers`.
+> Przed zmianą serwerów DNS możesz przeprowadzić zaawansowane wyszukiwanie za pomocą pola <code className="action">Show options</code>, wpisując "dns1.test.tld" i "dns2.test.tld" w polach `Nameservers`.
 >
 > Zonemaster przeprowadzi test tak, jakbyś używał serwerów "dns1.test.tld" i "dns2.test.tld" dla domeny "domain.tld".
 >
 > <img className="thumbnail" alt="Zaawansowane opcje formularza Zonemaster z dwoma wpisanymi serwerami nazw." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Po wpisaniu nazwy domeny i kliknięciu przycisków <code className="action">Fetch NS from parent zone</code> oraz <code className="action">Fetch DS from parent zone</code> wyświetlą się serwery DNS powiązane z nazwą domeny, a także dane rekordu DS (DNSSEC), jeśli został skonfigurowany.
+Po wpisaniu nazwy domeny i kliknięciu przycisków <code className="action">Fetch nameservers from parent zone</code> oraz <code className="action">Fetch DS from parent zone</code> wyświetlą się serwery DNS powiązane z nazwą domeny, a także dane rekordu DS (DNSSEC), jeśli został skonfigurowany.
 
 <img className="thumbnail" alt="Strona wyników Zonemaster z rozwiniętą sekcją Addresses." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
@@ -77,7 +77,7 @@ Jeśli masz dodatkowe pytania dotyczące narzędzia Zonemaster, zapoznaj się z 
 
 [Modyfikacja strefy DNS](/guides/web-cloud/domains/dns-zone-edit).
 
-[Zabezpieczenie nazwy domeny przed atakiem Cache Poisoning za pomocą DNSSEC](/links/web/domains-dnssec).
+[Zabezpieczenie nazwy domeny przed atakiem Cache Poisoning za pomocą DNSSEC](/guides/web-cloud/domains/dns-dnssec).
 
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 

--- a/docs/pl/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-icloud.mdx
@@ -1,97 +1,116 @@
 ---
-title: "How to use an OVHcloud domain with iCloud Mail"
-description: "Find out how to configure your OVHcloud domain name with iCloud to create custom email addresses"
-lastUpdated: 2025-08-27
+title: Jak używać nazwy domeny OVHcloud z usługą iCloud Mail
+description: Dowiedz się, jak skonfigurować nazwę domeny OVHcloud z usługą iCloud, aby tworzyć spersonalizowane adresy e-mail
+lastUpdated: 2026-03-27
 availableIn: [eu, ca, apac]
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 [[fragment:support-scope]]
 
-## Objective
+## Wprowadzenie
 
-This guide explains how to use an OVHcloud-registered domain name with the Apple iCloud Mail service. You can then create custom email addresses (`firstname@mydomain.com`), which are fully managed and hosted by Apple.
+W tym przewodniku dowiesz się, jak używać nazwy domeny zarejestrowanej w OVHcloud z usługą iCloud Mail firmy Apple. Dzięki temu możesz tworzyć spersonalizowane adresy e-mail (`imie@mojadomena.pl`), w pełni zarządzane i hostowane przez Apple.
 
-## Requirements
+## Wymagania początkowe
 
-- A [domain name](/links/web/domains) registered with OVHcloud.
-- You have access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- You have the rights to manage the DNS zone for the domain name concerned via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- An Apple ID with an **iCloud+** subscription.
+- Posiadanie [nazwy domeny](/links/web/domains) zarejestrowanej w OVHcloud.
+- Posiadanie identyfikatora Apple z abonamentem **iCloud+**.
 
-## Instructions
+{/* CP-NAV-START:web-dns-zone */}
+---
 
-### Step 1: Activate the domain name in iCloud <a id="step1"></a>
+### Dostęp do Panelu klienta OVHcloud
 
-To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section, to find the DNS records to add to your OVHcloud DNS zone.
+- **Link bezpośredni:** <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>
+- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Strefy DNS</code> > Wybierz nazwę domeny
 
-At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
+---
+{/* CP-NAV-END:web-dns-zone */}
 
-### Step 2: Configure the DNS records in your OVHcloud Control Panel
+## W praktyce
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-2. Go to the `Web Cloud` section.
-3. Click `DNS zones`, then choose the domain name concerned.
-4. Add or edit the records mentioned below.
+### 1 - Aktywacja nazwy domeny w usłudze iCloud <a name="step1"></a>
 
-To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+Aby aktywować nazwę domeny w usłudze iCloud, postępuj zgodnie z instrukcjami na stronie "Add a domain you own to iCloud Mail on iCloud.com" w [oficjalnej dokumentacji Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Zwróć szczególną uwagę na sekcję "Step 3: Update the records with your domain registrar", aby poznać rekordy DNS, które należy dodać do Twojej strefy DNS OVHcloud.
 
-Using the DNS records you previously retrieved ([Step 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
+Na końcu tego etapu Apple przekaże Ci listę rekordów DNS (MX, CNAME, TXT) do skonfigurowania w Twojej strefie DNS OVHcloud. Zachowaj je na potrzeby kolejnego etapu.
 
-- **MX** : for receiving emails.
-- **CNAME**: for DKIM keys (`sig1._domainkey...`, `sig2._domainkey...`).
-- **TXT**: for SPF (merge if an SPF record already exists).
-- **TXT DMARC**: Optional but recommended ([Step 3](#step3)).
+### 2 - Konfiguracja rekordów DNS w Panelu klienta OVHcloud
+
+Kliknij poniższe zakładki, aby wyświetlić kolejno każdy z **2** etapów.
+
+<Tabs>
+  <Tab label="Krok 1">
+    Przejdź na stronę <ManagerLink to="/#/web/zone">Strefy DNS</ManagerLink>, a następnie wybierz odpowiednią nazwę domeny.
+
+    <img className="thumbnail" alt="Zrzut ekranu Panelu klienta OVHcloud z listą stref DNS." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+  </Tab>
+  <Tab label="Krok 2">
+    Aby dowiedzieć się, jak dodać, zmodyfikować lub usunąć poszczególne typy rekordów DNS (MX, CNAME, TXT itp.), zapoznaj się z naszym przewodnikiem "[Wszystko o rekordach DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+    Korzystając z wcześniej uzyskanych rekordów DNS ([Część 1](#step1)), utwórz lub zaktualizuj odpowiednie pola w Twojej strefie DNS OVHcloud:
+
+    - **MX**: do odbierania wiadomości e-mail.
+    - **CNAME**: dla kluczy DKIM (`sig1._domainkey...`, `sig2._domainkey...`).
+    - **TXT**: dla SPF (scal rekordy, jeśli rekord SPF już istnieje).
+    - **TXT DMARC**: opcjonalny, ale zalecany ([Część 3](#step3)).
+
+    :::warning
+    Używaj wyłącznie prostych cudzysłowów `”`, tak jak są one przedstawione w dokumentacji technicznej Apple (zazwyczaj w wersji angielskiej). Cudzysłowów typograficznych « » lub “ “ wyświetlanych w niektórych tłumaczeniach nie należy stosować w konfiguracji DNS.
+
+    :::
+
+  </Tab>
+</Tabs>
+
+### 3 - Dodanie rekordu DMARC (opcjonalnie) <a name="step3"></a>
+
+Aby poprawić dostarczalność wiadomości e-mail i zapobiec ich trafianiu do spamu, dodaj rekord **DMARC**.
+
+Aby dowiedzieć się, jak utworzyć rekord DMARC w Panelu klienta OVHcloud, zapoznaj się z naszym przewodnikiem "[Poprawa bezpieczeństwa e-maili dzięki rejestracji DMARC](/guides/web-cloud/domains/dns-zone-dmarc)".
+
+### 4 - Weryfikacja i aktywacja domeny w usłudze iCloud
+
+Po prawidłowym dodaniu rekordów DNS (MX, CNAME, TXT, DMARC) do Twojej strefy DNS OVHcloud wróć na stronę [iCloud.com](https://www.icloud.com).
+
+Postępuj zgodnie z instrukcjami na stronie "Add a domain you own to iCloud Mail on iCloud.com" w [oficjalnej dokumentacji Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Zwróć szczególną uwagę na sekcję "Step 4: Finish setting up the domain".
+
+Po zakończeniu tego etapu Twoja spersonalizowana nazwa domeny jest w pełni aktywna i możesz utworzyć maksymalnie 3 adresy na osobę w ramach rodziny.
 
 :::warning
-Use only the quotation marks `"` as they appear in Apple's technical documentation (usually in English). The quotation marks « » or " " displayed in some translations should not be used in DNS configuration.
+Weryfikacja może się nie powieść, jeśli rekordy DNS nie zostały jeszcze rozpropagowane. Propagacja może potrwać kilka godzin.
+
 :::
 
-### Step 3: Add a DMARC record (optional) <a id="step3"></a>
+### Najczęstsze problemy
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+#### Sprawdzenie, gdzie zarządzana jest strefa DNS
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, please refer to our guide on [Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+Jeśli Twoja nazwa domeny jest powiązana z serwerami DNS zewnętrznymi wobec OVHcloud (Wix, Squarespace, Cloudflare itp.), konfigurację należy przeprowadzić w interfejsie zarządzania tymi serwerami DNS, poza Panelem klienta OVHcloud.
 
-### Step 4: Verify and activate the domain in iCloud
+#### Rekord CNAME już istnieje
 
-Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
+- Rekord **CNAME** nie może współistnieć z rekordem **A, AAAA lub TXT** skonfigurowanym dla tej samej domeny lub subdomeny.
+- Usuń stary rekord przed utworzeniem rekordu CNAME wymaganego przez Apple.
 
-Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
+#### Zduplikowany rekord SPF
 
-Once this step is complete, your custom domain is fully activated and you can create up to 3 addresses per person within your family.
+- Dla jednej nazwy domeny może istnieć tylko **jeden rekord SPF**. Jeśli rekord SPF OVHcloud już istnieje (np.: `v=spf1 include:mx.ovh.com ~all`), scal go z rekordem dostarczonym przez Apple (np.: `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
-:::warning
-Validation may fail if your DNS records have not yet been propagated. This propagation may take several hours.
-:::
+#### Niekompletny DKIM
 
-### Common troubleshooting
+- Apple zaleca zapisanie w Twojej strefie DNS kilku kluczy DKIM (`sig1`, `sig2` itp.).
 
-#### Check where the DNS zone is managed
+#### Czas propagacji
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc. ), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+- Zmiany DNS mogą zostać rozpoznane przez Apple dopiero po kilku godzinach (do 24 godzin).
 
-#### CNAME already exists
+## Sprawdź również
 
-- A **CNAME** record cannot coexist with a **A, AAAA, or TXT** record configured on the same domain or subdomain.
-- Delete the old record before creating the CNAME requested by Apple.
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-#### Duplicate SPF
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 
-- There can only be **one SPF record** per domain name. If an OVHcloud SPF record already exists (e.g.: `v=spf1 include:mx.ovh.com ~all`), merge it with the one provided by Apple (e.g.:
-`v=spf1 include:mx.ovh.com include:icloud.com ~all`).
-
-#### Incomplete DKIM
-
-- Apple invites you to save several DKIM keys (`sig1`, `sig2`, etc.) in your DNS zone.
-
-#### Propagation time
-
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
-
-## Go further
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner) .
-
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
-
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/web-cloud/domains/dns-ips-update.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-ips-update.mdx
@@ -1,64 +1,64 @@
 ---
-title: "List of IP addresses of OVHcloud DNS servers"
-description: "Find out the updated IP addresses for OVHcloud DNS servers"
+title: Alteração dos endereços IP dos servidores DNS da OVHcloud
+description: Descubra a lista dos novos endereços IP dos servidores DNS da OVHcloud
 lastUpdated: 2025-08-07
 availableIn: [eu, ca, apac]
 ---
 
 import { Region } from '@components/Zone';
 
-## Objective
+## Objetivo
 
-This guide explains the IP addresses changes affecting part of our DNS servers hosted in Europe, which will apply from **August 2025**.
+Este guia apresenta as alterações de endereços IP que afetam uma parte dos nossos servidores DNS alojados na Europa, aplicáveis a partir de **agosto de 2025**.
 
-**Discover the list of new IP addresses for OVHcloud DNS servers.**
+**Descubra a lista dos novos endereços IP dos servidores DNS.**
 
-## Requirements
+## Requisitos
 
-- Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> to manage the domain name concerned.
+- Ter acesso à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> para gerir o nome de domínio em causa.
 
-## Instructions
+## Instruções
 
-### Who is concerned?
+### Quem é afetado?
 
-This change can impact customers who:
+Esta alteração pode afetar os clientes que:
 
-- Have defined a custom DNS server name in the DNS records of type `NS` of their DNS zone, and have associated an IP address of an OVHcloud DNS server with this name via a DNS record of type `A`.
-- Have also configured a `GLUE` record for this custom name, in order to associate it with the IP address of an OVHcloud DNS server, in the configuration of the domain name's DNS servers.
-- Are currently using this custom name as their domain name's DNS server (defined in their Control Panel or at their registrar).
+- Definiram um nome de servidor DNS personalizado nos registos DNS do tipo `NS` da sua zona DNS e associaram a esse nome o endereço IP de um servidor DNS da OVHcloud através de um registo DNS do tipo `A`.
+- Configuraram igualmente um registo `GLUE` para esse nome personalizado, a fim de o associar ao endereço IP de um servidor DNS da OVHcloud, na configuração dos servidores DNS do nome de domínio.
+- Utilizam atualmente esse nome personalizado como servidor DNS do seu nome de domínio (definido na sua área de cliente ou junto do seu agente de registo).
 
-For more information, please read our guide on [Customizing a domain name's DNS servers (Glue Records)](/guides/web-cloud/domains/glue-registry).
+Para mais informações, consulte o nosso guia "[Personalizar os servidores DNS de um domínio (Glue Records)](/guides/web-cloud/domains/glue-registry)".
 
 :::warning
-If you have not made any manual changes to the DNS configuration (default setting), you will not be affected by this change.
+Se não efetuou qualquer alteração manual à configuração DNS (parametrização por defeito), esta alteração não o afeta.
 :::
 
-### Schedule
+### Calendário
 
-| Step                                | Estimated date           |
+| Etapa | Data prevista |
 |------------------------------|------------------------------|
-| Delete IPv6 traffic on old IPs         | Completed on 05 August 2025 |
-| Commissioning of new IPs   | Starting August 5, 2025 |
-| Send the first informational email to the identified customers | Mid-August 2025 |
-| Send second reminder email         | September 15, 2025 |
-| Deletion of IPv4 traffic          | Early October 2025 |
+| Eliminação do tráfego IPv6 nos antigos endereços IP | Efetuada a 5 de agosto de 2025 |
+| Entrada em funcionamento dos novos endereços IP | A partir de 5 de agosto de 2025 |
+| Envio do primeiro e-mail informativo aos clientes identificados | Meados de agosto de 2025 |
+| Envio do segundo e-mail de lembrete | 15 de setembro de 2025 |
+| Eliminação do tráfego IPv4 | Início de outubro de 2025 |
 
 :::warning
-Using old IP addresses after this date will cause DNS resolution failure for domain names whose configuration has not been updated.
+A utilização dos antigos endereços IP após essa data provocará a falha da resolução DNS dos nomes de domínio cuja configuração não tenha sido atualizada.
 :::
 
-### What can I do if I am concerned?
+### O que fazer se for afetado?
 
-1. Determine if you are still using an old IP address in your DNS zone.
-2. Replace it with the new IP address (see the table below).
-3. [Update your GLUE records](/guides/web-cloud/domains/glue-registry) if you have configured one in your OVHcloud Control Panel.
+1. Verifique se ainda utiliza um antigo endereço IP na sua zona DNS.
+2. **Substitua-o** pelo novo endereço IP (consulte a tabela abaixo).
+3. [Atualize os seus registos GLUE](/guides/web-cloud/domains/glue-registry) caso os tenha configurado na sua área de cliente.
 
-### IP address mapping table
+### Tabela de correspondência dos endereços IP
 
-| Hostname     | Old IPv4   | New IPv4   | Old IPv6       | New IPv6         |
-|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 <Region zones={['eu']}>
 
+| Nome do host     | Antigo IPv4   | Novo IPv4   | Antigo IPv6       | Novo IPv6         |
+|:---------------|:----------------|:---------------|:---------------------|:----------------------------|
 | dns.ovh.net    | 213.186.33.102  | 5.135.230.153   | 2001:41d0:3:166::1  | 2001:41d0:d00:e400::2 |
 | ns.ovh.net     | 213.251.128.136 | 5.135.230.149   | 2001:41d0:209::1    | 2001:41d0:b00:ea00::2 |
 | dns10.ovh.net  | 213.251.188.129 | 5.135.85.109    | 2001:41d0:1:4a81::1 | 2001:41d0:d00:6100::2 |
@@ -116,17 +116,17 @@ Using old IP addresses after this date will cause DNS resolution failure for dom
 
 <Region zones={['ca', 'apac']}>
 
-| Server | IP |
+| Servidor | IP |
 |---|---|
 | dns10.ovh.ca | 192.99.60.247 |
 | ns10.ovh.ca | 167.114.154.30 |
 
 </Region>
 
-## Go further
+## Quer saber mais?
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+Se pretender usufruir de ajuda na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -25,16 +25,16 @@ Para compreender melhor a noção de DNS, consulte o guia "[Saber tudo sobre a z
 
 A ferramenta Zonemaster permite verificar uma configuração DNS instalada num nome de domínio ou testar uma zona DNS pré-configurada em futuros servidores DNS.
 
-Para verificar a configuração atual de um nome de domínio, introduza o seu nome de domínio e clique em <code className="action">Run</code>
+Para verificar a configuração atual de um nome de domínio, introduza o seu nome de domínio e clique em <code className="action">Run test</code>
 
 <img className="thumbnail" alt="Formulário do Zonemaster com um nome de domínio introduzido, pronto a testar." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
-Para verificar uma configuração DNS que foi preparada, mas ainda não aplicada ao nome de domínio em causa, selecione a opção <code className="action">Options</code> e introduza as seguintes informações:
+Para verificar uma configuração DNS que foi preparada, mas ainda não aplicada ao nome de domínio em causa, selecione a opção <code className="action">Show options</code> e introduza as seguintes informações:
 
-- **Nameservers**: introduza as informações do servidor de nome associado a um nome de domínio. Clique em <code className="action">+</code> para poder adicionar um servidor de nome suplementar. A introdução de um endereço IP é facultativa.
-- **DS records**: no quadro de uma proteção DNSSEC, introduza os elementos do registo DS. Clique em <code className="action">+</code> para poder adicionar um registo DS suplementar. Se os servidores DNS não utilizarem o protocolo DNSSEC, pode deixar estes campos livres. No caso de uma zona assinada com DNSSEC, esta função permite verificar se a zona funciona corretamente com um resolvedor valioso, com os registos DS que estamos prestes a publicar, antes da sua publicação.
+- **Nameservers**: introduza as informações do servidor de nome associado a um nome de domínio. Um novo bloco `Nameserver` é apresentado automaticamente assim que o anterior é preenchido, o que permite declarar vários. A introdução de um endereço IP é facultativa.
+- **DS records**: no quadro de uma proteção DNSSEC, introduza os elementos do registo DS. Um novo bloco `DS record` é apresentado automaticamente assim que o anterior é preenchido. Se os servidores DNS não utilizarem o protocolo DNSSEC, pode deixar estes campos livres. No caso de uma zona assinada com DNSSEC, esta função permite verificar se a zona funciona corretamente com um resolvedor valioso, com os registos DS que estamos prestes a publicar, antes da sua publicação.
 
-Também pode forçar as verificações num protocolo IP específico através das células `Desativar IPv6` e `Desativar IPv4`
+Também pode forçar as verificações num protocolo IP específico através das opções `IPv4 and IPv6`, `IPv4 only` e `IPv6 only`
 
 > **Exemplo**:
 >
@@ -42,14 +42,14 @@ Também pode forçar as verificações num protocolo IP específico através das
 >
 > Configurou uma zona DNS para este nome de domínio nos servidores DNS "dns1.test.tld" e "dns2.test.tld".
 >
-> Antes de alterar os servidores DNS, pode efetuar uma pesquisa avançada através da opção <code className="action">Options</code> introduzindo "dns1.test.tld" e "dns2.test.tld" nas casas `Nameservers`.
+> Antes de alterar os servidores DNS, pode efetuar uma pesquisa avançada através da opção <code className="action">Show options</code> introduzindo "dns1.test.tld" e "dns2.test.tld" nas casas `Nameservers`.
 >
 > Zonemaster realizará um teste como se estivesse a utilizar os servidores "dns1.test.tld" e "dns2.test.tld" em "domain.tld".
 >
 > <img className="thumbnail" alt="Opções avançadas do formulário Zonemaster com dois servidores de nomes introduzidos." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
-Ao introduzir um nome de domínio e ao clicar no botão <code className="action">Fetch NS from parent zone</code> e <code className="action">Fetch DS from parent zone</code>, aparecerão os servidores DNS associados ao nome de domínio, bem como as informações do registo DS (DNSSEC), se este tiver sido configurado.
+Ao introduzir um nome de domínio e ao clicar no botão <code className="action">Fetch nameservers from parent zone</code> e <code className="action">Fetch DS from parent zone</code>, aparecerão os servidores DNS associados ao nome de domínio, bem como as informações do registo DS (DNSSEC), se este tiver sido configurado.
 <img className="thumbnail" alt="Página de resultados do Zonemaster com a secção Addresses expandida." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
@@ -76,7 +76,7 @@ Se tiver questões adicionais sobre Zonemaster, consulte a secção [FAQ](https:
 
 [Modificação de uma zona DNS da OVHcloud](/guides/web-cloud/domains/dns-zone-edit).
 
-[Proteja o seu nome de domínio contra o Cache Poisoning graças ao DNSSEC](/links/web/domains-dnssec)
+[Proteja o seu nome de domínio contra o Cache Poisoning graças ao DNSSEC](/guides/web-cloud/domains/dns-dnssec)
 
 Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 

--- a/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tutorial - Utilização de Zonemaster
+description: Saiba como analisar a configuração DNS de um nome de domínio com o Zonemaster e identificar os elementos a corrigir ou melhorar
 lastUpdated: 2026-02-10
 availableIn: [eu, ca, apac]
 ---
@@ -35,11 +36,17 @@ Para verificar uma configuração DNS que foi preparada, mas ainda não aplicada
 
 Também pode forçar as verificações num protocolo IP específico através das células `Desativar IPv6` e `Desativar IPv4`
 
-> **Exemplo**:<br/><br/> É titular do nome de domínio "domain.tld", que utiliza atualmente os servidores DNS "dnsXX.ovh.net" e "nsXX.ovh.net".
-> Configurou uma zona DNS para este nome de domínio nos servidores DNS "dns1.test.tld" e "dns2.test.tld".<br/>
-> Antes de alterar os servidores DNS, pode efetuar uma pesquisa avançada através da opção <code className="action">Options</code> introduzindo "dns1.test.tld" e "dns2.test.tld" nas casas `Nameservers`.<br/>
-> Zonemaster realizará um teste como se estivesse a utilizar os servidores "dns1.test.tld" e "dns2.test.tld" em "domain.tld".<br/>
-> <img className="thumbnail" alt="Captura de tela das opções avançadas do formulário Zonemaster. Os dois servidores de nomes &quot;dns1.test.tld&quot; e &quot;dns2.test.tld&quot; foram introduzidos na secção &quot;Nameservers&quot; do formulário." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> **Exemplo**:
+>
+> É titular do nome de domínio "domain.tld", que utiliza atualmente os servidores DNS "dnsXX.ovh.net" e "nsXX.ovh.net".
+>
+> Configurou uma zona DNS para este nome de domínio nos servidores DNS "dns1.test.tld" e "dns2.test.tld".
+>
+> Antes de alterar os servidores DNS, pode efetuar uma pesquisa avançada através da opção <code className="action">Options</code> introduzindo "dns1.test.tld" e "dns2.test.tld" nas casas `Nameservers`.
+>
+> Zonemaster realizará um teste como se estivesse a utilizar os servidores "dns1.test.tld" e "dns2.test.tld" em "domain.tld".
+>
+> <img className="thumbnail" alt="Captura de ecrã das opções avançadas do formulário Zonemaster. Os dois servidores de nomes &quot;dns1.test.tld&quot; e &quot;dns2.test.tld&quot; foram introduzidos na secção &quot;Nameservers&quot; do formulário." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Ao introduzir um nome de domínio e ao clicar no botão <code className="action">Fetch NS from parent zone</code> e <code className="action">Fetch DS from parent zone</code>, aparecerão os servidores DNS associados ao nome de domínio, bem como as informações do registo DS (DNSSEC), se este tiver sido configurado.
@@ -57,7 +64,7 @@ Depois de validado o formulário, os resultados são classificados por código d
 
 Para cada teste, é possível obter mais pormenores, por exemplo para compreender o erro no caso de uma anomalia, ou apenas a título indicativo.
 
-<img className="thumbnail" alt="nome de domínio" src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
+<img className="thumbnail" alt="Página de resultados do Zonemaster com os grupos de testes ordenados por severidade." src="/images/assets/screens/other/web-tools/zonemaster/domain-analysis.png" loading="lazy" />
 
 ### Informações úteis
 

--- a/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tutorial - Utilização de Zonemaster
 description: Saiba como analisar a configuração DNS de um nome de domínio com o Zonemaster e identificar os elementos a corrigir ou melhorar
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zonemaster.mdx
@@ -27,7 +27,7 @@ A ferramenta Zonemaster permite verificar uma configuração DNS instalada num n
 
 Para verificar a configuração atual de um nome de domínio, introduza o seu nome de domínio e clique em <code className="action">Run</code>
 
-<img className="thumbnail" alt="Captura de ecrã do formulário de introdução do Zonemaster. O nome de domínio &quot;domain.tld&quot; já foi introduzido e está pronto para ser testado." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
+<img className="thumbnail" alt="Formulário do Zonemaster com um nome de domínio introduzido, pronto a testar." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test.png" loading="lazy" />
 
 Para verificar uma configuração DNS que foi preparada, mas ainda não aplicada ao nome de domínio em causa, selecione a opção <code className="action">Options</code> e introduza as seguintes informações:
 
@@ -46,11 +46,11 @@ Também pode forçar as verificações num protocolo IP específico através das
 >
 > Zonemaster realizará um teste como se estivesse a utilizar os servidores "dns1.test.tld" e "dns2.test.tld" em "domain.tld".
 >
-> <img className="thumbnail" alt="Captura de ecrã das opções avançadas do formulário Zonemaster. Os dois servidores de nomes &quot;dns1.test.tld&quot; e &quot;dns2.test.tld&quot; foram introduzidos na secção &quot;Nameservers&quot; do formulário." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
+> <img className="thumbnail" alt="Opções avançadas do formulário Zonemaster com dois servidores de nomes introduzidos." src="/images/assets/screens/other/web-tools/zonemaster/run-domain-test-nameservers-option.png" loading="lazy" />
 
 :::info
 Ao introduzir um nome de domínio e ao clicar no botão <code className="action">Fetch NS from parent zone</code> e <code className="action">Fetch DS from parent zone</code>, aparecerão os servidores DNS associados ao nome de domínio, bem como as informações do registo DS (DNSSEC), se este tiver sido configurado.
-<img className="thumbnail" alt="Captura de ecrã das opções avançadas do formulário Zonemaster. O botão &quot;Fetch NS from parent zone&quot; (Obter NS da zona-mãe) está realçado e os servidores de nomes do nome de domínio &quot;domain.tld&quot; são pré-preenchidos na secção Nameservers (Servidores de nomes) do formulário." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
+<img className="thumbnail" alt="Página de resultados do Zonemaster com a secção Addresses expandida." src="/images/assets/screens/other/web-tools/zonemaster/fetch-ns-from-parent-zone.png" loading="lazy" />
 :::
 
 ### Resultado

--- a/docs/pt/guides/web-cloud/domains/domain-icloud.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-icloud.mdx
@@ -1,97 +1,116 @@
 ---
-title: "How to use an OVHcloud domain with iCloud Mail"
-description: "Find out how to configure your OVHcloud domain name with iCloud to create custom email addresses"
-lastUpdated: 2025-08-27
+title: Como utilizar um nome de domínio OVHcloud com o iCloud Mail
+description: Saiba como configurar o seu nome de domínio OVHcloud com o iCloud para criar endereços de e-mail personalizados
+lastUpdated: 2026-03-27
 availableIn: [eu, ca, apac]
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 [[fragment:support-scope]]
 
-## Objective
+## Objetivo
 
-This guide explains how to use an OVHcloud-registered domain name with the Apple iCloud Mail service. You can then create custom email addresses (`firstname@mydomain.com`), which are fully managed and hosted by Apple.
+Este guia explica-lhe como utilizar um nome de domínio registado na OVHcloud com o serviço iCloud Mail da Apple. Poderá assim criar endereços de e-mail personalizados (`nome@omeudominio.pt`), integralmente geridos e alojados pela Apple.
 
-## Requirements
+## Requisitos
 
-- A [domain name](/links/web/domains) registered with OVHcloud.
-- You have access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- You have the rights to manage the DNS zone for the domain name concerned via the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-- An Apple ID with an **iCloud+** subscription.
+- Dispor de um [nome de domínio](/links/web/domains) registado na OVHcloud.
+- Dispor de um ID Apple com uma subscrição **iCloud+**.
 
-## Instructions
+{/* CP-NAV-START:web-dns-zone */}
+---
 
-### Step 1: Activate the domain name in iCloud <a id="step1"></a>
+### Acesso à Área de Cliente OVHcloud
 
-To activate your domain name in iCloud, follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 3: Update the records with your domain registrar" section, to find the DNS records to add to your OVHcloud DNS zone.
+- **Ligação direta:** <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink>
+- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Zonas DNS</code> > Selecione o seu nome de domínio
 
-At the end of this step, Apple will send you a list of DNS records (MX, CNAME, TXT) to configure in your OVHcloud DNS zone. Save them for the next step.
+---
+{/* CP-NAV-END:web-dns-zone */}
 
-### Step 2: Configure the DNS records in your OVHcloud Control Panel
+## Instruções
 
-1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
-2. Go to the `Web Cloud` section.
-3. Click `DNS zones`, then choose the domain name concerned.
-4. Add or edit the records mentioned below.
+### 1 - Ativar o nome de domínio no iCloud <a name="step1"></a>
 
-To find out how to add, modify or delete each type of DNS record (MX, CNAME, TXT, etc.), read our guide [Everything you need to know about DNS records](/guides/web-cloud/domains/dns-zone-records).
+Para ativar o seu nome de domínio no iCloud, siga as instruções da página "Add a domain you own to iCloud Mail on iCloud.com" da [documentação oficial da Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentre-se na secção "Step 3: Update the records with your domain registrar" (Atualizar os registos junto do seu agente de registo de domínios), para obter os registos DNS a adicionar à sua zona DNS OVHcloud.
 
-Using the DNS records you previously retrieved ([Step 1](#step1)), create or update the corresponding fields in your OVHcloud DNS zone:
+No final desta etapa, a Apple comunicar-lhe-á uma lista de registos DNS (MX, CNAME, TXT) a configurar na sua zona DNS OVHcloud. Guarde-os para a etapa seguinte.
 
-- **MX** : for receiving emails.
-- **CNAME**: for DKIM keys (`sig1._domainkey...`, `sig2._domainkey...`).
-- **TXT**: for SPF (merge if an SPF record already exists).
-- **TXT DMARC**: Optional but recommended ([Step 3](#step3)).
+### 2 - Configurar os registos DNS na sua área de cliente OVHcloud
+
+Clique nos separadores abaixo para visualizar sucessivamente cada uma das **2** etapas.
+
+<Tabs>
+  <Tab label="Etapa 1">
+    Aceda à página <ManagerLink to="/#/web/zone">Zonas DNS</ManagerLink> e escolha o nome de domínio em causa.
+
+    <img className="thumbnail" alt="Captura de ecrã da área de cliente OVHcloud com a lista de zonas DNS." src="/images/assets/screens/control-panel/product-selection/web-cloud/dns-zones.png" loading="lazy" />
+  </Tab>
+  <Tab label="Etapa 2">
+    Para saber como adicionar, modificar ou eliminar cada tipo de registo DNS (MX, CNAME, TXT, etc.), consulte o nosso guia "[Saber tudo sobre os registos DNS](/guides/web-cloud/domains/dns-zone-records)".
+
+    Com base nos registos DNS obtidos anteriormente ([Parte 1](#step1)), crie ou atualize os campos correspondentes na sua zona DNS OVHcloud:
+
+    - **MX**: para a receção dos e-mails.
+    - **CNAME**: para as chaves DKIM (`sig1._domainkey...`, `sig2._domainkey...`).
+    - **TXT**: para o SPF (junte-o caso já exista um registo SPF).
+    - **TXT DMARC**: facultativo, mas recomendado ([Parte 3](#step3)).
+
+    :::warning
+    Utilize apenas aspas retas `”` tal como aparecem na documentação técnica da Apple (geralmente na versão inglesa). As aspas tipográficas « » ou “ “ apresentadas em algumas traduções não devem ser utilizadas na configuração DNS.
+
+    :::
+
+  </Tab>
+</Tabs>
+
+### 3 - Adicionar um registo DMARC (facultativo) <a name="step3"></a>
+
+Para melhorar a entregabilidade dos seus e-mails e evitar que as suas mensagens sejam recebidas como spam, adicione um registo **DMARC**.
+
+Para saber como criar um registo DMARC na sua área de cliente OVHcloud, consulte o nosso guia "[Melhorar a segurança dos e-mails através do registo DMARC](/guides/web-cloud/domains/dns-zone-dmarc)".
+
+### 4 - Verificar e ativar o domínio no iCloud
+
+Depois de os registos DNS (MX, CNAME, TXT, DMARC) terem sido corretamente adicionados à sua zona DNS OVHcloud, volte a [iCloud.com](https://www.icloud.com).
+
+Siga as instruções da página "Add a domain you own to iCloud Mail on iCloud.com" da [documentação oficial da Apple](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Concentre-se na secção "Step 4: Finish setting up the domain".
+
+Uma vez concluída esta etapa, o seu nome de domínio personalizado fica totalmente ativado e pode criar até 3 endereços por pessoa, no âmbito familiar.
 
 :::warning
-Use only the quotation marks `"` as they appear in Apple's technical documentation (usually in English). The quotation marks « » or " " displayed in some translations should not be used in DNS configuration.
+A validação pode falhar se os seus registos DNS ainda não tiverem sido propagados. Esta propagação pode demorar várias horas.
+
 :::
 
-### Step 3: Add a DMARC record (optional) <a id="step3"></a>
+### Resoluções de problemas frequentes
 
-To improve the deliverability of your emails and prevent them from being delivered as SPAM, add a **DMARC** record.
+#### Verificar onde é gerida a zona DNS
 
-To find out how to create a DMARC record in the OVHcloud Control Panel, please refer to our guide on [Enhancing email security via a DMARC record](/guides/web-cloud/domains/dns-zone-dmarc).
+Se o seu nome de domínio estiver associado a servidores DNS externos à OVHcloud (Wix, Squarespace, Cloudflare, etc.), a configuração deve ser efetuada na interface de gestão desses servidores DNS, fora da área de cliente OVHcloud.
 
-### Step 4: Verify and activate the domain in iCloud
+#### CNAME já existente
 
-Once the DNS records (MX, CNAME, TXT, DMARC) have been correctly added to your OVHcloud DNS zone, go back to [iCloud.com](https://www.icloud.com).
+- Um registo **CNAME** não pode coexistir com um registo **A, AAAA ou TXT** configurado no mesmo domínio ou subdomínio.
+- Elimine o registo antigo antes de criar o CNAME solicitado pela Apple.
 
-Follow the instructions from the "Add a domain you own to iCloud Mail on iCloud.com" page in [Apple's official documentation](https://support.apple.com/guide/icloud/add-a-domain-you-own-mma473945269/icloud). Focus on the "Step 4: Finish setting up the domain" section.
+#### SPF duplicado
 
-Once this step is complete, your custom domain is fully activated and you can create up to 3 addresses per person within your family.
+- Só pode existir **um único registo SPF** por nome de domínio. Se já existir um registo SPF OVHcloud (ex.: `v=spf1 include:mx.ovh.com ~all`), junte-o ao fornecido pela Apple (ex.: `v=spf1 include:mx.ovh.com include:icloud.com ~all`).
 
-:::warning
-Validation may fail if your DNS records have not yet been propagated. This propagation may take several hours.
-:::
+#### DKIM incompleto
 
-### Common troubleshooting
+- A Apple convida-o a registar várias chaves DKIM (`sig1`, `sig2`, etc.) na sua zona DNS.
 
-#### Check where the DNS zone is managed
+#### Prazo de propagação
 
-If your domain name is associated with DNS servers external to OVHcloud (Wix, Squarespace, Cloudflare, etc. ), the configuration must be carried out in the management interface for these DNS servers, outside of the OVHcloud Control Panel.
+- As alterações DNS podem demorar várias horas (até 24 h) até serem reconhecidas pela Apple.
 
-#### CNAME already exists
+## Quer saber mais?
 
-- A **CNAME** record cannot coexist with a **A, AAAA, or TXT** record configured on the same domain or subdomain.
-- Delete the old record before creating the CNAME requested by Apple.
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-#### Duplicate SPF
+Se pretender usufruir de ajuda na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-- There can only be **one SPF record** per domain name. If an OVHcloud SPF record already exists (e.g.: `v=spf1 include:mx.ovh.com ~all`), merge it with the one provided by Apple (e.g.:
-`v=spf1 include:mx.ovh.com include:icloud.com ~all`).
-
-#### Incomplete DKIM
-
-- Apple invites you to save several DKIM keys (`sig1`, `sig2`, etc.) in your DNS zone.
-
-#### Propagation time
-
-- DNS changes can take several hours (up to 24 hours) to be recognized by Apple.
-
-## Go further
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner) .
-
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
-
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
## Context

SK2763 — missing translations on the Domains / DNS guides.

## Translations added

| Guide | Locales | Source |
|---|---|---|
| `dns-ips-update` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `dns-zonemaster` | de, pl | EN |
| `domain-icloud` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `domains/overview` | de | EN |

`de/dns-zonemaster.mdx` and `pl/dns-zonemaster.mdx` were symlinks to the EN file; they are now real translations (shown as a type change `T` in the diff). Future edits to the EN guide will therefore need to be propagated manually to those two locales.

On the DE overview, the `essentials:` labels reuse the frontmatter titles of the German target guides, matching what the FR/ES/IT/PL/PT overviews already do. All 5 targets are genuine German translations, not EN fallbacks.

## Fixes applied during the proofread pass

Across the 7 locales, including the EN/FR sources:

- **`dns-ips-update`** — added the "access to the Control Panel" requirement, which was missing from both EN and FR, then propagated it; in FR, the EU table header sat outside its `<Region>` block (rendering bug).
- **`dns-zonemaster`** — added the missing `description` frontmatter field; replaced the 4 `<br/>` in the example block with blockquote paragraph breaks.
- **Alt text** — two screenshots had alt text that was too short (`domains`, `DNS zones`), left in English in the FR file, or describing the wrong image in ES/IT. Rewritten across the 7 locales.
- **Language and typography** — `SPAM` → `spam`, `e-mail` → `email` in IT, French non-breaking spaces, curly apostrophes and quotes in EN, EN-GB spelling, the Brazilian `tela` → `ecrã` in PT, and one alt text left in Spanish inside the IT file.
- **Consistency** — the DMARC guide link label now matches its target title, schedule date formats are uniform per language, and the EN schedule is back in the past tense.

## Verification

- Manager buttons: the **full** navigation path was checked against the Manager repo for all 7 locales — `Web Cloud` in the container sidebar translations, `zones_title` in `web/client/app/dns-zone/zones`.
- External links: all fetched, 200.
- `/links/` keys present in `config/links.ts`, guides registered in `config/sidebar/index.md`, `pnpm sidebar:validate` ✅.
- Structural and zoning parity (`<Region>` EU vs CA/APAC) verified across the 7 locales.
- `[[fragment:support-scope]]` tokens: valid key, body present for all 7 locales.

## Known open points

- `lastUpdated` was not bumped on the modified guides.
- `it` and `pt` show `Run` where the Zonemaster label is `Run test` (pre-existing).
- The FR/ES Zonemaster labels cannot be verified automatically, as the button is rendered client-side.
- The register in `it/dns-zonemaster` mixes *Lei*, *tu* and *voi* inside the example block (pre-existing).
