### PR TITLE
feat(account): add e-invoicing error guide (FR)

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -63,6 +63,7 @@
             + [Payer une commande en tant qu’administration publique](account-and-service-management/managing-billing-payments-and-services/public-administration)
             + [Correcting a bank details error](account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error)
             + [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
+            + [Understanding and correcting electronic invoicing errors](account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
             + [Hosted Private Cloud](account-and-service-management-managing-billing-payments-and-services-invoices-billing-and-payments-hosted-private-cloud)
                 + [Hosted Private Cloud billing information](account-and-service-management/managing-billing-payments-and-services/facturation-private-cloud)
             + [AI Notebooks](account-and-service-management-managing-billing-payments-and-services-invoices-billing-and-payments-ai-notebooks)

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/best-practices.mdx
@@ -118,4 +118,8 @@ Ensuite, utilisez [ce formulaire](https://www.ovh.com/fr/protection-donnees-pers
 
 [Gérer mes factures OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management)
 
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error.mdx
@@ -44,4 +44,8 @@ Le prélèvement de votre facture a déjà été effectué sur le moyen de paiem
 
 Consultez le guide [Gérer mes moyens de paiement](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods) pour la procédure détaillée.
 
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -1,0 +1,251 @@
+---
+title: Comprendre et corriger les erreurs de facturation électronique
+description: Identifiez le motif d'erreur signalé sur une facture électronique OVHcloud et découvrez la marche à suivre pour régulariser la situation
+lastUpdated: 2026-08-19
+---
+
+<Banner kind="siret-fr" />
+
+## Objectif
+
+**Votre plateforme de facturation électronique peut signaler un motif d'erreur sur une facture OVHcloud, sous la forme d'un statut et d'un code (par exemple « litige 207 – TX_TVA_ERR »).**
+
+Ce guide regroupe l'ensemble de ces motifs et indique, pour chacun, la marche à suivre. Il vous permet de partir du code affiché sur votre plateforme pour identifier directement l'action à réaliser.
+
+Pour toute question générale sur la réforme, la réception de vos factures ou les statuts de la plateforme, consultez la « [FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing) ».
+
+## Prérequis
+
+- Disposer d'un accès au compte client de facturation.
+- Avoir relevé le statut et le code d'erreur affichés sur votre plateforme de facturation électronique.
+
+## En pratique
+
+### Le contexte réglementaire
+
+Dans le cadre de la réforme française de la facturation électronique, les factures sont émises, transmises et reçues via une **plateforme agréée** (PA), c'est-à-dire une entreprise privée immatriculée par l'État qui assure la transmission des factures, le suivi de leur traitement et, lorsque cela est requis, la transmission des données à l'administration fiscale.
+
+Le calendrier officiel est le suivant :
+
+- **à partir du 1er septembre 2026 :** toutes les entreprises assujetties à la TVA doivent être en mesure de **recevoir** des factures électroniques ; les grandes entreprises et les ETI doivent également **émettre** les leurs ;
+- **à partir du 1er septembre 2027 :** les PME, TPE et micro-entreprises doivent à leur tour **émettre** leurs factures électroniques.
+
+La réforme impose également de nouvelles mentions obligatoires sur les factures, parmi lesquelles le **numéro SIREN du client** et l'**adresse complète de livraison** lorsqu'elle diffère de l'adresse de facturation. Des informations incorrectes dans votre espace client peuvent empêcher l'association de votre compte avec votre plateforme de facturation électronique.
+
+Enfin, seuls les formats normalisés (UBL, CII ou format mixte associant données structurées et fichier image) sont acceptés : un PDF ordinaire, une facture papier numérisée ou une pièce jointe à un e-mail ne constituent pas des factures électroniques valides.
+
+Pour en savoir plus sur la réforme, consultez les ressources officielles suivantes :
+
+- [Je découvre la facturation électronique](https://www.impots.gouv.fr/professionnel/je-decouvre-la-facturation-electronique) (impots.gouv.fr) ;
+- [J'approfondis mes connaissances sur la réforme](https://www.impots.gouv.fr/japprofondis-mes-connaissances-sur-la-reforme) (impots.gouv.fr) ;
+- [Tout savoir sur la facturation électronique pour les entreprises](https://www.economie.gouv.fr/tout-savoir-sur-la-facturation-electronique-pour-les-entreprises) (economie.gouv.fr).
+
+### Comprendre les trois statuts
+
+Les motifs d'erreur sont rattachés à l'un des trois statuts suivants, attribués depuis votre plateforme de facturation électronique :
+
+| Statut | Conséquence |
+|---|---|
+| **Litige (207)** | La facture reste due. Votre signalement est transmis à nos équipes, qui analysent la situation. |
+| **Refusé (210)** | La facture reste due. Le refus nous informe de votre désaccord, mais ne suspend pas les délais de paiement. |
+| **Approuvé partiellement (206)** | La facture reste due. Votre signalement est transmis à nos équipes, qui analysent la situation. |
+
+Le libellé exact de chaque statut, ainsi que la liste des codes disponibles, sont propres à votre plateforme de facturation électronique. Sélectionnez le **code correspondant le mieux au motif de votre demande**.
+
+:::warning
+Quel que soit le statut appliqué, une facture contestée doit être **régularisée dans les délais prévus** afin d'éviter toute interruption de service. Le changement de statut nous informe de votre désaccord, mais **ne suspend pas les délais de paiement**. Sans régularisation, vos services sont soumis à une suspension automatique, conformément à nos conditions générales.
+
+:::
+
+:::info
+Ces statuts sont attribués depuis votre plateforme et ne peuvent pas être modifiés par OVHcloud. À distinguer d'une facture **rejetée**, qui n'a pas été acceptée par la plateforme pour un motif technique : dans ce cas, nos équipes sont informées automatiquement, corrigent la facture et procèdent à un nouveau dépôt. Aucune action n'est attendue de votre part, hormis un délai d'attente de 48 heures.
+
+:::
+
+### Tableau récapitulatif des motifs d'erreur
+
+Repérez ci-dessous le code affiché sur votre plateforme, puis consultez la section indiquée.
+
+:::info
+Les codes en majuscules (`TX_TVA_ERR`, `SIRET_ERR`, `NON_CONFORME`, etc.) sont ceux de la norme **AFNOR XP Z12-012** (annexe A), qui définit les motifs associés aux statuts du cycle de vie de la facture. Ils sont communs à l'ensemble des plateformes agréées. Le libellé affiché sur votre plateforme peut être formulé différemment.
+
+:::
+
+#### Litige (207)
+
+| Code | Motif | Marche à suivre |
+|---|---|---|
+| `TX_TVA_ERR` | Taux de TVA erroné | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| `SIRET_ERR` | SIRET erroné ou absent | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| `COORD_BANC_ERR` | Erreur de coordonnées bancaires | [Erreurs de paiement](#erreurs-de-paiement) |
+| `MODPAI_ERR` | Modalités de paiement incorrectes | [Erreurs de paiement](#erreurs-de-paiement) |
+| `REF_ERR` | Référence incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `PU_ERR` | Prix unitaires incorrects | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `REM_ERR` | Remise erronée | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `ART_ERR` | Article facturé incorrect | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `QTE_ERR` | Quantité facturée incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `LIVR_INCOMP` | Problème de livraison | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `CODE_ROUTAGE_ERR` | Code de routage absent ou erroné | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+
+#### Refusé (210)
+
+| Code | Motif | Marche à suivre |
+|---|---|---|
+| `DEST_ERR` | Erreur de destinataire | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| `ADR_ERR` | Adresse de facturation électronique erronée | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| `DOUBLON` | Facture en doublon (déjà émise / reçue) | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| `DOUBLE_FACT` | Double facturation | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| `CMD_ERR` | N° de commande incorrect ou manquant | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| `CONTRAT_TERM` | Contrat terminé | [Contrat terminé](#contrat-terminé) |
+| `TRANSAC_INC` | Transaction inconnue | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `EMMET_INC` | Émetteur inconnu | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `MONTANTTOTAL_ERR` | Montant total erroné | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `CALCUL_ERR` | Erreur de calcul de la facture | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `NON_CONFORME` | Mention légale manquante | [Mentions légales manquantes](#mentions-légales-manquantes) |
+
+#### Approuvé partiellement (206)
+
+| Code | Motif | Marche à suivre |
+|---|---|---|
+| `SIRET_ERR` | SIRET erroné ou absent | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| `MODPAI_ERR` | Modalités de paiement incorrectes | [Erreurs de paiement](#erreurs-de-paiement) |
+| `Prix_Unit_Inc` | Voir `PU_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `Remise_ERR` | Voir `REM_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `Quantité_Err` | Voir `QTE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `Article_INC` | Voir `ART_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `PRB_LIV` | Voir `LIVR_INCOMP` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| `QUALITE_ERR` | Qualité d'article livré incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+
+:::info
+Certaines plateformes affichent, pour le statut « Approuvé partiellement », des variantes de libellé (`Prix_Unit_Inc`, `Remise_ERR`, `Quantité_Err`, `Article_INC`, `PRB_LIV`). Elles correspondent aux mêmes motifs que les codes normalisés indiqués ci-dessus et relèvent de la même marche à suivre.
+
+:::
+
+### Erreurs d'identification de votre entreprise
+
+**Codes concernés :** litige 207 – `TX_TVA_ERR` ; litige 207 – `SIRET_ERR` ; Approuvé partiellement – 206 – `SIRET_ERR` ; Refusé – 210 – `DEST_ERR` ; `ADR_ERR` ; `CODE_ROUTAGE_ERR`.
+
+Ces motifs signalent que les données d'identification de votre entreprise sont incorrectes ou absentes dans votre espace client. Comme le SIREN du client est une mention obligatoire de la facture électronique, une donnée erronée peut empêcher l'association de votre compte avec votre plateforme de réception.
+
+Renseigner votre numéro de SIRET déclenche une mise à jour automatique des coordonnées de votre société, dont votre taux de TVA, à partir du catalogue gouvernemental des déclarations de société. L'assistant recherche également l'**adresse de réception de vos factures électroniques** auprès de la plateforme agréée.
+
+La procédure complète est décrite dans le guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+
+:::info
+Le code `DEST_ERR` correspond au cas d'une facture adressée à la mauvaise entité, notamment lorsque plusieurs sociétés appartiennent à un même groupe. Vérifiez que le SIRET et l'adresse de réception enregistrés dans votre espace client correspondent bien à l'entité qui doit recevoir la facture.
+
+:::
+
+Pour les codes `ADR_ERR` et `CODE_ROUTAGE_ERR`, l'erreur porte sur l'adresse de réception ou le code de routage. Vérifiez ces informations auprès de votre plateforme de réception, puis contrôlez l'**adresse de réception de vos factures électroniques** enregistrée dans votre espace client. Si l'adresse affichée n'est pas correcte même après avoir relancé l'assistant, contactez votre plateforme agréée afin de faire corriger les informations de son annuaire.
+
+Si votre adresse postale, votre nom de société ou votre pays doivent évoluer, notre système se base sur les informations déclarées auprès de l'INPI. Vous devez donc déclarer ce changement sur le [Guichet unique de l'INPI](https://procedures.inpi.fr/) avant de pouvoir mettre à jour vos données dans votre espace client. Le délai de mise à jour est généralement de quelques jours ouvrés.
+
+:::warning
+La facture est générée à partir des informations renseignées dans votre espace client **au moment de son émission**. Une fois éditée, elle ne peut plus être modifiée ni rééditée avec de nouvelles informations. La correction de vos données vaut donc pour vos **prochaines** factures.
+
+:::
+
+### Erreurs de paiement
+
+**Codes concernés :** litige 207 – `COORD_BANC_ERR` ; litige 207 – `MODPAI_ERR` ; Approuvé partiellement – 206 – `MODPAI_ERR`.
+
+Ces motifs signalent que les coordonnées bancaires ou le mode de paiement enregistrés sur votre compte ne sont pas ceux attendus. Vérifiez le moyen de paiement enregistré sur votre compte client depuis la page <ManagerLink to="/#/billing/payment/method">Mes moyens de paiement</ManagerLink>.
+
+Pour la marche à suivre détaillée, consultez les guides suivants :
+
+- « [Corriger une erreur de coordonnées bancaires](/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error) » pour le code `COORD_BANC_ERR` ;
+- « [Gérer mes moyens de paiement](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods) » pour la procédure complète d'ajout, de modification du moyen de paiement par défaut et de suppression.
+
+:::info
+Le prélèvement de votre facture a déjà été effectué sur le moyen de paiement enregistré au moment de son édition. Le moyen de paiement utilisé pour cette facture ne peut donc pas être corrigé. Une fois votre moyen de paiement mis à jour et défini par défaut, vos prochains prélèvements seront effectués sur les coordonnées à jour.
+
+:::
+
+### Écarts entre la commande et la facture
+
+**Codes concernés :** litige 207 – `REF_ERR`, `PU_ERR`, `REM_ERR`, `ART_ERR`, `QTE_ERR`, `LIVR_INCOMP` ; Refusé – 210 – `TRANSAC_INC`, `EMMET_INC`, `MONTANTTOTAL_ERR`, `CALCUL_ERR` ; Approuvé partiellement – 206 – `Prix_Unit_Inc`, `Remise_ERR`, `Quantité_Err`, `Article_INC`, `PRB_LIV`.
+
+Ces motifs signalent un écart entre votre commande initiale et la facture émise. Consultez votre commande initiale sur la page <ManagerLink to="/#/billing/orders">Mes commandes</ManagerLink> et vérifiez que les produits, services et options qu'elle contient correspondent bien à ceux figurant sur votre facture, disponible sur la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>.
+
+La marche à suivre est décrite dans la section « [Vérifier votre commande en cas d'erreur de facturation](/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders) » du guide dédié à la gestion de vos commandes.
+
+Pour les produits **facturés à la consommation** (litige 207 – `QTE_ERR`, Approuvé partiellement – 206 – `Quantité_Err`), faites le point sur cette même page : la facturation de ce type se base sur votre consommation du mois précédent. Un écart apparent peut donc correspondre à un usage réel supérieur à celui attendu.
+
+Si le **numéro de commande (PO)** est absent ou incorrect sur votre facture, renseignez-le dans votre espace client avant l'émission de vos prochaines factures, en vous aidant du guide « [Notion de Numéro de commande ou Purchase Order (PO)](/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order) ».
+
+
+### Mentions légales manquantes
+
+**Code concerné :** Refusé – 210 – `NON_CONFORME`.
+
+Ce motif signale qu'une mention obligatoire est absente de la facture. La réforme impose en effet de nouvelles mentions, parmi lesquelles le **numéro SIREN du client** et l'**adresse complète de livraison** lorsqu'elle diffère de l'adresse de facturation.
+
+Ces mentions étant renseignées à partir des données de votre espace client, vérifiez que celles-ci sont complètes et à jour en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+
+Si vos données sont correctes, la correction relève de nos équipes : nos équipes sont informées du refus et vous adressent les éléments nécessaires à la régularisation.
+
+### Doublons et références de commande
+
+**Codes concernés :** Refusé – 210 – `DOUBLON` ; Refusé – 210 – `DOUBLE_FACT` ; Refusé – 210 – `CMD_ERR`.
+
+Avant de traiter une facture reçue plusieurs fois, **vérifiez son numéro**. Il peut arriver, à titre exceptionnel, que la même facture soit transmise par plusieurs canaux (espace client, PDF, e-mail) afin d'assurer la continuité des échanges en cas d'incident. Il ne s'agit alors pas de plusieurs factures différentes, mais de duplicatas de la même facture.
+
+:::warning
+Si le numéro de facture est identique, effectuez **un seul traitement comptable et un seul paiement** afin d'éviter tout doublon.
+
+:::
+
+S'il s'agit de deux factures distinctes, consultez vos commandes afin de faire le point sur les produits et services facturés, puis vérifiez les paiements associés. Pour cela, reportez-vous à la section « [Suivre vos paiements](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management#suivre-vos-paiements) » du guide dédié à la gestion de vos factures.
+
+:::info
+Si vous constatez une différence entre un paiement et le montant d'une facture, cela signifie que vous possédiez un avoir qui a automatiquement diminué le montant prélevé.
+
+:::
+
+### Contrat terminé
+
+**Code concerné :** Refusé – 210 – `CONTRAT_TERM`.
+
+Ce motif signale une facture reçue pour un service que vous considérez comme résilié. Vérifiez la date d'expiration de vos services depuis la page <ManagerLink to="/#/billing/autorenew/services">Mes offres et services</ManagerLink>. Cette date est également disponible sur vos précédentes <ManagerLink to="/#/billing/orders">commandes</ManagerLink> et <ManagerLink to="/#/billing/history">factures</ManagerLink>.
+
+Si le service est toujours actif, son renouvellement automatique a pu générer la facture. Pour interrompre les prochaines échéances, consultez les guides « [Comment renouveler mes services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/automatic-renewal) » et « [Comment résilier mes services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services) ».
+
+### Après votre signalement
+
+Une fois le statut de votre facture mis à jour depuis votre plateforme, veillez à sélectionner le **code correspondant le mieux au motif de votre demande** : c'est lui qui détermine le traitement appliqué.
+
+Vous recevrez ensuite une notification confirmant la prise en compte de votre demande, puis les éléments nécessaires pour vous guider dans sa résolution. Nos équipes étudient chaque signalement afin d'analyser la situation.
+
+:::info
+Le passage d'une facture au statut « Refusée » ou « Litige » **n'entraîne pas automatiquement** l'émission d'un avoir, d'un remboursement ou d'une nouvelle facture. Un avoir ne peut être émis qu'après validation de votre demande à l'issue de cette analyse.
+
+:::
+
+Un avoir est un document comptable qui permet de corriger ou d'annuler tout ou partie d'une facture précédemment émise. Il est toujours associé à une facture d'origine.
+
+### Si aucun code ne correspond
+
+- Si votre facture **n'apparaît pas** sur votre plateforme, vérifiez d'abord que votre commande est bien finalisée : une facture n'est générée qu'à cette condition. Vérifiez ensuite que votre numéro de SIRET est à jour.
+- Si votre facture a été **rejetée** pour un motif technique, nos équipes sont informées automatiquement et procèdent à la correction puis à un nouveau dépôt. Patientez 48 heures.
+- Si vous ne reconnaissez ni l'émetteur ni le service facturé, consultez le guide « [Comprendre une facture d'un émetteur ou service inconnu](/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice) ».
+- Si votre situation n'est couverte par aucun des cas ci-dessus, [créez un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant le numéro de la facture concernée ainsi que le statut et le code affichés sur votre plateforme.
+
+## Aller plus loin
+
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
+
+[Corriger une erreur de coordonnées bancaires](/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error)
+
+[Gérer mes factures OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management)
+
+[Gérer mes commandes OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders)
+
+[Gérer mes moyens de paiement](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods)
+
+[Notion de Numéro de commande ou Purchase Order (PO)](/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order)
+
+[Spécifications externes et normes pour la facturation électronique](https://www.impots.gouv.fr/specifications-externes-b2b) (impots.gouv.fr — norme AFNOR XP Z12-012)
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -46,9 +46,9 @@ Les motifs d'erreur sont rattachés à l'un des trois statuts suivants, attribu�
 
 | Statut | Conséquence |
 |---|---|
-| **Litige (207)** | La facture reste due. Votre signalement est transmis à nos équipes, qui analysent la situation. |
+| **Litige (207)** | La facture reste due. Vous recevez automatiquement une notification contenant le guide correspondant au code que vous avez sélectionné, afin de vous permettre de régulariser la situation. |
 | **Refusé (210)** | La facture reste due. Le refus nous informe de votre désaccord, mais ne suspend pas les délais de paiement. |
-| **Approuvé partiellement (206)** | La facture reste due. Votre signalement est transmis à nos équipes, qui analysent la situation. |
+| **Approuvé partiellement (206)** | La facture reste due. Vous recevez automatiquement une notification contenant le guide correspondant au code que vous avez sélectionné, afin de vous permettre de régulariser la situation. |
 
 Le libellé exact de chaque statut, ainsi que la liste des codes disponibles, sont propres à votre plateforme de facturation électronique. Sélectionnez le **code correspondant le mieux au motif de votre demande**.
 
@@ -182,7 +182,7 @@ Ce motif signale qu'une mention obligatoire est absente de la facture. La réfor
 
 Ces mentions étant renseignées à partir des données de votre espace client, vérifiez que celles-ci sont complètes et à jour en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
-Si vos données sont correctes, la correction relève de nos équipes : nos équipes sont informées du refus et vous adressent les éléments nécessaires à la régularisation.
+Si vos données sont correctes, la correction relève de nos équipes : le refus déclenche l'envoi automatique des éléments nécessaires à la régularisation.
 
 ### Doublons et références de commande
 
@@ -214,10 +214,10 @@ Si le service est toujours actif, son renouvellement automatique a pu générer 
 
 Une fois le statut de votre facture mis à jour depuis votre plateforme, veillez à sélectionner le **code correspondant le mieux au motif de votre demande** : c'est lui qui détermine le traitement appliqué.
 
-Vous recevrez ensuite une notification confirmant la prise en compte de votre demande, puis les éléments nécessaires pour vous guider dans sa résolution. Nos équipes étudient chaque signalement afin d'analyser la situation.
+Vous recevez ensuite automatiquement une notification contenant le guide correspondant au code sélectionné, ainsi que les éléments nécessaires pour vous guider dans la régularisation. C'est pourquoi le choix du code conditionne directement la pertinence des informations reçues.
 
 :::info
-Le passage d'une facture au statut « Refusée » ou « Litige » **n'entraîne pas automatiquement** l'émission d'un avoir, d'un remboursement ou d'une nouvelle facture. Un avoir ne peut être émis qu'après validation de votre demande à l'issue de cette analyse.
+Le passage d'une facture au statut « Refusée » ou « Litige » **n'entraîne pas automatiquement** l'émission d'un avoir, d'un remboursement ou d'une nouvelle facture. L'émission d'un avoir suppose une validation préalable de votre demande par nos équipes.
 
 :::
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -1,23 +1,28 @@
 ---
 title: Comprendre et corriger les erreurs de facturation électronique
-description: Identifiez le motif d'erreur signalé sur une facture électronique OVHcloud et découvrez la marche à suivre pour régulariser la situation
-lastUpdated: 2026-08-19
+description: Découvrez quel code sélectionner selon le motif d'erreur constaté sur une facture OVHcloud et comment corriger vos données pour vos prochaines factures
+lastUpdated: 2026-08-20
 ---
 
 <Banner kind="siret-fr" />
 
 ## Objectif
 
-**Votre plateforme de facturation électronique peut signaler un motif d'erreur sur une facture OVHcloud, sous la forme d'un statut et d'un code (par exemple « litige 207 – TX_TVA_ERR »).**
+**Un motif d'erreur peut être associé à une facture OVHcloud sur votre plateforme de facturation électronique, sous la forme d'un statut et d'un code (par exemple « litige 207 – TX_TVA_ERR »).**
 
-Ce guide regroupe l'ensemble de ces motifs et indique, pour chacun, la marche à suivre. Il vous permet de partir du code affiché sur votre plateforme pour identifier directement l'action à réaliser.
+Ce motif a deux origines possibles, qui n'appellent pas les mêmes actions :
+
+- **vous sélectionnez vous-même un code** sur votre plateforme pour signaler un désaccord sur une facture reçue (statuts 206, 207 et 210) ;
+- **la plateforme rejette la facture** pour un motif technique, sans intervention de votre part (statut 213).
+
+Ce guide décrit les deux cas et indique, pour chacun, la marche à suivre.
 
 Pour toute question générale sur la réforme, la réception de vos factures ou les statuts de la plateforme, consultez la « [FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing) ».
 
 ## Prérequis
 
 - Disposer d'un accès au compte client de facturation.
-- Avoir relevé le statut et le code d'erreur affichés sur votre plateforme de facturation électronique.
+- Avoir identifié le motif associé à votre facture : celui que vous avez sélectionné, ou celui signalé par votre plateforme.
 
 ## En pratique
 
@@ -40,31 +45,52 @@ Pour en savoir plus sur la réforme, consultez les ressources officielles suivan
 - [J'approfondis mes connaissances sur la réforme](https://www.impots.gouv.fr/japprofondis-mes-connaissances-sur-la-reforme) (impots.gouv.fr) ;
 - [Tout savoir sur la facturation électronique pour les entreprises](https://www.economie.gouv.fr/tout-savoir-sur-la-facturation-electronique-pour-les-entreprises) (economie.gouv.fr).
 
-### Comprendre les trois statuts
+### Deux cas de figure
 
-Les motifs d'erreur sont rattachés à l'un des trois statuts suivants, attribués depuis votre plateforme de facturation électronique :
+Selon l'origine du motif, la marche à suivre diffère radicalement.
 
-| Statut | Conséquence |
+#### Cas 1 — vous sélectionnez un code (statuts 206, 207 et 210)
+
+Vous n'êtes pas d'accord avec une facture reçue. Depuis votre plateforme, vous modifiez son statut et sélectionnez le code correspondant au motif de votre demande.
+
+| Statut | Ce que vous exprimez |
 |---|---|
-| **Litige (207)** | La facture reste due. Vous recevez automatiquement une notification contenant le guide correspondant au code que vous avez sélectionné, afin de vous permettre de régulariser la situation. |
-| **Refusé (210)** | La facture reste due. Le refus nous informe de votre désaccord, mais ne suspend pas les délais de paiement. |
-| **Approuvé partiellement (206)** | La facture reste due. Vous recevez automatiquement une notification contenant le guide correspondant au code que vous avez sélectionné, afin de vous permettre de régulariser la situation. |
+| **Litige (207)** | Vous contestez un ou plusieurs éléments de la facture. |
+| **Refusé (210)** | Vous refusez la facture dans son intégralité. |
+| **Approuvé partiellement (206)** | Vous acceptez la facture en signalant une réserve. |
 
-Le libellé exact de chaque statut, ainsi que la liste des codes disponibles, sont propres à votre plateforme de facturation électronique. Sélectionnez le **code correspondant le mieux au motif de votre demande**.
+Ce qui se passe ensuite :
+
+- vous recevez **automatiquement** une notification vous indiquant les instructions à suivre pour le motif que vous avez sélectionné ;
+- la facture concernée **n'est pas rééditée** : elle a été générée à partir des informations présentes dans votre espace client au moment de son émission ;
+- les instructions reçues vous permettent de **corriger vos données pour que vos prochaines factures soient émises correctement**.
 
 :::warning
-Quel que soit le statut appliqué, une facture contestée doit être **régularisée dans les délais prévus** afin d'éviter toute interruption de service. Le changement de statut nous informe de votre désaccord, mais **ne suspend pas les délais de paiement**. Sans régularisation, vos services sont soumis à une suspension automatique, conformément à nos conditions générales.
+La facture reste due. Le changement de statut nous informe de votre désaccord, mais **ne suspend pas les délais de paiement**. Une facture contestée doit être **régularisée dans les délais prévus** afin d'éviter toute interruption de service : sans régularisation, vos services sont soumis à une suspension automatique, conformément à nos conditions générales.
 
 :::
 
 :::info
-Ces statuts sont attribués depuis votre plateforme et ne peuvent pas être modifiés par OVHcloud. À distinguer d'une facture **rejetée**, qui n'a pas été acceptée par la plateforme pour un motif technique : dans ce cas, nos équipes sont informées automatiquement, corrigent la facture et procèdent à un nouveau dépôt. Aucune action n'est attendue de votre part, hormis un délai d'attente de 48 heures.
+Le choix du code conditionne directement les instructions que vous recevez. Sélectionnez le **code correspondant le mieux au motif de votre demande**.
+
+En tant que destinataire, vous n'êtes pas tenu de renseigner tous les statuts. Si vous êtes d'accord avec votre facture, aucune action n'est nécessaire.
 
 :::
 
-### Tableau récapitulatif des motifs d'erreur
+#### Cas 2 — la plateforme rejette la facture (statut 213)
 
-Repérez ci-dessous le code affiché sur votre plateforme, puis consultez la section indiquée.
+Le rejet est **technique** et n'implique aucune action de votre part : la facture n'a pas été acceptée par la plateforme, par exemple parce qu'elle ne respecte pas le format attendu ou qu'une information obligatoire est manquante.
+
+Nos équipes en sont informées automatiquement, corrigent la facture, puis la transmettent de nouveau à votre plateforme de réception. Vous recevez un e-mail confirmant cette prise en charge. Nous vous invitons alors à patienter 48 heures.
+
+:::info
+Les statuts sont attribués depuis votre plateforme et ne peuvent pas être modifiés par OVHcloud. Le libellé exact de chaque statut, ainsi que la liste des codes disponibles, sont propres à votre plateforme.
+
+:::
+
+### Codes à sélectionner selon votre motif
+
+Les tableaux ci-dessous concernent le **cas 1** : vous signalez un désaccord depuis votre plateforme. Identifiez d'abord le motif qui correspond à votre situation, puis sélectionnez le code associé. La dernière colonne indique la marche à suivre pour que vos **prochaines** factures soient émises correctement.
 
 :::info
 Les codes en majuscules (`TX_TVA_ERR`, `SIRET_ERR`, `NON_CONFORME`, etc.) sont ceux de la norme **AFNOR XP Z12-012** (annexe A), qui définit les motifs associés aux statuts du cycle de vie de la facture. Ils sont communs à l'ensemble des plateformes agréées. Le libellé affiché sur votre plateforme peut être formulé différemment.
@@ -73,48 +99,48 @@ Les codes en majuscules (`TX_TVA_ERR`, `SIRET_ERR`, `NON_CONFORME`, etc.) sont c
 
 #### Litige (207)
 
-| Code | Motif | Marche à suivre |
+| Motif | Code à sélectionner | Marche à suivre pour vos prochaines factures |
 |---|---|---|
-| `TX_TVA_ERR` | Taux de TVA erroné | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
-| `SIRET_ERR` | SIRET erroné ou absent | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
-| `COORD_BANC_ERR` | Erreur de coordonnées bancaires | [Erreurs de paiement](#erreurs-de-paiement) |
-| `MODPAI_ERR` | Modalités de paiement incorrectes | [Erreurs de paiement](#erreurs-de-paiement) |
-| `REF_ERR` | Référence incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `PU_ERR` | Prix unitaires incorrects | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `REM_ERR` | Remise erronée | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `ART_ERR` | Article facturé incorrect | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `QTE_ERR` | Quantité facturée incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `LIVR_INCOMP` | Problème de livraison | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `CODE_ROUTAGE_ERR` | Code de routage absent ou erroné | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| Taux de TVA erroné | `TX_TVA_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| SIRET erroné ou absent | `SIRET_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| Erreur de coordonnées bancaires | `COORD_BANC_ERR` | [Erreurs de paiement](#erreurs-de-paiement) |
+| Modalités de paiement incorrectes | `MODPAI_ERR` | [Erreurs de paiement](#erreurs-de-paiement) |
+| Référence incorrecte | `REF_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Prix unitaires incorrects | `PU_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Remise erronée | `REM_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Article facturé incorrect | `ART_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Quantité facturée incorrecte | `QTE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Problème de livraison | `LIVR_INCOMP` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Code de routage absent ou erroné | `CODE_ROUTAGE_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
 
 #### Refusé (210)
 
-| Code | Motif | Marche à suivre |
+| Motif | Code à sélectionner | Marche à suivre pour vos prochaines factures |
 |---|---|---|
-| `DEST_ERR` | Erreur de destinataire | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
-| `ADR_ERR` | Adresse de facturation électronique erronée | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
-| `DOUBLON` | Facture en doublon (déjà émise / reçue) | [Doublons et références de commande](#doublons-et-références-de-commande) |
-| `DOUBLE_FACT` | Double facturation | [Doublons et références de commande](#doublons-et-références-de-commande) |
-| `CMD_ERR` | N° de commande incorrect ou manquant | [Doublons et références de commande](#doublons-et-références-de-commande) |
-| `CONTRAT_TERM` | Contrat terminé | [Contrat terminé](#contrat-terminé) |
-| `TRANSAC_INC` | Transaction inconnue | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `EMMET_INC` | Émetteur inconnu | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `MONTANTTOTAL_ERR` | Montant total erroné | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `CALCUL_ERR` | Erreur de calcul de la facture | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `NON_CONFORME` | Mention légale manquante | [Mentions légales manquantes](#mentions-légales-manquantes) |
+| Erreur de destinataire | `DEST_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| Adresse de facturation électronique erronée | `ADR_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| Facture en doublon (déjà émise / reçue) | `DOUBLON` | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| Double facturation | `DOUBLE_FACT` | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| N° de commande incorrect ou manquant | `CMD_ERR` | [Doublons et références de commande](#doublons-et-références-de-commande) |
+| Contrat terminé | `CONTRAT_TERM` | [Contrat terminé](#contrat-terminé) |
+| Transaction inconnue | `TRANSAC_INC` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Émetteur inconnu | `EMMET_INC` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Montant total erroné | `MONTANTTOTAL_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Erreur de calcul de la facture | `CALCUL_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Mention légale manquante | `NON_CONFORME` | [Mentions légales manquantes](#mentions-légales-manquantes) |
 
 #### Approuvé partiellement (206)
 
-| Code | Motif | Marche à suivre |
+| Motif | Code à sélectionner | Marche à suivre pour vos prochaines factures |
 |---|---|---|
-| `SIRET_ERR` | SIRET erroné ou absent | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
-| `MODPAI_ERR` | Modalités de paiement incorrectes | [Erreurs de paiement](#erreurs-de-paiement) |
-| `Prix_Unit_Inc` | Voir `PU_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `Remise_ERR` | Voir `REM_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `Quantité_Err` | Voir `QTE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `Article_INC` | Voir `ART_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `PRB_LIV` | Voir `LIVR_INCOMP` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| `QUALITE_ERR` | Qualité d'article livré incorrecte | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| SIRET erroné ou absent | `SIRET_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
+| Modalités de paiement incorrectes | `MODPAI_ERR` | [Erreurs de paiement](#erreurs-de-paiement) |
+| Prix unitaires incorrects (variante) | `Prix_Unit_Inc` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Remise erronée (variante) | `Remise_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Quantité facturée incorrecte (variante) | `Quantité_Err` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Article facturé incorrect (variante) | `Article_INC` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Problème de livraison (variante) | `PRB_LIV` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Qualité d'article livré incorrecte | `QUALITE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
 
 :::info
 Certaines plateformes affichent, pour le statut « Approuvé partiellement », des variantes de libellé (`Prix_Unit_Inc`, `Remise_ERR`, `Quantité_Err`, `Article_INC`, `PRB_LIV`). Elles correspondent aux mêmes motifs que les codes normalisés indiqués ci-dessus et relèvent de la même marche à suivre.
@@ -210,25 +236,17 @@ Ce motif signale une facture reçue pour un service que vous considérez comme r
 
 Si le service est toujours actif, son renouvellement automatique a pu générer la facture. Pour interrompre les prochaines échéances, consultez les guides « [Comment renouveler mes services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/automatic-renewal) » et « [Comment résilier mes services OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/how-to-cancel-services) ».
 
-### Après votre signalement
+### Avoirs et remboursements
 
-Une fois le statut de votre facture mis à jour depuis votre plateforme, veillez à sélectionner le **code correspondant le mieux au motif de votre demande** : c'est lui qui détermine le traitement appliqué.
+Le passage d'une facture au statut « Refusée » ou « Litige » **n'entraîne pas automatiquement** l'émission d'un avoir, d'un remboursement ou d'une nouvelle facture.
 
-Vous recevez ensuite automatiquement une notification contenant le guide correspondant au code sélectionné, ainsi que les éléments nécessaires pour vous guider dans la régularisation. C'est pourquoi le choix du code conditionne directement la pertinence des informations reçues.
+Un avoir est un document comptable qui permet de corriger ou d'annuler tout ou partie d'une facture précédemment émise. Il est toujours associé à une facture d'origine. Son émission suppose une validation préalable de votre demande par nos équipes.
 
-:::info
-Le passage d'une facture au statut « Refusée » ou « Litige » **n'entraîne pas automatiquement** l'émission d'un avoir, d'un remboursement ou d'une nouvelle facture. L'émission d'un avoir suppose une validation préalable de votre demande par nos équipes.
-
-:::
-
-Un avoir est un document comptable qui permet de corriger ou d'annuler tout ou partie d'une facture précédemment émise. Il est toujours associé à une facture d'origine.
-
-### Si aucun code ne correspond
+### Si aucun motif ne correspond
 
 - Si votre facture **n'apparaît pas** sur votre plateforme, vérifiez d'abord que votre commande est bien finalisée : une facture n'est générée qu'à cette condition. Vérifiez ensuite que votre numéro de SIRET est à jour.
-- Si votre facture a été **rejetée** pour un motif technique, nos équipes sont informées automatiquement et procèdent à la correction puis à un nouveau dépôt. Patientez 48 heures.
-- Si vous ne reconnaissez ni l'émetteur ni le service facturé, consultez le guide « [Comprendre une facture d'un émetteur ou service inconnu](/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice) ».
-- Si votre situation n'est couverte par aucun des cas ci-dessus, [créez un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant le numéro de la facture concernée ainsi que le statut et le code affichés sur votre plateforme.
+- Si vous ne reconnaissez ni l'émetteur ni le service facturé, consultez le guide « [Comprendre une facture d'un émetteur ou service inconnu](/guides/account-and-service-management/managing-billing-payments-and-services/understand-unknown-invoice) ».
+- Si votre situation n'est couverte par aucun des cas ci-dessus, [créez un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant le numéro de la facture concernée ainsi que le statut et le code associés.
 
 ## Aller plus loin
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comprendre et corriger les erreurs de facturation électronique
 description: Découvrez quel code sélectionner selon le motif d'erreur constaté sur une facture OVHcloud et comment corriger vos données pour vos prochaines factures
-lastUpdated: 2026-08-20
+lastUpdated: 2026-08-25
 ---
 
 <Banner kind="siret-fr" />
@@ -227,6 +227,8 @@ S'il s'agit de deux factures distinctes, consultez vos commandes afin de faire l
 Si vous constatez une différence entre un paiement et le montant d'une facture, cela signifie que vous possédiez un avoir qui a automatiquement diminué le montant prélevé.
 
 :::
+
+Si le **numéro de commande (PO)** est absent ou incorrect sur votre facture, renseignez-le dans votre espace client avant l'émission de vos prochaines factures, en vous aidant du guide « [Notion de Numéro de commande ou Purchase Order (PO)](/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order) ».
 
 ### Contrat terminé
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
@@ -342,4 +342,6 @@ L'émission d'un avoir n'est pas automatique : elle intervient uniquement aprè
 
 [Payer une commande en tant qu'administration publique](/guides/account-and-service-management/managing-billing-payments-and-services/public-administration)
 
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management.mdx
@@ -166,4 +166,8 @@ En cas de facture en doublon (Refusé – 210 – DOUBLON) et si vous êtes conc
 
 [Gérer mes moyens de paiement](/guides/account-and-service-management/managing-billing-payments-and-services/manage-payment-methods)
 
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
@@ -147,4 +147,8 @@ En cas de facturation en double (Refusé – 210 – DOUBLE_FACT) ou de numéro 
 
 ## Aller plus loin
 
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -79,4 +79,8 @@ Vous n'aurez pas la possibilité de changer le statut de l'entreprise de sociét
 
 ## Aller plus loin
 
+[FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
+
+[Comprendre et corriger les erreurs de facturation électronique](/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors)
+
 Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
Compile every e-invoicing error code scattered across the billing guides into one FR-only troubleshooting guide, so customers can start from the code shown on their platform and reach the right remediation.

Content:
- lookup table of 30 rows grouped by the 3 lifecycle statuses (Litige 207 / Refuse 210 / Approuve partiellement 206)
- 6 remediation sections: identification, payment, order mismatch, missing legal mentions, duplicates, terminated contract
- regulatory context sourced from impots.gouv.fr

Motif labels use the AFNOR XP Z12-012 (annexe A) wording. The 5 variant spellings from ovh-orders.mdx are cross-referenced to their standard equivalent rather than given a label, since they are absent from the standard's 45-code list.

Also adds FAQ + new-guide links to the 5 billing guides that mention error codes, and registers the guide in the sidebar.