### PR TITLE
fix(account): correct CP-NAV button label in VAT guide

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -32,7 +32,7 @@ Votre numéro SIRET est composé de 14 chiffres. Cette donnée étant publique, 
 ### Accès à l'espace client OVHcloud
 
 - **Lien direct :** <ManagerLink to="/#/account/useraccount/infos">Mon profil</ManagerLink>
-- **Pour y accéder :** Cliquez sur votre nom en haut à droite > <code className="action">Gérer mon compte</code> > <code className="action">Éditer mon profil</code>
+- **Pour y accéder :** Cliquez sur votre nom en haut à droite > <code className="action">Mon compte</code> > <code className="action">Éditer mon profil</code>
 
 ---
 {/* CP-NAV-END:account-profile */}


### PR DESCRIPTION
The account-profile CP-NAV block named "Gérer mon compte", which is only the title/aria-label of the avatar toggle button and is never visible to the user. The clickable dropdown entry is "Mon compte".

Sources in the Manager repo (container app, user-account-menu):
- user_account_menu_manage_my_account -> tooltip only (Button.tsx)
- user_account_menu_profile -> "Mon compte", links to #/useraccount/dashboard (constants.ts)

Reported via guide feedback. The 7 all-about-username locales sharing this CP-NAV block were already correct, so no other guide is affected.