### PR TITLE
docs: translate the missing Web Hosting guides into de, es, it, pl and pt

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,1 +1,413 @@
-../../../../en/guides/web-cloud/web-hosting/api-webhosting.mdx
+---
+title: Webanwendung über die öffentliche OVHcloud API erstellen und verwalten
+description: "Erfahren Sie, wie Sie mit der öffentlichen OVHcloud API eine Webanwendung erstellen: Domains anbinden, Datenbanken verwalten, SSL-Zertifikate konfigurieren"
+lastUpdated: 2026-08-19
+availableIn: [eu, ca, apac]
+---
+
+import Api from '@components/Api';
+
+## Ziel
+
+Diese Anleitung erklärt Ihnen, wie Sie die öffentliche OVHcloud API verwenden, um eine Webanwendung auf Ihrem Hosting zu erstellen und zu verwalten. Sie lernen dabei die wichtigsten Operationen kennen: Domains anbinden, Datenbanken verwalten und SSL-Zertifikate konfigurieren.
+
+## Voraussetzungen
+
+- Sie verfügen über ein OVHcloud [Webhosting](/links/web/hosting).
+- Sie verfügen über Grundkenntnisse der REST API.
+- Sie haben Zugriff auf die OVHcloud API. Lesen Sie hierzu unsere Anleitung [Erste Schritte mit der OVHcloud API](/guides/manage-and-operate/api/first-steps).
+
+:::warning
+Die Nutzung der OVHcloud APIs setzt fortgeschrittene Kenntnisse in diesem Bereich voraus. Sollten Sie auf Schwierigkeiten stoßen, wenden Sie sich an die [OVHcloud Partner](/links/partner).
+:::
+
+## In der praktischen Anwendung
+
+### Serviceinformationen abrufen
+
+Der erste Schritt besteht darin, den `serviceName` abzurufen, eine eindeutige ID für Ihren Webhosting-Service. Sie benötigen ihn für die meisten der folgenden API-Aufrufe.
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
+
+Dieser Befehl gibt eine Liste Ihrer Webhosting-Services zurück. Jeder Eintrag der Liste ist ein `serviceName`.
+
+**Beispielantwort**:
+
+```json
+[
+  "example.cluster01.hosting.ovh.net",
+  "example2.cluster02.hosting.ovh.net"
+]
+```
+
+### Eine Domain anbinden
+
+Binden Sie eine Domain an Ihren Webhosting-Service an:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/attachedDomain"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| bypassDNSConfiguration | nein | Wenn aktiviert, wird die DNS-Zone nicht aktualisiert |
+| cdn | nein | Gibt an, ob die Domain mit dem CDN des Hostings verknüpft ist. Zulässige Werte: active┃none |
+| domain | nein | Zu verknüpfende Domain |
+| firewall | nein | Gibt an, ob die Firewall für diese Domain aktiv ist. Zulässige Werte: active┃none |
+| ipLocation | nein | Legt den IP-Standort fest, der der Domain zugeordnet ist. Zulässige Werte: BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| ownLog | nein | Domain zur Trennung der Logs |
+| path | nein | Pfad, unter dem die Webdateien gespeichert werden |
+| runtimeId | nein | ID der Runtime-Konfiguration, die für diese Domain verwendet wird |
+| ssl | nein | Option zur Aktivierung von SSL für die Domain |
+
+**Beispielantwort**:
+
+```json
+{
+ "doneDate": "2024-08-22T08:13:50.740Z",
+ "function": "abuse/close",
+ "id": 0,
+ "lastUpdate": "2024-08-22T08:13:50.740Z",
+ "objectId": "string",
+ "objectType": "Abuse",
+ "startDate": "2024-08-22T08:13:50.740Z",
+ "status": "cancelled"
+}
+```
+
+### SSL-Zertifikate erstellen
+
+Konfigurieren und verwalten Sie SSL-Zertifikate, um Ihre Website abzusichern:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/ssl"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| certificate | nein | Zu installierendes SSL-Zertifikat |
+| chain | nein | Zertifikatskette zur Validierung des SSL-Zertifikats |
+| key | nein | Privater Schlüssel, der zum SSL-Zertifikat gehört |
+
+**Beispielantwort**:
+
+```json
+{
+ "isReportable": false,
+ "provider": "COMODO",
+ "regenerable": false,
+ "status": "created",
+ "taskId": 0,
+ "type": "CUSTOM"
+}
+```
+
+### Datenbanken verwalten
+
+Mit den OVHcloud Webhosting APIs können Sie auch Ihre Datenbanken verwalten.
+
+#### Eine Datenbank erstellen
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| capacity | ja | Kapazitäten der Datenbank. Werte: extraSqlPersonal┃local┃privateDatabase┃sqlLocal┃sqlPersonal┃sqlPro |
+| user | ja | Benutzername der Datenbank. Muss kleingeschrieben sein und mit der ID Ihres Webhostings beginnen |
+| password | nein | Passwort der Datenbank |
+| quota | nein | Zugewiesener Speicherplatz. Werte: 25┃100┃200┃256┃400┃512┃800┃1024 |
+| type | ja | Typ der Datenbank. Werte: mariadb┃mysql┃postgresql┃redis |
+| version | nein | Version der Datenbank |
+
+**Beispielantwort**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Vorhandene Datenbanken auflisten
+
+Listen Sie alle Datenbanken auf, die Ihrem Webhosting-Service zugeordnet sind:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| mode | ja | Zulässige Werte: besteffort ┃ classic ┃ module |
+
+**Beispielantwort**:
+
+```json
+[
+ "example.mysql.db",
+ "example2.mysql.db"
+]
+```
+
+### Module verwalten
+
+#### Eine Liste der Module abrufen
+
+Rufen Sie eine Liste der verfügbaren Module ab, die Sie auf Ihrem Webhosting installieren können:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| active | nein | Filtert aktivierte oder deaktivierte Module |
+| branch | nein | Filtert die Module nach Version. Zulässige Werte: old ┃ stable ┃ testing |
+| latest | nein | Filter zur Anzeige der Module, die der neuesten Version entsprechen |
+
+**Beispielantwort**:
+
+```json
+[
+ 195,
+ 184,
+ 38,
+ 176
+]
+```
+
+#### Informationen zu einem Modul abrufen
+
+Rufen Sie die Details eines bestimmten Moduls ab, das auf Ihrem Webhosting installiert ist:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList/\{id\}"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| id | ja | ID des Moduls |
+
+**Beispielantwort**:
+
+```json
+{
+ "keywords": [
+   "gallery"
+ ],
+ "adminNameType": "string",
+ "author": "OVH",
+ "branch": "old",
+ "id": 195,
+ "size": {
+   "value": 0,
+   "unit": "B"
+ },
+ "name": "myname",
+ "upgradeFrom": [],
+ "language": [
+   "en",
+   "fr",
+   "de",
+   "es",
+   "pl"
+ ],
+ "version": "1.4.2.2",
+ "active": false,
+ "languageRequirement": {
+   "value": "php",
+   "unit": "supported versions: ''\nnon supported versions: '8+'"
+ },
+ "latest": true
+}
+```
+
+### Ein neues Modul installieren
+
+Installieren Sie ein neues Modul auf Ihrem Webhosting-Service:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/module"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| moduleId | ja | ID des zu installierenden Moduls |
+| adminName | nein | Name des Administrators |
+| adminpassword | nein | Passwort des Administratorkontos |
+| domain | nein | Domainname, unter dem das Modul bereitgestellt wird |
+| language | nein | Sprache der Modulinstallation |
+| path | nein | Pfad auf dem Server, unter dem das Modul installiert wird |
+| dependencies -> name | nein | Name des abhängigen Service |
+| dependencies -> password | nein | Passwort für den abhängigen Service |
+| dependencies -> port | nein | Verbindungsport des Service |
+| dependencies -> prefix | nein | Präfix, das in der Konfiguration des Service verwendet wird |
+| dependencies -> server | nein | Serveradresse des abhängigen Service |
+| dependencies -> type | nein | Typ des Service (z. B. MySQL) |
+| dependencies -> user | nein | Benutzername für den abhängigen Service |
+
+**Beispielantwort**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+### FTP-Benutzer verwalten
+
+Verwalten Sie die FTP-/SSH-Benutzer Ihres Webhostings, um Zugriffe und Konfigurationen zu erleichtern.
+
+#### Einen neuen FTP-/SSH-Benutzer erstellen
+
+Erstellen Sie einen neuen FTP- oder SSH-Benutzer für den Zugriff auf Ihr Webhosting:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| home | ja | Home-Verzeichnis |
+| login | ja | Benutzername |
+| password | ja | Passwort |
+| sshState | nein | Legt den Status des SSH-Zugriffs für den Benutzer fest. Zulässige Werte: active ┃none ┃sftponly |
+
+**Beispielantwort**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### FTP-/SSH-Benutzer auflisten
+
+Listen Sie alle vorhandenen FTP-/SSH-Benutzer Ihres Hosting-Service auf:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| home | nein | Filtert die Benutzer nach ihrem Home-Verzeichnis |
+| login | nein | Filtert die Benutzer nach ihrem Benutzernamen |
+
+**Beispielantwort**:
+
+```json
+[
+ "user1",
+ "user2",
+ "user3",
+ "user4"
+]
+```
+
+### Eine Datenbank wiederherstellen
+
+Erstellen, listen und stellen Sie Datenbank-Backups für Ihre Website wieder her.
+
+#### Ein Backup einer Datenbank erstellen
+
+Erstellen Sie ein Backup Ihrer Datenbank, um sie bei Bedarf wiederherzustellen:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| name | ja | Name der Datenbank |
+| date | ja | Art des Backups. Zulässige Werte: daily.1┃now┃weekly.1 |
+| sendEmail | nein | Wenn dieser Parameter aktiviert ist, wird eine E-Mail gesendet, sobald das Backup verfügbar ist |
+
+**Beispielantwort**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Verfügbare Datenbank-Backups auflisten
+
+Listen Sie alle für Ihre Datenbanken verfügbaren Backups auf:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| name | ja | Name der Datenbank |
+| creationDate.from | nein | Filtert die ab diesem Datum erstellten Backups |
+| creationDate.to | nein | Filtert die bis zu diesem Datum erstellten Backups |
+| deletionDate.from | nein | Filtert die ab diesem Datum gelöschten Backups |
+| deletionDate.to | nein | Filtert die bis zu diesem Datum gelöschten Backups |
+| type | nein | Filtert die Backups nach Art. Zulässige Werte: daily.1┃now┃weekly.1 |
+
+**Beispielantwort**:
+
+```json
+[
+ 1,
+ 12
+]
+```
+
+#### Ein bestimmtes Backup einer Datenbank wiederherstellen
+
+Stellen Sie im Problemfall ein bestimmtes Backup Ihrer Datenbank wieder her:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump/\{id\}/restore"} />
+
+| Parameter | Erforderlich | Beschreibung |
+|---|---|---|
+| serviceName | ja | Name des Service |
+| name | ja | Name der Datenbank |
+| id | ja | ID des Backups |
+
+**Beispielantwort**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+## Fazit
+
+Diese Anleitung hat Ihnen die wichtigsten API-Anfragen zur Verwaltung Ihres OVHcloud Webhostings vorgestellt, etwa das Anbinden von Domains sowie die Verwaltung von SSL-Zertifikaten und Datenbanken.
+
+Es stehen jedoch viele weitere API-Aufrufe zur Verfügung, die Sie je nach Ihren spezifischen Anforderungen erkunden können. Weitere Optionen und Funktionen finden Sie im Abschnitt "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" der OVHcloud API.
+
+## Weiterführende Informationen
+
+[Order a domain name via API](/guides/web-cloud/domains/api-domain-order)
+
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,124 +1,118 @@
 ---
-title: "Backing up your WordPress websites with MainWP"
-description: "Find out how to back up and restore your WordPress websites with MainWP"
-lastUpdated: 2024-01-25
+title: WordPress Websites mit MainWP sichern
+description: "Erfahren Sie, wie Sie Ihre WordPress Websites mit MainWP und der Erweiterung UpdraftPlus über ein einziges Dashboard sichern und wiederherstellen"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Ziel
 
-Backing up a website is a vital part of running your business. It offers several advantages:
+Das Backup einer Website ist eine zentrale Praxis für die Führung Ihres Unternehmens. Es bietet mehrere Vorteile:
 
-- **Data security**: Regular backups ensure your website's data is protected in the event of a cyberattack, technical failure or human error.
-- **Protection against update errors**: A backup made before a WordPress plugin or theme is updated allows you to go back in time if an error or version conflict occurs during the update.
-- **Rapid Restore**: In the event of a technical error, the backup can be reverted to a previous version to offer your customers a functional website and business continuity.
-- **Legal Compliance**: Maintaining regular backups may be a regulatory compliance requirement for your organization and may protect you from legal action.
+- **Datensicherheit**: Regelmäßige Backups stellen sicher, dass die Daten Ihrer Website bei einem Cyberangriff, einem technischen Ausfall oder einem menschlichen Fehler geschützt sind.
+- **Schutz vor Update-Fehlern**: Ein Backup, das vor dem Update von WordPress, eines Plugins oder eines Themes erstellt wurde, ermöglicht es, bei einem Fehler oder Versionskonflikt während des Updates zum vorherigen Stand zurückzukehren.
+- **Schnelle Wiederherstellung**: Bei einem technischen Fehler ermöglicht das Backup die Rückkehr zu einer früheren Version, um Ihren Kunden eine funktionsfähige Website und die Fortführung des Geschäftsbetriebs zu bieten.
+- **Rechtliche Konformität**: Für Ihr Unternehmen kann die Pflege regelmäßiger Backups einer regulatorischen Anforderung entsprechen und Sie vor rechtlichen Schritten schützen.
 
-MainWP offers several extensions for backing up your websites.
+MainWP bietet mehrere Erweiterungen zum Sichern Ihrer Websites an.
 
-**This guide explains how to back up your WordPress websites with the UpdraftPlus extension.**
+**Diese Anleitung erklärt Ihnen, wie Sie Ihre WordPress Websites mit der Erweiterung UpdraftPlus sichern.**
 
-## Requirements
+## Voraussetzungen
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Sie verfügen über ein [Web Cloud Hosting](/links/web/hosting).
+- Sie sind mit Ihrem MainWP Dashboard verbunden.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
 :::
 
-## Instructions
+## In der praktischen Anwendung
 
-### Install the UpdraftPlus extension
+### Die Erweiterung UpdraftPlus installieren
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Wenn Sie noch nie eine MainWP Erweiterung installiert haben, erfahren Sie in [dieser Anleitung](/guides/web-cloud/web-hosting/mainwp-general), wie Sie eine Erweiterung installieren.
 :::
 
-To find all the extensions linked to the backup, go to the [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) section of MainWP. You can also search for an extension by clicking `Extensions` from the MainWP main menu, then `Install Extensions`. Click on the `Backup` tab to view the list of extensions linked to the backup.
+Alle Erweiterungen rund um das Backup finden Sie im Bereich [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) von MainWP. Sie können eine Erweiterung auch suchen, indem Sie im Hauptmenü von MainWP auf <code className="action">Extensions</code> und dann auf <code className="action">Install Extensions</code> klicken. Klicken Sie auf den Tab <code className="action">Backup</code>, um die Liste der Erweiterungen rund um das Backup anzuzeigen.
 
-In this example, we choose the free UpdraftPlus extension, but you are free to choose the extension of your choice.
+In diesem Beispiel wählen wir die kostenlose Erweiterung UpdraftPlus, Sie können jedoch die Erweiterung Ihrer Wahl verwenden.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+Klicken Sie nach der Auswahl der Erweiterung auf <code className="action">Install Selected Extensions</code>.
 
-Once you have selected the extension, click `Install Selected Extensions`.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Extensions</code> und dann auf <code className="action">Manage Extensions</code>. Die zuvor installierte Erweiterung UpdraftPlus wird angezeigt.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed UpdraftPlus extension appears.
+Klicken Sie auf <code className="action">Enable</code>, um die Erweiterung zu aktivieren. Wenn eine Fehlermeldung anzeigt, dass die Lizenz nicht aktiviert ist, klicken Sie einfach auf die Schaltfläche <code className="action">License</code>. Bevor Sie UpdraftPlus verwenden können, müssen Sie das Plugin UpdraftPlus auf den Child-Sites aktivieren, die Sie sichern möchten.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+### Das Plugin UpdraftPlus auf einer Child-Site installieren
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button. Before you can use UpdraftPlus, you must enable the UpdraftPlus plugin on the child sites that you want to back up.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Sites</code> und dann auf <code className="action">Install Plugins</code>. Geben Sie in die Suchleiste "UpdraftPlus" ein.
 
-### Install the UpdraftPlus plugin on a child site
+<img className="thumbnail" alt="MainWP Plugin-Suchfeld mit eingegebenem UpdraftPlus" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-In the main menu of MainWP, click `Sites` then `Install Plugins`. In the search bar, type UpdraftPlus.
+Sobald Sie das Plugin "UpdraftPlus: WordPress Backup & Migration" gefunden haben, klicken Sie auf <code className="action">Install Plugin</code>. Wählen Sie anschließend rechts auf dem Bildschirm die Child-Website aus, auf der Sie UpdraftPlus installieren möchten. Klicken Sie auf <code className="action">Complete Installation</code>. Denken Sie daran, <code className="action">Activate after installation</code> anzukreuzen.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png)
+Gehen Sie nach Abschluss der Installation in das Hauptmenü von MainWP. Klicken Sie auf <code className="action">Sites</code>, <code className="action">Plugins</code> und dann auf <code className="action">Manage Plugins</code>. Um zu prüfen, ob UpdraftPlus auf Ihren Websites installiert ist, wählen Sie rechts auf dem Bildschirm die gewünschten Child-Websites aus. Geben Sie weiter unten im Suchfeld <code className="action">Search Options</code> "UpdraftPlus" ein und wählen Sie dann <code className="action">Show Plugins</code>.
 
-Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click `Install Plugin`. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click `Complete Installation`. Remember to tick `Activate after installation`.
+<img className="thumbnail" alt="MainWP Seite Manage Plugins, gefiltert nach UpdraftPlus für die Child-Sites" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-Once the installation is complete, go to the MainWP main menu. Click `Sites`, `Plugins` then `Manage Plugins`. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field `Search Options`, type "UpdraftPlus" then select `Show Plugins`.
+Die Erweiterung "MainWP UpdraftPlus Extension" und das Plugin "UpdraftPlus - Backup/Restore" werden angezeigt, was bedeutet, dass sie auf den betreffenden Child-Websites korrekt installiert sind.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png)
+Wählen Sie die Erweiterung "MainWP UpdraftPlus Extension" und das Plugin "UpdraftPlus - Backup/Restore" aus und klicken Sie dann auf <code className="action">Install to Selected Site(s)</code> (Schaltfläche oben rechts).
 
-The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Retore" are displayed, which means that they are correctly installed on the child websites concerned.
+Um sicherzugehen, dass die Plugins auf Ihrer Child-Website aktiviert sind, klicken Sie oben rechts in der Oberfläche auf <code className="action">Sync Dashboard with Sites</code>.
 
-Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Retore" plugin, then click `Install to Selected Site(s)` (button in the top right-hand corner).
+<img className="thumbnail" alt="Schaltfläche Sync Dashboard with Sites oben rechts in der MainWP Oberfläche" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
-To ensure that the plugins are enabled on your child website, click `Sync Dashboard with Sites`, in the top right-hand corner of the interface.
+Sie können nun mit UpdraftPlus Backups Ihrer Child-Websites erstellen.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png)
+### Backups mit UpdraftPlus erstellen
 
-You can now create backups of your child websites with UpdraftPlus.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Sites</code> und dann auf <code className="action">Manage Sites</code>. Klicken Sie auf die Child-Site, für die Sie ein Backup erstellen möchten, und dann auf den Tab <code className="action">UpdraftPlus Backups</code>.
 
-### Create a backup with UpdraftPlus
+Klicken Sie auf dem angezeigten Bildschirm auf <code className="action">Backup Now</code> und folgen Sie den Anweisungen. Klicken Sie zur Bestätigung des Backups auf <code className="action">Backup Now</code>.
 
-In the main menu of MainWP, click `Sites` then `Manage Sites`. Click the child site for which you want to create a backup, then click the `UpdraftPlus Backups` tab.
+<img className="thumbnail" alt="UpdraftPlus Fenster Backup Now auf einer MainWP Child-Site" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/tab-updraftPlus.png)
+Klicken Sie nach Abschluss des Backups auf den Tab <code className="action">ExistingBackups</code>.
 
-On the screen that pops up, click `Backup Now` and follow the instructions. To confirm the backup, click `Backup Now`.
+<img className="thumbnail" alt="UpdraftPlus Tab ExistingBackups mit dem soeben erstellten Backup" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png)
+Eine neue Zeile für Ihr Backup wird angezeigt. Sie können verschiedene Aktionen für Ihr Backup ausführen, darunter die Wiederherstellung.
 
-Once the backup is complete, click the `ExistingBackups` tab.
+### Eine gesicherte Version einer Child-Site wiederherstellen
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png)
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Extensions</code> und dann auf <code className="action">UpdraftPlus</code>. Wenn Sie auf <code className="action">Existing Backups</code> klicken, wird die Liste Ihrer Backups angezeigt.
 
-A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
+Um Ihre Website wiederherzustellen, suchen Sie die Zeile Ihres Backups und klicken Sie dann auf <code className="action">Restore</code>.
 
-### Restore a backed up version of a child site
+<img className="thumbnail" alt="Backup-Zeile in UpdraftPlus mit der Schaltfläche Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
-In the MainWP main menu, click `Extensions` then `UpdraftPlus`. If you click `Existing Backups`, a list of your backups will appear.
+Ein neues Fenster wird angezeigt. Es enthält verschiedene Informationen, darunter die Liste Ihrer Backups.
 
-To restore your website, locate the line corresponding to your backup, then click `Restore`.
+Suchen Sie das Backup, das Sie wiederherstellen möchten, und klicken Sie dann auf <code className="action">Restore</code>. Prüfen Sie das Datum, um Fehler zu vermeiden.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png)
+<img className="thumbnail" alt="UpdraftPlus Fenster mit den für die Wiederherstellung verfügbaren Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-A new window will appear. It contains some information, including a list of your backups.
+Wählen Sie die Elemente aus, die Sie wiederherstellen möchten, und bestätigen Sie. Die folgende Bestätigungsmeldung wird angezeigt:
 
-Identify the backup you want to restore, then click `Restore`. Remember to check the date to avoid any errors.
+<img className="thumbnail" alt="Meldung, die den erfolgreichen Abschluss der UpdraftPlus Wiederherstellung bestätigt" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png)
+## Weiterführende Informationen <a name="go-further"></a>
 
-Select the elements you want to restore, then confirm. The following confirmation message is displayed:
+[Mehrere WordPress Websites mit dem Plugin MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-general)
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png)
+[Kundeninformationen Ihrer WordPress Websites mit MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-## Go further <a id="go-further"></a>
+[Sicherheit Ihrer Website mit dem WordPress Plugin MainWP verbessern](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Tutorial - Backup Ihrer WordPress Installation](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Den Speicherplatz Ihres Webhostings wiederherstellen](/guides/web-cloud/web-hosting/ftp-save-and-backup)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-[Tutorial - Backup your WordPress website](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
-
-[Restore your web hosting plan's storage space](/guides/web-cloud/web-hosting/ftp-save-and-backup)
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
-
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,88 +1,88 @@
 ---
-title: "Managing customer information on your WordPress websites with MainWP"
-description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard"
-lastUpdated: 2024-01-25
+title: Kundeninformationen Ihrer WordPress Websites mit MainWP verwalten
+description: "Erfahren Sie, wie Sie alle Kunden Ihrer WordPress Websites über das MainWP Dashboard verwalten: Informationen hinzufügen, bearbeiten und löschen"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Ziel
 
-Retaining customers is vital to your company's development. Whether you have one or more websites, it's important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+Die Kundenbindung ist entscheidend für die Entwicklung Ihres Unternehmens. Ob Sie eine oder mehrere Websites betreiben: Es ist wichtig, Ihre Kunden so gut wie möglich zu kennen, um sie zu binden und zufriedenzustellen. Mit dem WordPress Plugin MainWP verwalten Sie die Kunden Ihrer Websites effizient. Wie in einem CRM (Customer Relationship Management) können Sie sämtliche Kundeninformationen kostenlos und mit wenigen Klicks hinzufügen, löschen und aktualisieren.
 
-**This guide will show you how to manage your website's customers' data efficiently using MainWP.**
+**Diese Anleitung erklärt Ihnen, wie Sie die Kundendaten Ihrer Websites mit MainWP effizient verwalten.**
 
-## Requirements
+## Voraussetzungen
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
+- Sie verfügen über ein [Web Cloud Hosting](/links/web/hosting).
+- Sie sind mit Ihrem MainWP Dashboard verbunden. Weitere Informationen finden Sie in unserer Anleitung [Mehrere WordPress Websites mit dem Plugin MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-general).
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
 :::
 
-## Instructions
+## In der praktischen Anwendung
 
-In the MainWP main menu, click `Clients`. On the screen that opens, there are three tabs:
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Clients</code>. Auf dem Bildschirm, der sich öffnet, finden Sie drei Tabs:
 
-- Customers: displays a list of all your customers
-- Add Client: allows you to create new customers
-- Client Fields: allows you to create new fields related to your customers
+- Customers: zeigt die Liste all Ihrer Kunden an
+- Add Client: ermöglicht das Anlegen neuer Kunden
+- Client Fields: ermöglicht das Anlegen neuer Felder für Ihre Kunden
 
-### Add a customer
+### Einen Kunden hinzufügen
 
-To get started, add your first customer. In the main menu of MainWP, click `Clients` then `Add Client`. In the form that appears, fill in your customer's details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click `Add Client`.
+Fügen Sie zunächst Ihren ersten Kunden hinzu. Klicken Sie im Hauptmenü von MainWP auf <code className="action">Clients</code> und dann auf <code className="action">Add Client</code>. Füllen Sie im angezeigten Formular die Daten Ihres Kunden aus. Wählen Sie rechts auf dem Bildschirm die Websites aus, auf denen Sie Ihren neuen Kunden anlegen möchten, und klicken Sie dann auf <code className="action">Add Client</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/add-client.png)
+<img className="thumbnail" alt="MainWP Formular Add Client mit ausgefüllten Kundendaten" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
-### View your customers
+### Ihre Kunden anzeigen
 
-In the main menu of MainWP, click `Clients` then `Clients`. A list of all your customers will appear. You can search for a specific customer (in the `Search` field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Clients</code> und dann auf <code className="action">Clients</code>. Die Liste all Ihrer Kunden wird angezeigt. Sie können nach einem bestimmten Kunden suchen (im Feld <code className="action">Search</code> oben rechts in der Tabelle), indem Sie den Wert eines seiner Felder eingeben, zum Beispiel seinen Namen.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/search-client.png)
+<img className="thumbnail" alt="MainWP Kundenliste mit dem Feld Search oben rechts" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
-You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column `Customer Email`) or the number of websites to which your customer is attached (column `Websites`).
+Sie können die gewünschten Spalten per Drag-and-drop verschieben, um die relevanten Informationen Ihrer Kunden hervorzuheben, etwa die E-Mail-Adresse (Spalte <code className="action">Customer Email</code>) oder die Anzahl der Websites, denen Ihr Kunde zugeordnet ist (Spalte <code className="action">Websites</code>).
 
-From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click `Bulk actions`, `Delete` then `Apply` to confirm.
+Über diese Tabelle können Sie beliebige Kunden löschen. Wählen Sie die Zeilen der zu löschenden Kunden aus und klicken Sie auf <code className="action">Bulk actions</code>, <code className="action">Delete</code> und dann zur Bestätigung auf <code className="action">Apply</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png)
+<img className="thumbnail" alt="MainWP Kundentabelle mit den Optionen Bulk actions und Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
-Finally, click `Yes, proceed` to confirm the deletion of the customers.
+Klicken Sie abschließend auf <code className="action">Yes, proceed</code>, um das Löschen der Kunden zu bestätigen.
 
-In the table representing your customers, identify the customer of your choice and click on the `...`.
+Suchen Sie in der Tabelle Ihrer Kunden den gewünschten Kunden und klicken Sie auf <code className="action">...</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/more-client.png)
+<img className="thumbnail" alt="Aktionsmenü eines Kunden in der MainWP Kundentabelle" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-You can:
+Sie können:
 
-- edit customer information (`Edit`)
-- delete the customer (`Delete`)
-- see the websites concerned by your customer (`View Sites`)
+- die Kundeninformationen bearbeiten (<code className="action">Edit</code>)
+- den Kunden löschen (<code className="action">Delete</code>)
+- die Websites einsehen, die Ihrem Kunden zugeordnet sind (<code className="action">View Sites</code>)
 
-### Create new fields for your customers
+### Neue Felder für Ihre Kunden anlegen
 
-For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
-In the main menu of MainWP, click `Clients` then `Clients Fields`. To create a new field, click `New Field`. In the window that appears, enter the name and description for your new field.
+Für jeden Kunden sind zahlreiche Standardfelder vorhanden, etwa Name, E-Mail-Adresse, Land, Telefonnummer oder Links zu sozialen Netzwerken. Wenn Sie spezifische Informationen hinzufügen möchten, die standardmäßig nicht vorhanden sind, können Sie die gewünschten Felder manuell ergänzen.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Clients</code> und dann auf <code className="action">Clients Fields</code>. Klicken Sie auf <code className="action">New Field</code>, um ein neues Feld anzulegen. Geben Sie im angezeigten Fenster den Namen und die Beschreibung Ihres neuen Felds ein.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png)
+<img className="thumbnail" alt="MainWP Fenster zum Anlegen eines neuen Kundenfelds mit Name und Beschreibung" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click `Save Field`. Now, when creating a new customer, the new "loyalty" field will be available.
+In unserem Beispiel legen wir ein neues Feld "loyalty" mit einer zugehörigen Beschreibung an. Klicken Sie auf <code className="action">Save Field</code>, um die Erstellung des neuen Felds zu bestätigen. Beim Anlegen eines neuen Kunden steht das neue Feld "loyalty" nun zur Verfügung.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png)
+<img className="thumbnail" alt="MainWP Formular Add Client mit dem neuen Feld loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
+Sobald Sie Ihren neuen Kunden angelegt haben, öffnen Sie Ihre Kundenliste. Klicken Sie auf den soeben erstellten Kunden. Das neue Feld "loyalty" und der zugehörige Wert werden angezeigt.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/details-client.png)
+<img className="thumbnail" alt="Details eines MainWP Kunden mit dem Feld loyalty und seinem Wert" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
-## Go further <a id="go-further"></a>
+## Weiterführende Informationen <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Mehrere WordPress Websites mit dem Plugin MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Sicherheit Ihrer Website mit dem WordPress Plugin MainWP verbessern](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[WordPress Websites mit MainWP sichern](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,185 +1,199 @@
 ---
-title: "Managing multiple WordPress websites with the MainWP plugin"
-description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin"
-lastUpdated: 2024-01-25
+title: Mehrere WordPress Websites mit dem Plugin MainWP verwalten
+description: "Erfahren Sie, wie Sie mit dem Plugin MainWP mehrere WordPress Websites über ein einziges Tool verwalten: Updates, Erweiterungen und Child-Sites"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Ziel
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Die Verwaltung mehrerer Websites kann komplex und zeitaufwendig sein. Wenn Sie mehrere WordPress Websites betreiben, müssen Sie die technische Wartung der Websites, die Updates von Plugins und Themes sowie die Zugangsdaten verwalten. Das WordPress Plugin MainWP ist eine effiziente Lösung, um mehrere WordPress Websites über ein einziges Dashboard zu verwalten. Mit MainWP können Sie:
 
-- control all your websites from a single dashboard
-- update the technical components in one click
-- [manage your customer information](/guides/web-cloud/web-hosting/mainwp-client-management)
-- download extensions to perform multiple tasks
+- alle Ihre Websites über ein einziges Dashboard steuern
+- die technischen Komponenten mit einem Klick aktualisieren
+- [Ihre Kundeninformationen verwalten](/guides/web-cloud/web-hosting/mainwp-client-management)
+- Erweiterungen herunterladen, um zahlreiche Aufgaben auszuführen
 
-**Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
+**Erfahren Sie, wie Sie mit dem MainWP Dashboard mehrere WordPress Websites verwalten.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+In dieser Anleitung haben wir uns für das Plugin MainWP entschieden. Es gibt weitere vergleichbare Lösungen; Sie können selbstverständlich das Plugin Ihrer Wahl verwenden.
+
 :::
 
-## Requirements
+## Voraussetzungen
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
-- Access to the WordPress administration interface.
+- Sie verfügen über ein [Web Cloud Hosting](/links/web/hosting).
+- Sie haben Zugriff auf die Administrationsoberfläche von WordPress.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
 :::
 
-## Instructions
+{/* CP-NAV-START:web-hosting */}
+---
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+### Zugriff auf das OVHcloud Kundencenter
 
-![mainWP](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png)
+- **Direkter Link:** <ManagerLink to="/#/web/hosting">Hosting-Pakete</ManagerLink>
+- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Hosting-Pakete</code> > Wählen Sie Ihr Webhosting aus
 
-Enter your login and password to log in. The WordPress dashboard appears.
+---
+{/* CP-NAV-END:web-hosting */}
 
-### Install the MainWP plugin 
+## In der praktischen Anwendung
 
-Go to the main WordPress menu, on the left-hand side of the screen, and click `Plugins` then `Add New Plugin`.
+Falls Sie noch nicht angemeldet sind, öffnen Sie die Administrationsoberfläche des 1-Klick-Moduls, für das Sie das MainWP Dashboard installieren möchten.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png)
+<img className="thumbnail" alt="OVHcloud Kundencenter mit der Liste der 1-Klick-Module und ihrem Administrationslink" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
+Geben Sie Ihren Benutzernamen und Ihr Passwort ein, um sich anzumelden. Das WordPress Dashboard wird angezeigt.
+
+### Das Plugin MainWP installieren
+
+Gehen Sie in das Hauptmenü von WordPress links auf dem Bildschirm und klicken Sie auf <code className="action">Plugins</code> und dann auf <code className="action">Add New Plugin</code>.
+
+<img className="thumbnail" alt="WordPress Menü mit dem Eintrag Plugins und der Option Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+
+Eine Liste der beliebtesten WordPress Plugins wird angezeigt. Geben Sie oben rechts in die Suchleiste "MainWP" ein und bestätigen Sie. Unter den Ergebnissen werden mehrere von "MainWP" angebotene Plugins angezeigt. Installieren Sie die folgenden beiden Plugins:
 
 - MainWP Dashboard
 - Child MainWP
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png)
+<img className="thumbnail" alt="WordPress Plugin-Suchergebnisse mit MainWP Dashboard und MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br />
-MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
+MainWP Dashboard ist das Haupt-Plugin, mit dem Sie Ihre Websites über ein einziges Dashboard verwalten.
+
+MainWP Child ermöglicht es Ihnen, Ihre WordPress Website (auch "Child-Site" genannt) mit dem MainWP Dashboard zu verbinden.
 
 :::warning
-An error may occur if you install MainWP Child first. Make sure to install MainWP Dashboard **before** MainWP Child.
+Es kann ein Fehler auftreten, wenn Sie MainWP Child zuerst installieren. Installieren Sie MainWP Dashboard unbedingt **vor** MainWP Child.
+
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
-Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
+Denken Sie nach der Installation beider Plugins daran, diese zu aktivieren, um sie nutzen zu können.
+Sobald die beiden Plugins installiert und aktiviert sind, erscheint oben auf Ihrem Bildschirm die folgende Warnmeldung:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png)
+<img className="thumbnail" alt="Warnmeldung mit der Aufforderung, die Child-Site mit dem MainWP Dashboard zu verbinden" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
-This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
+Diese Meldung informiert Sie darüber, dass Sie soeben das Plugin MainWP Child aktiviert haben und Ihre Child-Website nun mit dem MainWP Dashboard verbinden müssen. Deaktivieren Sie das Plugin MainWP Child aus Sicherheitsgründen, wenn Sie Ihre Child-Website nicht sofort verbinden möchten. Aktivieren Sie das Plugin MainWP Child wieder, sobald Sie bereit sind, Ihre WordPress Website mit dem MainWP Dashboard zu verbinden.
 
-### Connect a child site to the MainWP dashboard
+### Eine Child-Site mit dem MainWP Dashboard verbinden
 
-In the main menu on the left, click `Sites`, then `Add New`. The following screen appears:
+Klicken Sie im Hauptmenü links auf <code className="action">Sites</code> und dann auf <code className="action">Add New</code>. Der folgende Bildschirm wird angezeigt:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png)
+<img className="thumbnail" alt="MainWP Formular zum Hinzufügen einer neuen Child-Site" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
+Geben Sie die URL der Child-Site ein, die Sie mit dem MainWP Dashboard verbinden möchten. Wählen Sie direkt darunter die Schaltfläche aus, mit der Sie angeben, dass Sie das Plugin MainWP Child auf Ihrer Child-Website installiert und aktiviert haben. Die folgenden zwei neuen Felder werden angezeigt:
 
-- `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the `Web Cloud` section. Select the web hosting plan concerned, and click the `1-click modules` tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the `Login` column.
-- `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
+- `Administrator username`: Loggen Sie sich in Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein und öffnen Sie den Bereich <code className="action">Web Cloud</code>. Wählen Sie das betreffende Webhosting aus und klicken Sie auf den Tab <code className="action">1-Klick-Module</code>. Suchen Sie in der angezeigten Tabelle die Zeile, die Ihrem 1-Klick-Modul entspricht. Ihr Administratorname steht in der Spalte <code className="action">Login</code>.
+- `Site title`: Geben Sie den gewünschten Wert ein. Wenn Sie zahlreiche Child-Websites verbinden, wählen Sie einen eindeutigen Titel.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site.png)
+<img className="thumbnail" alt="MainWP Formular zum Hinzufügen einer Site mit ausgefülltem Administratornamen und Site-Titel" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-When all the fields of the form are filled in, click the `Add Site` button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
+Wenn alle Felder des Formulars ausgefüllt sind, klicken Sie zur Bestätigung unterhalb des Formulars auf die Schaltfläche <code className="action">Add Site</code>. Wenn kein Fehler auftritt, erhalten Sie die folgende Bestätigungsmeldung, die anzeigt, dass Ihre Child-Site nun mit dem MainWP Dashboard verbunden ist:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png)
+<img className="thumbnail" alt="Meldung, die bestätigt, dass die Child-Site mit dem MainWP Dashboard verbunden ist" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
-To check that your child website is available in the MainWP dashboard, click `Sites` in the main menu on the left-hand side, then `Manage Sites`.
+Um zu prüfen, ob Ihre Child-Website im MainWP Dashboard verfügbar ist, klicken Sie im Hauptmenü links auf <code className="action">Sites</code> und dann auf <code className="action">Manage Sites</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png)
+<img className="thumbnail" alt="MainWP Seite Manage Sites mit der Liste der verbundenen Child-Sites" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
-In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
+In unserem Beispiel erscheint die Website "my website" in der Liste der mit dem MainWP Dashboard verbundenen Child-Sites. Sie können beliebig viele Child-Sites hinzufügen.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png)
+<img className="thumbnail" alt="MainWP Rasteransicht mit allen verbundenen Child-Sites" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
-Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
+Denken Sie daran, das Plugin MainWP Child auf jeder Child-Site zu installieren, die Sie mit dem MainWP Dashboard verbinden möchten.
+
 :::
 
-### Manage software updates from the MainWP dashboard
+### Software-Updates über das MainWP Dashboard verwalten
 
-If you use several plugins and themes for your websites, you may encounter errors due to the different versions. With the MainWP dashboard, you can manage the following updates in one place:
+Wenn Sie mehrere Plugins und Themes für Ihre Websites verwenden, können aufgrund der unterschiedlichen Versionen Fehler auftreten. Mit dem MainWP Dashboard verwalten Sie die folgenden Updates an einem einzigen Ort:
 
 - WordPress
 - Plugins
 - Themes
-- Translations
+- Übersetzungen
 
-In the main menu on the left, click `Sites` then `Updates`. The following screen appears:
+Klicken Sie im Hauptmenü links auf <code className="action">Sites</code> und dann auf <code className="action">Updates</code>. Der folgende Bildschirm wird angezeigt:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png)
+<img className="thumbnail" alt="MainWP Seite Updates mit den verfügbaren Plugin- und Theme-Updates" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
-At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the `Themes Updates` tab, you will see a list of the four themes affected by the updates.
+Oben in der Oberfläche zeigen die Tabs an, dass ein Plugin und vier Themes zum Update verfügbar sind. Klicken Sie auf den gewünschten Tab, um die verfügbaren Updates anzuzeigen. Wenn Sie in unserem Beispiel auf den Tab <code className="action">Themes Updates</code> klicken, sehen Sie die Liste der vier von den Updates betroffenen Themes.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png)
+<img className="thumbnail" alt="MainWP Tab Themes Updates mit den vier zu aktualisierenden Themes" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
-If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click `Update Selected Themes`.
-The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
+Wenn Sie mehrere Themes (oder alle Themes gleichzeitig) aktualisieren möchten, wählen Sie die entsprechenden Zeilen aus (indem Sie das Kästchen links neben jeder Zeile ankreuzen) und klicken Sie dann auf <code className="action">Update Selected Themes</code>.
+Die folgende Bestätigungsmeldung wird angezeigt. Sie gibt an, auf welchen Websites die zuvor ausgewählten Themes aktualisiert werden.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png)
+<img className="thumbnail" alt="Bestätigungsmeldung mit den Websites, auf denen die ausgewählten Themes aktualisiert werden" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
-In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click `Yes, proceed` to confirm. The progress window appears. It will close when the updates are complete.
+In unserem Beispiel werden die ausgewählten Themes für die Websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" und "blog 3" aktualisiert. Klicken Sie zur Bestätigung auf <code className="action">Yes, proceed</code>. Das Fortschrittsfenster wird angezeigt. Es schließt sich, sobald die Updates abgeschlossen sind.
 
-Do the same to update WordPress, your plugins or your translations.
+Gehen Sie ebenso vor, um WordPress, Ihre Plugins oder Ihre Übersetzungen zu aktualisieren.
 
-### Extensions
+### Erweiterungen
 
-MainWP offers native features, such as software update management or [customer information management](/guides/web-cloud/web-hosting/mainwp-client-management). However, MainWP becomes even more powerful thanks to its many extensions, offering a wide range of features.
+MainWP bietet native Funktionen wie die Verwaltung von Software-Updates oder die [Verwaltung von Kundeninformationen](/guides/web-cloud/web-hosting/mainwp-client-management). Durch seine zahlreichen Erweiterungen mit einem breiten Funktionsumfang wird MainWP jedoch noch leistungsfähiger.
 
-There are different [extension categories](https://mainwp.com/mainwp-extensions/), such as Administrative, Backup, Analytics, Security, etc. For each of the categories, there are three different types of extensions:
+Es gibt verschiedene [Erweiterungskategorien](https://mainwp.com/mainwp-extensions/), etwa Administrative, Backup, Analytics oder Security. Für jede Kategorie existieren drei verschiedene Arten von Erweiterungen:
 
-- Free: free extensions developed by MainWP
-- Professional: premium extensions developed by MainWP
-- .Org: free extensions developed by a third-party publisher
+- Free: kostenlose, von MainWP entwickelte Erweiterungen
+- Professional: kostenpflichtige, von MainWP entwickelte Erweiterungen
+- .Org: kostenlose, von einem Drittanbieter entwickelte Erweiterungen
 
-Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-account/) to create your account.
+Bevor Sie eine Erweiterung installieren können, erstellen Sie Ihr Konto auf [MainWP.com](https://mainwp.com/my-account/).
 
-#### Order an extension
+#### Eine Erweiterung bestellen
 
-Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
+Sobald Sie Ihr MainWP Konto erstellt haben, öffnen Sie den [Erweiterungsbereich von MainWP.com](https://mainwp.com/mainwp-extensions/). Für unser Beispiel wählen wir die kostenlose Erweiterung UpdraftPlus. Klicken Sie auf die Erweiterung UpdraftPlus.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png)
+<img className="thumbnail" alt="Karte der Erweiterung UpdraftPlus auf der Erweiterungsseite von MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
-A page dedicated to the extension will appear. Click `Get the free Bundle`, then `Proceed to checkout`. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking `Place order`.
+Eine Seite zur Erweiterung wird angezeigt. Klicken Sie auf <code className="action">Get the free Bundle</code> und dann auf <code className="action">Proceed to checkout</code>. Sie müssen keine Zahlungsdaten angeben, da diese Erweiterung kostenlos ist. Geben Sie nur die erforderlichen Informationen ein. Kreuzen Sie die erforderlichen Felder an und klicken Sie abschließend auf <code className="action">Place order</code>.
 
-You will now need to retrieve the API key corresponding to your MainWP username, which will enable you to log in to the MainWP dashboard to download the extensions of your choice.
+Nun müssen Sie den API-Schlüssel abrufen, der Ihrem MainWP Benutzernamen entspricht. Er ermöglicht es Ihnen, sich im MainWP Dashboard anzumelden, um die gewünschten Erweiterungen herunterzuladen.
 
-#### Enter the API key
+#### Den API-Schlüssel eingeben
 
-Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
+Öffnen Sie [Ihr MainWP Konto](https://mainwp.com/my-account/my-api-keys/) und kopieren Sie den API-Schlüssel.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png)
+<img className="thumbnail" alt="MainWP Kontoseite mit dem zu kopierenden API-Schlüssel" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
-Go back to the MainWP dashboard and click on `Extensions` in the main menu on the left. In the top right-hand corner of the screen that appears, click `Install and Activate Extensions`.
+Kehren Sie zum MainWP Dashboard zurück und klicken Sie im Hauptmenü links auf <code className="action">Extensions</code>. Klicken Sie oben rechts auf dem angezeigten Bildschirm auf <code className="action">Install and Activate Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png)
+<img className="thumbnail" alt="MainWP Seite Extensions mit der Schaltfläche Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-In the `Enter your MainWP API Key` field, paste the API key you have previously copied, tick the `Remember MainWP Main API Key` box and click `Validate my MainWP Main API Key`. If there are no errors, the following confirmation message is displayed:
+Fügen Sie im Feld <code className="action">Enter your MainWP API Key</code> den zuvor kopierten API-Schlüssel ein, kreuzen Sie das Kästchen <code className="action">Remember MainWP Main API Key</code> an und klicken Sie auf <code className="action">Validate my MainWP Main API Key</code>. Wenn kein Fehler auftritt, wird die folgende Bestätigungsmeldung angezeigt:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png)
+<img className="thumbnail" alt="Meldung, die bestätigt, dass der MainWP API-Schlüssel gültig ist" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
-Finally, click `Install Extension` to install the extensions of your choice.
+Klicken Sie abschließend auf <code className="action">Install Extension</code>, um die gewünschten Erweiterungen zu installieren.
 
-#### Install an extension
+#### Eine Erweiterung installieren
 
-After clicking `Install Extensions`, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click `Install Selected Extensions`.
+Nach dem Klick auf <code className="action">Install Extensions</code> wird ein Fenster mit der Liste der verfügbaren Erweiterungen angezeigt, sortiert nach Kategorie. In unserem Beispiel wählen wir die kostenlose Erweiterung "UpdraftPlus" aus der Kategorie Backups. Klicken Sie nach der Auswahl von UpdraftPlus auf <code className="action">Install Selected Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+<img className="thumbnail" alt="MainWP Erweiterungsliste mit ausgewähltem UpdraftPlus in der Kategorie Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
-Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
+Nach Abschluss der Installation ist UpdraftPlus in der Liste der Erweiterungen Ihres MainWP Dashboards verfügbar.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+<img className="thumbnail" alt="UpdraftPlus in der Liste der Erweiterungen des MainWP Dashboards" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button.
+Klicken Sie auf <code className="action">Enable</code>, um die Erweiterung zu aktivieren. Wenn eine Fehlermeldung anzeigt, dass die Lizenz nicht aktiviert ist, klicken Sie einfach auf die Schaltfläche <code className="action">License</code>.
 
-## Go further <a id="go-further"></a>
+## Weiterführende Informationen <a name="go-further"></a>
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Kundeninformationen Ihrer WordPress Websites mit MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Sicherheit Ihrer Website mit dem WordPress Plugin MainWP verbessern](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[WordPress Websites mit MainWP sichern](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,97 +1,97 @@
 ---
-title: "Improving your website's security with the MainWP plugin for WordPress"
-description: "Find out how to control the security of your websites from a single interface using MainWP"
-lastUpdated: 2024-01-25
+title: Sicherheit Ihrer Website mit dem WordPress Plugin MainWP verbessern
+description: "Erfahren Sie, wie Sie die Sicherheit Ihrer Websites über eine einzige Oberfläche mit MainWP und der Erweiterung Sucuri steuern: Scans und Korrekturen"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Ziel
 
-Maintaining the security of your websites is crucial for the development of your brand. Optimum security for your websites can protect your company's data, as well as your customers' data, thereby preserving your company's image and trust. With extensions to the WordPress MainWP plugin, you can control the security of your websites from a single interface.
+Die Sicherheit Ihrer Websites aufrechtzuerhalten, ist entscheidend für die Entwicklung Ihrer Marke. Eine optimale Sicherheit Ihrer Websites schützt die Daten Ihres Unternehmens ebenso wie die Ihrer Kunden und bewahrt so Image und Vertrauen. Mit den Erweiterungen des WordPress Plugins MainWP steuern Sie die Sicherheit Ihrer Websites über eine einzige Oberfläche.
 
-**This guide will show you how to improve website security via the MainWP dashboard**
+**Diese Anleitung erklärt Ihnen, wie Sie die Sicherheit Ihrer Website über das MainWP Dashboard verbessern.**
 
-## Requirements
+## Voraussetzungen
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Sie verfügen über ein [Web Cloud Hosting](/links/web/hosting).
+- Sie sind mit Ihrem MainWP Dashboard verbunden.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
 :::
 
-## Instructions
+## In der praktischen Anwendung
 
-### Install the Sucuri extension
+### Die Erweiterung Sucuri installieren
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Wenn Sie noch nie eine MainWP Erweiterung installiert haben, erfahren Sie in [dieser Anleitung](/guides/web-cloud/web-hosting/mainwp-general), wie Sie eine Erweiterung installieren.
 :::
 
-To find all the security-related extensions, go to the [security](https://mainwp.com/mainwp-extensions/extension-category/security/) section of MainWP. You can also search for an extension by clicking `Extensions` in the MainWP main menu, then `Install Extensions`.
+Alle Erweiterungen rund um die Sicherheit finden Sie im Bereich [security](https://mainwp.com/mainwp-extensions/extension-category/security/) von MainWP. Sie können eine Erweiterung auch suchen, indem Sie im Hauptmenü von MainWP auf <code className="action">Extensions</code> und dann auf <code className="action">Install Extensions</code> klicken.
 
-Click on the `Security` tab to view the list of security-related extensions. In this example, we choose the free Sucuri extension, but you are free to choose the extension of your choice. Once you have selected the extension, click `Install Selected Extensions`.
+Klicken Sie auf den Tab <code className="action">Security</code>, um die Liste der Erweiterungen rund um die Sicherheit anzuzeigen. In diesem Beispiel wählen wir die kostenlose Erweiterung Sucuri, Sie können jedoch die Erweiterung Ihrer Wahl verwenden. Klicken Sie nach der Auswahl der Erweiterung auf <code className="action">Install Selected Extensions</code>.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed Sucuri extension appears.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Extensions</code> und dann auf <code className="action">Manage Extensions</code>. Die zuvor installierte Erweiterung Sucuri wird angezeigt.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png)
+<img className="thumbnail" alt="Erweiterung Sucuri auf der MainWP Seite Manage Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
-If you have not already done so, click `Enable`, then `License` to use the extension.
+Falls noch nicht geschehen, klicken Sie auf <code className="action">Enable</code> und dann auf <code className="action">License</code>, um die Erweiterung zu nutzen.
 
-### Perform a security scan
+### Einen Sicherheitsscan durchführen
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click on the `Security` tab.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Sites</code> und wählen Sie die gewünschte Child-Site aus. Klicken Sie oben auf dem Bildschirm auf den Tab <code className="action">Security</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png)
+<img className="thumbnail" alt="Tab Security einer MainWP Child-Site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
-To perform a security scan on your website, click `Scan Website`.
+Um einen Sicherheitsscan Ihrer Website durchzuführen, klicken Sie auf <code className="action">Scan Website</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png)
+<img className="thumbnail" alt="Sucuri Scanner mit der Schaltfläche Scan Website auf einer MainWP Child-Site" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
-Once the security scan is complete, a new line will appear, corresponding to the security scan report.
+Nach Abschluss des Sicherheitsscans erscheint eine neue Zeile, die dem Bericht des Sicherheitsscans entspricht.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png)
+<img className="thumbnail" alt="Neue Zeile für den Sucuri Bericht des Sicherheitsscans" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
-Click `Show Report` to view the security report.
+Klicken Sie auf <code className="action">Show Report</code>, um den Sicherheitsbericht anzuzeigen.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png)
+<img className="thumbnail" alt="Detailansicht des Sucuri Sicherheitsberichts für eine Child-Site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-The security scan report provides a lot of important information about the security of your website:
+Der Bericht des Sicherheitsscans liefert zahlreiche wichtige Informationen zur Sicherheit Ihrer Website:
 
-- presence of viruses and malicious software
-- anomaly detection
-- dangerous links
-- SPAM attempts
+- Vorhandensein von Viren und Schadsoftware
+- Erkennung von Anomalien
+- gefährliche Links
+- Spam-Versuche
 - etc.
 
-Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of `Remind me if I don't scan my child site for`. For example, if you choose `1 week`, Sucuri will remind you every week to carry out a security scan.
+Denken Sie daran, regelmäßig Sicherheitsscans durchzuführen. Mit Sucuri können Sie eine Erinnerung aktivieren. Klicken Sie unterhalb der Liste Ihrer Sicherheitsberichte auf die Dropdown-Liste rechts neben <code className="action">Remind me if I don't scan my child site for</code>. Wenn Sie zum Beispiel <code className="action">1 week</code> wählen, erinnert Sucuri Sie jede Woche daran, einen Sicherheitsscan durchzuführen.
 
-### Identify and resolve security issues
+### Sicherheitsprobleme erkennen und beheben
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click the `Security` tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
+Klicken Sie im Hauptmenü von MainWP auf <code className="action">Sites</code> und wählen Sie die gewünschte Child-Site aus. Klicken Sie oben auf dem Bildschirm auf den Tab <code className="action">Security</code>. Auf dem angezeigten Dashboard sehen Sie, ob Sucuri Sicherheitsprobleme festgestellt hat.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png)
+<img className="thumbnail" alt="Sucuri Dashboard mit den auf einer Child-Site festgestellten Sicherheitsproblemen" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
-In our example, Sucuri tells us that three security issues have been identified. Click `Fix all issues` to resolve all security issues. If you would like to find out more about the issues identified, click the `Security` tab at the top of the interface. A list of security issues is displayed.
+In unserem Beispiel meldet Sucuri drei festgestellte Sicherheitsprobleme. Klicken Sie auf <code className="action">Fix all issues</code>, um alle Sicherheitsprobleme zu beheben. Wenn Sie mehr über die festgestellten Probleme erfahren möchten, klicken Sie oben in der Oberfläche auf den Tab <code className="action">Security</code>. Eine Liste der Sicherheitsprobleme wird angezeigt.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-list.png)
+<img className="thumbnail" alt="Liste der von Sucuri auf einer Child-Site festgestellten Sicherheitsprobleme" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
-To resolve an issue, identify the corresponding line and click the `Fix` button to the right of the line.
+Um ein Problem zu beheben, suchen Sie die entsprechende Zeile und klicken Sie rechts davon auf die Schaltfläche <code className="action">Fix</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png)
+<img className="thumbnail" alt="In Sucuri behobenes Sicherheitsproblem mit verfügbarer Schaltfläche Unfix" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
-Once the problem has been resolved, you can cancel the changes made by clicking the `Unfix` button.
+Sobald das Problem behoben ist, können Sie die vorgenommenen Änderungen über die Schaltfläche <code className="action">Unfix</code> rückgängig machen.
 
-## Go further <a id="go-further"></a>
+## Weiterführende Informationen <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Mehrere WordPress Websites mit dem Plugin MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Manage customers for your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Kundeninformationen Ihrer WordPress Websites mit MainWP verwalten](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[WordPress Websites mit MainWP sichern](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
 
-Join our [community of users](/links/community).
+Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/en/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create and manage a web application using the OVHcloud public API
-description: Find out how to use the OVHcloud public API to create and manage a web application
-lastUpdated: 2024-09-05
+description: "Find out how to use the OVHcloud public API to create and manage a web application: attach domains, manage databases and configure SSL certificates"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -9,7 +9,7 @@ import Api from '@components/Api';
 
 ## Objective
 
-This guide explains how to use the OVHcloud public API to create and manage a web application on your hosting plan. You will learn how to perform key operations such as attaching domains, managing databases, and configuring SSL certificates.
+This guide explains how to use the OVHcloud public API to create and manage a web application on your hosting plan. You will learn to attach domains, manage databases and configure SSL certificates.
 
 ## Requirements
 
@@ -29,9 +29,9 @@ The first step is to retrieve the `serviceName`, a unique ID for your web hostin
 
 <Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
 
-This command returns a list of your web hosting services. Each entry in the list is a `serviceName`.
+This call returns a list of your web hosting services. Each entry in the list is a `serviceName`.
 
-**Return example** :
+**Return example**:
 
 ```json
 [
@@ -59,7 +59,7 @@ Attach a domain to your web hosting service:
 | runtimeId               | no         | Runtime configuration ID used on this domain   |
 | ssl                     | no         | Option to activate SSL for the domain   |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -87,7 +87,7 @@ Configure and manage SSL certificates to secure your website:
 | chain         | no         | Certificate chain used to validate SSL certificate |
 | key           | no         | Private key associated with the SSL certificate|
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -118,7 +118,7 @@ With the OVHcloud Web Hosting APIs, you can also manage your databases.
 | type               | yes                  | DB type. Values: mariadb┃mysql┃postgresql┃redis|
 | version           | no                  | DB version      |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -144,7 +144,7 @@ List all the databases associated with your web hosting service:
 | serviceName   | yes         |        Service name                |
 | mode          | yes         |        Allowed values: besteffort ┃ classic ┃ module     |
 
-**Return example** :
+**Return example**:
 
 ```json
 [
@@ -167,7 +167,7 @@ Get a list of available modules that you can install on your web hosting plan:
 | branch        | no            | Filter modules by version. Allowed values: old ┃ stable ┃ testing |
 | latest         | no           | Filter to show modules matching the latest version |
 
-**Return example** :
+**Return example**:
 
 ```json
 [
@@ -188,7 +188,7 @@ Get the details of a specific module installed on your web hosting plan:
 | ------------ | ---------- | ----------------------------- |
 | id            | yes         |        Module ID        |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -245,7 +245,7 @@ Install a new module on your web hosting service:
 | dependencies -> type        | no      | Type of service (e.g. MySQL)    |
 | dependencies -> user        | no      | Username for dependent service   |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -278,7 +278,7 @@ Create a new FTP or SSH user to access your web hosting plan:
 | password      | yes         | Password |
 | sshState      | no    | Determines the SSH access state for the user. Allowed values: active ┃none ┃sftponly |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -305,7 +305,7 @@ List all existing FTP/SSH users on your hosting service:
 | home          | no         | Filter users based on their home directory |
 | login         | no         | Filter users based on their user name    |
 
-**Return example** :
+**Return example**:
 
 ```json
 [
@@ -333,7 +333,7 @@ Create a backup of your database to restore if necessary:
 | date          | yes     | Backup type. Allowed values: daily.1┃now┃weekly.1   |
 | sendEmail     | no | If this setting is enabled, an email is sent when the backup is available   |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -364,7 +364,7 @@ List all available backups for your databases:
 | deletionDate.to     | no   | Filter deleted backups up to this date        |
 | type               | no   | Filter backups by type. Allowed values: daily.1┃now┃weekly.1|
 
-**Return example** :
+**Return example**:
 
 ```json
 [
@@ -385,7 +385,7 @@ Restore a specific backup of your database if there is a problem:
 | name          | yes         | Database name           |
 | id            | yes         | Backup ID        |
 
-**Return example** :
+**Return example**:
 
 ```json
 {
@@ -402,9 +402,9 @@ Restore a specific backup of your database if there is a problem:
 
 ## Conclusion
 
-This guide has introduced you to the main API requests for managing your OVHcloud web hosting plan, such as domain attachment, SSL certificate management and database management.
+This guide has introduced you to the main API requests for managing your OVHcloud web hosting plan, such as attaching domains and managing SSL certificates and databases.
 
-However, there are many other API calls available, which you can explore depending on your specific needs. For more options and features, you can refer to the « <ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink> » section of the OVHcloud API.
+Many other API calls are available; explore them depending on your needs. For more options and features, see the "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" section of the OVHcloud API.
 
 ## Go further
 

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Backing up your WordPress websites with MainWP
-description: Find out how to back up and restore your WordPress websites with MainWP
-lastUpdated: 2024-01-25
+description: "Find out how to back up and restore your WordPress websites with MainWP and the UpdraftPlus extension, from a single dashboard"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -51,21 +51,21 @@ Click <code className="action">Enable</code> to enable the extension. If an erro
 
 In the main menu of MainWP, click <code className="action">Sites</code> then <code className="action">Install Plugins</code>. In the search bar, type UpdraftPlus.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP plugin search field with UpdraftPlus entered" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
 Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click <code className="action">Install Plugin</code>. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click <code className="action">Complete Installation</code>. Remember to tick <code className="action">Activate after installation</code>.
 
-Once the installation is complete, go to the MainWP main menu. Click <code className="action">Sites</code>, <code className="action">Plugins</code> then <code className="action">Manage Plugins</code>. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field <code className="action">Search Options</code>, type “UpdraftPlus” then select <code className="action">Show Plugins</code>.
+Once the installation is complete, go to the MainWP main menu. Click <code className="action">Sites</code>, <code className="action">Plugins</code> then <code className="action">Manage Plugins</code>. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field <code className="action">Search Options</code>, type "UpdraftPlus" then select <code className="action">Show Plugins</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Manage Plugins page filtered on UpdraftPlus for the child sites" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-The extension “MainWP UpdraftPlus Extension” and the plugin “UpdraftPlus - Backup/Restore” are displayed, which means that they are correctly installed on the child websites concerned.
+The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Restore" are displayed, which means that they are correctly installed on the child websites concerned.
 
-Select the “MainWP UpdraftPlus Extension” and the “UpdraftPlus - Backup/Restore” plugin, then click <code className="action">Install to Selected Site(s)</code> (button in the top right-hand corner).
+Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Restore" plugin, then click <code className="action">Install to Selected Site(s)</code> (button in the top right-hand corner).
 
 To ensure that the plugins are enabled on your child website, click <code className="action">Sync Dashboard with Sites</code>, in the top right-hand corner of the interface.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
+<img className="thumbnail" alt="Sync Dashboard with Sites button at the top right of the MainWP interface" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
 You can now create backups of your child websites with UpdraftPlus.
 
@@ -75,11 +75,11 @@ In the main menu of MainWP, click <code className="action">Sites</code> then <co
 
 On the screen that pops up, click <code className="action">Backup Now</code> and follow the instructions. To confirm the backup, click <code className="action">Backup Now</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus Backup Now window on a MainWP child site" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
 Once the backup is complete, click the <code className="action">ExistingBackups</code> tab.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus ExistingBackups tab listing the backup that was just created" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
 A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
 
@@ -89,17 +89,17 @@ In the MainWP main menu, click <code className="action">Extensions</code> then <
 
 To restore your website, locate the line corresponding to your backup, then click <code className="action">Restore</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
+<img className="thumbnail" alt="Backup line in UpdraftPlus with the Restore button" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
 A new window will appear. It contains some information, including a list of your backups.
 
 Identify the backup you want to restore, then click <code className="action">Restore</code>. Remember to check the date to avoid any errors.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus window listing the backups available for restoring" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
 Select the elements you want to restore, then confirm. The following confirmation message is displayed:
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirming that the UpdraftPlus restore completed successfully" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,13 +1,13 @@
 ---
 title: Managing customer information on your WordPress websites with MainWP
-description: Find out how to manage all the customers of your WordPress websites from the MainWP dashboard
-lastUpdated: 2024-01-25
+description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard: add, edit and delete their information"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
 ## Objective
 
-Retaining customers is vital to your company’s development. Whether you have one or more websites, it’s important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+Retaining customers is vital to your company’s development. Whether you have one or more websites, it’s important to get to know your customers as well as possible to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
 
 **This guide will show you how to manage your website’s customers’ data efficiently using MainWP.**
 
@@ -34,25 +34,25 @@ In the MainWP main menu, click <code className="action">Clients</code>. On the s
 
 To get started, add your first customer. In the main menu of MainWP, click <code className="action">Clients</code> then <code className="action">Add Client</code>. In the form that appears, fill in your customer’s details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click <code className="action">Add Client</code>.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Add Client form with the customer details filled in" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
 ### View your customers
 
 In the main menu of MainWP, click <code className="action">Clients</code> then <code className="action">Clients</code>. A list of all your customers will appear. You can search for a specific customer (in the <code className="action">Search</code> field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP customer list with the Search field at the top right" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
 You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column <code className="action">Customer Email</code>) or the number of websites to which your customer is attached (column <code className="action">Websites</code>).
 
 From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click <code className="action">Bulk actions</code>, <code className="action">Delete</code> then <code className="action">Apply</code> to confirm.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP customer table with the Bulk actions and Delete options" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
 Finally, click <code className="action">Yes, proceed</code> to confirm the deletion of the customers.
 
 In the table representing your customers, identify the customer of your choice and click on the <code className="action">...</code>.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
+<img className="thumbnail" alt="Actions menu of a customer in the MainWP customer table" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
 You can:
 
@@ -65,15 +65,15 @@ You can:
 For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
 In the main menu of MainWP, click <code className="action">Clients</code> then <code className="action">Clients Fields</code>. To create a new field, click <code className="action">New Field</code>. In the window that appears, enter the name and description for your new field.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP window for creating a new customer field with its name and description" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new “loyalty” field, along with an associated description. To confirm the creation of the new field, click <code className="action">Save Field</code>. Now, when creating a new customer, the new “loyalty” field will be available.
+In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click <code className="action">Save Field</code>. Now, when creating a new customer, the new "loyalty" field will be available.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Add Client form showing the new loyalty field" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new “loyalty” field and the corresponding value are displayed.
+Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
+<img className="thumbnail" alt="Details of a MainWP customer showing the loyalty field and its value" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,13 +1,13 @@
 ---
 title: Managing multiple WordPress websites with the MainWP plugin
-description: Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin
-lastUpdated: 2024-01-25
+description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin: updates, extensions and child sites"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
 ## Objective
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you must handle the technical maintenance of the sites, the plugin and theme updates, and the login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
 
 - control all your websites from a single dashboard
 - update the technical components in one click
@@ -17,7 +17,7 @@ Managing multiple websites can be complex and time-consuming. If you manage mult
 **Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+In this guide, we have chosen the MainWP plugin. Other similar solutions exist, and you are of course free to choose the plugin you want.
 
 :::
 
@@ -45,26 +45,27 @@ This tutorial is designed to help you with common tasks. However, we recommend c
 
 ## Instructions
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+If you are not already logged in, access the administration interface of the 1-click module on which you want to install the MainWP dashboard.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Control Panel listing the 1-click modules and their administration link" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
 Enter your login and password to log in. The WordPress dashboard appears.
 
-### Install the MainWP plugin 
+### Install the MainWP plugin
 
 Go to the main WordPress menu, on the left-hand side of the screen, and click <code className="action">Plugins</code> then <code className="action">Add New Plugin</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+<img className="thumbnail" alt="WordPress menu with the Plugins entry and the Add New Plugin option" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type “MainWP”, then confirm. Among the results, several plugins offered by “MainWP” are displayed. Install the following two plugins:
+A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
 
 - MainWP Dashboard
 - Child MainWP
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
+<img className="thumbnail" alt="WordPress plugin search results showing MainWP Dashboard and MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br/>
+MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.
+
 MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
 
 :::warning
@@ -72,10 +73,10 @@ An error may occur if you install MainWP Child first. Make sure to install MainW
 
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
+Once both plugins are installed, remember to enable them.
 Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
+<img className="thumbnail" alt="Warning message asking to connect the child site to the MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
 This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
 
@@ -83,26 +84,26 @@ This message informs you that you have just activated the MainWP Child plugin, a
 
 In the main menu on the left, click <code className="action">Sites</code>, then <code className="action">Add New</code>. The following screen appears:
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP form for adding a new child site" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
 Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
 
 - `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the <code className="action">Web Cloud</code> section. Select the web hosting plan concerned, and click the <code className="action">1-click modules</code> tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the <code className="action">Login</code> column.
 - `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP add-site form with the administrator username and the site title filled in" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
 When all the fields of the form are filled in, click the <code className="action">Add Site</code> button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirming that the child site is connected to the MainWP dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
 To check that your child website is available in the MainWP dashboard, click <code className="action">Sites</code> in the main menu on the left-hand side, then <code className="action">Manage Sites</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Manage Sites page listing the connected child sites" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
 In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP grid view showing all the connected child sites" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
 Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
@@ -120,16 +121,16 @@ If you use several plugins and themes for your websites, you may encounter error
 
 In the main menu on the left, click <code className="action">Sites</code> then <code className="action">Updates</code>. The following screen appears:
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Updates page showing the available plugin and theme updates" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
 At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the <code className="action">Themes Updates</code> tab, you will see a list of the four themes affected by the updates.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Themes Updates tab listing the four themes to update" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
 If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click <code className="action">Update Selected Themes</code>.
 The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
+<img className="thumbnail" alt="Confirmation message listing the sites where the selected themes will be updated" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
 In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click <code className="action">Yes, proceed</code> to confirm. The progress window appears. It will close when the updates are complete.
 
@@ -151,7 +152,7 @@ Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-ac
 
 Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus extension card on the MainWP.com extensions page" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
 A page dedicated to the extension will appear. Click <code className="action">Get the free Bundle</code>, then <code className="action">Proceed to checkout</code>. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking <code className="action">Place order</code>.
 
@@ -161,27 +162,27 @@ You will now need to retrieve the API key corresponding to your MainWP username,
 
 Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP account page showing the API key to copy" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
 Go back to the MainWP dashboard and click on <code className="action">Extensions</code> in the main menu on the left. In the top right-hand corner of the screen that appears, click <code className="action">Install and Activate Extensions</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP Extensions page with the Install and Activate Extensions button" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
 In the <code className="action">Enter your MainWP API Key</code> field, paste the API key you have previously copied, tick the <code className="action">Remember MainWP Main API Key</code> box and click <code className="action">Validate my MainWP Main API Key</code>. If there are no errors, the following confirmation message is displayed:
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirming that the MainWP API key is valid" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
 Finally, click <code className="action">Install Extension</code> to install the extensions of your choice.
 
 #### Install an extension
 
-After clicking <code className="action">Install Extensions</code>, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free “UpdraftPlus” extension from the Backups category. After selecting UpdraftPlus, click <code className="action">Install Selected Extensions</code>.
+After clicking <code className="action">Install Extensions</code>, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click <code className="action">Install Selected Extensions</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
+<img className="thumbnail" alt="MainWP extension list with UpdraftPlus selected in the Backups category" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
 Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus listed among the extensions of the MainWP dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
 Click <code className="action">Enable</code> to enable the extension. If an error message indicates that the license is not activated, simply click the <code className="action">License</code> button.
 

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Improving your website's security with the MainWP plugin for WordPress"
-description: Find out how to control the security of your websites from a single interface using MainWP
-lastUpdated: 2024-01-25
+description: "Find out how to control the security of your websites from a single interface using MainWP and the Sucuri extension: scans and fixes"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -36,7 +36,7 @@ Click on the <code className="action">Security</code> tab to view the list of se
 
 In the MainWP main menu, click <code className="action">Extensions</code> then <code className="action">Manage Extensions</code>. The previously installed Sucuri extension appears.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
+<img className="thumbnail" alt="Sucuri extension shown in the MainWP Manage Extensions page" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
 If you have not already done so, click <code className="action">Enable</code>, then <code className="action">License</code> to use the extension.
 
@@ -44,26 +44,26 @@ If you have not already done so, click <code className="action">Enable</code>, t
 
 In the main menu of MainWP, click <code className="action">Sites</code> then select the child site of your choice. At the top of the screen, click on the <code className="action">Security</code> tab.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
+<img className="thumbnail" alt="Security tab of a MainWP child site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
 To perform a security scan on your website, click <code className="action">Scan Website</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
+<img className="thumbnail" alt="Sucuri scanner with the Scan Website button on a MainWP child site" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
 Once the security scan is complete, a new line will appear, corresponding to the security scan report.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
+<img className="thumbnail" alt="New line corresponding to the Sucuri security scan report" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
 Click <code className="action">Show Report</code> to view the security report.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
+<img className="thumbnail" alt="Detail of the Sucuri security scan report for a child site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
 The security scan report provides a lot of important information about the security of your website:
 
 - presence of viruses and malicious software
 - anomaly detection
 - dangerous links
-- SPAM attempts
+- spam attempts
 - etc.
 
 Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of <code className="action">Remind me if I don't scan my child site for</code>. For example, if you choose <code className="action">1 week</code>, Sucuri will remind you every week to carry out a security scan.
@@ -72,15 +72,15 @@ Remember to carry out regular security scans. With Sucuri, you can enable a remi
 
 In the main menu of MainWP, click <code className="action">Sites</code> then select the child site of your choice. At the top of the screen, click the <code className="action">Security</code> tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
+<img className="thumbnail" alt="Sucuri dashboard showing the security issues detected on a child site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
 In our example, Sucuri tells us that three security issues have been identified. Click <code className="action">Fix all issues</code> to resolve all security issues. If you would like to find out more about the issues identified, click the <code className="action">Security</code> tab at the top of the interface. A list of security issues is displayed.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
+<img className="thumbnail" alt="List of the security issues detected by Sucuri on a child site" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
 To resolve an issue, identify the corresponding line and click the <code className="action">Fix</code> button to the right of the line.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
+<img className="thumbnail" alt="Security issue resolved in Sucuri with the Unfix button available" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
 Once the problem has been resolved, you can cancel the changes made by clicking the <code className="action">Unfix</code> button.
 

--- a/docs/es/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,1 +1,413 @@
-../../../../en/guides/web-cloud/web-hosting/api-webhosting.mdx
+---
+title: Cómo crear y gestionar una aplicación web con la API pública de OVHcloud
+description: "Descubra cómo utilizar la API pública de OVHcloud para crear una aplicación web: vincular dominios, gestionar bases de datos y configurar el SSL"
+lastUpdated: 2026-08-19
+availableIn: [eu, ca, apac]
+---
+
+import Api from '@components/Api';
+
+## Objetivo
+
+Esta guía le explica cómo utilizar la API pública de OVHcloud para crear y gestionar una aplicación web en su alojamiento. Aprenderá a realizar operaciones clave como vincular dominios, gestionar bases de datos o configurar certificados SSL.
+
+## Requisitos
+
+- Disponer de una oferta de [alojamiento web de OVHcloud](/links/web/hosting).
+- Conocimientos básicos de la API REST.
+- Tener acceso a la API de OVHcloud. Consulte nuestra guía [Primeros pasos con las API de OVHcloud](/guides/manage-and-operate/api/first-steps).
+
+:::warning
+El uso de las API de OVHcloud requiere conocimientos avanzados en este ámbito. Si tiene alguna dificultad, contacte con los [partners de OVHcloud](/links/partner).
+:::
+
+## Procedimiento
+
+### Obtener la información del servicio
+
+El primer paso consiste en obtener el `serviceName`, un identificador único de su servicio de alojamiento web. Lo necesitará para la mayoría de las llamadas a la API siguientes.
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
+
+Este comando devuelve una lista de sus servicios de alojamiento web. Cada entrada de la lista es un `serviceName`.
+
+**Ejemplo de respuesta**:
+
+```json
+[
+  "example.cluster01.hosting.ovh.net",
+  "example2.cluster02.hosting.ovh.net"
+]
+```
+
+### Vincular un dominio
+
+Vincule un dominio a su servicio de alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/attachedDomain"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| bypassDNSConfiguration | no | Si está activado, la zona DNS no se actualizará |
+| cdn | no | Indica si el dominio está vinculado al CDN del alojamiento. Valores permitidos: active┃none |
+| domain | no | Dominio que se desea vincular |
+| firewall | no | Indica si el cortafuegos está activo para este dominio. Valores permitidos: active┃none |
+| ipLocation | no | Define la localización IP asociada al dominio. Valores permitidos: BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| ownLog | no | Dominio para separar los logs |
+| path | no | Ruta en la que se almacenarán los archivos web |
+| runtimeId | no | Identificador de la configuración runtime utilizada en este dominio |
+| ssl | no | Opción para activar el SSL en el dominio |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+ "doneDate": "2024-08-22T08:13:50.740Z",
+ "function": "abuse/close",
+ "id": 0,
+ "lastUpdate": "2024-08-22T08:13:50.740Z",
+ "objectId": "string",
+ "objectType": "Abuse",
+ "startDate": "2024-08-22T08:13:50.740Z",
+ "status": "cancelled"
+}
+```
+
+### Generar certificados SSL
+
+Configure y gestione los certificados SSL para proteger su sitio web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/ssl"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| certificate | no | Certificado SSL que se desea instalar |
+| chain | no | Cadena de certificados utilizada para validar el certificado SSL |
+| key | no | Clave privada asociada al certificado SSL |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+ "isReportable": false,
+ "provider": "COMODO",
+ "regenerable": false,
+ "status": "created",
+ "taskId": 0,
+ "type": "CUSTOM"
+}
+```
+
+### Gestionar las bases de datos
+
+Las API de alojamiento web de OVHcloud también le permiten gestionar sus bases de datos.
+
+#### Crear una base de datos
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| capacity | sí | Capacidades de la base de datos. Valores: extraSqlPersonal┃local┃privateDatabase┃sqlLocal┃sqlPersonal┃sqlPro |
+| user | sí | Nombre de usuario de la base de datos. Debe estar en minúsculas y empezar por el identificador de su alojamiento web |
+| password | no | Contraseña de la base de datos |
+| quota | no | Espacio asignado. Valores: 25┃100┃200┃256┃400┃512┃800┃1024 |
+| type | sí | Tipo de base de datos. Valores: mariadb┃mysql┃postgresql┃redis |
+| version | no | Versión de la base de datos |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar las bases de datos existentes
+
+Liste todas las bases de datos asociadas a su servicio de alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| mode | sí | Valores permitidos: besteffort ┃ classic ┃ module |
+
+**Ejemplo de respuesta**:
+
+```json
+[
+ "example.mysql.db",
+ "example2.mysql.db"
+]
+```
+
+### Gestionar los módulos
+
+#### Obtener una lista de módulos
+
+Obtenga una lista de los módulos disponibles que puede instalar en su alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| active | no | Filtra los módulos activados o desactivados |
+| branch | no | Filtra los módulos según su versión. Valores permitidos: old ┃ stable ┃ testing |
+| latest | no | Filtro que permite mostrar los módulos correspondientes a la versión más reciente |
+
+**Ejemplo de respuesta**:
+
+```json
+[
+ 195,
+ 184,
+ 38,
+ 176
+]
+```
+
+#### Obtener la información de un módulo
+
+Obtenga los detalles de un módulo concreto instalado en su alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList/\{id\}"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| id | sí | Identificador del módulo |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+ "keywords": [
+   "gallery"
+ ],
+ "adminNameType": "string",
+ "author": "OVH",
+ "branch": "old",
+ "id": 195,
+ "size": {
+   "value": 0,
+   "unit": "B"
+ },
+ "name": "myname",
+ "upgradeFrom": [],
+ "language": [
+   "en",
+   "fr",
+   "de",
+   "es",
+   "pl"
+ ],
+ "version": "1.4.2.2",
+ "active": false,
+ "languageRequirement": {
+   "value": "php",
+   "unit": "supported versions: ''\nnon supported versions: '8+'"
+ },
+ "latest": true
+}
+```
+
+### Instalar un nuevo módulo
+
+Instale un nuevo módulo en su servicio de alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/module"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| moduleId | sí | Identificador del módulo que se desea instalar |
+| adminName | no | Nombre del administrador |
+| adminpassword | no | Contraseña de la cuenta de administrador |
+| domain | no | Nombre de dominio en el que se desplegará el módulo |
+| language | no | Idioma de la instalación del módulo |
+| path | no | Ruta del servidor en la que se instalará el módulo |
+| dependencies -> name | no | Nombre del servicio dependiente |
+| dependencies -> password | no | Contraseña del servicio dependiente |
+| dependencies -> port | no | Puerto de conexión del servicio |
+| dependencies -> prefix | no | Prefijo utilizado en la configuración del servicio |
+| dependencies -> server | no | Dirección del servidor del servicio dependiente |
+| dependencies -> type | no | Tipo de servicio (ej.: MySQL) |
+| dependencies -> user | no | Nombre de usuario del servicio dependiente |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+### Gestionar los usuarios FTP
+
+Gestione los usuarios FTP/SSH de su alojamiento web para facilitar los accesos y las configuraciones.
+
+#### Crear un nuevo usuario FTP/SSH
+
+Cree un nuevo usuario FTP o SSH para acceder a su alojamiento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| home | sí | Directorio principal |
+| login | sí | Nombre de usuario |
+| password | sí | Contraseña |
+| sshState | no | Determina el estado del acceso SSH del usuario. Valores permitidos: active ┃none ┃sftponly |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar los usuarios FTP/SSH
+
+Liste todos los usuarios FTP/SSH existentes en su servicio de alojamiento:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| home | no | Filtra los usuarios en función de su directorio principal |
+| login | no | Filtra los usuarios en función de su nombre de usuario |
+
+**Ejemplo de respuesta**:
+
+```json
+[
+ "user1",
+ "user2",
+ "user3",
+ "user4"
+]
+```
+
+### Restaurar una base de datos
+
+Cree, liste y restaure backups de bases de datos para su sitio web.
+
+#### Crear un backup de una base de datos
+
+Cree un backup de su base de datos para restaurarla si es necesario:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| name | sí | Nombre de la base de datos |
+| date | sí | Tipo de backup. Valores permitidos: daily.1┃now┃weekly.1 |
+| sendEmail | no | Si este parámetro está activado, se envía un correo electrónico cuando el backup está disponible |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar los backups de bases de datos disponibles
+
+Liste todos los backups disponibles de sus bases de datos:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| name | sí | Nombre de la base de datos |
+| creationDate.from | no | Filtra los backups creados a partir de esta fecha |
+| creationDate.to | no | Filtra los backups creados hasta esta fecha |
+| deletionDate.from | no | Filtra los backups eliminados a partir de esta fecha |
+| deletionDate.to | no | Filtra los backups eliminados hasta esta fecha |
+| type | no | Filtra los backups según su tipo. Valores permitidos: daily.1┃now┃weekly.1 |
+
+**Ejemplo de respuesta**:
+
+```json
+[
+ 1,
+ 12
+]
+```
+
+#### Restaurar un backup específico de una base de datos
+
+Restaure un backup concreto de su base de datos en caso de problema:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump/\{id\}/restore"} />
+
+| Parámetro | Obligatorio | Descripción |
+|---|---|---|
+| serviceName | sí | Nombre del servicio |
+| name | sí | Nombre de la base de datos |
+| id | sí | Identificador del backup |
+
+**Ejemplo de respuesta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+## Conclusión
+
+Esta guía le ha presentado las principales peticiones a la API para gestionar su alojamiento web de OVHcloud, como la vinculación de dominios y la gestión de certificados SSL y de bases de datos.
+
+No obstante, existen muchas otras llamadas a la API disponibles, que puede explorar en función de sus necesidades. Para más opciones y funcionalidades, consulte la sección "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" de la API de OVHcloud.
+
+## Más información
+
+[Order a domain name via API](/guides/web-cloud/domains/api-domain-order)
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,124 +1,118 @@
 ---
-title: "Backing up your WordPress websites with MainWP"
-description: "Find out how to back up and restore your WordPress websites with MainWP"
-lastUpdated: 2024-01-25
+title: Guardar copias de seguridad de sus sitios web WordPress con MainWP
+description: "Descubra cómo guardar y restaurar copias de seguridad de sus sitios web WordPress con MainWP y la extensión UpdraftPlus desde un único dashboard"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Backing up a website is a vital part of running your business. It offers several advantages:
+Guardar una copia de seguridad de un sitio web es una práctica crucial para la gestión de su empresa. Ofrece varias ventajas:
 
-- **Data security**: Regular backups ensure your website's data is protected in the event of a cyberattack, technical failure or human error.
-- **Protection against update errors**: A backup made before a WordPress plugin or theme is updated allows you to go back in time if an error or version conflict occurs during the update.
-- **Rapid Restore**: In the event of a technical error, the backup can be reverted to a previous version to offer your customers a functional website and business continuity.
-- **Legal Compliance**: Maintaining regular backups may be a regulatory compliance requirement for your organization and may protect you from legal action.
+- **Seguridad de los datos**: las copias de seguridad periódicas garantizan que los datos de su sitio web estén protegidos en caso de ciberataque, fallo técnico o error humano.
+- **Protección frente a errores de actualización**: una copia de seguridad realizada antes de actualizar WordPress, un plugin o un tema permite volver atrás en caso de error o conflicto de versiones durante la actualización.
+- **Restauración rápida**: en caso de error técnico, la copia de seguridad permite volver a una versión anterior para ofrecer a sus clientes un sitio web funcional y garantizar la continuidad de la actividad.
+- **Conformidad legal**: para su empresa, mantener copias de seguridad periódicas puede responder a una exigencia de cumplimiento normativo y protegerle frente a acciones judiciales.
 
-MainWP offers several extensions for backing up your websites.
+MainWP ofrece varias extensiones que permiten guardar copias de seguridad de sus sitios web.
 
-**This guide explains how to back up your WordPress websites with the UpdraftPlus extension.**
+**Esta guía le explica cómo guardar copias de seguridad de sus sitios web WordPress con la extensión UpdraftPlus.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Disponer de una [oferta de alojamiento Web Cloud](/links/web/hosting).
+- Estar conectado a su dashboard de MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
 :::
 
-## Instructions
+## Procedimiento
 
-### Install the UpdraftPlus extension
+### Instalar la extensión UpdraftPlus
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Si nunca ha instalado una extensión de MainWP, consulte [esta guía](/guides/web-cloud/web-hosting/mainwp-general) para saber cómo instalar una.
 :::
 
-To find all the extensions linked to the backup, go to the [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) section of MainWP. You can also search for an extension by clicking `Extensions` from the MainWP main menu, then `Install Extensions`. Click on the `Backup` tab to view the list of extensions linked to the backup.
+Para encontrar todas las extensiones relacionadas con las copias de seguridad, acceda a la sección [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) de MainWP. También puede buscar una extensión haciendo clic en <code className="action">Extensions</code> en el menú principal de MainWP y luego en <code className="action">Install Extensions</code>. Haga clic en la pestaña <code className="action">Backup</code> para mostrar la lista de extensiones relacionadas con las copias de seguridad.
 
-In this example, we choose the free UpdraftPlus extension, but you are free to choose the extension of your choice.
+En este ejemplo elegimos la extensión gratuita UpdraftPlus, pero puede elegir la extensión que prefiera.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+Una vez seleccionada la extensión, haga clic en <code className="action">Install Selected Extensions</code>.
 
-Once you have selected the extension, click `Install Selected Extensions`.
+En el menú principal de MainWP, haga clic en <code className="action">Extensions</code> y luego en <code className="action">Manage Extensions</code>. Aparecerá la extensión UpdraftPlus instalada anteriormente.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed UpdraftPlus extension appears.
+Haga clic en <code className="action">Enable</code> para activar la extensión. Si un mensaje de error indica que la licencia no está activada, simplemente haga clic en el botón <code className="action">License</code>. Antes de poder utilizar UpdraftPlus, debe activar el plugin UpdraftPlus en los sitios hijos de los que desee guardar una copia de seguridad.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+### Instalar el plugin UpdraftPlus en un sitio hijo
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button. Before you can use UpdraftPlus, you must enable the UpdraftPlus plugin on the child sites that you want to back up.
+En el menú principal de MainWP, haga clic en <code className="action">Sites</code> y luego en <code className="action">Install Plugins</code>. En la barra de búsqueda, escriba "UpdraftPlus".
 
-### Install the UpdraftPlus plugin on a child site
+<img className="thumbnail" alt="Campo de búsqueda de plugins de MainWP con UpdraftPlus introducido" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-In the main menu of MainWP, click `Sites` then `Install Plugins`. In the search bar, type UpdraftPlus.
+Una vez localizado el plugin "UpdraftPlus: WordPress Backup & Migration", haga clic en <code className="action">Install Plugin</code>. A continuación, a la derecha de la pantalla, seleccione el sitio hijo en el que desea instalar UpdraftPlus. Haga clic en <code className="action">Complete Installation</code>. No olvide marcar <code className="action">Activate after installation</code>.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png)
+Una vez finalizada la instalación, acceda al menú principal de MainWP. Haga clic en <code className="action">Sites</code>, <code className="action">Plugins</code> y luego en <code className="action">Manage Plugins</code>. Para comprobar que UpdraftPlus está instalado en sus sitios web, seleccione los sitios hijos que desee, a la derecha de la pantalla. Más abajo, en el campo de búsqueda <code className="action">Search Options</code>, escriba "UpdraftPlus" y seleccione <code className="action">Show Plugins</code>.
 
-Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click `Install Plugin`. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click `Complete Installation`. Remember to tick `Activate after installation`.
+<img className="thumbnail" alt="Página Manage Plugins de MainWP filtrada por UpdraftPlus para los sitios hijos" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-Once the installation is complete, go to the MainWP main menu. Click `Sites`, `Plugins` then `Manage Plugins`. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field `Search Options`, type "UpdraftPlus" then select `Show Plugins`.
+Se mostrarán la extensión "MainWP UpdraftPlus Extension" y el plugin "UpdraftPlus - Backup/Restore", lo que significa que están correctamente instalados en los sitios hijos correspondientes.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png)
+Seleccione la extensión "MainWP UpdraftPlus Extension" y el plugin "UpdraftPlus - Backup/Restore" y haga clic en <code className="action">Install to Selected Site(s)</code> (botón situado en la parte superior derecha).
 
-The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Retore" are displayed, which means that they are correctly installed on the child websites concerned.
+Para asegurarse de que los plugins están activados en su sitio hijo, haga clic en <code className="action">Sync Dashboard with Sites</code>, en la parte superior derecha de la interfaz.
 
-Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Retore" plugin, then click `Install to Selected Site(s)` (button in the top right-hand corner).
+<img className="thumbnail" alt="Botón Sync Dashboard with Sites en la parte superior derecha de la interfaz de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
-To ensure that the plugins are enabled on your child website, click `Sync Dashboard with Sites`, in the top right-hand corner of the interface.
+Ya puede realizar copias de seguridad de sus sitios hijos con UpdraftPlus.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png)
+### Realizar copias de seguridad con UpdraftPlus
 
-You can now create backups of your child websites with UpdraftPlus.
+En el menú principal de MainWP, haga clic en <code className="action">Sites</code> y luego en <code className="action">Manage Sites</code>. Haga clic en el sitio hijo del que desea realizar la copia de seguridad y después en la pestaña <code className="action">UpdraftPlus Backups</code>.
 
-### Create a backup with UpdraftPlus
+En la pantalla que aparece, haga clic en <code className="action">Backup Now</code> y siga las instrucciones. Para confirmar la copia de seguridad, haga clic en <code className="action">Backup Now</code>.
 
-In the main menu of MainWP, click `Sites` then `Manage Sites`. Click the child site for which you want to create a backup, then click the `UpdraftPlus Backups` tab.
+<img className="thumbnail" alt="Ventana Backup Now de UpdraftPlus en un sitio hijo de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/tab-updraftPlus.png)
+Una vez finalizada la copia de seguridad, haga clic en la pestaña <code className="action">ExistingBackups</code>.
 
-On the screen that pops up, click `Backup Now` and follow the instructions. To confirm the backup, click `Backup Now`.
+<img className="thumbnail" alt="Pestaña ExistingBackups de UpdraftPlus con la copia de seguridad recién creada" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png)
+Aparecerá una nueva línea correspondiente a su copia de seguridad. Puede realizar diversas acciones sobre ella, entre ellas la restauración.
 
-Once the backup is complete, click the `ExistingBackups` tab.
+### Restaurar una versión guardada de un sitio hijo
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png)
+En el menú principal de MainWP, haga clic en <code className="action">Extensions</code> y luego en <code className="action">UpdraftPlus</code>. Si hace clic en <code className="action">Existing Backups</code>, aparecerá la lista de sus copias de seguridad.
 
-A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
+Para restaurar su sitio web, localice la línea correspondiente a su copia de seguridad y haga clic en <code className="action">Restore</code>.
 
-### Restore a backed up version of a child site
+<img className="thumbnail" alt="Línea de copia de seguridad en UpdraftPlus con el botón Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
-In the MainWP main menu, click `Extensions` then `UpdraftPlus`. If you click `Existing Backups`, a list of your backups will appear.
+Aparecerá una nueva ventana. Contiene diversa información, entre ella la lista de sus copias de seguridad.
 
-To restore your website, locate the line corresponding to your backup, then click `Restore`.
+Localice la copia de seguridad que desea restaurar y haga clic en <code className="action">Restore</code>. No olvide comprobar la fecha para evitar errores.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png)
+<img className="thumbnail" alt="Ventana de UpdraftPlus con las copias de seguridad disponibles para restaurar" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-A new window will appear. It contains some information, including a list of your backups.
+Seleccione los elementos que desea restaurar y confirme. Se mostrará el siguiente mensaje de confirmación:
 
-Identify the backup you want to restore, then click `Restore`. Remember to check the date to avoid any errors.
+<img className="thumbnail" alt="Mensaje que confirma que la restauración de UpdraftPlus ha finalizado correctamente" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png)
+## Más información <a name="go-further"></a>
 
-Select the elements you want to restore, then confirm. The following confirmation message is displayed:
+[Gestionar varios sitios web WordPress con el plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png)
+[Gestionar la información de los clientes de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-## Go further <a id="go-further"></a>
+[Mejorar la seguridad de su sitio web con el plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Tutorial - Guardar una copia de seguridad de su sitio web WordPress](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Restaurar el espacio de almacenamiento de un alojamiento web](/guides/web-cloud/web-hosting/ftp-save-and-backup)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-[Tutorial - Backup your WordPress website](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
-
-[Restore your web hosting plan's storage space](/guides/web-cloud/web-hosting/ftp-save-and-backup)
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
-
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,88 +1,88 @@
 ---
-title: "Managing customer information on your WordPress websites with MainWP"
-description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard"
-lastUpdated: 2024-01-25
+title: Gestionar la información de los clientes de sus sitios web WordPress con MainWP
+description: "Descubra cómo gestionar todos los clientes de sus sitios web WordPress desde el dashboard de MainWP: añadir, modificar y eliminar su información"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Retaining customers is vital to your company's development. Whether you have one or more websites, it's important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+Fidelizar a los clientes es esencial para el desarrollo de su empresa. Tanto si tiene uno como varios sitios web, es importante conocer a sus clientes lo mejor posible para fidelizarlos y satisfacerlos. El plugin MainWP para WordPress le permite gestionar de forma eficaz los clientes de sus sitios web. Al igual que un CRM (Customer Relationship Management), le permite añadir, eliminar y actualizar toda la información de sus clientes de forma gratuita y en unos pocos clics.
 
-**This guide will show you how to manage your website's customers' data efficiently using MainWP.**
+**Esta guía le explica cómo gestionar de forma eficaz los datos de los clientes de sus sitios web con MainWP.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
+- Disponer de una [oferta de alojamiento Web Cloud](/links/web/hosting).
+- Estar conectado a su dashboard de MainWP. Para más información, consulte nuestra guía [Gestionar varios sitios web WordPress con el plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general).
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
 :::
 
-## Instructions
+## Procedimiento
 
-In the MainWP main menu, click `Clients`. On the screen that opens, there are three tabs:
+En el menú principal de MainWP, haga clic en <code className="action">Clients</code>. En la pantalla que se abre hay tres pestañas:
 
-- Customers: displays a list of all your customers
-- Add Client: allows you to create new customers
-- Client Fields: allows you to create new fields related to your customers
+- Customers: muestra la lista de todos sus clientes
+- Add Client: permite crear nuevos clientes
+- Client Fields: permite crear nuevos campos relacionados con sus clientes
 
-### Add a customer
+### Añadir un cliente
 
-To get started, add your first customer. In the main menu of MainWP, click `Clients` then `Add Client`. In the form that appears, fill in your customer's details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click `Add Client`.
+Para empezar, añada su primer cliente. En el menú principal de MainWP, haga clic en <code className="action">Clients</code> y luego en <code className="action">Add Client</code>. En el formulario que aparece, introduzca los datos de su cliente. A la derecha de la pantalla, seleccione los sitios web en los que desea crear el nuevo cliente y haga clic en <code className="action">Add Client</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/add-client.png)
+<img className="thumbnail" alt="Formulario Add Client de MainWP con los datos del cliente introducidos" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
-### View your customers
+### Consultar sus clientes
 
-In the main menu of MainWP, click `Clients` then `Clients`. A list of all your customers will appear. You can search for a specific customer (in the `Search` field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
+En el menú principal de MainWP, haga clic en <code className="action">Clients</code> y luego en <code className="action">Clients</code>. Aparecerá la lista de todos sus clientes. Puede buscar un cliente concreto (en el campo <code className="action">Search</code>, en la parte superior derecha de la tabla) introduciendo el valor de uno de sus campos, como su nombre.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/search-client.png)
+<img className="thumbnail" alt="Lista de clientes de MainWP con el campo Search en la parte superior derecha" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
-You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column `Customer Email`) or the number of websites to which your customer is attached (column `Websites`).
+Puede arrastrar y soltar las columnas que desee para destacar la información relevante de sus clientes, como la dirección de correo electrónico (columna <code className="action">Customer Email</code>) o el número de sitios web asociados al cliente (columna <code className="action">Websites</code>).
 
-From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click `Bulk actions`, `Delete` then `Apply` to confirm.
+Desde esta tabla puede eliminar cualquier cliente. Seleccione las líneas correspondientes a los clientes que desea eliminar, haga clic en <code className="action">Bulk actions</code>, <code className="action">Delete</code> y luego en <code className="action">Apply</code> para confirmar.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png)
+<img className="thumbnail" alt="Tabla de clientes de MainWP con las opciones Bulk actions y Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
-Finally, click `Yes, proceed` to confirm the deletion of the customers.
+Por último, haga clic en <code className="action">Yes, proceed</code> para confirmar la eliminación de los clientes.
 
-In the table representing your customers, identify the customer of your choice and click on the `...`.
+En la tabla de sus clientes, localice el cliente que desee y haga clic en <code className="action">...</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/more-client.png)
+<img className="thumbnail" alt="Menú de acciones de un cliente en la tabla de clientes de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-You can:
+Podrá:
 
-- edit customer information (`Edit`)
-- delete the customer (`Delete`)
-- see the websites concerned by your customer (`View Sites`)
+- modificar la información del cliente (<code className="action">Edit</code>)
+- eliminar el cliente (<code className="action">Delete</code>)
+- consultar los sitios web asociados a su cliente (<code className="action">View Sites</code>)
 
-### Create new fields for your customers
+### Crear nuevos campos para sus clientes
 
-For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
-In the main menu of MainWP, click `Clients` then `Clients Fields`. To create a new field, click `New Field`. In the window that appears, enter the name and description for your new field.
+Para cada cliente existen numerosos campos predeterminados, como el nombre, el correo electrónico, el país, el número o los enlaces a las redes sociales. Si desea añadir información específica que no está presente por defecto, puede añadir manualmente los campos que desee.
+En el menú principal de MainWP, haga clic en <code className="action">Clients</code> y luego en <code className="action">Clients Fields</code>. Para crear un nuevo campo, haga clic en <code className="action">New Field</code>. En la ventana que aparece, introduzca el nombre y la descripción de su nuevo campo.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png)
+<img className="thumbnail" alt="Ventana de MainWP para crear un nuevo campo de cliente" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click `Save Field`. Now, when creating a new customer, the new "loyalty" field will be available.
+En nuestro ejemplo, creamos un nuevo campo "loyalty" con su descripción correspondiente. Para confirmar la creación del nuevo campo, haga clic en <code className="action">Save Field</code>. A partir de ahora, al crear un nuevo cliente estará disponible el nuevo campo "loyalty".
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png)
+<img className="thumbnail" alt="Formulario Add Client de MainWP con el nuevo campo loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
+Una vez creado el nuevo cliente, acceda a su lista de clientes. Haga clic en el cliente que acaba de crear. Se mostrarán el nuevo campo "loyalty" y el valor correspondiente.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/details-client.png)
+<img className="thumbnail" alt="Detalles de un cliente de MainWP con el campo loyalty y su valor" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
-## Go further <a id="go-further"></a>
+## Más información <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gestionar varios sitios web WordPress con el plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Mejorar la seguridad de su sitio web con el plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Guardar copias de seguridad de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,185 +1,199 @@
 ---
-title: "Managing multiple WordPress websites with the MainWP plugin"
-description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin"
-lastUpdated: 2024-01-25
+title: Gestionar varios sitios web WordPress con el plugin MainWP
+description: "Descubra cómo gestionar varios sitios web WordPress desde una única herramienta con el plugin MainWP: actualizaciones, extensiones y sitios hijos"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Gestionar varios sitios web puede resultar complejo y llevar mucho tiempo. Si gestiona varios sitios web WordPress, deberá ocuparse del mantenimiento técnico de los sitios, de las actualizaciones de plugins y temas, e incluso de las credenciales de conexión. El plugin MainWP para WordPress es una solución eficaz para gestionar varios sitios web WordPress desde un único dashboard. MainWP le permite:
 
-- control all your websites from a single dashboard
-- update the technical components in one click
-- [manage your customer information](/guides/web-cloud/web-hosting/mainwp-client-management)
-- download extensions to perform multiple tasks
+- controlar todos sus sitios web desde un único dashboard
+- actualizar los componentes técnicos con un solo clic
+- [gestionar la información de sus clientes](/guides/web-cloud/web-hosting/mainwp-client-management)
+- descargar extensiones para realizar múltiples tareas
 
-**Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
+**Descubra cómo utilizar el dashboard de MainWP para gestionar varios sitios web WordPress.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+En esta guía hemos elegido el plugin MainWP. Existen otras soluciones similares, por lo que puede elegir libremente el plugin que prefiera.
+
 :::
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
-- Access to the WordPress administration interface.
+- Disponer de una [oferta de alojamiento Web Cloud](/links/web/hosting).
+- Tener acceso a la interfaz de administración de WordPress.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
 :::
 
-## Instructions
+{/* CP-NAV-START:web-hosting */}
+---
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+### Acceso al área de cliente de OVHcloud
 
-![mainWP](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png)
+- **Enlace directo:** <ManagerLink to="/#/web/hosting">Alojamientos</ManagerLink>
+- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Alojamientos</code> > Seleccione su alojamiento web
 
-Enter your login and password to log in. The WordPress dashboard appears.
+---
+{/* CP-NAV-END:web-hosting */}
 
-### Install the MainWP plugin 
+## Procedimiento
 
-Go to the main WordPress menu, on the left-hand side of the screen, and click `Plugins` then `Add New Plugin`.
+Si aún no ha iniciado sesión, acceda a la interfaz de administración de su módulo en un clic en el que desea instalar el dashboard de MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png)
+<img className="thumbnail" alt="Área de cliente de OVHcloud con la lista de los módulos en un clic" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
+Introduzca su nombre de usuario y su contraseña para conectarse. Aparecerá el dashboard de WordPress.
+
+### Instalar el plugin MainWP
+
+Acceda al menú principal de WordPress, a la izquierda de la pantalla, y haga clic en <code className="action">Plugins</code> y luego en <code className="action">Add New Plugin</code>.
+
+<img className="thumbnail" alt="Menú de WordPress con la entrada Plugins y la opción Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+
+Se muestra una lista de los plugins de WordPress más populares. En la barra de búsqueda, en la parte superior derecha, escriba "MainWP" y confirme. Entre los resultados aparecerán varios plugins ofrecidos por "MainWP". Instale los dos plugins siguientes:
 
 - MainWP Dashboard
 - Child MainWP
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png)
+<img className="thumbnail" alt="Resultados de búsqueda de plugins de WordPress con MainWP Dashboard y MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br />
-MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
+MainWP Dashboard es el plugin principal que permite gestionar sus sitios web desde un único dashboard.
+
+MainWP Child permite conectar su sitio web WordPress (también llamado "sitio hijo") al MainWP Dashboard.
 
 :::warning
-An error may occur if you install MainWP Child first. Make sure to install MainWP Dashboard **before** MainWP Child.
+Puede producirse un error si instala primero MainWP Child. Asegúrese de instalar MainWP Dashboard **antes** que MainWP Child.
+
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
-Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
+Una vez instalados ambos plugins, recuerde activarlos para poder utilizarlos.
+Una vez instalados y activados los dos plugins, aparecerá el siguiente mensaje de advertencia en la parte superior de la pantalla:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png)
+<img className="thumbnail" alt="Mensaje de advertencia que invita a conectar el sitio hijo al MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
-This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
+Este mensaje le informa de que acaba de activar el plugin MainWP Child y de que ahora debe conectar su sitio hijo al MainWP Dashboard. Por motivos de seguridad, desactive el plugin MainWP Child si no desea conectar ahora su sitio hijo. Vuelva a activarlo cuando esté listo para conectar su sitio web WordPress al dashboard de MainWP.
 
-### Connect a child site to the MainWP dashboard
+### Conectar un sitio hijo al dashboard de MainWP
 
-In the main menu on the left, click `Sites`, then `Add New`. The following screen appears:
+En el menú principal de la izquierda, haga clic en <code className="action">Sites</code> y luego en <code className="action">Add New</code>. Aparecerá la siguiente pantalla:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png)
+<img className="thumbnail" alt="Formulario de MainWP para añadir un nuevo sitio hijo" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
+Introduzca la URL del sitio hijo que desea conectar al dashboard de MainWP. Justo debajo, seleccione el botón que indica que ha instalado y activado el plugin MainWP Child en su sitio hijo. Aparecerán los dos nuevos campos siguientes:
 
-- `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the `Web Cloud` section. Select the web hosting plan concerned, and click the `1-click modules` tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the `Login` column.
-- `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
+- `Administrator username`: conéctese a su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> y acceda a la sección <code className="action">Web Cloud</code>. Seleccione el alojamiento web correspondiente y haga clic en la pestaña <code className="action">Módulos en un clic</code>. En la tabla que aparece, localice la línea correspondiente a su módulo en un clic. Su nombre de administrador figura en la columna <code className="action">Usuario</code>.
+- `Site title`: introduzca el valor que desee. Si conecta muchos sitios hijos, indique un título de sitio explícito.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site.png)
+<img className="thumbnail" alt="Formulario de adición de sitio de MainWP con el nombre de administrador indicado" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-When all the fields of the form are filled in, click the `Add Site` button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
+Cuando todos los campos del formulario estén rellenados, haga clic en el botón <code className="action">Add Site</code> situado debajo del formulario para confirmar. Si no hay ningún error, recibirá el siguiente mensaje de confirmación, que indica que su sitio hijo ya está conectado al dashboard de MainWP:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png)
+<img className="thumbnail" alt="Mensaje que confirma que el sitio hijo está conectado al dashboard de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
-To check that your child website is available in the MainWP dashboard, click `Sites` in the main menu on the left-hand side, then `Manage Sites`.
+Para comprobar que su sitio hijo está disponible en el dashboard de MainWP, haga clic en <code className="action">Sites</code> en el menú principal de la izquierda y luego en <code className="action">Manage Sites</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png)
+<img className="thumbnail" alt="Página Manage Sites de MainWP con la lista de los sitios hijos conectados" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
-In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
+En nuestro ejemplo, el sitio web "my website" aparece en la lista de sitios hijos conectados al dashboard de MainWP. Puede añadir tantos sitios hijos como desee.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png)
+<img className="thumbnail" alt="Vista en cuadrícula de MainWP con todos los sitios hijos conectados" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
-Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
+Recuerde instalar el plugin MainWP Child en cada sitio hijo que desee conectar al dashboard de MainWP.
+
 :::
 
-### Manage software updates from the MainWP dashboard
+### Gestionar las actualizaciones desde el dashboard de MainWP
 
-If you use several plugins and themes for your websites, you may encounter errors due to the different versions. With the MainWP dashboard, you can manage the following updates in one place:
+Si utiliza varios plugins y temas en sus sitios web, pueden producirse errores debido a las diferentes versiones. El dashboard de MainWP le permite gestionar desde un único lugar las siguientes actualizaciones:
 
 - WordPress
 - Plugins
-- Themes
-- Translations
+- Temas
+- Traducciones
 
-In the main menu on the left, click `Sites` then `Updates`. The following screen appears:
+En el menú principal de la izquierda, haga clic en <code className="action">Sites</code> y luego en <code className="action">Updates</code>. Aparecerá la siguiente pantalla:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png)
+<img className="thumbnail" alt="Página Updates de MainWP con las actualizaciones de plugins y temas disponibles" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
-At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the `Themes Updates` tab, you will see a list of the four themes affected by the updates.
+En la parte superior de la interfaz, las pestañas indican que hay un plugin y cuatro temas disponibles para actualizar. Haga clic en la pestaña que desee para consultar las actualizaciones disponibles. En nuestro ejemplo, si hace clic en la pestaña <code className="action">Themes Updates</code>, verá la lista de los cuatro temas afectados por las actualizaciones.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png)
+<img className="thumbnail" alt="Pestaña Themes Updates de MainWP con los cuatro temas que se deben actualizar" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
-If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click `Update Selected Themes`.
-The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
+Si desea actualizar varios temas (o todos los temas a la vez), seleccione las líneas correspondientes (marcando la casilla situada a la izquierda de cada línea) y haga clic en <code className="action">Update Selected Themes</code>.
+Aparecerá el siguiente mensaje de confirmación, que indica los sitios en los que se actualizarán los temas seleccionados anteriormente.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png)
+<img className="thumbnail" alt="Mensaje de confirmación con los sitios en los que se actualizarán los temas seleccionados" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
-In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click `Yes, proceed` to confirm. The progress window appears. It will close when the updates are complete.
+En nuestro ejemplo, los temas seleccionados se actualizarán en los sitios web "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" y "blog 3". Haga clic en <code className="action">Yes, proceed</code> para confirmar. Aparecerá la ventana de progreso, que se cerrará cuando finalicen las actualizaciones.
 
-Do the same to update WordPress, your plugins or your translations.
+Proceda del mismo modo para actualizar WordPress, sus plugins o sus traducciones.
 
-### Extensions
+### Extensiones
 
-MainWP offers native features, such as software update management or [customer information management](/guides/web-cloud/web-hosting/mainwp-client-management). However, MainWP becomes even more powerful thanks to its many extensions, offering a wide range of features.
+MainWP ofrece funcionalidades nativas, como la gestión de las actualizaciones o la [gestión de la información de los clientes](/guides/web-cloud/web-hosting/mainwp-client-management). No obstante, MainWP resulta aún más potente gracias a sus numerosas extensiones, que ofrecen una amplia gama de funcionalidades.
 
-There are different [extension categories](https://mainwp.com/mainwp-extensions/), such as Administrative, Backup, Analytics, Security, etc. For each of the categories, there are three different types of extensions:
+Existen diferentes [categorías de extensiones](https://mainwp.com/mainwp-extensions/), como Administrative, Backup, Analytics o Security. Para cada categoría hay tres tipos distintos de extensiones:
 
-- Free: free extensions developed by MainWP
-- Professional: premium extensions developed by MainWP
-- .Org: free extensions developed by a third-party publisher
+- Free: extensiones gratuitas desarrolladas por MainWP
+- Professional: extensiones de pago desarrolladas por MainWP
+- .Org: extensiones gratuitas desarrolladas por un editor externo
 
-Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-account/) to create your account.
+Antes de poder instalar una extensión, cree su cuenta en [MainWP.com](https://mainwp.com/my-account/).
 
-#### Order an extension
+#### Contratar una extensión
 
-Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
+Una vez creada su cuenta de MainWP, acceda a la [sección de extensiones de MainWP.com](https://mainwp.com/mainwp-extensions/). Para nuestro ejemplo elegimos la extensión gratuita UpdraftPlus. Haga clic en la extensión UpdraftPlus.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png)
+<img className="thumbnail" alt="Ficha de la extensión UpdraftPlus en la página de extensiones de MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
-A page dedicated to the extension will appear. Click `Get the free Bundle`, then `Proceed to checkout`. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking `Place order`.
+Aparecerá una página dedicada a la extensión. Haga clic en <code className="action">Get the free Bundle</code> y luego en <code className="action">Proceed to checkout</code>. No necesita introducir sus datos de pago, ya que esta extensión es gratuita. Introduzca únicamente la información requerida. Marque las casillas necesarias y termine haciendo clic en <code className="action">Place order</code>.
 
-You will now need to retrieve the API key corresponding to your MainWP username, which will enable you to log in to the MainWP dashboard to download the extensions of your choice.
+Ahora deberá obtener la clave API correspondiente a su nombre de usuario de MainWP, que le permitirá conectarse al dashboard de MainWP para descargar las extensiones que desee.
 
-#### Enter the API key
+#### Introducir la clave API
 
-Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
+Acceda a [su cuenta de MainWP](https://mainwp.com/my-account/my-api-keys/) y copie la clave API.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png)
+<img className="thumbnail" alt="Página de la cuenta de MainWP con la clave API que se debe copiar" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
-Go back to the MainWP dashboard and click on `Extensions` in the main menu on the left. In the top right-hand corner of the screen that appears, click `Install and Activate Extensions`.
+Vuelva al dashboard de MainWP y haga clic en <code className="action">Extensions</code> en el menú principal de la izquierda. En la parte superior derecha de la pantalla que aparece, haga clic en <code className="action">Install and Activate Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png)
+<img className="thumbnail" alt="Página Extensions de MainWP con el botón Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-In the `Enter your MainWP API Key` field, paste the API key you have previously copied, tick the `Remember MainWP Main API Key` box and click `Validate my MainWP Main API Key`. If there are no errors, the following confirmation message is displayed:
+En el campo <code className="action">Enter your MainWP API Key</code>, pegue la clave API copiada anteriormente, marque la casilla <code className="action">Remember MainWP Main API Key</code> y haga clic en <code className="action">Validate my MainWP Main API Key</code>. Si no hay ningún error, se mostrará el siguiente mensaje de confirmación:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png)
+<img className="thumbnail" alt="Mensaje que confirma que la clave API de MainWP es válida" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
-Finally, click `Install Extension` to install the extensions of your choice.
+Por último, haga clic en <code className="action">Install Extension</code> para instalar las extensiones que desee.
 
-#### Install an extension
+#### Instalar una extensión
 
-After clicking `Install Extensions`, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click `Install Selected Extensions`.
+Tras hacer clic en <code className="action">Install Extensions</code>, aparecerá una ventana con la lista de extensiones disponibles, ordenadas por categoría. En nuestro ejemplo elegimos la extensión gratuita "UpdraftPlus" de la categoría Backups. Una vez seleccionada UpdraftPlus, haga clic en <code className="action">Install Selected Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+<img className="thumbnail" alt="Lista de extensiones de MainWP con UpdraftPlus seleccionada en la categoría Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
-Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
+Una vez finalizada la instalación, UpdraftPlus estará disponible en la lista de extensiones de su dashboard de MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+<img className="thumbnail" alt="UpdraftPlus incluida entre las extensiones del dashboard de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button.
+Haga clic en <code className="action">Enable</code> para activar la extensión. Si un mensaje de error indica que la licencia no está activada, simplemente haga clic en el botón <code className="action">License</code>.
 
-## Go further <a id="go-further"></a>
+## Más información <a name="go-further"></a>
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gestionar la información de los clientes de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Mejorar la seguridad de su sitio web con el plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Guardar copias de seguridad de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,97 +1,97 @@
 ---
-title: "Improving your website's security with the MainWP plugin for WordPress"
-description: "Find out how to control the security of your websites from a single interface using MainWP"
-lastUpdated: 2024-01-25
+title: Mejorar la seguridad de su sitio web con el plugin MainWP para WordPress
+description: "Descubra cómo controlar la seguridad de sus sitios web desde una única interfaz con MainWP y la extensión Sucuri: análisis y correcciones"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Maintaining the security of your websites is crucial for the development of your brand. Optimum security for your websites can protect your company's data, as well as your customers' data, thereby preserving your company's image and trust. With extensions to the WordPress MainWP plugin, you can control the security of your websites from a single interface.
+Mantener la seguridad de sus sitios web es crucial para el desarrollo de su marca. Una seguridad óptima de sus sitios web permite proteger los datos de su empresa y los de sus clientes, preservando así la imagen y la confianza depositada en su empresa. Con las extensiones del plugin MainWP para WordPress, puede controlar la seguridad de sus sitios web desde una única interfaz.
 
-**This guide will show you how to improve website security via the MainWP dashboard**
+**Esta guía le explica cómo mejorar la seguridad de su sitio web desde el dashboard de MainWP.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Disponer de una [oferta de alojamiento Web Cloud](/links/web/hosting).
+- Estar conectado a su dashboard de MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
 :::
 
-## Instructions
+## Procedimiento
 
-### Install the Sucuri extension
+### Instalar la extensión Sucuri
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Si nunca ha instalado una extensión de MainWP, consulte [esta guía](/guides/web-cloud/web-hosting/mainwp-general) para saber cómo instalar una.
 :::
 
-To find all the security-related extensions, go to the [security](https://mainwp.com/mainwp-extensions/extension-category/security/) section of MainWP. You can also search for an extension by clicking `Extensions` in the MainWP main menu, then `Install Extensions`.
+Para encontrar todas las extensiones relacionadas con la seguridad, acceda a la sección [security](https://mainwp.com/mainwp-extensions/extension-category/security/) de MainWP. También puede buscar una extensión haciendo clic en <code className="action">Extensions</code> en el menú principal de MainWP y luego en <code className="action">Install Extensions</code>.
 
-Click on the `Security` tab to view the list of security-related extensions. In this example, we choose the free Sucuri extension, but you are free to choose the extension of your choice. Once you have selected the extension, click `Install Selected Extensions`.
+Haga clic en la pestaña <code className="action">Security</code> para mostrar la lista de extensiones relacionadas con la seguridad. En este ejemplo elegimos la extensión gratuita Sucuri, pero puede elegir la extensión que prefiera. Una vez seleccionada la extensión, haga clic en <code className="action">Install Selected Extensions</code>.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed Sucuri extension appears.
+En el menú principal de MainWP, haga clic en <code className="action">Extensions</code> y luego en <code className="action">Manage Extensions</code>. Aparecerá la extensión Sucuri instalada anteriormente.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png)
+<img className="thumbnail" alt="Extensión Sucuri en la página Manage Extensions de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
-If you have not already done so, click `Enable`, then `License` to use the extension.
+Si aún no lo ha hecho, haga clic en <code className="action">Enable</code> y luego en <code className="action">License</code> para utilizar la extensión.
 
-### Perform a security scan
+### Realizar un análisis de seguridad
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click on the `Security` tab.
+En el menú principal de MainWP, haga clic en <code className="action">Sites</code> y seleccione el sitio hijo que desee. En la parte superior de la pantalla, haga clic en la pestaña <code className="action">Security</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png)
+<img className="thumbnail" alt="Pestaña Security de un sitio hijo de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
-To perform a security scan on your website, click `Scan Website`.
+Para realizar un análisis de seguridad de su sitio web, haga clic en <code className="action">Scan Website</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png)
+<img className="thumbnail" alt="Escáner de Sucuri con el botón Scan Website en un sitio hijo de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
-Once the security scan is complete, a new line will appear, corresponding to the security scan report.
+Una vez finalizado el análisis de seguridad, aparecerá una nueva línea correspondiente al informe del análisis.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png)
+<img className="thumbnail" alt="Nueva línea correspondiente al informe del análisis de seguridad de Sucuri" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
-Click `Show Report` to view the security report.
+Haga clic en <code className="action">Show Report</code> para consultar el informe de seguridad.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png)
+<img className="thumbnail" alt="Detalle del informe del análisis de seguridad de Sucuri para un sitio hijo" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-The security scan report provides a lot of important information about the security of your website:
+El informe del análisis de seguridad ofrece mucha información importante sobre la seguridad de su sitio web:
 
-- presence of viruses and malicious software
-- anomaly detection
-- dangerous links
-- SPAM attempts
+- presencia de virus y software malicioso
+- detección de anomalías
+- enlaces peligrosos
+- intentos de spam
 - etc.
 
-Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of `Remind me if I don't scan my child site for`. For example, if you choose `1 week`, Sucuri will remind you every week to carry out a security scan.
+Recuerde realizar análisis de seguridad periódicos. Sucuri le permite activar un recordatorio. Debajo de la lista de sus informes de seguridad, haga clic en la lista desplegable situada a la derecha de <code className="action">Remind me if I don't scan my child site for</code>. Por ejemplo, si elige <code className="action">1 week</code>, Sucuri le recordará cada semana que realice un análisis de seguridad.
 
-### Identify and resolve security issues
+### Identificar y resolver los problemas de seguridad
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click the `Security` tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
+En el menú principal de MainWP, haga clic en <code className="action">Sites</code> y seleccione el sitio hijo que desee. En la parte superior de la pantalla, haga clic en la pestaña <code className="action">Security</code>. En el dashboard que aparece podrá ver si Sucuri ha detectado problemas de seguridad.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png)
+<img className="thumbnail" alt="Dashboard de Sucuri con los problemas de seguridad detectados en un sitio hijo" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
-In our example, Sucuri tells us that three security issues have been identified. Click `Fix all issues` to resolve all security issues. If you would like to find out more about the issues identified, click the `Security` tab at the top of the interface. A list of security issues is displayed.
+En nuestro ejemplo, Sucuri indica que se han detectado tres problemas de seguridad. Haga clic en <code className="action">Fix all issues</code> para resolver todos los problemas de seguridad. Si desea saber más sobre los problemas detectados, haga clic en la pestaña <code className="action">Security</code> en la parte superior de la interfaz. Se mostrará una lista de los problemas de seguridad.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-list.png)
+<img className="thumbnail" alt="Lista de los problemas de seguridad detectados por Sucuri en un sitio hijo" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
-To resolve an issue, identify the corresponding line and click the `Fix` button to the right of the line.
+Para resolver un problema, localice la línea correspondiente y haga clic en el botón <code className="action">Fix</code> situado a la derecha de la línea.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png)
+<img className="thumbnail" alt="Problema de seguridad resuelto en Sucuri con el botón Unfix disponible" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
-Once the problem has been resolved, you can cancel the changes made by clicking the `Unfix` button.
+Una vez resuelto el problema, puede anular los cambios realizados haciendo clic en el botón <code className="action">Unfix</code>.
 
-## Go further <a id="go-further"></a>
+## Más información <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gestionar varios sitios web WordPress con el plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Manage customers for your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gestionar la información de los clientes de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Guardar copias de seguridad de sus sitios web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para servicios especializados (posicionamiento web, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comment créer et gérer une application web en utilisant l'API publique OVHcloud"
-description: "Découvrez comment utiliser l'API publique OVHcloud pour créer et gérer une application web"
-lastUpdated: 2024-09-05
+description: "Découvrez comment utiliser l'API publique OVHcloud pour créer une application web : rattacher des domaines, gérer des bases de données et le SSL"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -9,7 +9,7 @@ import Api from '@components/Api';
 
 ## Objectif
 
-Ce guide vous explique comment utiliser l’API publique OVHcloud pour créer et gérer une application web sur votre hébergement. Vous apprendrez à effectuer des opérations clés telles que rattacher des domaines, gérer des bases de données ou encore la configuration de certificats SSL.
+Ce guide vous explique comment utiliser l’API publique OVHcloud pour créer et gérer une application web sur votre hébergement. Vous apprendrez à rattacher des domaines, gérer des bases de données et configurer des certificats SSL.
 
 ## Prérequis
 
@@ -29,9 +29,9 @@ La première étape consiste à récupérer le `serviceName`, un identifiant uni
 
 <Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
 
-Cette commande renvoie une liste de vos services d’hébergement web. Chaque entrée de la liste est un `serviceName`.
+Cet appel renvoie une liste de vos services d’hébergement web. Chaque entrée de la liste est un `serviceName`.
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 [
@@ -50,16 +50,16 @@ Attachez un domaine à votre service d’hébergement web.
 |-------------------------|-------------|-------------------|
 | serviceName             | oui         | Nom du service       |
 | bypassDNSConfiguration  | non         | Si activé, la zone DNS ne sera pas mise à jour    |
-| cdn                     | non         | Indique si le domaine est lié au CDN de l’hébergement. Valeurs autorisées : active┃none |
+| cdn                     | non         | Indique si le domaine est lié au CDN de l’hébergement. Valeurs autorisées : active┃none |
 | domain                  | non         | Domaine à lier      |
-| firewall                | non         | Indique si le pare-feu est actif pour ce domaine. Valeurs autorisées : active┃none |
-| ipLocation              | non         | Définit la localisation IP associée au domaine. Valeurs autorisées : BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| firewall                | non         | Indique si le pare-feu est actif pour ce domaine. Valeurs autorisées : active┃none |
+| ipLocation              | non         | Définit la localisation IP associée au domaine. Valeurs autorisées : BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
 | ownLog                  | non         | Domaine pour séparer les logs    |
 | path                    | non         | Chemin où seront stockés les fichiers web      |
 | runtimeId               | non         | Identifiant de configuration runtime utilisé sur ce domaine   |
 | ssl                     | non         | Option pour activer le SSL pour le domaine   |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -87,7 +87,7 @@ Configurez et gérez des certificats SSL pour sécuriser votre site web.
 | chain         | non         | Chaîne de certificats utilisée pour valider le certificat SSL |
 | key           | non         | Clé privée associée au certificat SSL|
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -111,14 +111,14 @@ Les API Web Hosting d’OVHcloud vous permettent également de gérer vos bases 
 | Paramètre     | Obligatoire |  Description                         |
 | ------------- | ----------- | -----------------------------------  |
 | serviceName   | oui         |             Nom du service           |
-| capabilitie   | oui         | Capacités de la BDD. Valeurs : extraSqlPerso┃local┃privateDatabase┃sqlLocal┃sqlPerso┃sqlPro         |
+| capabilitie   | oui         | Capacités de la BDD. Valeurs : extraSqlPerso┃local┃privateDatabase┃sqlLocal┃sqlPerso┃sqlPro         |
 | user         | oui         |  Nom d’utilisateur de la BDD. Doit être en minuscule et commencer par votre identifiant d’hébergement web                                        |
 | password           | non                  | Mot de passe de la BDD |
-| quota              | non                  | Espace alloué. Valeurs : 25┃100┃200┃256┃400┃512┃800┃1024|
-| type               | oui                  | Type de la BDD. Valeurs : mariadb┃mysql┃postgresql┃redis|
+| quota              | non                  | Espace alloué. Valeurs : 25┃100┃200┃256┃400┃512┃800┃1024|
+| type               | oui                  | Type de la BDD. Valeurs : mariadb┃mysql┃postgresql┃redis|
 |  version           | non                  | Version de la BDD      |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -142,9 +142,9 @@ Listez toutes les bases de données associées à votre service d’hébergement
 | Paramètre     | Obligatoire |  Description                         |
 | ------------- | ----------- |  ----------------------------------- |
 | serviceName   | oui         |        Nom du service                |
-| mode          | oui         |        Valeurs autorisées : besteffort ┃ classic ┃ module     |
+| mode          | oui         |        Valeurs autorisées : besteffort ┃ classic ┃ module     |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 [
@@ -164,10 +164,10 @@ Obtenez une liste de modules disponibles que vous pouvez installer sur votre hé
 | Paramètre     | Obligatoire    | Description                         |
 | ------------- | -----------    | ----------------------------------- |
 | active        | non            | Filtre les modules activés ou désactivés |
-| branch        | non            | Filtre les modules en fonction de leur version. Valeurs autorisées : old ┃ stable ┃ testing |
+| branch        | non            | Filtre les modules en fonction de leur version. Valeurs autorisées : old ┃ stable ┃ testing |
 | latest         | non           | Filtre permettant d’afficher les modules correspondant à la version la plus récente |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 [
@@ -188,7 +188,7 @@ Obtenez les détails d’un module spécifique installé sur votre hébergement 
 | ------------- | ----------- | ----------------------------------- |
 | id            | oui         |        Identifiant du module        |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -242,10 +242,10 @@ Installez un nouveau module sur votre service d’hébergement web.
 | dependencies -> port        | non  | Port de connexion du service       |
 | dependencies -> prefix      | non    | Préfixe utilisé dans la configuration du service    |
 | dependencies -> server      | non       | Adresse du serveur du service dépendant     |
-| dependencies -> type        | non      | Type de service (ex. : MySQL)    |
+| dependencies -> type        | non      | Type de service (ex. : MySQL)    |
 | dependencies -> user        | non      | Nom d’utilisateur pour le service dépendant   |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -276,9 +276,9 @@ Créez un nouvel utilisateur FTP ou SSH pour accéder à votre hébergement web.
 | home          | oui         | Répertoire d’accueil|
 | login         | oui         | Nom d’utilisateur |
 | password      | oui         | Mot de passe |
-| sshState      | non    | Détermine l’état d’accès SSH pour l’utilisateur. Valeurs autorisées : active ┃none ┃sftponly |
+| sshState      | non    | Détermine l’état d’accès SSH pour l’utilisateur. Valeurs autorisées : active ┃none ┃sftponly |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -305,7 +305,7 @@ Listez tous les utilisateurs FTP/SSH existants sur votre service d’hébergemen
 | home          | non         | Filtre les utilisateurs en fonction de leur répertoire principal |
 | login         | non         | Filtre les utilisateurs en fonction de leur nom d’utilisateur    |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 [
@@ -330,10 +330,10 @@ Créez une sauvegarde de votre base de données pour la restaurer en cas de beso
 | ------------- | ----------- | ----------------------------------- |
 | serviceName   | oui   | Nom du service    |
 | name          | oui     | Nom de la base de données    |
-| date          | oui     | Type de sauvegarde. Valeurs autorisées : daily.1┃now┃weekly.1   |
+| date          | oui     | Type de sauvegarde. Valeurs autorisées : daily.1┃now┃weekly.1   |
 | sendEmail     | non  | Si ce paramètre est activé, un e-mail est envoyé lorsque la sauvegarde est disponible   |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -362,9 +362,9 @@ Listez toutes les sauvegardes disponibles pour vos bases de données.
 | creationDate.to     | non   | Filtre les sauvegardes créées jusqu’à cette date         |
 | deletionDate.from   | non   | Filtre les sauvegardes supprimées à partir de cette date       |
 | deletionDate.to     | non   | Filtre les sauvegardes supprimées jusqu’à cette date        |
-| type               | non   | Filtre les sauvegardes selon leur type. Valeurs autorisées : daily.1┃now┃weekly.1|
+| type               | non   | Filtre les sauvegardes selon leur type. Valeurs autorisées : daily.1┃now┃weekly.1|
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 [
@@ -385,7 +385,7 @@ Restaurez une sauvegarde spécifique de votre base de données en cas de problè
 | name          | oui         | Nom de la base de données           |
 | id            | oui         | Identifiant de la sauvegarde        |
 
-**Exemple de réponse** :
+**Exemple de réponse** :
 
 ```json
 {
@@ -402,9 +402,9 @@ Restaurez une sauvegarde spécifique de votre base de données en cas de problè
 
 ## Conclusion
 
-Ce guide vous a présenté les principales requêtes API pour gérer votre hébergement web OVHcloud, comme l’attachement de domaines, la gestion des certificats SSL et des bases de données. 
+Ce guide vous a présenté les principales requêtes API pour gérer votre hébergement web OVHcloud, comme rattacher des domaines et gérer les certificats SSL et les bases de données.
 
-Il existe cependant de nombreux autres appels API disponibles, que vous pouvez explorer en fonction de vos besoins spécifiques. Pour plus d’options et de fonctionnalités, vous pouvez consulter la section « <ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink> » de l’API OVHcloud.
+De nombreux autres appels API sont cependant disponibles ; explorez-les selon vos besoins. Pour plus d’options et de fonctionnalités, consultez la section « <ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink> » de l’API OVHcloud.
 
 ## Aller plus loin
 

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,18 +1,18 @@
 ---
 title: Sauvegarder ses sites web WordPress avec MainWP
-description: Découvrez comment sauvegarder et restaurer vos sites web WordPress avec MainWP
-lastUpdated: 2024-01-24
+description: "Découvrez comment sauvegarder et restaurer vos sites web WordPress avec MainWP et l'extension UpdraftPlus, depuis un seul dashboard"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
 ## Objectif
 
-La sauvegarde d’un site web est une pratique cruciale pour la gestion de votre entreprise. Elle offre plusieurs avantages :
+La sauvegarde d’un site web est une pratique cruciale pour la gestion de votre entreprise. Elle offre plusieurs avantages :
 
-- **Sécurité des données** : les sauvegardes régulières garantissent que les données de votre site sont protégées en cas de cyberattaque, de défaillance technique ou d’erreur humaine.
-- **Protection contre des erreurs de mise à jour** : une sauvegarde effectuée avant la mise à jour de WordPress, d’un plugin ou d’un thème permet de revenir en arrière en cas d’erreur ou de conflit de versions lors de la mise à jour.
-- **Restauration rapide** : en cas d’erreur technique, la sauvegarde permet de revenir à une version précédente pour proposer à vos clients un site web fonctionnel et une continuité des opérations commerciales.
-- **Conformité légale** : pour votre entreprise, maintenir des sauvegardes régulières peut correspondre à une exigence de conformité réglementaire et vous protéger contre des actions en justice.
+- **Sécurité des données** : les sauvegardes régulières garantissent que les données de votre site sont protégées en cas de cyberattaque, de défaillance technique ou d’erreur humaine.
+- **Protection contre des erreurs de mise à jour** : une sauvegarde effectuée avant la mise à jour de WordPress, d’un plugin ou d’un thème permet de revenir en arrière en cas d’erreur ou de conflit de versions lors de la mise à jour.
+- **Restauration rapide** : en cas d’erreur technique, la sauvegarde permet de revenir à une version précédente pour proposer à vos clients un site web fonctionnel et une continuité des opérations commerciales.
+- **Conformité légale** : pour votre entreprise, maintenir des sauvegardes régulières peut correspondre à une exigence de conformité réglementaire et vous protéger contre des actions en justice.
 
 MainWP propose plusieurs extensions permettant de sauvegarder vos sites web.
 
@@ -51,13 +51,13 @@ Cliquez sur <code className="action">Enable</code> pour activer l’extension. S
 
 Dans le menu principal de MainWP, cliquez sur <code className="action">Sites</code> puis sur <code className="action">Install Plugins</code>. Dans la barre de recherche, tapez « UpdraftPlus ».
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
+<img className="thumbnail" alt="Champ de recherche de plugins MainWP avec UpdraftPlus saisi" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-Une fois le plugin « UpdraftPlus : WordPress Backup & Migration » identifié, cliquez sur <code className="action">Install Plugin</code> puis, à droite de l’écran, sélectionnez le site enfant sur lequel vous souhaitez installer UpdraftPlus. Cliquez sur <code className="action">Complete Installation</code>. N’oubliez pas de cocher <code className="action">Activate after installation</code>.
+Une fois le plugin « UpdraftPlus : WordPress Backup & Migration » identifié, cliquez sur <code className="action">Install Plugin</code> puis, à droite de l’écran, sélectionnez le site enfant sur lequel vous souhaitez installer UpdraftPlus. Cliquez sur <code className="action">Complete Installation</code>. N’oubliez pas de cocher <code className="action">Activate after installation</code>.
 
-Une fois l’installation terminée, dirigez-vous dans le menu principal de MainWP. Cliquez sur <code className="action">Sites</code>, <code className="action">Plugins</code> puis <code className="action">Manage Plugins</code>. Pour vérifier que UpdraftPlus est bien installé sur vos sites web, sélectionnez les sites enfants de votre choix, à droite de l’écran. Plus bas, dans le champ de recherche <code className="action">Search Options</code>, tapez « UpdraftPlus » puis sélectionnez <code className="action">Show Plugins</code>.
+Une fois l’installation terminée, accédez au menu principal de MainWP. Cliquez sur <code className="action">Sites</code>, <code className="action">Plugins</code> puis <code className="action">Manage Plugins</code>. Pour vérifier que UpdraftPlus est bien installé sur vos sites web, sélectionnez les sites enfants de votre choix, à droite de l’écran. Plus bas, dans le champ de recherche <code className="action">Search Options</code>, tapez « UpdraftPlus » puis sélectionnez <code className="action">Show Plugins</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
+<img className="thumbnail" alt="Page Manage Plugins de MainWP filtrée sur UpdraftPlus pour les sites enfants" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
 L’extension « MainWP UpdraftPlus Extension » et le plugin « UpdraftPlus – Backup/Retore » s’affichent, ce qui veut dire qu’ils sont bien installés sur les sites enfants concernés.
 
@@ -65,7 +65,7 @@ Sélectionnez l’extension « MainWP UpdraftPlus Extension » et le plugin « U
 
 Pour être sûr que les plugins sont bien activés sur votre site enfant, cliquez sur <code className="action">Sync Dashboard with Sites</code>, en haut à droite de l’interface.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton Sync Dashboard with Sites en haut à droite de l'interface MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
 Vous pouvez désormais effectuer des sauvegardes de vos sites enfants avec UpdraftPlus.
 
@@ -75,11 +75,11 @@ Dans le menu principal de MainWP, cliquez sur <code className="action">Sites</co
 
 Sur l’écran qui s’affiche, cliquez sur <code className="action">Backup Now</code> et suivez les instructions. Pour valider la sauvegarde, cliquez sur <code className="action">Backup Now</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre Backup Now d'UpdraftPlus sur un site enfant MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
 Une fois la sauvegarde achevée, cliquez sur l’onglet <code className="action">ExistingBackups</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet ExistingBackups d'UpdraftPlus listant la sauvegarde qui vient d'être créée" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
 Une nouvelle ligne correspondant à votre sauvegarde apparait. Vous pouvez effectuer différentes actions sur votre sauvegarde, dont la restauration.
 
@@ -89,17 +89,17 @@ Dans le menu principal de MainWP, cliquez sur <code className="action">Extension
 
 Pour restaurer votre site web, identifiez la ligne correspondant à votre sauvegarde puis cliquez sur <code className="action">Restore</code>.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
+<img className="thumbnail" alt="Ligne de sauvegarde dans UpdraftPlus avec le bouton Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
 Une nouvelle fenêtre s’affiche. Elle contient un certain nombre d’informations dont la liste de vos sauvegardes.
 
 Identifiez la sauvegarde que vous souhaitez restaurer puis cliquez sur <code className="action">Restore</code>. Pensez à vérifier la date pour éviter toute erreur.
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre UpdraftPlus listant les sauvegardes disponibles pour la restauration" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-Sélectionnez les éléments que vous souhaitez restaurer puis validez. Le message de confirmation suivant s’affiche :
+Sélectionnez les éléments que vous souhaitez restaurer puis validez. Le message de confirmation suivant s’affiche :
 
-<img className="thumbnail" alt="mainWP backup" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirmant que la restauration UpdraftPlus s'est terminée avec succès" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gérer les informations des clients de vos sites web WordPress avec MainWP
-description: Découvrez comment gérer tous les clients de vos sites web WordPress depuis le dashboard MainWP
-lastUpdated: 2024-01-25
+description: "Découvrez comment gérer tous les clients de vos sites web WordPress depuis le dashboard MainWP : ajouter, modifier et supprimer leurs informations"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,40 +24,40 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 ## En pratique
 
-Dans le menu principal de MainWP, cliquez sur <code className="action">Clients</code>. Sur l’écran qui s’affiche, trois onglets sont présents :
+Dans le menu principal de MainWP, cliquez sur <code className="action">Clients</code>. Sur l’écran qui s’affiche, trois onglets sont présents :
 
-- Clients : affiche la liste de tous vos clients
-- Add Client : permet de créer de nouveaux clients
-- Client Fields : permet de créer de nouveaux champs relatifs à vos clients
+- Clients : affiche la liste de tous vos clients
+- Add Client : permet de créer de nouveaux clients
+- Client Fields : permet de créer de nouveaux champs relatifs à vos clients
 
 ### Ajouter un client
 
 Pour commencer, ajoutez votre premier client. Dans le menu principal de MainWP, cliquez sur <code className="action">Clients</code> puis sur <code className="action">Add Client</code>. Dans le formulaire qui apparaît, remplissez les informations de votre client. À droite de l’écran, sélectionnez les sites web sur lesquels vous voulez créer votre nouveau client puis cliquez sur <code className="action">Add Client</code>.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire Add Client de MainWP avec les informations du client renseignées" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
 ### Visualiser vos clients
 
 Dans le menu principal de MainWP, cliquez sur <code className="action">Clients</code> puis sur <code className="action">Clients</code>. La liste de tous vos clients s’affiche. Vous pouvez rechercher un client spécifique (dans le champ <code className="action">Search</code> en haut à droite du tableau) en entrant la valeur d’un de ses champs, comme son nom par exemple.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des clients MainWP avec le champ Search en haut à droite" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
 Vous pouvez effectuer un glisser-déposer des colonnes de votre choix pour mettre en avant les informations pertinentes de vos clients, comme l’adresse e-mail (colonne <code className="action">Client Email</code>) ou encore le nombre de sites web auxquels votre client est rattaché (colonne <code className="action">Websites</code>).
 
 Depuis ce tableau, vous pouvez supprimer les clients de votre choix. Sélectionnez les lignes correspondant aux clients que vous souhaitez supprimer, cliquez sur <code className="action">Bulk actions</code>, <code className="action">Delete</code> puis sur <code className="action">Apply</code> pour confirmer.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau des clients MainWP avec les options Bulk actions et Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
 Enfin, cliquez sur <code className="action">Yes, proceed</code> pour confirmer la suppression des clients.
 
-Dans le tableau représentant vos clients, identifiez le client de votre choix et cliquez sur le bouton représenté par trois points (…).
+Dans le tableau représentant vos clients, identifiez le client de votre choix et cliquez sur <code className="action">...</code>.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
+<img className="thumbnail" alt="Menu d'actions d'un client dans le tableau des clients MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-Vous pouvez :
+Vous pouvez :
 
-- éditer les informations du client (<code className="action">Edit</code>) ;
-- supprimer le client (<code className="action">Delete</code>) ;
+- éditer les informations du client (<code className="action">Edit</code>) ;
+- supprimer le client (<code className="action">Delete</code>) ;
 - voir les sites web concernés par votre client (<code className="action">View Sites</code>).
 
 ### Créer de nouveaux champs pour vos clients
@@ -65,15 +65,15 @@ Vous pouvez :
 Pour chaque client, de nombreux champs par défaut sont présents, comme le nom, l’e-mail, le pays, le numéro ou encore les liens vers les réseaux sociaux. Si vous souhaitez rajouter une information spécifique qui n’est pas présente par défaut, il est possible de rajouter manuellement les champs de votre choix.
 Dans le menu principal de MainWP, cliquez sur <code className="action">Clients</code> puis sur <code className="action">Clients Fields</code>. Pour créer un nouveau champ, cliquez sur le bouton <code className="action">New Field</code>. Dans la fenêtre qui s’affiche, entrez le nom et la description de votre nouveau champ.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre MainWP de création d'un nouveau champ client avec son nom et sa description" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
 Dans notre exemple, nous créons un nouveau champ « loyalty » (fidélité), ainsi qu’une description associée. Pour confirmer la création du nouveau champ, cliquez sur <code className="action">Save Field</code>. Maintenant, lors de la création d’un nouveau client, le nouveau champ « loyalty » sera disponible.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire Add Client de MainWP affichant le nouveau champ loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Une fois votre nouveau client créé, dirigez-vous dans la liste de vos clients. Cliquez sur le client que vous venez de créer. Le nouveau champ « loyalty » et la valeur correspondante s’affichent.
+Une fois votre nouveau client créé, accédez à la liste de vos clients. Cliquez sur le client que vous venez de créer. Le nouveau champ « loyalty » et la valeur correspondante s’affichent.
 
-<img className="thumbnail" alt="mainWPClientMngt" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
+<img className="thumbnail" alt="Détails d'un client MainWP affichant le champ loyalty et sa valeur" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,23 +1,23 @@
 ---
 title: Administrer plusieurs sites web WordPress avec le plugin MainWP
-description: Découvrez comment gérer plusieurs sites web WordPress depuis un seul outil grâce au plugin MainWP
-lastUpdated: 2024-01-24
+description: "Découvrez comment administrer plusieurs sites web WordPress depuis un seul outil avec le plugin MainWP : mises à jour, extensions et sites enfants"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
 ## Objectif
 
-Administrer plusieurs sites web peut s’avérer complexe et chronophage. Si vous gérez plusieurs sites web WordPress, vous devez gérer la maintenance technique des sites, les mises à jour de plugins et de thèmes ou encore la gestion des identifiants de connexion. Le plugin MainWP pour WordPress est une solution efficace pour administrer plusieurs sites web WordPress depuis un seul et même tableau de bord (*dashboard*). MainWP permet entre autres de :
+Administrer plusieurs sites web peut s’avérer complexe et chronophage. Si vous gérez plusieurs sites web WordPress, vous devez gérer la maintenance technique des sites, les mises à jour de plugins et de thèmes ou encore la gestion des identifiants de connexion. Le plugin MainWP pour WordPress est une solution efficace pour administrer plusieurs sites web WordPress depuis un seul et même tableau de bord (*dashboard*). MainWP permet entre autres de :
 
-- contrôler l’intégralité de vos sites web depuis un seul dashboard ;
-- mettre à jour en un clic les composants techniques ;
-- [gérer les informations de vos clients](/guides/web-cloud/web-hosting/mainwp-client-management) ;
+- contrôler l’intégralité de vos sites web depuis un seul dashboard ;
+- mettre à jour en un clic les composants techniques ;
+- [gérer les informations de vos clients](/guides/web-cloud/web-hosting/mainwp-client-management) ;
 - télécharger des extensions pour effectuer de multiples tâches.
 
 **Ce guide vous explique comment utiliser le dashboard MainWP pour administrer plusieurs sites web WordPress.**
 
 :::info
-Dans ce guide, nous avons choisi le plugin MainWP. D’autres solutions analogues existent, vous êtes bien entendu libre de choisir le plugin que vous souhaitez.
+Dans ce guide, nous avons choisi le plugin MainWP. D’autres solutions analogues existent et vous êtes bien entendu libre de choisir le plugin que vous souhaitez.
 
 :::
 
@@ -37,8 +37,8 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 ### Accès à l’espace client OVHcloud
 
-- **Lien direct :** <ManagerLink to="/#/web/hosting">Hébergements</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Hébergements</code> > Sélectionnez votre hébergement web
+- **Lien direct :** <ManagerLink to="/#/web/hosting">Hébergements</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Hébergements</code> > Sélectionnez votre hébergement web
 
 ---
 {/* CP-NAV-END:web-hosting */}
@@ -47,24 +47,25 @@ Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux 
 
 Si vous n’êtes pas déjà connecté, accédez à l’interface d’administration de votre module en un clic sur lequel vous voulez installer le dashboard MainWP.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
+<img className="thumbnail" alt="Espace client OVHcloud listant les modules 1 clic et leur lien d'administration" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
 Entrez votre login et votre mot de passe pour vous connecter. Le dashboard WordPress s’affiche.
 
-### Installer le plugin MainWP 
+### Installer le plugin MainWP
 
-Dirigez-vous dans le menu principal de WordPress, à gauche de l’écran, et cliquez sur <code className="action">Plugins</code> puis sur <code className="action">Add New Plugin</code>.
+Accédez au menu principal de WordPress, à gauche de l’écran, et cliquez sur <code className="action">Plugins</code> puis sur <code className="action">Add New Plugin</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+<img className="thumbnail" alt="Menu WordPress avec l'entrée Plugins et l'option Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
 
-La liste des plugins WordPress les plus populaires s’affiche. En haut à droite, dans la barre de recherche, tapez « MainWP » puis validez. Parmi les résultats, plusieurs plugins proposés par « MainWP » s’affichent. Installez les deux plugins suivants :
+La liste des plugins WordPress les plus populaires s’affiche. En haut à droite, dans la barre de recherche, tapez « MainWP » puis validez. Parmi les résultats, plusieurs plugins proposés par « MainWP » s’affichent. Installez les deux plugins suivants :
 
 - MainWP Dashboard
 - MainWP Child
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
+<img className="thumbnail" alt="Résultats de recherche de plugins WordPress affichant MainWP Dashboard et MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard correspond au plugin principal, celui vous permettant de gérer vos sites web depuis un seul et même dashboard.<br/>
+MainWP Dashboard correspond au plugin principal, celui vous permettant de gérer vos sites web depuis un seul et même dashboard.
+
 MainWP Child permet de connecter votre site WordPress (aussi appelé « site enfant ») au MainWP Dashboard.
 
 :::warning
@@ -73,36 +74,36 @@ Il se peut qu’une erreur survienne si vous installez MainWP Child en premier. 
 :::
 
 Après avoir installé les deux plugins, n’oubliez pas de les activer pour pouvoir les utiliser.
-Une fois les deux plugins installés et activés, le message d’avertissement suivant s’affiche en haut de votre écran :
+Une fois les deux plugins installés et activés, le message d’avertissement suivant s’affiche en haut de votre écran :
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
+<img className="thumbnail" alt="Message d'avertissement invitant à connecter le site enfant au MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
 Ce message vous indique que vous venez d’activer le plugin MainWP Child et que vous devez à présent connecter votre site enfant à MainWP Dashboard. Pour des raisons de sécurité, désactivez le plugin MainWP Child si vous ne voulez pas connecter votre site enfant dès maintenant. Réactivez le plugin MainWP Child lorsque vous serez prêt à connecter votre site WordPress au dashboard MainWP.
 
 ### Connecter un site enfant au dashboard MainWP
 
-Dans le menu principal à gauche, cliquez sur <code className="action">Sites</code>, puis sur <code className="action">Add New</code>. L’écran suivant s’affiche :
+Dans le menu principal à gauche, cliquez sur <code className="action">Sites</code>, puis sur <code className="action">Add New</code>. L’écran suivant s’affiche :
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire MainWP d'ajout d'un nouveau site enfant" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Renseignez l’URL du site enfant que vous voulez connecter au dashboard MainWP. Juste en dessous, sélectionnez le bouton pour indiquer que vous avez bien installé et activé le plugin MainWP Child sur votre site enfant. Les deux nouveaux champs suivants s’affichent :
+Renseignez l’URL du site enfant que vous voulez connecter au dashboard MainWP. Juste en dessous, sélectionnez le bouton pour indiquer que vous avez bien installé et activé le plugin MainWP Child sur votre site enfant. Les deux nouveaux champs suivants s’affichent :
 
-- `Administrator username` (nom d’administrateur) : connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, puis rendez-vous dans la partie <code className="action">Web Cloud</code>. Sélectionnez l’hébergement web concerné et cliquez sur l’onglet <code className="action">Modules en 1 clic</code>. Dans le tableau qui s’affiche, identifiez la ligne correspondant à votre module en un clic. Votre nom d’administrateur se trouve dans la colonne <code className="action">Login</code>.
-- `Site title` (titre du site) : renseignez la valeur que vous souhaitez. Si vous connectez de nombreux sites web enfants, pensez à renseigner un titre de site explicite.
+- `Administrator username` (nom d’administrateur) : connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, puis rendez-vous dans la partie <code className="action">Web Cloud</code>. Sélectionnez l’hébergement web concerné et cliquez sur l’onglet <code className="action">Modules 1 clic</code>. Dans le tableau qui s’affiche, identifiez la ligne correspondant à votre module en un clic. Votre nom d’administrateur se trouve dans la colonne <code className="action">Login</code>.
+- `Site title` (titre du site) : renseignez la valeur que vous souhaitez. Si vous connectez de nombreux sites web enfants, pensez à renseigner un titre de site explicite.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire d'ajout de site MainWP avec le nom d'administrateur et le titre du site renseignés" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-Lorsque tous les champs du formulaire sont remplis, cliquez sur le bouton <code className="action">Add Site</code> en-dessous du formulaire pour valider. S’il n’y a aucune erreur, le message de confirmation suivant s’affiche, vous indiquant que votre site enfant est désormais connecté au dashboard MainWP :
+Lorsque tous les champs du formulaire sont remplis, cliquez sur le bouton <code className="action">Add Site</code> en-dessous du formulaire pour valider. S’il n’y a aucune erreur, le message de confirmation suivant s’affiche, vous indiquant que votre site enfant est désormais connecté au dashboard MainWP :
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirmant que le site enfant est connecté au dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
 Pour vérifier que votre site enfant est bien disponible dans le dashboard MainWP, cliquez sur <code className="action">Sites</code> dans le menu principal à gauche puis sur <code className="action">Manage Sites</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="Page Manage Sites de MainWP listant les sites enfants connectés" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
 Dans notre exemple, le site web « mon site » apparait bien dans la liste des sites enfants connectés au dashboard MainWP. Vous pouvez ajouter autant de sites enfants que vous le souhaitez.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
+<img className="thumbnail" alt="Vue en grille de MainWP affichant tous les sites enfants connectés" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
 Pensez à installer le plugin MainWP child sur chaque site enfant que vous souhaitez connecter au dashboard MainWP.
@@ -111,25 +112,25 @@ Pensez à installer le plugin MainWP child sur chaque site enfant que vous souha
 
 ### Gérer les mises à jour logicielles depuis le dashboard MainWP
 
-Si vous utilisez plusieurs plugins et thèmes pour vos sites web, il se peut que vous rencontriez des erreurs à cause des différentes versions. Grâce au dashboard MainWP, vous pouvez gérer à un seul endroit les mises à jour suivantes :
+Si vous utilisez plusieurs plugins et thèmes pour vos sites web, il se peut que vous rencontriez des erreurs à cause des différentes versions. Grâce au dashboard MainWP, vous pouvez gérer à un seul endroit les mises à jour suivantes :
 
 - WordPress
 - Plugins
 - Thèmes
 - Traductions
 
-Dans le menu principal à gauche, cliquez sur <code className="action">Sites</code> puis sur <code className="action">Updates</code>. L’écran suivant s’affiche :
+Dans le menu principal à gauche, cliquez sur <code className="action">Sites</code> puis sur <code className="action">Updates</code>. L’écran suivant s’affiche :
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
+<img className="thumbnail" alt="Page Updates de MainWP affichant les mises à jour de plugins et de thèmes disponibles" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
 En haut de l’interface, les onglets indiquent que la mise à jour d’un plugin et de quatre thèmes sont disponibles. Cliquez sur l’onglet de votre choix pour prendre connaissance des mises à jour disponibles. Dans notre exemple, si on clique sur l’onglet <code className="action">Themes Updates</code>, la liste des quatre thèmes concernés par les mises à jour s’affiche.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Themes Updates de MainWP listant les quatre thèmes à mettre à jour" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
 Si vous souhaitez mettre à jour plusieurs thèmes (ou tous les thèmes en même temps), sélectionnez les lignes correspondantes (en cochant le bouton à gauche de chaque ligne) puis cliquez sur <code className="action">Update Selected Themes</code>.
 Le message de confirmation suivant s’affiche, indiquant les sites sur lesquels les thèmes précédemment sélectionnés vont être mis à jour.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
+<img className="thumbnail" alt="Message de confirmation listant les sites où les thèmes sélectionnés seront mis à jour" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
 Dans notre exemple, les thèmes sélectionnés seront mis à jour pour les sites « www.example.fr », « www.example2.ovh », « blog 1 », « blog 2 » et « blog 3 ». Cliquez sur <code className="action">Yes, proceed</code> pour confirmer. La fenêtre de progression s’affiche et disparaît lorsque les mises à jour sont terminées.
 
@@ -139,11 +140,11 @@ Effectuez la même opération pour mettre à jour WordPress, vos plugins ou vos 
 
 MainWP propose des fonctionnalités natives, telles que la gestion des mises à jour logicielles ou encore la [gestion des informations clients](/guides/web-cloud/web-hosting/mainwp-client-management). Cependant, MainWP devient encore plus puissant grâce à ses nombreuses extensions, proposant un large éventail de fonctionnalités.
 
-Il existe différentes [catégories d’extensions](https://mainwp.com/mainwp-extensions/), comme Administrative, Backups, Analytics, Security, etc. Pour chacune des catégories, trois différents types d’extensions existent :
+Il existe différentes [catégories d’extensions](https://mainwp.com/mainwp-extensions/), comme Administrative, Backups, Analytics, Security, etc. Pour chacune des catégories, trois différents types d’extensions existent :
 
-- Free : extensions gratuites développées par MainWP
-- Pro : extensions premium développées par MainWP
-- .Org : extensions gratuites développées par un éditeur tiers
+- Free : extensions gratuites développées par MainWP
+- Pro : extensions premium développées par MainWP
+- .Org : extensions gratuites développées par un éditeur tiers
 
 Avant de pouvoir installer une extension, rendez-vous sur [MainWP](https://mainwp.com/my-account/) pour créer votre compte.
 
@@ -151,7 +152,7 @@ Avant de pouvoir installer une extension, rendez-vous sur [MainWP](https://mainw
 
 Après avoir créé votre compte MainWP, rendez-vous sur la rubrique [extensions](https://mainwp.com/mainwp-extensions/) de MainWP. Pour notre exemple, nous choisissons l’extension gratuite UpdraftPlus. Cliquez sur l’extension UpdraftPlus.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
+<img className="thumbnail" alt="Fiche de l'extension UpdraftPlus sur la page des extensions MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
 Une page dédiée à l’extension s’affiche. Cliquez sur <code className="action">Get the free Bundle</code>, puis sur <code className="action">Proceed to checkout</code>. Vous n’avez pas besoin de renseigner vos informations de paiement car cette extension est gratuite. Entrez uniquement les informations obligatoires. Cochez les boutons requis puis terminez en cliquant sur <code className="action">Place order</code>.
 
@@ -161,15 +162,15 @@ Vous devez maintenant récupérer la clé API correspondant à votre identifiant
 
 Rendez-vous sur [votre compte MainWP](https://mainwp.com/my-account/my-api-keys/) puis copiez la clé API.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
+<img className="thumbnail" alt="Page du compte MainWP affichant la clé API à copier" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
 Retournez sur le dashboard MainWP et cliquez sur <code className="action">Extensions</code> dans le menu principal à gauche. En haut à droite de l’écran qui s’affiche, cliquez sur <code className="action">Install and Activate Extensions</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
+<img className="thumbnail" alt="Page Extensions de MainWP avec le bouton Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-Dans le champ <code className="action">Enter your MainWP API Key</code>, collez la clé API que vous avez précédemment copiée, cochez la case <code className="action">Remember MainWP Main API Key</code> et cliquez sur <code className="action">Validate my MainWP Main API Key</code>. S’il n’y a aucune erreur, le message de confirmation suivant s’affiche :
+Dans le champ <code className="action">Enter your MainWP API Key</code>, collez la clé API que vous avez précédemment copiée, cochez la case <code className="action">Remember MainWP Main API Key</code> et cliquez sur <code className="action">Validate my MainWP Main API Key</code>. S’il n’y a aucune erreur, le message de confirmation suivant s’affiche :
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
+<img className="thumbnail" alt="Message confirmant que la clé API MainWP est valide" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
 Enfin, cliquez sur <code className="action">Install Extension</code> pour installer les extensions de votre choix.
 
@@ -177,11 +178,11 @@ Enfin, cliquez sur <code className="action">Install Extension</code> pour instal
 
 Après avoir cliqué sur <code className="action">Install Extensions</code>, une fenêtre s’affiche avec la liste des extensions disponibles, classées par catégories. Dans notre exemple, nous choisissons l’extension gratuite « UpdraftPlus » de la catégorie Backups. Après avoir sélectionné UpdraftPlus, cliquez sur <code className="action">Install Selected Extensions</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des extensions MainWP avec UpdraftPlus sélectionnée dans la catégorie Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
 Une fois l’installation terminée, UpdraftPlus est disponible dans la liste des extensions de votre dashboard MainWP.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
+<img className="thumbnail" alt="UpdraftPlus figurant parmi les extensions du dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
 Cliquez sur <code className="action">Enable</code> pour activer l’extension. Si un message d’erreur vous indique que la licence n’est pas activée, cliquez simplement sur le bouton <code className="action">License</code>.
 

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité de son site web avec le plugin MainWP pour WordPress
-description: Découvrez comment contrôler la sécurité de vos sites web depuis une seule interface grâce à MainWP
-lastUpdated: 2024-01-25
+description: "Découvrez comment contrôler la sécurité de vos sites web depuis une seule interface avec MainWP et l'extension Sucuri : scans et corrections"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
@@ -36,7 +36,7 @@ Cliquez sur l’onglet <code className="action">Security</code> pour afficher la
 
 Dans le menu principal de MainWP, cliquez sur <code className="action">Extensions</code> puis sur <code className="action">Manage Extensions</code>. L’extension Sucuri précédemment installée apparaît.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
+<img className="thumbnail" alt="Extension Sucuri affichée dans la page Manage Extensions de MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
 Si ce n’est pas déjà fait, cliquez sur <code className="action">Enable</code> puis sur <code className="action">License</code> pour pouvoir utiliser l’extension.
 
@@ -44,26 +44,26 @@ Si ce n’est pas déjà fait, cliquez sur <code className="action">Enable</code
 
 Dans le menu principal de MainWP, cliquez sur <code className="action">Sites</code> puis sélectionnez le site enfant de votre choix. En haut de l’écran, cliquez sur l’onglet <code className="action">Security</code>.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Security d'un site enfant MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
 Pour effectuer un scan de sécurité sur votre site web, cliquez sur <code className="action">Scan Website</code>.
 
-<img className="thumbnail" alt="mainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
+<img className="thumbnail" alt="Scanner Sucuri avec le bouton Scan Website sur un site enfant MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
 Une fois le scan de sécurité effectué, une nouvelle ligne s’affiche, correspondant au rapport du scan de sécurité.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
+<img className="thumbnail" alt="Nouvelle ligne correspondant au rapport de scan de sécurité Sucuri" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
 Cliquez sur <code className="action">Show Report</code> pour visualiser le rapport de sécurité.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
+<img className="thumbnail" alt="Détail du rapport de scan de sécurité Sucuri pour un site enfant" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-Le rapport du scan de sécurité fournit de nombreuses informations importantes concernant la sécurité de votre site web :
+Le rapport du scan de sécurité fournit de nombreuses informations importantes concernant la sécurité de votre site web :
 
-- présence de virus et de logiciels malveillants ;
-- détection d’anomalies ;
-- liens dangereux ;
-- tentatives de SPAM ;
+- présence de virus et de logiciels malveillants ;
+- détection d’anomalies ;
+- liens dangereux ;
+- tentatives de spam ;
 - etc.
 
 Pensez à effectuer régulièrement des scans de sécurité. Avec Sucuri, il est possible d’activer un rappel. En bas de la liste de vos rapports de sécurité, cliquez sur la liste déroulante à droite de <code className="action">Remind me if I don't scan my child site for</code>. Par exemple, si vous choisissez <code className="action">1 week</code>, Sucuri vous rappellera chaque semaine d’effectuer un scan de sécurité.
@@ -72,15 +72,15 @@ Pensez à effectuer régulièrement des scans de sécurité. Avec Sucuri, il est
 
 Dans le menu principal de MainWP, cliquez sur <code className="action">Sites</code> puis sélectionnez le site enfant de votre choix. En haut de l’écran, cliquez sur l’onglet <code className="action">Security</code>. Sur le dashboard qui s’affiche, vous pouvez voir si des problèmes de sécurité ont été identifiés par Sucuri.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord Sucuri affichant les problèmes de sécurité détectés sur un site enfant" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
 Dans notre exemple, Sucuri nous indique que trois problèmes de sécurité ont été identifiés. Cliquez sur <code className="action">Fix all issues</code> pour résoudre tous les problèmes de sécurité. Si vous voulez en savoir plus sur les problèmes identifiés, cliquez sur l’onglet <code className="action">Security</code> en haut de l’interface. La liste des problèmes de sécurité s’affiche.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des problèmes de sécurité détectés par Sucuri sur un site enfant" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
 Pour résoudre un problème, identifiez la ligne correspondante et cliquez sur le bouton <code className="action">Fix</code> à droite de la ligne.
 
-<img className="thumbnail" alt="mainWP security" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
+<img className="thumbnail" alt="Problème de sécurité résolu dans Sucuri avec le bouton Unfix disponible" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
 Une fois le problème résolu, vous pouvez annuler les modifications apportées en cliquant sur le bouton <code className="action">Unfix</code>.
 

--- a/docs/it/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,1 +1,413 @@
-../../../../en/guides/web-cloud/web-hosting/api-webhosting.mdx
+---
+title: Come creare e gestire un'applicazione web utilizzando l'API pubblica OVHcloud
+description: "Scopri come utilizzare l'API pubblica OVHcloud per creare un'applicazione web: collegare domini, gestire database e configurare i certificati SSL"
+lastUpdated: 2026-08-19
+availableIn: [eu, ca, apac]
+---
+
+import Api from '@components/Api';
+
+## Obiettivo
+
+Questa guida ti spiega come utilizzare l'API pubblica OVHcloud per creare e gestire un'applicazione web sul tuo hosting. Imparerai a effettuare le operazioni principali: collegare domini, gestire database e configurare certificati SSL.
+
+## Prerequisiti
+
+- Disporre di un'offerta di [hosting web OVHcloud](/links/web/hosting).
+- Conoscenze di base dell'API REST.
+- Avere accesso all'API OVHcloud. Consulta la nostra guida [Iniziare a utilizzare le API OVHcloud](/guides/manage-and-operate/api/first-steps).
+
+:::warning
+L'utilizzo delle API OVHcloud richiede conoscenze avanzate in questo ambito. In caso di difficoltà, contatta i [partner OVHcloud](/links/partner).
+:::
+
+## Procedura
+
+### Recuperare le informazioni del servizio
+
+Il primo passaggio consiste nel recuperare il `serviceName`, un identificativo univoco del tuo servizio di hosting web. Ti servirà per la maggior parte delle chiamate API seguenti.
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
+
+Questo comando restituisce la lista dei tuoi servizi di hosting web. Ogni voce della lista è un `serviceName`.
+
+**Esempio di risposta**:
+
+```json
+[
+  "example.cluster01.hosting.ovh.net",
+  "example2.cluster02.hosting.ovh.net"
+]
+```
+
+### Collegare un dominio
+
+Collega un dominio al tuo servizio di hosting web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/attachedDomain"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| bypassDNSConfiguration | no | Se attivo, la zona DNS non viene aggiornata |
+| cdn | no | Indica se il dominio è collegato al CDN dell'hosting. Valori consentiti: active┃none |
+| domain | no | Dominio da collegare |
+| firewall | no | Indica se il firewall è attivo per questo dominio. Valori consentiti: active┃none |
+| ipLocation | no | Definisce la localizzazione IP associata al dominio. Valori consentiti: BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| ownLog | no | Dominio per separare i log |
+| path | no | Percorso in cui vengono memorizzati i file web |
+| runtimeId | no | Identificativo della configurazione runtime utilizzata su questo dominio |
+| ssl | no | Opzione per attivare l'SSL sul dominio |
+
+**Esempio di risposta**:
+
+```json
+{
+ "doneDate": "2024-08-22T08:13:50.740Z",
+ "function": "abuse/close",
+ "id": 0,
+ "lastUpdate": "2024-08-22T08:13:50.740Z",
+ "objectId": "string",
+ "objectType": "Abuse",
+ "startDate": "2024-08-22T08:13:50.740Z",
+ "status": "cancelled"
+}
+```
+
+### Generare certificati SSL
+
+Configura e gestisci i certificati SSL per proteggere il tuo sito web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/ssl"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| certificate | no | Certificato SSL da installare |
+| chain | no | Catena di certificati utilizzata per convalidare il certificato SSL |
+| key | no | Chiave privata associata al certificato SSL |
+
+**Esempio di risposta**:
+
+```json
+{
+ "isReportable": false,
+ "provider": "COMODO",
+ "regenerable": false,
+ "status": "created",
+ "taskId": 0,
+ "type": "CUSTOM"
+}
+```
+
+### Gestire i database
+
+Le API di hosting web OVHcloud ti permettono anche di gestire i tuoi database.
+
+#### Creare un database
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| capacity | sì | Capacità del database. Valori: extraSqlPersonal┃local┃privateDatabase┃sqlLocal┃sqlPersonal┃sqlPro |
+| user | sì | Nome utente del database. Deve essere in minuscolo e iniziare con l'identificativo del tuo hosting web |
+| password | no | Password del database |
+| quota | no | Spazio allocato. Valori: 25┃100┃200┃256┃400┃512┃800┃1024 |
+| type | sì | Tipo di database. Valori: mariadb┃mysql┃postgresql┃redis |
+| version | no | Versione del database |
+
+**Esempio di risposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Elencare i database esistenti
+
+Elenca tutti i database associati al tuo servizio di hosting web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| mode | sì | Valori consentiti: besteffort ┃ classic ┃ module |
+
+**Esempio di risposta**:
+
+```json
+[
+ "example.mysql.db",
+ "example2.mysql.db"
+]
+```
+
+### Gestire i moduli
+
+#### Recuperare una lista di moduli
+
+Ottieni la lista dei moduli disponibili che puoi installare sul tuo hosting web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| active | no | Filtra i moduli attivati o disattivati |
+| branch | no | Filtra i moduli in base alla versione. Valori consentiti: old ┃ stable ┃ testing |
+| latest | no | Filtro che permette di visualizzare i moduli corrispondenti alla versione più recente |
+
+**Esempio di risposta**:
+
+```json
+[
+ 195,
+ 184,
+ 38,
+ 176
+]
+```
+
+#### Recuperare le informazioni di un modulo
+
+Ottieni i dettagli di uno specifico modulo installato sul tuo hosting web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList/\{id\}"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| id | sì | Identificativo del modulo |
+
+**Esempio di risposta**:
+
+```json
+{
+ "keywords": [
+   "gallery"
+ ],
+ "adminNameType": "string",
+ "author": "OVH",
+ "branch": "old",
+ "id": 195,
+ "size": {
+   "value": 0,
+   "unit": "B"
+ },
+ "name": "myname",
+ "upgradeFrom": [],
+ "language": [
+   "en",
+   "fr",
+   "de",
+   "es",
+   "pl"
+ ],
+ "version": "1.4.2.2",
+ "active": false,
+ "languageRequirement": {
+   "value": "php",
+   "unit": "supported versions: ''\nnon supported versions: '8+'"
+ },
+ "latest": true
+}
+```
+
+### Installare un nuovo modulo
+
+Installa un nuovo modulo sul tuo servizio di hosting web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/module"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| moduleId | sì | Identificativo del modulo da installare |
+| adminName | no | Nome dell'amministratore |
+| adminpassword | no | Password dell'account amministratore |
+| domain | no | Nome di dominio su cui verrà installato il modulo |
+| language | no | Lingua dell'installazione del modulo |
+| path | no | Percorso sul server in cui verrà installato il modulo |
+| dependencies -> name | no | Nome del servizio dipendente |
+| dependencies -> password | no | Password del servizio dipendente |
+| dependencies -> port | no | Porta di connessione del servizio |
+| dependencies -> prefix | no | Prefisso utilizzato nella configurazione del servizio |
+| dependencies -> server | no | Indirizzo del server del servizio dipendente |
+| dependencies -> type | no | Tipo di servizio (es.: MySQL) |
+| dependencies -> user | no | Nome utente del servizio dipendente |
+
+**Esempio di risposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+### Gestire gli utenti FTP
+
+Gestisci gli utenti FTP/SSH del tuo hosting web per semplificare accessi e configurazioni.
+
+#### Creare un nuovo utente FTP/SSH
+
+Crea un nuovo utente FTP o SSH per accedere al tuo hosting web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| home | sì | Directory principale |
+| login | sì | Nome utente |
+| password | sì | Password |
+| sshState | no | Determina lo stato dell'accesso SSH per l'utente. Valori consentiti: active ┃none ┃sftponly |
+
+**Esempio di risposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Elencare gli utenti FTP/SSH
+
+Elenca tutti gli utenti FTP/SSH esistenti sul tuo servizio di hosting:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| home | no | Filtra gli utenti in base alla loro directory principale |
+| login | no | Filtra gli utenti in base al loro nome utente |
+
+**Esempio di risposta**:
+
+```json
+[
+ "user1",
+ "user2",
+ "user3",
+ "user4"
+]
+```
+
+### Ripristinare un database
+
+Crea, elenca e ripristina i backup dei database del tuo sito web.
+
+#### Creare un backup di un database
+
+Crea un backup del tuo database per ripristinarlo in caso di necessità:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| name | sì | Nome del database |
+| date | sì | Tipo di backup. Valori consentiti: daily.1┃now┃weekly.1 |
+| sendEmail | no | Se questo parametro è attivo, viene inviata un'email quando il backup è disponibile |
+
+**Esempio di risposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Elencare i backup di database disponibili
+
+Elenca tutti i backup disponibili per i tuoi database:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| name | sì | Nome del database |
+| creationDate.from | no | Filtra i backup creati a partire da questa data |
+| creationDate.to | no | Filtra i backup creati fino a questa data |
+| deletionDate.from | no | Filtra i backup eliminati a partire da questa data |
+| deletionDate.to | no | Filtra i backup eliminati fino a questa data |
+| type | no | Filtra i backup in base al tipo. Valori consentiti: daily.1┃now┃weekly.1 |
+
+**Esempio di risposta**:
+
+```json
+[
+ 1,
+ 12
+]
+```
+
+#### Ripristinare un backup specifico di un database
+
+Ripristina un backup specifico del tuo database in caso di problemi:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump/\{id\}/restore"} />
+
+| Parametro | Obbligatorio | Descrizione |
+|---|---|---|
+| serviceName | sì | Nome del servizio |
+| name | sì | Nome del database |
+| id | sì | Identificativo del backup |
+
+**Esempio di risposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+## Conclusione
+
+Questa guida ti ha presentato le principali richieste API per gestire il tuo hosting web OVHcloud, come il collegamento di domini e la gestione di certificati SSL e database.
+
+Esistono tuttavia molte altre chiamate API disponibili, che puoi esplorare in base alle tue esigenze. Per ulteriori opzioni e funzionalità, consulta la sezione "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" dell'API OVHcloud.
+
+## Per saperne di più
+
+[Order a domain name via API](/guides/web-cloud/domains/api-domain-order)
+
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,124 +1,118 @@
 ---
-title: "Backing up your WordPress websites with MainWP"
-description: "Find out how to back up and restore your WordPress websites with MainWP"
-lastUpdated: 2024-01-25
+title: Effettuare il backup dei tuoi siti web WordPress con MainWP
+description: "Scopri come effettuare il backup dei tuoi siti web WordPress e ripristinarli con MainWP e l'estensione UpdraftPlus da un unico dashboard"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Obiettivo
 
-Backing up a website is a vital part of running your business. It offers several advantages:
+Il backup di un sito web è una pratica fondamentale per la gestione della tua azienda. Offre diversi vantaggi:
 
-- **Data security**: Regular backups ensure your website's data is protected in the event of a cyberattack, technical failure or human error.
-- **Protection against update errors**: A backup made before a WordPress plugin or theme is updated allows you to go back in time if an error or version conflict occurs during the update.
-- **Rapid Restore**: In the event of a technical error, the backup can be reverted to a previous version to offer your customers a functional website and business continuity.
-- **Legal Compliance**: Maintaining regular backups may be a regulatory compliance requirement for your organization and may protect you from legal action.
+- **Sicurezza dei dati**: i backup regolari garantiscono che i dati del tuo sito siano protetti in caso di attacco informatico, guasto tecnico o errore umano.
+- **Protezione dagli errori di aggiornamento**: un backup effettuato prima dell'aggiornamento di WordPress, di un plugin o di un tema permette di tornare indietro in caso di errore o conflitto di versioni durante l'aggiornamento.
+- **Ripristino rapido**: in caso di errore tecnico, il backup permette di tornare a una versione precedente per offrire ai tuoi clienti un sito web funzionante e garantire la continuità dell'attività.
+- **Conformità legale**: per la tua azienda, mantenere backup regolari può rispondere a un obbligo di conformità normativa e proteggerti da azioni legali.
 
-MainWP offers several extensions for backing up your websites.
+MainWP propone diverse estensioni che permettono di effettuare il backup dei tuoi siti web.
 
-**This guide explains how to back up your WordPress websites with the UpdraftPlus extension.**
+**Questa guida ti spiega come effettuare il backup dei tuoi siti web WordPress con l'estensione UpdraftPlus.**
 
-## Requirements
+## Prerequisiti
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Disporre di un'[offerta di hosting Web Cloud](/links/web/hosting).
+- Essere connesso al tuo dashboard MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
 :::
 
-## Instructions
+## Procedura
 
-### Install the UpdraftPlus extension
+### Installare l'estensione UpdraftPlus
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Se non hai mai installato un'estensione MainWP, scopri in [questa guida](/guides/web-cloud/web-hosting/mainwp-general) come installarne una.
 :::
 
-To find all the extensions linked to the backup, go to the [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) section of MainWP. You can also search for an extension by clicking `Extensions` from the MainWP main menu, then `Install Extensions`. Click on the `Backup` tab to view the list of extensions linked to the backup.
+Per trovare tutte le estensioni legate al backup, accedi alla sezione [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) di MainWP. Puoi anche cercare un'estensione cliccando su <code className="action">Extensions</code> nel menu principale di MainWP e poi su <code className="action">Install Extensions</code>. Clicca sul tab <code className="action">Backup</code> per visualizzare la lista delle estensioni legate al backup.
 
-In this example, we choose the free UpdraftPlus extension, but you are free to choose the extension of your choice.
+In questo esempio scegliamo l'estensione gratuita UpdraftPlus, ma sei libero di scegliere l'estensione che preferisci.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+Dopo aver selezionato l'estensione, clicca su <code className="action">Install Selected Extensions</code>.
 
-Once you have selected the extension, click `Install Selected Extensions`.
+Nel menu principale di MainWP, clicca su <code className="action">Extensions</code> e poi su <code className="action">Manage Extensions</code>. Viene visualizzata l'estensione UpdraftPlus installata in precedenza.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed UpdraftPlus extension appears.
+Clicca su <code className="action">Enable</code> per attivare l'estensione. Se un messaggio di errore indica che la licenza non è attiva, clicca semplicemente sul pulsante <code className="action">License</code>. Prima di poter utilizzare UpdraftPlus, devi attivare il plugin UpdraftPlus sui siti figli di cui vuoi effettuare il backup.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+### Installare il plugin UpdraftPlus su un sito figlio
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button. Before you can use UpdraftPlus, you must enable the UpdraftPlus plugin on the child sites that you want to back up.
+Nel menu principale di MainWP, clicca su <code className="action">Sites</code> e poi su <code className="action">Install Plugins</code>. Nella barra di ricerca, digita "UpdraftPlus".
 
-### Install the UpdraftPlus plugin on a child site
+<img className="thumbnail" alt="Campo di ricerca dei plugin MainWP con UpdraftPlus inserito" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-In the main menu of MainWP, click `Sites` then `Install Plugins`. In the search bar, type UpdraftPlus.
+Una volta individuato il plugin "UpdraftPlus: WordPress Backup & Migration", clicca su <code className="action">Install Plugin</code>. Poi, a destra della schermata, seleziona il sito figlio su cui vuoi installare UpdraftPlus. Clicca su <code className="action">Complete Installation</code>. Ricorda di selezionare <code className="action">Activate after installation</code>.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png)
+Al termine dell'installazione, accedi al menu principale di MainWP. Clicca su <code className="action">Sites</code>, <code className="action">Plugins</code> e poi su <code className="action">Manage Plugins</code>. Per verificare che UpdraftPlus sia installato sui tuoi siti web, seleziona i siti figli desiderati, a destra della schermata. Più in basso, nel campo di ricerca <code className="action">Search Options</code>, digita "UpdraftPlus" e seleziona <code className="action">Show Plugins</code>.
 
-Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click `Install Plugin`. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click `Complete Installation`. Remember to tick `Activate after installation`.
+<img className="thumbnail" alt="Pagina Manage Plugins di MainWP filtrata su UpdraftPlus per i siti figli" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-Once the installation is complete, go to the MainWP main menu. Click `Sites`, `Plugins` then `Manage Plugins`. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field `Search Options`, type "UpdraftPlus" then select `Show Plugins`.
+Vengono visualizzate l'estensione "MainWP UpdraftPlus Extension" e il plugin "UpdraftPlus - Backup/Restore": significa che sono installati correttamente sui siti figli interessati.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png)
+Seleziona l'estensione "MainWP UpdraftPlus Extension" e il plugin "UpdraftPlus - Backup/Restore", poi clicca su <code className="action">Install to Selected Site(s)</code> (pulsante in alto a destra).
 
-The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Retore" are displayed, which means that they are correctly installed on the child websites concerned.
+Per assicurarti che i plugin siano attivi sul tuo sito figlio, clicca su <code className="action">Sync Dashboard with Sites</code>, in alto a destra nell'interfaccia.
 
-Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Retore" plugin, then click `Install to Selected Site(s)` (button in the top right-hand corner).
+<img className="thumbnail" alt="Pulsante Sync Dashboard with Sites in alto a destra nell'interfaccia MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
-To ensure that the plugins are enabled on your child website, click `Sync Dashboard with Sites`, in the top right-hand corner of the interface.
+Ora puoi effettuare i backup dei tuoi siti figli con UpdraftPlus.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png)
+### Effettuare backup con UpdraftPlus
 
-You can now create backups of your child websites with UpdraftPlus.
+Nel menu principale di MainWP, clicca su <code className="action">Sites</code> e poi su <code className="action">Manage Sites</code>. Clicca sul sito figlio di cui vuoi effettuare il backup, poi clicca sul tab <code className="action">UpdraftPlus Backups</code>.
 
-### Create a backup with UpdraftPlus
+Nella schermata visualizzata, clicca su <code className="action">Backup Now</code> e segui le istruzioni. Per confermare il backup, clicca su <code className="action">Backup Now</code>.
 
-In the main menu of MainWP, click `Sites` then `Manage Sites`. Click the child site for which you want to create a backup, then click the `UpdraftPlus Backups` tab.
+<img className="thumbnail" alt="Finestra Backup Now di UpdraftPlus su un sito figlio MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/tab-updraftPlus.png)
+Una volta completato il backup, clicca sul tab <code className="action">ExistingBackups</code>.
 
-On the screen that pops up, click `Backup Now` and follow the instructions. To confirm the backup, click `Backup Now`.
+<img className="thumbnail" alt="Tab ExistingBackups di UpdraftPlus con il backup appena creato" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png)
+Compare una nuova riga corrispondente al tuo backup. Puoi effettuare diverse azioni sul backup, tra cui il ripristino.
 
-Once the backup is complete, click the `ExistingBackups` tab.
+### Ripristinare una versione salvata di un sito figlio
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png)
+Nel menu principale di MainWP, clicca su <code className="action">Extensions</code> e poi su <code className="action">UpdraftPlus</code>. Cliccando su <code className="action">Existing Backups</code> viene visualizzata la lista dei tuoi backup.
 
-A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
+Per ripristinare il tuo sito web, individua la riga corrispondente al tuo backup, poi clicca su <code className="action">Restore</code>.
 
-### Restore a backed up version of a child site
+<img className="thumbnail" alt="Riga di backup in UpdraftPlus con il pulsante Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
-In the MainWP main menu, click `Extensions` then `UpdraftPlus`. If you click `Existing Backups`, a list of your backups will appear.
+Compare una nuova finestra. Contiene diverse informazioni, tra cui la lista dei tuoi backup.
 
-To restore your website, locate the line corresponding to your backup, then click `Restore`.
+Individua il backup che vuoi ripristinare, poi clicca su <code className="action">Restore</code>. Ricorda di verificare la data per evitare errori.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png)
+<img className="thumbnail" alt="Finestra UpdraftPlus con i backup disponibili per il ripristino" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-A new window will appear. It contains some information, including a list of your backups.
+Seleziona gli elementi che vuoi ripristinare, poi conferma. Viene visualizzato il seguente messaggio di conferma:
 
-Identify the backup you want to restore, then click `Restore`. Remember to check the date to avoid any errors.
+<img className="thumbnail" alt="Messaggio che conferma il completamento del ripristino UpdraftPlus" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png)
+## Per saperne di più <a name="go-further"></a>
 
-Select the elements you want to restore, then confirm. The following confirmation message is displayed:
+[Gestire più siti web WordPress con il plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png)
+[Gestire le informazioni dei clienti dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-## Go further <a id="go-further"></a>
+[Migliorare la sicurezza del tuo sito web con il plugin MainWP per WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Tutorial - Salva il tuo sito WordPress](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Ripristinare i dati dello spazio di storage di un hosting Web](/guides/web-cloud/web-hosting/ftp-save-and-backup)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-[Tutorial - Backup your WordPress website](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
-
-[Restore your web hosting plan's storage space](/guides/web-cloud/web-hosting/ftp-save-and-backup)
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
-
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,88 +1,88 @@
 ---
-title: "Managing customer information on your WordPress websites with MainWP"
-description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard"
-lastUpdated: 2024-01-25
+title: Gestire le informazioni dei clienti dei tuoi siti web WordPress con MainWP
+description: "Scopri come gestire tutti i clienti dei tuoi siti web WordPress dal dashboard MainWP: aggiungere, modificare ed eliminare le loro informazioni"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Obiettivo
 
-Retaining customers is vital to your company's development. Whether you have one or more websites, it's important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+La fidelizzazione dei clienti è essenziale per lo sviluppo della tua azienda. Che tu abbia uno o più siti web, è importante conoscere al meglio i tuoi clienti per fidelizzarli e soddisfarli. Il plugin MainWP per WordPress ti permette di gestire in modo efficace i clienti dei tuoi siti web. Come farebbe un CRM (Customer Relationship Management), puoi aggiungere, eliminare e aggiornare tutte le informazioni dei tuoi clienti gratuitamente e in pochi clic.
 
-**This guide will show you how to manage your website's customers' data efficiently using MainWP.**
+**Questa guida ti spiega come gestire in modo efficace i dati dei clienti dei tuoi siti web con MainWP.**
 
-## Requirements
+## Prerequisiti
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
+- Disporre di un'[offerta di hosting Web Cloud](/links/web/hosting).
+- Essere connesso al tuo dashboard MainWP. Per maggiori informazioni, consulta la nostra guida [Gestire più siti web WordPress con il plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general).
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
 :::
 
-## Instructions
+## Procedura
 
-In the MainWP main menu, click `Clients`. On the screen that opens, there are three tabs:
+Nel menu principale di MainWP, clicca su <code className="action">Clients</code>. Nella schermata che si apre sono presenti tre tab:
 
-- Customers: displays a list of all your customers
-- Add Client: allows you to create new customers
-- Client Fields: allows you to create new fields related to your customers
+- Customers: mostra la lista di tutti i tuoi clienti
+- Add Client: permette di creare nuovi clienti
+- Client Fields: permette di creare nuovi campi relativi ai tuoi clienti
 
-### Add a customer
+### Aggiungere un cliente
 
-To get started, add your first customer. In the main menu of MainWP, click `Clients` then `Add Client`. In the form that appears, fill in your customer's details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click `Add Client`.
+Per iniziare, aggiungi il tuo primo cliente. Nel menu principale di MainWP, clicca su <code className="action">Clients</code> e poi su <code className="action">Add Client</code>. Nel modulo visualizzato, inserisci i dati del cliente. A destra della schermata, seleziona i siti web su cui vuoi creare il nuovo cliente, poi clicca su <code className="action">Add Client</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/add-client.png)
+<img className="thumbnail" alt="Modulo Add Client di MainWP con i dati del cliente compilati" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
-### View your customers
+### Consultare i tuoi clienti
 
-In the main menu of MainWP, click `Clients` then `Clients`. A list of all your customers will appear. You can search for a specific customer (in the `Search` field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
+Nel menu principale di MainWP, clicca su <code className="action">Clients</code> e poi su <code className="action">Clients</code>. Viene visualizzata la lista di tutti i tuoi clienti. Puoi cercare un cliente specifico (nel campo <code className="action">Search</code>, in alto a destra nella tabella) inserendo il valore di uno dei suoi campi, ad esempio il nome.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/search-client.png)
+<img className="thumbnail" alt="Lista dei clienti MainWP con il campo Search in alto a destra" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
-You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column `Customer Email`) or the number of websites to which your customer is attached (column `Websites`).
+Puoi trascinare le colonne che preferisci per mettere in evidenza le informazioni rilevanti dei tuoi clienti, come l'indirizzo email (colonna <code className="action">Customer Email</code>) o il numero di siti web associati al cliente (colonna <code className="action">Websites</code>).
 
-From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click `Bulk actions`, `Delete` then `Apply` to confirm.
+Da questa tabella puoi eliminare qualsiasi cliente. Seleziona le righe corrispondenti ai clienti da eliminare, clicca su <code className="action">Bulk actions</code>, <code className="action">Delete</code> e poi su <code className="action">Apply</code> per confermare.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png)
+<img className="thumbnail" alt="Tabella dei clienti MainWP con le opzioni Bulk actions e Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
-Finally, click `Yes, proceed` to confirm the deletion of the customers.
+Infine, clicca su <code className="action">Yes, proceed</code> per confermare l'eliminazione dei clienti.
 
-In the table representing your customers, identify the customer of your choice and click on the `...`.
+Nella tabella dei tuoi clienti, individua il cliente desiderato e clicca su <code className="action">...</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/more-client.png)
+<img className="thumbnail" alt="Menu delle azioni di un cliente nella tabella dei clienti MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-You can:
+Puoi:
 
-- edit customer information (`Edit`)
-- delete the customer (`Delete`)
-- see the websites concerned by your customer (`View Sites`)
+- modificare le informazioni del cliente (<code className="action">Edit</code>)
+- eliminare il cliente (<code className="action">Delete</code>)
+- consultare i siti web associati al cliente (<code className="action">View Sites</code>)
 
-### Create new fields for your customers
+### Creare nuovi campi per i tuoi clienti
 
-For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
-In the main menu of MainWP, click `Clients` then `Clients Fields`. To create a new field, click `New Field`. In the window that appears, enter the name and description for your new field.
+Per ogni cliente sono presenti numerosi campi predefiniti, come nome, email, Paese, numero o link ai social network. Se vuoi aggiungere informazioni specifiche non presenti di default, puoi aggiungere manualmente i campi desiderati.
+Nel menu principale di MainWP, clicca su <code className="action">Clients</code> e poi su <code className="action">Clients Fields</code>. Per creare un nuovo campo, clicca su <code className="action">New Field</code>. Nella finestra visualizzata, inserisci il nome e la descrizione del nuovo campo.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png)
+<img className="thumbnail" alt="Finestra MainWP per creare un nuovo campo cliente con nome e descrizione" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click `Save Field`. Now, when creating a new customer, the new "loyalty" field will be available.
+Nel nostro esempio creiamo un nuovo campo "loyalty" con la relativa descrizione. Per confermare la creazione del nuovo campo, clicca su <code className="action">Save Field</code>. Da questo momento, al momento della creazione di un nuovo cliente il campo "loyalty" sarà disponibile.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png)
+<img className="thumbnail" alt="Modulo Add Client di MainWP con il nuovo campo loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
+Dopo aver creato il nuovo cliente, accedi alla lista dei tuoi clienti. Clicca sul cliente appena creato. Vengono visualizzati il nuovo campo "loyalty" e il valore corrispondente.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/details-client.png)
+<img className="thumbnail" alt="Dettagli di un cliente MainWP con il campo loyalty e il relativo valore" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
-## Go further <a id="go-further"></a>
+## Per saperne di più <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gestire più siti web WordPress con il plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Migliorare la sicurezza del tuo sito web con il plugin MainWP per WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Effettuare il backup dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,185 +1,199 @@
 ---
-title: "Managing multiple WordPress websites with the MainWP plugin"
-description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin"
-lastUpdated: 2024-01-25
+title: Gestire più siti web WordPress con il plugin MainWP
+description: "Scopri come gestire più siti web WordPress da un unico strumento con il plugin MainWP: aggiornamenti, estensioni e siti figli collegati"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Obiettivo
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Gestire più siti web può essere complesso e richiedere molto tempo. Se gestisci più siti web WordPress, dovrai occuparti della manutenzione tecnica dei siti, degli aggiornamenti di plugin e temi e anche delle credenziali di accesso. Il plugin MainWP per WordPress è una soluzione efficace per gestire più siti web WordPress da un unico dashboard. MainWP ti permette di:
 
-- control all your websites from a single dashboard
-- update the technical components in one click
-- [manage your customer information](/guides/web-cloud/web-hosting/mainwp-client-management)
-- download extensions to perform multiple tasks
+- controllare tutti i tuoi siti web da un unico dashboard
+- aggiornare i componenti tecnici con un clic
+- [gestire le informazioni dei tuoi clienti](/guides/web-cloud/web-hosting/mainwp-client-management)
+- scaricare estensioni per svolgere numerose attività
 
-**Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
+**Scopri come utilizzare il dashboard MainWP per gestire più siti web WordPress.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+In questa guida abbiamo scelto il plugin MainWP. Esistono altre soluzioni simili: sei ovviamente libero di scegliere il plugin che preferisci.
+
 :::
 
-## Requirements
+## Prerequisiti
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
-- Access to the WordPress administration interface.
+- Disporre di un'[offerta di hosting Web Cloud](/links/web/hosting).
+- Avere accesso all'interfaccia di amministrazione di WordPress.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
 :::
 
-## Instructions
+{/* CP-NAV-START:web-hosting */}
+---
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+### Accesso allo Spazio Cliente OVHcloud
 
-![mainWP](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png)
+- **Link diretto:** <ManagerLink to="/#/web/hosting">Hosting</ManagerLink>
+- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Hosting</code> > Seleziona il tuo hosting web
 
-Enter your login and password to log in. The WordPress dashboard appears.
+---
+{/* CP-NAV-END:web-hosting */}
 
-### Install the MainWP plugin 
+## Procedura
 
-Go to the main WordPress menu, on the left-hand side of the screen, and click `Plugins` then `Add New Plugin`.
+Se non hai ancora effettuato l'accesso, apri l'interfaccia di amministrazione del tuo CMS in 1 click per cui vuoi installare il dashboard MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png)
+<img className="thumbnail" alt="Spazio Cliente OVHcloud con la lista dei CMS in 1 click" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
+Inserisci il tuo nome utente e la tua password per accedere. Viene visualizzato il dashboard WordPress.
+
+### Installare il plugin MainWP
+
+Accedi al menu principale di WordPress, a sinistra della schermata, e clicca su <code className="action">Plugins</code> e poi su <code className="action">Add New Plugin</code>.
+
+<img className="thumbnail" alt="Menu WordPress con la voce Plugins e l'opzione Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+
+Viene visualizzata la lista dei plugin WordPress più popolari. Nella barra di ricerca, in alto a destra, digita "MainWP" e conferma. Tra i risultati compaiono diversi plugin proposti da "MainWP". Installa i due plugin seguenti:
 
 - MainWP Dashboard
 - Child MainWP
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png)
+<img className="thumbnail" alt="Risultati di ricerca dei plugin WordPress con MainWP Dashboard e MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br />
-MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
+MainWP Dashboard è il plugin principale che permette di gestire i tuoi siti web da un unico dashboard.
+
+MainWP Child permette di collegare il tuo sito web WordPress (chiamato anche "sito figlio") al MainWP Dashboard.
 
 :::warning
-An error may occur if you install MainWP Child first. Make sure to install MainWP Dashboard **before** MainWP Child.
+Se installi prima MainWP Child può verificarsi un errore. Assicurati di installare MainWP Dashboard **prima** di MainWP Child.
+
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
-Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
+Dopo aver installato entrambi i plugin, ricorda di attivarli per poterli utilizzare.
+Una volta installati e attivati i due plugin, nella parte superiore della schermata compare il seguente messaggio di avviso:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png)
+<img className="thumbnail" alt="Messaggio di avviso che invita a collegare il sito figlio al MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
-This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
+Questo messaggio ti informa che hai appena attivato il plugin MainWP Child e che ora devi collegare il tuo sito figlio al MainWP Dashboard. Per motivi di sicurezza, disattiva il plugin MainWP Child se non vuoi collegare subito il tuo sito figlio. Riattivalo quando sei pronto a collegare il tuo sito WordPress al dashboard MainWP.
 
-### Connect a child site to the MainWP dashboard
+### Collegare un sito figlio al dashboard MainWP
 
-In the main menu on the left, click `Sites`, then `Add New`. The following screen appears:
+Nel menu principale a sinistra, clicca su <code className="action">Sites</code> e poi su <code className="action">Add New</code>. Compare la schermata seguente:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png)
+<img className="thumbnail" alt="Modulo MainWP per aggiungere un nuovo sito figlio" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
+Inserisci l'URL del sito figlio che vuoi collegare al dashboard MainWP. Subito sotto, seleziona il pulsante che indica che hai installato e attivato il plugin MainWP Child sul tuo sito figlio. Compaiono i due nuovi campi seguenti:
 
-- `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the `Web Cloud` section. Select the web hosting plan concerned, and click the `1-click modules` tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the `Login` column.
-- `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
+- `Administrator username`: accedi al tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, poi apri la sezione <code className="action">Web Cloud</code>. Seleziona l'hosting web interessato e clicca sul tab <code className="action">CMS in 1 click</code>. Nella tabella visualizzata, individua la riga corrispondente al tuo CMS. Il nome dell'amministratore si trova nella colonna <code className="action">Login</code>.
+- `Site title`: inserisci il valore che preferisci. Se colleghi molti siti figli, scegli un titolo esplicito.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site.png)
+<img className="thumbnail" alt="Modulo di aggiunta sito MainWP con nome amministratore e titolo del sito compilati" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-When all the fields of the form are filled in, click the `Add Site` button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
+Quando tutti i campi del modulo sono compilati, clicca sul pulsante <code className="action">Add Site</code> sotto il modulo per confermare. Se non ci sono errori, ricevi il seguente messaggio di conferma, che indica che il tuo sito figlio è ora collegato al dashboard MainWP:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png)
+<img className="thumbnail" alt="Messaggio che conferma il collegamento del sito figlio al dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
-To check that your child website is available in the MainWP dashboard, click `Sites` in the main menu on the left-hand side, then `Manage Sites`.
+Per verificare che il tuo sito figlio sia disponibile nel dashboard MainWP, clicca su <code className="action">Sites</code> nel menu principale a sinistra, poi su <code className="action">Manage Sites</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png)
+<img className="thumbnail" alt="Pagina Manage Sites di MainWP con la lista dei siti figli collegati" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
-In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
+Nel nostro esempio, il sito web "my website" compare nella lista dei siti figli collegati al dashboard MainWP. Puoi aggiungere tutti i siti figli che desideri.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png)
+<img className="thumbnail" alt="Vista a griglia di MainWP con tutti i siti figli collegati" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
-Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
+Ricorda di installare il plugin MainWP Child su ogni sito figlio che vuoi collegare al dashboard MainWP.
+
 :::
 
-### Manage software updates from the MainWP dashboard
+### Gestire gli aggiornamenti dal dashboard MainWP
 
-If you use several plugins and themes for your websites, you may encounter errors due to the different versions. With the MainWP dashboard, you can manage the following updates in one place:
+Se utilizzi diversi plugin e temi sui tuoi siti web, possono verificarsi errori dovuti alle diverse versioni. Il dashboard MainWP ti permette di gestire in un unico punto gli aggiornamenti di:
 
 - WordPress
-- Plugins
-- Themes
-- Translations
+- Plugin
+- Temi
+- Traduzioni
 
-In the main menu on the left, click `Sites` then `Updates`. The following screen appears:
+Nel menu principale a sinistra, clicca su <code className="action">Sites</code> e poi su <code className="action">Updates</code>. Compare la schermata seguente:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png)
+<img className="thumbnail" alt="Pagina Updates di MainWP con gli aggiornamenti di plugin e temi disponibili" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
-At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the `Themes Updates` tab, you will see a list of the four themes affected by the updates.
+Nella parte superiore dell'interfaccia, i tab indicano che sono disponibili aggiornamenti per un plugin e quattro temi. Clicca sul tab desiderato per visualizzare gli aggiornamenti disponibili. Nel nostro esempio, cliccando sul tab <code className="action">Themes Updates</code>, visualizzi la lista dei quattro temi interessati dagli aggiornamenti.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png)
+<img className="thumbnail" alt="Tab Themes Updates di MainWP con i quattro temi da aggiornare" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
-If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click `Update Selected Themes`.
-The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
+Se vuoi aggiornare più temi (o tutti i temi contemporaneamente), seleziona le righe corrispondenti (selezionando la casella a sinistra di ogni riga), poi clicca su <code className="action">Update Selected Themes</code>.
+Compare il seguente messaggio di conferma, che indica i siti su cui verranno aggiornati i temi selezionati in precedenza.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png)
+<img className="thumbnail" alt="Messaggio di conferma con i siti su cui verranno aggiornati i temi selezionati" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
-In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click `Yes, proceed` to confirm. The progress window appears. It will close when the updates are complete.
+Nel nostro esempio, i temi selezionati verranno aggiornati per i siti web "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" e "blog 3". Clicca su <code className="action">Yes, proceed</code> per confermare. Compare la finestra di avanzamento, che si chiude al termine degli aggiornamenti.
 
-Do the same to update WordPress, your plugins or your translations.
+Procedi allo stesso modo per aggiornare WordPress, i tuoi plugin o le tue traduzioni.
 
-### Extensions
+### Estensioni
 
-MainWP offers native features, such as software update management or [customer information management](/guides/web-cloud/web-hosting/mainwp-client-management). However, MainWP becomes even more powerful thanks to its many extensions, offering a wide range of features.
+MainWP offre funzionalità native, come la gestione degli aggiornamenti o la [gestione delle informazioni dei clienti](/guides/web-cloud/web-hosting/mainwp-client-management). MainWP diventa però ancora più potente grazie alle sue numerose estensioni, che offrono un'ampia gamma di funzionalità.
 
-There are different [extension categories](https://mainwp.com/mainwp-extensions/), such as Administrative, Backup, Analytics, Security, etc. For each of the categories, there are three different types of extensions:
+Esistono diverse [categorie di estensioni](https://mainwp.com/mainwp-extensions/), come Administrative, Backup, Analytics o Security. Per ogni categoria esistono tre tipi diversi di estensioni:
 
-- Free: free extensions developed by MainWP
-- Professional: premium extensions developed by MainWP
-- .Org: free extensions developed by a third-party publisher
+- Free: estensioni gratuite sviluppate da MainWP
+- Professional: estensioni a pagamento sviluppate da MainWP
+- .Org: estensioni gratuite sviluppate da un editore terzo
 
-Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-account/) to create your account.
+Prima di poter installare un'estensione, crea il tuo account su [MainWP.com](https://mainwp.com/my-account/).
 
-#### Order an extension
+#### Ordinare un'estensione
 
-Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
+Dopo aver creato il tuo account MainWP, accedi alla [sezione estensioni di MainWP.com](https://mainwp.com/mainwp-extensions/). Per il nostro esempio scegliamo l'estensione gratuita UpdraftPlus. Clicca sull'estensione UpdraftPlus.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png)
+<img className="thumbnail" alt="Scheda dell'estensione UpdraftPlus nella pagina delle estensioni di MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
-A page dedicated to the extension will appear. Click `Get the free Bundle`, then `Proceed to checkout`. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking `Place order`.
+Compare una pagina dedicata all'estensione. Clicca su <code className="action">Get the free Bundle</code>, poi su <code className="action">Proceed to checkout</code>. Non è necessario inserire i dati di pagamento perché questa estensione è gratuita. Inserisci solo le informazioni richieste. Seleziona le caselle necessarie e concludi cliccando su <code className="action">Place order</code>.
 
-You will now need to retrieve the API key corresponding to your MainWP username, which will enable you to log in to the MainWP dashboard to download the extensions of your choice.
+Ora dovrai recuperare la chiave API corrispondente al tuo nome utente MainWP, che ti permetterà di accedere al dashboard MainWP per scaricare le estensioni desiderate.
 
-#### Enter the API key
+#### Inserire la chiave API
 
-Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
+Accedi al [tuo account MainWP](https://mainwp.com/my-account/my-api-keys/) e copia la chiave API.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png)
+<img className="thumbnail" alt="Pagina dell'account MainWP con la chiave API da copiare" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
-Go back to the MainWP dashboard and click on `Extensions` in the main menu on the left. In the top right-hand corner of the screen that appears, click `Install and Activate Extensions`.
+Torna al dashboard MainWP e clicca su <code className="action">Extensions</code> nel menu principale a sinistra. In alto a destra nella schermata visualizzata, clicca su <code className="action">Install and Activate Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png)
+<img className="thumbnail" alt="Pagina Extensions di MainWP con il pulsante Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-In the `Enter your MainWP API Key` field, paste the API key you have previously copied, tick the `Remember MainWP Main API Key` box and click `Validate my MainWP Main API Key`. If there are no errors, the following confirmation message is displayed:
+Nel campo <code className="action">Enter your MainWP API Key</code>, incolla la chiave API copiata in precedenza, seleziona la casella <code className="action">Remember MainWP Main API Key</code> e clicca su <code className="action">Validate my MainWP Main API Key</code>. Se non ci sono errori, viene visualizzato il seguente messaggio di conferma:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png)
+<img className="thumbnail" alt="Messaggio che conferma la validità della chiave API MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
-Finally, click `Install Extension` to install the extensions of your choice.
+Infine, clicca su <code className="action">Install Extension</code> per installare le estensioni desiderate.
 
-#### Install an extension
+#### Installare un'estensione
 
-After clicking `Install Extensions`, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click `Install Selected Extensions`.
+Dopo aver cliccato su <code className="action">Install Extensions</code>, compare una finestra con la lista delle estensioni disponibili, ordinate per categoria. Nel nostro esempio scegliamo l'estensione gratuita "UpdraftPlus" della categoria Backups. Dopo aver selezionato UpdraftPlus, clicca su <code className="action">Install Selected Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+<img className="thumbnail" alt="Lista delle estensioni MainWP con UpdraftPlus selezionata nella categoria Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
-Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
+Al termine dell'installazione, UpdraftPlus è disponibile nella lista delle estensioni del tuo dashboard MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+<img className="thumbnail" alt="UpdraftPlus tra le estensioni del dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button.
+Clicca su <code className="action">Enable</code> per attivare l'estensione. Se un messaggio di errore indica che la licenza non è attiva, clicca semplicemente sul pulsante <code className="action">License</code>.
 
-## Go further <a id="go-further"></a>
+## Per saperne di più <a name="go-further"></a>
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gestire le informazioni dei clienti dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Migliorare la sicurezza del tuo sito web con il plugin MainWP per WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Effettuare il backup dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,97 +1,97 @@
 ---
-title: "Improving your website's security with the MainWP plugin for WordPress"
-description: "Find out how to control the security of your websites from a single interface using MainWP"
-lastUpdated: 2024-01-25
+title: Migliorare la sicurezza del tuo sito web con il plugin MainWP per WordPress
+description: "Scopri come controllare la sicurezza dei tuoi siti web da un'unica interfaccia con MainWP e l'estensione Sucuri: scansioni e correzioni"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Obiettivo
 
-Maintaining the security of your websites is crucial for the development of your brand. Optimum security for your websites can protect your company's data, as well as your customers' data, thereby preserving your company's image and trust. With extensions to the WordPress MainWP plugin, you can control the security of your websites from a single interface.
+Mantenere la sicurezza dei tuoi siti web è fondamentale per lo sviluppo del tuo brand. Una sicurezza ottimale dei siti web permette di proteggere i dati della tua azienda e quelli dei tuoi clienti, preservando così l'immagine e la fiducia riposta nella tua azienda. Con le estensioni del plugin MainWP per WordPress, puoi controllare la sicurezza dei tuoi siti web da un'unica interfaccia.
 
-**This guide will show you how to improve website security via the MainWP dashboard**
+**Questa guida ti spiega come migliorare la sicurezza del tuo sito web dal dashboard MainWP.**
 
-## Requirements
+## Prerequisiti
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Disporre di un'[offerta di hosting Web Cloud](/links/web/hosting).
+- Essere connesso al tuo dashboard MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
 :::
 
-## Instructions
+## Procedura
 
-### Install the Sucuri extension
+### Installare l'estensione Sucuri
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Se non hai mai installato un'estensione MainWP, scopri in [questa guida](/guides/web-cloud/web-hosting/mainwp-general) come installarne una.
 :::
 
-To find all the security-related extensions, go to the [security](https://mainwp.com/mainwp-extensions/extension-category/security/) section of MainWP. You can also search for an extension by clicking `Extensions` in the MainWP main menu, then `Install Extensions`.
+Per trovare tutte le estensioni legate alla sicurezza, accedi alla sezione [security](https://mainwp.com/mainwp-extensions/extension-category/security/) di MainWP. Puoi anche cercare un'estensione cliccando su <code className="action">Extensions</code> nel menu principale di MainWP e poi su <code className="action">Install Extensions</code>.
 
-Click on the `Security` tab to view the list of security-related extensions. In this example, we choose the free Sucuri extension, but you are free to choose the extension of your choice. Once you have selected the extension, click `Install Selected Extensions`.
+Clicca sul tab <code className="action">Security</code> per visualizzare la lista delle estensioni legate alla sicurezza. In questo esempio scegliamo l'estensione gratuita Sucuri, ma sei libero di scegliere l'estensione che preferisci. Dopo aver selezionato l'estensione, clicca su <code className="action">Install Selected Extensions</code>.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed Sucuri extension appears.
+Nel menu principale di MainWP, clicca su <code className="action">Extensions</code> e poi su <code className="action">Manage Extensions</code>. Viene visualizzata l'estensione Sucuri installata in precedenza.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png)
+<img className="thumbnail" alt="Estensione Sucuri nella pagina Manage Extensions di MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
-If you have not already done so, click `Enable`, then `License` to use the extension.
+Se non l'hai già fatto, clicca su <code className="action">Enable</code> e poi su <code className="action">License</code> per utilizzare l'estensione.
 
-### Perform a security scan
+### Effettuare una scansione di sicurezza
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click on the `Security` tab.
+Nel menu principale di MainWP, clicca su <code className="action">Sites</code> e seleziona il sito figlio desiderato. Nella parte superiore della schermata, clicca sul tab <code className="action">Security</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png)
+<img className="thumbnail" alt="Tab Security di un sito figlio MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
-To perform a security scan on your website, click `Scan Website`.
+Per effettuare una scansione di sicurezza del tuo sito web, clicca su <code className="action">Scan Website</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png)
+<img className="thumbnail" alt="Scanner Sucuri con il pulsante Scan Website su un sito figlio MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
-Once the security scan is complete, a new line will appear, corresponding to the security scan report.
+Al termine della scansione di sicurezza, compare una nuova riga corrispondente al report della scansione.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png)
+<img className="thumbnail" alt="Nuova riga corrispondente al report della scansione di sicurezza Sucuri" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
-Click `Show Report` to view the security report.
+Clicca su <code className="action">Show Report</code> per consultare il report di sicurezza.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png)
+<img className="thumbnail" alt="Dettaglio del report della scansione di sicurezza Sucuri per un sito figlio" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-The security scan report provides a lot of important information about the security of your website:
+Il report della scansione di sicurezza fornisce numerose informazioni importanti sulla sicurezza del tuo sito web:
 
-- presence of viruses and malicious software
-- anomaly detection
-- dangerous links
-- SPAM attempts
-- etc.
+- presenza di virus e software dannosi
+- rilevamento di anomalie
+- link pericolosi
+- tentativi di spam
+- ecc.
 
-Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of `Remind me if I don't scan my child site for`. For example, if you choose `1 week`, Sucuri will remind you every week to carry out a security scan.
+Ricorda di effettuare regolarmente delle scansioni di sicurezza. Con Sucuri puoi attivare un promemoria. Sotto la lista dei tuoi report di sicurezza, clicca sulla lista a discesa a destra di <code className="action">Remind me if I don't scan my child site for</code>. Se ad esempio scegli <code className="action">1 week</code>, Sucuri ti ricorderà ogni settimana di effettuare una scansione di sicurezza.
 
-### Identify and resolve security issues
+### Individuare e risolvere i problemi di sicurezza
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click the `Security` tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
+Nel menu principale di MainWP, clicca su <code className="action">Sites</code> e seleziona il sito figlio desiderato. Nella parte superiore della schermata, clicca sul tab <code className="action">Security</code>. Nel dashboard visualizzato puoi vedere se Sucuri ha rilevato problemi di sicurezza.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png)
+<img className="thumbnail" alt="Dashboard Sucuri con i problemi di sicurezza rilevati su un sito figlio" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
-In our example, Sucuri tells us that three security issues have been identified. Click `Fix all issues` to resolve all security issues. If you would like to find out more about the issues identified, click the `Security` tab at the top of the interface. A list of security issues is displayed.
+Nel nostro esempio, Sucuri segnala tre problemi di sicurezza rilevati. Clicca su <code className="action">Fix all issues</code> per risolvere tutti i problemi di sicurezza. Se vuoi saperne di più sui problemi rilevati, clicca sul tab <code className="action">Security</code> nella parte superiore dell'interfaccia. Viene visualizzata la lista dei problemi di sicurezza.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-list.png)
+<img className="thumbnail" alt="Lista dei problemi di sicurezza rilevati da Sucuri su un sito figlio" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
-To resolve an issue, identify the corresponding line and click the `Fix` button to the right of the line.
+Per risolvere un problema, individua la riga corrispondente e clicca sul pulsante <code className="action">Fix</code> a destra della riga.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png)
+<img className="thumbnail" alt="Problema di sicurezza risolto in Sucuri con il pulsante Unfix disponibile" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
-Once the problem has been resolved, you can cancel the changes made by clicking the `Unfix` button.
+Una volta risolto il problema, puoi annullare le modifiche effettuate cliccando sul pulsante <code className="action">Unfix</code>.
 
-## Go further <a id="go-further"></a>
+## Per saperne di più <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gestire più siti web WordPress con il plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Manage customers for your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gestire le informazioni dei clienti dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Effettuare il backup dei tuoi siti web WordPress con MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Per prestazioni specializzate (SEO, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,1 +1,413 @@
-../../../../en/guides/web-cloud/web-hosting/api-webhosting.mdx
+---
+title: Tworzenie aplikacji internetowej i zarządzanie nią przez publiczne API OVHcloud
+description: "Dowiedz się, jak korzystać z publicznego API OVHcloud, aby utworzyć aplikację internetową: podłączyć domeny, zarządzać bazami danych i skonfigurować SSL"
+lastUpdated: 2026-08-19
+availableIn: [eu, ca, apac]
+---
+
+import Api from '@components/Api';
+
+## Wprowadzenie
+
+W tym przewodniku dowiesz się, jak korzystać z publicznego API OVHcloud, aby tworzyć aplikację internetową na Twoim hostingu i nią zarządzać. Poznasz kluczowe operacje: podłączanie domen, zarządzanie bazami danych i konfigurację certyfikatów SSL.
+
+## Wymagania początkowe
+
+- Posiadanie [hostingu OVHcloud](/links/web/hosting).
+- Podstawowa znajomość API REST.
+- Dostęp do API OVHcloud. Zapoznaj się z naszym przewodnikiem [Pierwsze kroki z API OVHcloud](/guides/manage-and-operate/api/first-steps).
+
+:::warning
+Korzystanie z API OVHcloud wymaga zaawansowanej wiedzy w tym zakresie. Jeśli napotkasz trudności, skontaktuj się z [partnerami OVHcloud](/links/partner).
+:::
+
+## W praktyce
+
+### Pobieranie informacji o usłudze
+
+Pierwszym krokiem jest pobranie `serviceName`, czyli unikalnego identyfikatora Twojej usługi hostingu. Będzie on potrzebny do większości poniższych wywołań API.
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
+
+To polecenie zwraca listę Twoich usług hostingu. Każdy wpis na liście to `serviceName`.
+
+**Przykładowa odpowiedź**:
+
+```json
+[
+  "example.cluster01.hosting.ovh.net",
+  "example2.cluster02.hosting.ovh.net"
+]
+```
+
+### Podłączanie domeny
+
+Podłącz domenę do swojej usługi hostingu:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/attachedDomain"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| bypassDNSConfiguration | nie | Jeśli opcja jest włączona, strefa DNS nie zostanie zaktualizowana |
+| cdn | nie | Wskazuje, czy domena jest powiązana z CDN hostingu. Dozwolone wartości: active┃none |
+| domain | nie | Domena do powiązania |
+| firewall | nie | Wskazuje, czy zapora sieciowa jest aktywna dla tej domeny. Dozwolone wartości: active┃none |
+| ipLocation | nie | Określa lokalizację IP powiązaną z domeną. Dozwolone wartości: BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| ownLog | nie | Domena służąca do rozdzielenia logów |
+| path | nie | Ścieżka, w której będą przechowywane pliki strony |
+| runtimeId | nie | Identyfikator konfiguracji runtime używanej dla tej domeny |
+| ssl | nie | Opcja włączenia SSL dla domeny |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+ "doneDate": "2024-08-22T08:13:50.740Z",
+ "function": "abuse/close",
+ "id": 0,
+ "lastUpdate": "2024-08-22T08:13:50.740Z",
+ "objectId": "string",
+ "objectType": "Abuse",
+ "startDate": "2024-08-22T08:13:50.740Z",
+ "status": "cancelled"
+}
+```
+
+### Generowanie certyfikatów SSL
+
+Skonfiguruj certyfikaty SSL i zarządzaj nimi, aby zabezpieczyć swoją stronę:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/ssl"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| certificate | nie | Certyfikat SSL do zainstalowania |
+| chain | nie | Łańcuch certyfikatów służący do walidacji certyfikatu SSL |
+| key | nie | Klucz prywatny powiązany z certyfikatem SSL |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+ "isReportable": false,
+ "provider": "COMODO",
+ "regenerable": false,
+ "status": "created",
+ "taskId": 0,
+ "type": "CUSTOM"
+}
+```
+
+### Zarządzanie bazami danych
+
+Za pomocą API hostingu OVHcloud możesz również zarządzać swoimi bazami danych.
+
+#### Tworzenie bazy danych
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| capacity | tak | Możliwości bazy danych. Wartości: extraSqlPersonal┃local┃privateDatabase┃sqlLocal┃sqlPersonal┃sqlPro |
+| user | tak | Nazwa użytkownika bazy danych. Musi być zapisana małymi literami i zaczynać się od identyfikatora Twojego hostingu |
+| password | nie | Hasło bazy danych |
+| quota | nie | Przydzielona przestrzeń. Wartości: 25┃100┃200┃256┃400┃512┃800┃1024 |
+| type | tak | Typ bazy danych. Wartości: mariadb┃mysql┃postgresql┃redis |
+| version | nie | Wersja bazy danych |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Wyświetlanie istniejących baz danych
+
+Wyświetl wszystkie bazy danych powiązane z Twoją usługą hostingu:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| mode | tak | Dozwolone wartości: besteffort ┃ classic ┃ module |
+
+**Przykładowa odpowiedź**:
+
+```json
+[
+ "example.mysql.db",
+ "example2.mysql.db"
+]
+```
+
+### Zarządzanie modułami
+
+#### Pobieranie listy modułów
+
+Pobierz listę dostępnych modułów, które możesz zainstalować na swoim hostingu:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| active | nie | Filtruje moduły włączone lub wyłączone |
+| branch | nie | Filtruje moduły według wersji. Dozwolone wartości: old ┃ stable ┃ testing |
+| latest | nie | Filtr wyświetlający moduły odpowiadające najnowszej wersji |
+
+**Przykładowa odpowiedź**:
+
+```json
+[
+ 195,
+ 184,
+ 38,
+ 176
+]
+```
+
+#### Pobieranie informacji o module
+
+Pobierz szczegóły konkretnego modułu zainstalowanego na Twoim hostingu:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList/\{id\}"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| id | tak | Identyfikator modułu |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+ "keywords": [
+   "gallery"
+ ],
+ "adminNameType": "string",
+ "author": "OVH",
+ "branch": "old",
+ "id": 195,
+ "size": {
+   "value": 0,
+   "unit": "B"
+ },
+ "name": "myname",
+ "upgradeFrom": [],
+ "language": [
+   "en",
+   "fr",
+   "de",
+   "es",
+   "pl"
+ ],
+ "version": "1.4.2.2",
+ "active": false,
+ "languageRequirement": {
+   "value": "php",
+   "unit": "supported versions: ''\nnon supported versions: '8+'"
+ },
+ "latest": true
+}
+```
+
+### Instalacja nowego modułu
+
+Zainstaluj nowy moduł w swojej usłudze hostingu:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/module"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| moduleId | tak | Identyfikator modułu do zainstalowania |
+| adminName | nie | Nazwa administratora |
+| adminpassword | nie | Hasło konta administratora |
+| domain | nie | Nazwa domeny, w której moduł zostanie wdrożony |
+| language | nie | Język instalacji modułu |
+| path | nie | Ścieżka na serwerze, w której moduł zostanie zainstalowany |
+| dependencies -> name | nie | Nazwa usługi zależnej |
+| dependencies -> password | nie | Hasło do usługi zależnej |
+| dependencies -> port | nie | Port połączenia usługi |
+| dependencies -> prefix | nie | Prefiks używany w konfiguracji usługi |
+| dependencies -> server | nie | Adres serwera usługi zależnej |
+| dependencies -> type | nie | Typ usługi (np. MySQL) |
+| dependencies -> user | nie | Nazwa użytkownika usługi zależnej |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+### Zarządzanie użytkownikami FTP
+
+Zarządzaj użytkownikami FTP/SSH swojego hostingu, aby ułatwić dostęp i konfigurację.
+
+#### Tworzenie nowego użytkownika FTP/SSH
+
+Utwórz nowego użytkownika FTP lub SSH, aby uzyskać dostęp do swojego hostingu:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| home | tak | Katalog domowy |
+| login | tak | Nazwa użytkownika |
+| password | tak | Hasło |
+| sshState | nie | Określa stan dostępu SSH dla użytkownika. Dozwolone wartości: active ┃none ┃sftponly |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Wyświetlanie użytkowników FTP/SSH
+
+Wyświetl wszystkich istniejących użytkowników FTP/SSH swojej usługi hostingu:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| home | nie | Filtruje użytkowników według ich katalogu domowego |
+| login | nie | Filtruje użytkowników według ich nazwy użytkownika |
+
+**Przykładowa odpowiedź**:
+
+```json
+[
+ "user1",
+ "user2",
+ "user3",
+ "user4"
+]
+```
+
+### Przywracanie bazy danych
+
+Twórz, wyświetlaj i przywracaj kopie zapasowe baz danych swojej strony.
+
+#### Tworzenie kopii zapasowej bazy danych
+
+Utwórz kopię zapasową swojej bazy danych, aby móc ją w razie potrzeby przywrócić:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| name | tak | Nazwa bazy danych |
+| date | tak | Typ kopii zapasowej. Dozwolone wartości: daily.1┃now┃weekly.1 |
+| sendEmail | nie | Jeśli ten parametr jest włączony, po udostępnieniu kopii zapasowej wysyłana jest wiadomość e-mail |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Wyświetlanie dostępnych kopii zapasowych baz danych
+
+Wyświetl wszystkie dostępne kopie zapasowe swoich baz danych:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| name | tak | Nazwa bazy danych |
+| creationDate.from | nie | Filtruje kopie zapasowe utworzone od tej daty |
+| creationDate.to | nie | Filtruje kopie zapasowe utworzone do tej daty |
+| deletionDate.from | nie | Filtruje kopie zapasowe usunięte od tej daty |
+| deletionDate.to | nie | Filtruje kopie zapasowe usunięte do tej daty |
+| type | nie | Filtruje kopie zapasowe według typu. Dozwolone wartości: daily.1┃now┃weekly.1 |
+
+**Przykładowa odpowiedź**:
+
+```json
+[
+ 1,
+ 12
+]
+```
+
+#### Przywracanie konkretnej kopii zapasowej bazy danych
+
+Przywróć konkretną kopię zapasową swojej bazy danych w razie problemu:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump/\{id\}/restore"} />
+
+| Parametr | Wymagany | Opis |
+|---|---|---|
+| serviceName | tak | Nazwa usługi |
+| name | tak | Nazwa bazy danych |
+| id | tak | Identyfikator kopii zapasowej |
+
+**Przykładowa odpowiedź**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+## Podsumowanie
+
+W tym przewodniku przedstawiliśmy główne zapytania API służące do zarządzania hostingiem OVHcloud, takie jak podłączanie domen oraz zarządzanie certyfikatami SSL i bazami danych.
+
+Dostępnych jest jednak wiele innych wywołań API, które możesz poznać w zależności od swoich potrzeb. Więcej opcji i funkcji znajdziesz w sekcji "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" API OVHcloud.
+
+## Sprawdź również
+
+[Order a domain name via API](/guides/web-cloud/domains/api-domain-order)
+
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,124 +1,118 @@
 ---
-title: "Backing up your WordPress websites with MainWP"
-description: "Find out how to back up and restore your WordPress websites with MainWP"
-lastUpdated: 2024-01-25
+title: Tworzenie kopii zapasowych stron WordPress za pomocą MainWP
+description: "Dowiedz się, jak tworzyć kopie zapasowe stron WordPress i je przywracać za pomocą MainWP i rozszerzenia UpdraftPlus z jednego dashboardu"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Wprowadzenie
 
-Backing up a website is a vital part of running your business. It offers several advantages:
+Tworzenie kopii zapasowej strony to kluczowa praktyka w zarządzaniu firmą. Wiąże się z kilkoma korzyściami:
 
-- **Data security**: Regular backups ensure your website's data is protected in the event of a cyberattack, technical failure or human error.
-- **Protection against update errors**: A backup made before a WordPress plugin or theme is updated allows you to go back in time if an error or version conflict occurs during the update.
-- **Rapid Restore**: In the event of a technical error, the backup can be reverted to a previous version to offer your customers a functional website and business continuity.
-- **Legal Compliance**: Maintaining regular backups may be a regulatory compliance requirement for your organization and may protect you from legal action.
+- **Bezpieczeństwo danych**: regularne kopie zapasowe gwarantują ochronę danych Twojej strony w razie cyberataku, awarii technicznej lub błędu ludzkiego.
+- **Ochrona przed błędami aktualizacji**: kopia zapasowa wykonana przed aktualizacją WordPressa, wtyczki lub motywu pozwala cofnąć zmiany w razie błędu lub konfliktu wersji podczas aktualizacji.
+- **Szybkie przywracanie**: w razie błędu technicznego kopia zapasowa pozwala wrócić do wcześniejszej wersji, aby zapewnić klientom działającą stronę i ciągłość działania firmy.
+- **Zgodność z przepisami**: dla Twojej firmy utrzymywanie regularnych kopii zapasowych może wynikać z wymogów prawnych i chronić Cię przed postępowaniem sądowym.
 
-MainWP offers several extensions for backing up your websites.
+MainWP oferuje kilka rozszerzeń umożliwiających tworzenie kopii zapasowych stron.
 
-**This guide explains how to back up your WordPress websites with the UpdraftPlus extension.**
+**W tym przewodniku dowiesz się, jak tworzyć kopie zapasowe stron WordPress za pomocą rozszerzenia UpdraftPlus.**
 
-## Requirements
+## Wymagania początkowe
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Posiadanie [oferty hostingu Web Cloud](/links/web/hosting).
+- Zalogowanie się do dashboardu MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
 :::
 
-## Instructions
+## W praktyce
 
-### Install the UpdraftPlus extension
+### Instalacja rozszerzenia UpdraftPlus
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Jeśli nigdy nie instalowałeś rozszerzenia MainWP, dowiedz się z [tego przewodnika](/guides/web-cloud/web-hosting/mainwp-general), jak je zainstalować.
 :::
 
-To find all the extensions linked to the backup, go to the [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) section of MainWP. You can also search for an extension by clicking `Extensions` from the MainWP main menu, then `Install Extensions`. Click on the `Backup` tab to view the list of extensions linked to the backup.
+Aby znaleźć wszystkie rozszerzenia związane z kopiami zapasowymi, przejdź do sekcji [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) MainWP. Możesz również wyszukać rozszerzenie, klikając <code className="action">Extensions</code> w menu głównym MainWP, a następnie <code className="action">Install Extensions</code>. Kliknij zakładkę <code className="action">Backup</code>, aby wyświetlić listę rozszerzeń związanych z kopiami zapasowymi.
 
-In this example, we choose the free UpdraftPlus extension, but you are free to choose the extension of your choice.
+W tym przykładzie wybieramy bezpłatne rozszerzenie UpdraftPlus, ale możesz wybrać dowolne rozszerzenie.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+Po wybraniu rozszerzenia kliknij <code className="action">Install Selected Extensions</code>.
 
-Once you have selected the extension, click `Install Selected Extensions`.
+W menu głównym MainWP kliknij <code className="action">Extensions</code>, a następnie <code className="action">Manage Extensions</code>. Wyświetli się wcześniej zainstalowane rozszerzenie UpdraftPlus.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed UpdraftPlus extension appears.
+Kliknij <code className="action">Enable</code>, aby włączyć rozszerzenie. Jeśli komunikat o błędzie wskazuje, że licencja nie jest aktywna, kliknij po prostu przycisk <code className="action">License</code>. Zanim zaczniesz korzystać z UpdraftPlus, musisz włączyć wtyczkę UpdraftPlus na stronach podrzędnych, których kopie zapasowe chcesz tworzyć.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+### Instalacja wtyczki UpdraftPlus na stronie podrzędnej
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button. Before you can use UpdraftPlus, you must enable the UpdraftPlus plugin on the child sites that you want to back up.
+W menu głównym MainWP kliknij <code className="action">Sites</code>, a następnie <code className="action">Install Plugins</code>. W pasku wyszukiwania wpisz "UpdraftPlus".
 
-### Install the UpdraftPlus plugin on a child site
+<img className="thumbnail" alt="Pole wyszukiwania wtyczek MainWP z wpisanym UpdraftPlus" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-In the main menu of MainWP, click `Sites` then `Install Plugins`. In the search bar, type UpdraftPlus.
+Po znalezieniu wtyczki "UpdraftPlus: WordPress Backup & Migration" kliknij <code className="action">Install Plugin</code>. Następnie po prawej stronie ekranu wybierz stronę podrzędną, na której chcesz zainstalować UpdraftPlus. Kliknij <code className="action">Complete Installation</code>. Pamiętaj, aby zaznaczyć <code className="action">Activate after installation</code>.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png)
+Po zakończeniu instalacji przejdź do menu głównego MainWP. Kliknij <code className="action">Sites</code>, <code className="action">Plugins</code>, a następnie <code className="action">Manage Plugins</code>. Aby sprawdzić, czy UpdraftPlus jest zainstalowany na Twoich stronach, wybierz po prawej stronie ekranu odpowiednie strony podrzędne. Niżej, w polu wyszukiwania <code className="action">Search Options</code>, wpisz "UpdraftPlus", a następnie wybierz <code className="action">Show Plugins</code>.
 
-Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click `Install Plugin`. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click `Complete Installation`. Remember to tick `Activate after installation`.
+<img className="thumbnail" alt="Strona Manage Plugins w MainWP z filtrem UpdraftPlus dla stron podrzędnych" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-Once the installation is complete, go to the MainWP main menu. Click `Sites`, `Plugins` then `Manage Plugins`. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field `Search Options`, type "UpdraftPlus" then select `Show Plugins`.
+Wyświetlą się rozszerzenie "MainWP UpdraftPlus Extension" i wtyczka "UpdraftPlus - Backup/Restore", co oznacza, że są poprawnie zainstalowane na odpowiednich stronach podrzędnych.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png)
+Zaznacz rozszerzenie "MainWP UpdraftPlus Extension" i wtyczkę "UpdraftPlus - Backup/Restore", a następnie kliknij <code className="action">Install to Selected Site(s)</code> (przycisk w prawym górnym rogu).
 
-The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Retore" are displayed, which means that they are correctly installed on the child websites concerned.
+Aby upewnić się, że wtyczki są włączone na Twojej stronie podrzędnej, kliknij <code className="action">Sync Dashboard with Sites</code> w prawym górnym rogu interfejsu.
 
-Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Retore" plugin, then click `Install to Selected Site(s)` (button in the top right-hand corner).
+<img className="thumbnail" alt="Przycisk Sync Dashboard with Sites w prawym górnym rogu interfejsu MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
-To ensure that the plugins are enabled on your child website, click `Sync Dashboard with Sites`, in the top right-hand corner of the interface.
+Możesz teraz tworzyć kopie zapasowe swoich stron podrzędnych za pomocą UpdraftPlus.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png)
+### Tworzenie kopii zapasowych za pomocą UpdraftPlus
 
-You can now create backups of your child websites with UpdraftPlus.
+W menu głównym MainWP kliknij <code className="action">Sites</code>, a następnie <code className="action">Manage Sites</code>. Kliknij stronę podrzędną, której kopię zapasową chcesz utworzyć, a następnie kliknij zakładkę <code className="action">UpdraftPlus Backups</code>.
 
-### Create a backup with UpdraftPlus
+Na wyświetlonym ekranie kliknij <code className="action">Backup Now</code> i postępuj zgodnie z instrukcjami. Aby zatwierdzić kopię zapasową, kliknij <code className="action">Backup Now</code>.
 
-In the main menu of MainWP, click `Sites` then `Manage Sites`. Click the child site for which you want to create a backup, then click the `UpdraftPlus Backups` tab.
+<img className="thumbnail" alt="Okno Backup Now w UpdraftPlus na stronie podrzędnej MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/tab-updraftPlus.png)
+Po zakończeniu tworzenia kopii zapasowej kliknij zakładkę <code className="action">ExistingBackups</code>.
 
-On the screen that pops up, click `Backup Now` and follow the instructions. To confirm the backup, click `Backup Now`.
+<img className="thumbnail" alt="Zakładka ExistingBackups w UpdraftPlus z właśnie utworzoną kopią zapasową" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png)
+Pojawi się nowy wiersz odpowiadający Twojej kopii zapasowej. Możesz wykonać na niej różne działania, w tym przywracanie.
 
-Once the backup is complete, click the `ExistingBackups` tab.
+### Przywracanie zapisanej wersji strony podrzędnej
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png)
+W menu głównym MainWP kliknij <code className="action">Extensions</code>, a następnie <code className="action">UpdraftPlus</code>. Po kliknięciu <code className="action">Existing Backups</code> wyświetli się lista Twoich kopii zapasowych.
 
-A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
+Aby przywrócić stronę, znajdź wiersz odpowiadający Twojej kopii zapasowej, a następnie kliknij <code className="action">Restore</code>.
 
-### Restore a backed up version of a child site
+<img className="thumbnail" alt="Wiersz kopii zapasowej w UpdraftPlus z przyciskiem Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
-In the MainWP main menu, click `Extensions` then `UpdraftPlus`. If you click `Existing Backups`, a list of your backups will appear.
+Wyświetli się nowe okno. Zawiera ono szereg informacji, w tym listę Twoich kopii zapasowych.
 
-To restore your website, locate the line corresponding to your backup, then click `Restore`.
+Znajdź kopię zapasową, którą chcesz przywrócić, a następnie kliknij <code className="action">Restore</code>. Pamiętaj, aby sprawdzić datę i uniknąć pomyłki.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png)
+<img className="thumbnail" alt="Okno UpdraftPlus z kopiami zapasowymi dostępnymi do przywrócenia" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-A new window will appear. It contains some information, including a list of your backups.
+Zaznacz elementy, które chcesz przywrócić, a następnie zatwierdź. Wyświetli się następujący komunikat potwierdzający:
 
-Identify the backup you want to restore, then click `Restore`. Remember to check the date to avoid any errors.
+<img className="thumbnail" alt="Komunikat potwierdzający pomyślne zakończenie przywracania w UpdraftPlus" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png)
+## Sprawdź również <a name="go-further"></a>
 
-Select the elements you want to restore, then confirm. The following confirmation message is displayed:
+[Zarządzanie wieloma stronami WordPress za pomocą wtyczki MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png)
+[Zarządzanie informacjami o klientach stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-## Go further <a id="go-further"></a>
+[Poprawa bezpieczeństwa strony WWW za pomocą wtyczki MainWP dla WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Tutorial - Zapisz stronę WWW z modułem WordPress](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Przywracanie plików z kopii zapasowej OVHcloud](/guides/web-cloud/web-hosting/ftp-save-and-backup)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-[Tutorial - Backup your WordPress website](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
-
-[Restore your web hosting plan's storage space](/guides/web-cloud/web-hosting/ftp-save-and-backup)
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
-
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,88 +1,88 @@
 ---
-title: "Managing customer information on your WordPress websites with MainWP"
-description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard"
-lastUpdated: 2024-01-25
+title: Zarządzanie informacjami o klientach stron WordPress za pomocą MainWP
+description: "Dowiedz się, jak zarządzać wszystkimi klientami stron WordPress z poziomu dashboardu MainWP: dodawać, edytować i usuwać ich dane kontaktowe"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Wprowadzenie
 
-Retaining customers is vital to your company's development. Whether you have one or more websites, it's important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+Utrzymanie klientów jest kluczowe dla rozwoju Twojej firmy. Niezależnie od tego, czy prowadzisz jedną czy kilka stron, ważne jest, aby jak najlepiej poznać swoich klientów, by ich utrzymać i zapewnić im satysfakcję. Wtyczka MainWP dla WordPress pozwala skutecznie zarządzać klientami Twoich stron. Podobnie jak w systemie CRM (Customer Relationship Management), możesz bezpłatnie i w kilku kliknięciach dodawać, usuwać i aktualizować wszystkie informacje o klientach.
 
-**This guide will show you how to manage your website's customers' data efficiently using MainWP.**
+**W tym przewodniku dowiesz się, jak skutecznie zarządzać danymi klientów swoich stron za pomocą MainWP.**
 
-## Requirements
+## Wymagania początkowe
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
+- Posiadanie [oferty hostingu Web Cloud](/links/web/hosting).
+- Zalogowanie się do dashboardu MainWP. Więcej informacji znajdziesz w przewodniku [Zarządzanie wieloma stronami WordPress za pomocą wtyczki MainWP](/guides/web-cloud/web-hosting/mainwp-general).
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
 :::
 
-## Instructions
+## W praktyce
 
-In the MainWP main menu, click `Clients`. On the screen that opens, there are three tabs:
+W menu głównym MainWP kliknij <code className="action">Clients</code>. Na wyświetlonym ekranie znajdują się trzy zakładki:
 
-- Customers: displays a list of all your customers
-- Add Client: allows you to create new customers
-- Client Fields: allows you to create new fields related to your customers
+- Customers: wyświetla listę wszystkich Twoich klientów
+- Add Client: umożliwia tworzenie nowych klientów
+- Client Fields: umożliwia tworzenie nowych pól dotyczących Twoich klientów
 
-### Add a customer
+### Dodawanie klienta
 
-To get started, add your first customer. In the main menu of MainWP, click `Clients` then `Add Client`. In the form that appears, fill in your customer's details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click `Add Client`.
+Na początek dodaj swojego pierwszego klienta. W menu głównym MainWP kliknij <code className="action">Clients</code>, a następnie <code className="action">Add Client</code>. W wyświetlonym formularzu wypełnij dane klienta. Po prawej stronie ekranu wybierz strony, na których chcesz utworzyć nowego klienta, a następnie kliknij <code className="action">Add Client</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/add-client.png)
+<img className="thumbnail" alt="Formularz Add Client w MainWP z wypełnionymi danymi klienta" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
-### View your customers
+### Wyświetlanie klientów
 
-In the main menu of MainWP, click `Clients` then `Clients`. A list of all your customers will appear. You can search for a specific customer (in the `Search` field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
+W menu głównym MainWP kliknij <code className="action">Clients</code>, a następnie <code className="action">Clients</code>. Wyświetli się lista wszystkich Twoich klientów. Możesz wyszukać konkretnego klienta (w polu <code className="action">Search</code> w prawym górnym rogu tabeli), wpisując wartość jednego z jego pól, na przykład nazwę.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/search-client.png)
+<img className="thumbnail" alt="Lista klientów MainWP z polem Search w prawym górnym rogu" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
-You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column `Customer Email`) or the number of websites to which your customer is attached (column `Websites`).
+Możesz przeciągać i upuszczać wybrane kolumny, aby wyróżnić istotne informacje o klientach, takie jak adres e-mail (kolumna <code className="action">Customer Email</code>) czy liczba stron przypisanych do klienta (kolumna <code className="action">Websites</code>).
 
-From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click `Bulk actions`, `Delete` then `Apply` to confirm.
+Z poziomu tej tabeli możesz usunąć dowolnego klienta. Zaznacz wiersze odpowiadające klientom, których chcesz usunąć, kliknij <code className="action">Bulk actions</code>, <code className="action">Delete</code>, a następnie <code className="action">Apply</code>, aby potwierdzić.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png)
+<img className="thumbnail" alt="Tabela klientów MainWP z opcjami Bulk actions i Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
-Finally, click `Yes, proceed` to confirm the deletion of the customers.
+Na koniec kliknij <code className="action">Yes, proceed</code>, aby potwierdzić usunięcie klientów.
 
-In the table representing your customers, identify the customer of your choice and click on the `...`.
+W tabeli z klientami znajdź wybranego klienta i kliknij <code className="action">...</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/more-client.png)
+<img className="thumbnail" alt="Menu akcji klienta w tabeli klientów MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-You can:
+Możesz:
 
-- edit customer information (`Edit`)
-- delete the customer (`Delete`)
-- see the websites concerned by your customer (`View Sites`)
+- edytować informacje o kliencie (<code className="action">Edit</code>)
+- usunąć klienta (<code className="action">Delete</code>)
+- zobaczyć strony powiązane z klientem (<code className="action">View Sites</code>)
 
-### Create new fields for your customers
+### Tworzenie nowych pól dla klientów
 
-For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
-In the main menu of MainWP, click `Clients` then `Clients Fields`. To create a new field, click `New Field`. In the window that appears, enter the name and description for your new field.
+Dla każdego klienta dostępnych jest wiele domyślnych pól, takich jak nazwa, adres e-mail, kraj, numer telefonu czy odnośniki do sieci społecznościowych. Jeśli chcesz dodać konkretne informacje, których nie ma domyślnie, możesz ręcznie dodać wybrane pola.
+W menu głównym MainWP kliknij <code className="action">Clients</code>, a następnie <code className="action">Clients Fields</code>. Aby utworzyć nowe pole, kliknij <code className="action">New Field</code>. W wyświetlonym oknie wpisz nazwę i opis nowego pola.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png)
+<img className="thumbnail" alt="Okno MainWP tworzenia nowego pola klienta z jego nazwą i opisem" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click `Save Field`. Now, when creating a new customer, the new "loyalty" field will be available.
+W naszym przykładzie tworzymy nowe pole "loyalty" wraz z opisem. Aby zatwierdzić utworzenie nowego pola, kliknij <code className="action">Save Field</code>. Od teraz przy tworzeniu nowego klienta nowe pole "loyalty" będzie dostępne.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png)
+<img className="thumbnail" alt="Formularz Add Client w MainWP z nowym polem loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
+Po utworzeniu nowego klienta przejdź do listy klientów. Kliknij dopiero co utworzonego klienta. Wyświetlą się nowe pole "loyalty" i odpowiadająca mu wartość.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/details-client.png)
+<img className="thumbnail" alt="Szczegóły klienta MainWP z polem loyalty i jego wartością" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
-## Go further <a id="go-further"></a>
+## Sprawdź również <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Zarządzanie wieloma stronami WordPress za pomocą wtyczki MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Poprawa bezpieczeństwa strony WWW za pomocą wtyczki MainWP dla WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Tworzenie kopii zapasowych stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,185 +1,199 @@
 ---
-title: "Managing multiple WordPress websites with the MainWP plugin"
-description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin"
-lastUpdated: 2024-01-25
+title: Zarządzanie wieloma stronami WordPress za pomocą wtyczki MainWP
+description: "Dowiedz się, jak zarządzać wieloma stronami WordPress z jednego narzędzia dzięki wtyczce MainWP: aktualizacje, rozszerzenia i strony podrzędne"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Wprowadzenie
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Zarządzanie wieloma stronami bywa złożone i czasochłonne. Jeśli prowadzisz kilka stron WordPress, musisz zadbać o ich obsługę techniczną, aktualizacje wtyczek i motywów, a także o dane logowania. Wtyczka MainWP dla WordPress to skuteczne rozwiązanie pozwalające zarządzać wieloma stronami WordPress z jednego dashboardu. MainWP umożliwia:
 
-- control all your websites from a single dashboard
-- update the technical components in one click
-- [manage your customer information](/guides/web-cloud/web-hosting/mainwp-client-management)
-- download extensions to perform multiple tasks
+- kontrolować wszystkie strony z jednego dashboardu
+- aktualizować komponenty techniczne jednym kliknięciem
+- [zarządzać informacjami o klientach](/guides/web-cloud/web-hosting/mainwp-client-management)
+- pobierać rozszerzenia do wykonywania wielu zadań
 
-**Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
+**Dowiedz się, jak korzystać z dashboardu MainWP, aby zarządzać wieloma stronami WordPress.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+W tym przewodniku wybraliśmy wtyczkę MainWP. Istnieją inne podobne rozwiązania — oczywiście możesz wybrać dowolną wtyczkę.
+
 :::
 
-## Requirements
+## Wymagania początkowe
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
-- Access to the WordPress administration interface.
+- Posiadanie [oferty hostingu Web Cloud](/links/web/hosting).
+- Dostęp do interfejsu administracyjnego WordPress.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
 :::
 
-## Instructions
+{/* CP-NAV-START:web-hosting */}
+---
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+### Dostęp do Panelu klienta OVHcloud
 
-![mainWP](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png)
+- **Link bezpośredni:** <ManagerLink to="/#/web/hosting">Hosting</ManagerLink>
+- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Hosting</code> > Wybierz hosting WWW
 
-Enter your login and password to log in. The WordPress dashboard appears.
+---
+{/* CP-NAV-END:web-hosting */}
 
-### Install the MainWP plugin 
+## W praktyce
 
-Go to the main WordPress menu, on the left-hand side of the screen, and click `Plugins` then `Add New Plugin`.
+Jeśli nie jesteś jeszcze zalogowany, przejdź do interfejsu administracyjnego modułu CMS, dla którego chcesz zainstalować dashboard MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png)
+<img className="thumbnail" alt="Panel klienta OVHcloud z listą modułów CMS i odnośnikiem do administracji" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
+Wpisz swój login i hasło, aby się zalogować. Wyświetli się dashboard WordPress.
+
+### Instalacja wtyczki MainWP
+
+Przejdź do menu głównego WordPress po lewej stronie ekranu i kliknij <code className="action">Plugins</code>, a następnie <code className="action">Add New Plugin</code>.
+
+<img className="thumbnail" alt="Menu WordPress z pozycją Plugins i opcją Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+
+Wyświetli się lista najpopularniejszych wtyczek WordPress. W pasku wyszukiwania w prawym górnym rogu wpisz "MainWP" i zatwierdź. Wśród wyników pojawi się kilka wtyczek oferowanych przez "MainWP". Zainstaluj następujące dwie wtyczki:
 
 - MainWP Dashboard
 - Child MainWP
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png)
+<img className="thumbnail" alt="Wyniki wyszukiwania wtyczek WordPress z MainWP Dashboard i MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br />
-MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
+MainWP Dashboard to główna wtyczka pozwalająca zarządzać stronami z jednego dashboardu.
+
+MainWP Child umożliwia połączenie Twojej strony WordPress (nazywanej też "stroną podrzędną") z MainWP Dashboard.
 
 :::warning
-An error may occur if you install MainWP Child first. Make sure to install MainWP Dashboard **before** MainWP Child.
+Jeśli najpierw zainstalujesz MainWP Child, może wystąpić błąd. Zainstaluj MainWP Dashboard **przed** MainWP Child.
+
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
-Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
+Po zainstalowaniu obu wtyczek pamiętaj, aby je włączyć, by móc z nich korzystać.
+Po zainstalowaniu i włączeniu obu wtyczek u góry ekranu pojawi się następujący komunikat ostrzegawczy:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png)
+<img className="thumbnail" alt="Komunikat ostrzegawczy zachęcający do połączenia strony podrzędnej z MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
-This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
+Ten komunikat informuje, że właśnie włączyłeś wtyczkę MainWP Child i że musisz teraz połączyć swoją stronę podrzędną z MainWP Dashboard. Ze względów bezpieczeństwa wyłącz wtyczkę MainWP Child, jeśli nie chcesz od razu połączyć strony podrzędnej. Włącz ją ponownie, gdy będziesz gotowy połączyć swoją stronę WordPress z dashboardem MainWP.
 
-### Connect a child site to the MainWP dashboard
+### Podłączanie strony podrzędnej do dashboardu MainWP
 
-In the main menu on the left, click `Sites`, then `Add New`. The following screen appears:
+W menu głównym po lewej stronie kliknij <code className="action">Sites</code>, a następnie <code className="action">Add New</code>. Wyświetli się następujący ekran:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png)
+<img className="thumbnail" alt="Formularz MainWP dodawania nowej strony podrzędnej" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
+Wpisz adres URL strony podrzędnej, którą chcesz połączyć z dashboardem MainWP. Poniżej zaznacz przycisk wskazujący, że zainstalowałeś i włączyłeś wtyczkę MainWP Child na swojej stronie podrzędnej. Wyświetlą się następujące dwa nowe pola:
 
-- `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the `Web Cloud` section. Select the web hosting plan concerned, and click the `1-click modules` tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the `Login` column.
-- `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
+- `Administrator username`: zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, a następnie przejdź do sekcji <code className="action">Web Cloud</code>. Wybierz odpowiedni hosting i kliknij zakładkę <code className="action">Moduły CMS</code>. W wyświetlonej tabeli znajdź wiersz odpowiadający Twojemu modułowi. Nazwa administratora znajduje się w kolumnie <code className="action">Login</code>.
+- `Site title`: wpisz wybraną wartość. Jeśli podłączasz wiele stron podrzędnych, wpisz jednoznaczną nazwę strony.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site.png)
+<img className="thumbnail" alt="Formularz dodawania strony MainWP z wypełnioną nazwą administratora i tytułem strony" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-When all the fields of the form are filled in, click the `Add Site` button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
+Gdy wszystkie pola formularza są wypełnione, kliknij przycisk <code className="action">Add Site</code> pod formularzem, aby zatwierdzić. Jeśli nie wystąpi błąd, otrzymasz następujący komunikat potwierdzający, że Twoja strona podrzędna jest połączona z dashboardem MainWP:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png)
+<img className="thumbnail" alt="Komunikat potwierdzający połączenie strony podrzędnej z dashboardem MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
-To check that your child website is available in the MainWP dashboard, click `Sites` in the main menu on the left-hand side, then `Manage Sites`.
+Aby sprawdzić, czy Twoja strona podrzędna jest dostępna w dashboardzie MainWP, kliknij <code className="action">Sites</code> w menu głównym po lewej stronie, a następnie <code className="action">Manage Sites</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png)
+<img className="thumbnail" alt="Strona Manage Sites w MainWP z listą połączonych stron podrzędnych" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
-In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
+W naszym przykładzie strona "my website" pojawia się na liście stron podrzędnych połączonych z dashboardem MainWP. Możesz dodać dowolną liczbę stron podrzędnych.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png)
+<img className="thumbnail" alt="Widok siatki w MainWP ze wszystkimi połączonymi stronami podrzędnymi" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
-Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
+Pamiętaj, aby zainstalować wtyczkę MainWP Child na każdej stronie podrzędnej, którą chcesz połączyć z dashboardem MainWP.
+
 :::
 
-### Manage software updates from the MainWP dashboard
+### Zarządzanie aktualizacjami z poziomu dashboardu MainWP
 
-If you use several plugins and themes for your websites, you may encounter errors due to the different versions. With the MainWP dashboard, you can manage the following updates in one place:
+Jeśli używasz kilku wtyczek i motywów na swoich stronach, mogą wystąpić błędy wynikające z różnych wersji. Dashboard MainWP pozwala zarządzać w jednym miejscu aktualizacjami:
 
 - WordPress
-- Plugins
-- Themes
-- Translations
+- Wtyczki
+- Motywy
+- Tłumaczenia
 
-In the main menu on the left, click `Sites` then `Updates`. The following screen appears:
+W menu głównym po lewej stronie kliknij <code className="action">Sites</code>, a następnie <code className="action">Updates</code>. Wyświetli się następujący ekran:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png)
+<img className="thumbnail" alt="Strona Updates w MainWP z dostępnymi aktualizacjami wtyczek i motywów" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
-At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the `Themes Updates` tab, you will see a list of the four themes affected by the updates.
+U góry interfejsu zakładki wskazują, że dostępne są aktualizacje jednej wtyczki i czterech motywów. Kliknij wybraną zakładkę, aby wyświetlić dostępne aktualizacje. W naszym przykładzie, po kliknięciu zakładki <code className="action">Themes Updates</code>, zobaczysz listę czterech motywów objętych aktualizacjami.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png)
+<img className="thumbnail" alt="Zakładka Themes Updates w MainWP z czterema motywami do aktualizacji" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
-If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click `Update Selected Themes`.
-The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
+Jeśli chcesz zaktualizować kilka motywów (lub wszystkie naraz), zaznacz odpowiednie wiersze (zaznaczając pole po lewej stronie każdego wiersza), a następnie kliknij <code className="action">Update Selected Themes</code>.
+Wyświetli się następujący komunikat potwierdzający, wskazujący strony, na których zostaną zaktualizowane wybrane motywy.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png)
+<img className="thumbnail" alt="Komunikat potwierdzający z listą stron, na których zostaną zaktualizowane wybrane motywy" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
-In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click `Yes, proceed` to confirm. The progress window appears. It will close when the updates are complete.
+W naszym przykładzie wybrane motywy zostaną zaktualizowane na stronach "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" i "blog 3". Kliknij <code className="action">Yes, proceed</code>, aby potwierdzić. Wyświetli się okno postępu. Zamknie się ono po zakończeniu aktualizacji.
 
-Do the same to update WordPress, your plugins or your translations.
+Postępuj tak samo, aby zaktualizować WordPressa, wtyczki lub tłumaczenia.
 
-### Extensions
+### Rozszerzenia
 
-MainWP offers native features, such as software update management or [customer information management](/guides/web-cloud/web-hosting/mainwp-client-management). However, MainWP becomes even more powerful thanks to its many extensions, offering a wide range of features.
+MainWP oferuje natywne funkcje, takie jak zarządzanie aktualizacjami czy [zarządzanie informacjami o klientach](/guides/web-cloud/web-hosting/mainwp-client-management). MainWP staje się jednak jeszcze potężniejszy dzięki licznym rozszerzeniom o szerokim wachlarzu funkcji.
 
-There are different [extension categories](https://mainwp.com/mainwp-extensions/), such as Administrative, Backup, Analytics, Security, etc. For each of the categories, there are three different types of extensions:
+Istnieją różne [kategorie rozszerzeń](https://mainwp.com/mainwp-extensions/), takie jak Administrative, Backup, Analytics czy Security. W każdej kategorii występują trzy różne typy rozszerzeń:
 
-- Free: free extensions developed by MainWP
-- Professional: premium extensions developed by MainWP
-- .Org: free extensions developed by a third-party publisher
+- Free: bezpłatne rozszerzenia opracowane przez MainWP
+- Professional: płatne rozszerzenia opracowane przez MainWP
+- .Org: bezpłatne rozszerzenia opracowane przez zewnętrznego wydawcę
 
-Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-account/) to create your account.
+Zanim zainstalujesz rozszerzenie, utwórz konto na [MainWP.com](https://mainwp.com/my-account/).
 
-#### Order an extension
+#### Zamawianie rozszerzenia
 
-Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
+Po utworzeniu konta MainWP przejdź do [sekcji rozszerzeń MainWP.com](https://mainwp.com/mainwp-extensions/). W naszym przykładzie wybieramy bezpłatne rozszerzenie UpdraftPlus. Kliknij rozszerzenie UpdraftPlus.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png)
+<img className="thumbnail" alt="Karta rozszerzenia UpdraftPlus na stronie rozszerzeń MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
-A page dedicated to the extension will appear. Click `Get the free Bundle`, then `Proceed to checkout`. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking `Place order`.
+Wyświetli się strona poświęcona rozszerzeniu. Kliknij <code className="action">Get the free Bundle</code>, a następnie <code className="action">Proceed to checkout</code>. Nie musisz podawać danych płatności, ponieważ rozszerzenie jest bezpłatne. Wpisz tylko wymagane informacje. Zaznacz wymagane pola i na koniec kliknij <code className="action">Place order</code>.
 
-You will now need to retrieve the API key corresponding to your MainWP username, which will enable you to log in to the MainWP dashboard to download the extensions of your choice.
+Teraz musisz pobrać klucz API odpowiadający Twojej nazwie użytkownika MainWP, który pozwoli Ci zalogować się do dashboardu MainWP i pobrać wybrane rozszerzenia.
 
-#### Enter the API key
+#### Wprowadzanie klucza API
 
-Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
+Przejdź do [swojego konta MainWP](https://mainwp.com/my-account/my-api-keys/) i skopiuj klucz API.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png)
+<img className="thumbnail" alt="Strona konta MainWP z kluczem API do skopiowania" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
-Go back to the MainWP dashboard and click on `Extensions` in the main menu on the left. In the top right-hand corner of the screen that appears, click `Install and Activate Extensions`.
+Wróć do dashboardu MainWP i kliknij <code className="action">Extensions</code> w menu głównym po lewej stronie. W prawym górnym rogu wyświetlonego ekranu kliknij <code className="action">Install and Activate Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png)
+<img className="thumbnail" alt="Strona Extensions w MainWP z przyciskiem Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-In the `Enter your MainWP API Key` field, paste the API key you have previously copied, tick the `Remember MainWP Main API Key` box and click `Validate my MainWP Main API Key`. If there are no errors, the following confirmation message is displayed:
+W polu <code className="action">Enter your MainWP API Key</code> wklej wcześniej skopiowany klucz API, zaznacz pole <code className="action">Remember MainWP Main API Key</code> i kliknij <code className="action">Validate my MainWP Main API Key</code>. Jeśli nie wystąpi błąd, wyświetli się następujący komunikat potwierdzający:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png)
+<img className="thumbnail" alt="Komunikat potwierdzający poprawność klucza API MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
-Finally, click `Install Extension` to install the extensions of your choice.
+Na koniec kliknij <code className="action">Install Extension</code>, aby zainstalować wybrane rozszerzenia.
 
-#### Install an extension
+#### Instalacja rozszerzenia
 
-After clicking `Install Extensions`, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click `Install Selected Extensions`.
+Po kliknięciu <code className="action">Install Extensions</code> wyświetli się okno z listą dostępnych rozszerzeń, posortowanych według kategorii. W naszym przykładzie wybieramy bezpłatne rozszerzenie "UpdraftPlus" z kategorii Backups. Po wybraniu UpdraftPlus kliknij <code className="action">Install Selected Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+<img className="thumbnail" alt="Lista rozszerzeń MainWP z zaznaczonym UpdraftPlus w kategorii Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
-Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
+Po zakończeniu instalacji UpdraftPlus jest dostępny na liście rozszerzeń Twojego dashboardu MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+<img className="thumbnail" alt="UpdraftPlus na liście rozszerzeń dashboardu MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button.
+Kliknij <code className="action">Enable</code>, aby włączyć rozszerzenie. Jeśli komunikat o błędzie wskazuje, że licencja nie jest aktywna, kliknij po prostu przycisk <code className="action">License</code>.
 
-## Go further <a id="go-further"></a>
+## Sprawdź również <a name="go-further"></a>
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Zarządzanie informacjami o klientach stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Poprawa bezpieczeństwa strony WWW za pomocą wtyczki MainWP dla WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Tworzenie kopii zapasowych stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,97 +1,97 @@
 ---
-title: "Improving your website's security with the MainWP plugin for WordPress"
-description: "Find out how to control the security of your websites from a single interface using MainWP"
-lastUpdated: 2024-01-25
+title: Poprawa bezpieczeństwa strony WWW za pomocą wtyczki MainWP dla WordPress
+description: "Dowiedz się, jak kontrolować bezpieczeństwo swoich stron z jednego interfejsu za pomocą MainWP i rozszerzenia Sucuri: skanowanie i poprawki"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Wprowadzenie
 
-Maintaining the security of your websites is crucial for the development of your brand. Optimum security for your websites can protect your company's data, as well as your customers' data, thereby preserving your company's image and trust. With extensions to the WordPress MainWP plugin, you can control the security of your websites from a single interface.
+Utrzymanie bezpieczeństwa stron jest kluczowe dla rozwoju Twojej marki. Optymalne zabezpieczenie stron chroni dane Twojej firmy oraz dane Twoich klientów, a tym samym wizerunek firmy i zaufanie do niej. Rozszerzenia wtyczki MainWP dla WordPress pozwalają kontrolować bezpieczeństwo stron z jednego interfejsu.
 
-**This guide will show you how to improve website security via the MainWP dashboard**
+**W tym przewodniku dowiesz się, jak poprawić bezpieczeństwo swojej strony z poziomu dashboardu MainWP.**
 
-## Requirements
+## Wymagania początkowe
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Posiadanie [oferty hostingu Web Cloud](/links/web/hosting).
+- Zalogowanie się do dashboardu MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
 :::
 
-## Instructions
+## W praktyce
 
-### Install the Sucuri extension
+### Instalacja rozszerzenia Sucuri
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Jeśli nigdy nie instalowałeś rozszerzenia MainWP, dowiedz się z [tego przewodnika](/guides/web-cloud/web-hosting/mainwp-general), jak je zainstalować.
 :::
 
-To find all the security-related extensions, go to the [security](https://mainwp.com/mainwp-extensions/extension-category/security/) section of MainWP. You can also search for an extension by clicking `Extensions` in the MainWP main menu, then `Install Extensions`.
+Aby znaleźć wszystkie rozszerzenia związane z bezpieczeństwem, przejdź do sekcji [security](https://mainwp.com/mainwp-extensions/extension-category/security/) MainWP. Możesz również wyszukać rozszerzenie, klikając <code className="action">Extensions</code> w menu głównym MainWP, a następnie <code className="action">Install Extensions</code>.
 
-Click on the `Security` tab to view the list of security-related extensions. In this example, we choose the free Sucuri extension, but you are free to choose the extension of your choice. Once you have selected the extension, click `Install Selected Extensions`.
+Kliknij zakładkę <code className="action">Security</code>, aby wyświetlić listę rozszerzeń związanych z bezpieczeństwem. W tym przykładzie wybieramy bezpłatne rozszerzenie Sucuri, ale możesz wybrać dowolne rozszerzenie. Po wybraniu rozszerzenia kliknij <code className="action">Install Selected Extensions</code>.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed Sucuri extension appears.
+W menu głównym MainWP kliknij <code className="action">Extensions</code>, a następnie <code className="action">Manage Extensions</code>. Wyświetli się wcześniej zainstalowane rozszerzenie Sucuri.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png)
+<img className="thumbnail" alt="Rozszerzenie Sucuri na stronie Manage Extensions w MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
-If you have not already done so, click `Enable`, then `License` to use the extension.
+Jeśli jeszcze tego nie zrobiłeś, kliknij <code className="action">Enable</code>, a następnie <code className="action">License</code>, aby korzystać z rozszerzenia.
 
-### Perform a security scan
+### Przeprowadzanie skanowania bezpieczeństwa
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click on the `Security` tab.
+W menu głównym MainWP kliknij <code className="action">Sites</code>, a następnie wybierz wybraną stronę podrzędną. U góry ekranu kliknij zakładkę <code className="action">Security</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png)
+<img className="thumbnail" alt="Zakładka Security strony podrzędnej MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
-To perform a security scan on your website, click `Scan Website`.
+Aby przeprowadzić skanowanie bezpieczeństwa swojej strony, kliknij <code className="action">Scan Website</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png)
+<img className="thumbnail" alt="Skaner Sucuri z przyciskiem Scan Website na stronie podrzędnej MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
-Once the security scan is complete, a new line will appear, corresponding to the security scan report.
+Po zakończeniu skanowania bezpieczeństwa pojawi się nowy wiersz odpowiadający raportowi ze skanowania.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png)
+<img className="thumbnail" alt="Nowy wiersz odpowiadający raportowi ze skanowania bezpieczeństwa Sucuri" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
-Click `Show Report` to view the security report.
+Kliknij <code className="action">Show Report</code>, aby wyświetlić raport bezpieczeństwa.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png)
+<img className="thumbnail" alt="Szczegóły raportu ze skanowania bezpieczeństwa Sucuri dla strony podrzędnej" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-The security scan report provides a lot of important information about the security of your website:
+Raport ze skanowania bezpieczeństwa dostarcza wielu istotnych informacji o bezpieczeństwie Twojej strony:
 
-- presence of viruses and malicious software
-- anomaly detection
-- dangerous links
-- SPAM attempts
-- etc.
+- obecność wirusów i złośliwego oprogramowania
+- wykrywanie anomalii
+- niebezpieczne odnośniki
+- próby spamu
+- itp.
 
-Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of `Remind me if I don't scan my child site for`. For example, if you choose `1 week`, Sucuri will remind you every week to carry out a security scan.
+Pamiętaj o regularnym przeprowadzaniu skanowania bezpieczeństwa. Sucuri pozwala włączyć przypomnienie. Pod listą raportów bezpieczeństwa kliknij listę rozwijaną po prawej stronie pola <code className="action">Remind me if I don't scan my child site for</code>. Jeśli na przykład wybierzesz <code className="action">1 week</code>, Sucuri będzie co tydzień przypominać Ci o przeprowadzeniu skanowania.
 
-### Identify and resolve security issues
+### Identyfikacja i rozwiązywanie problemów z bezpieczeństwem
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click the `Security` tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
+W menu głównym MainWP kliknij <code className="action">Sites</code>, a następnie wybierz wybraną stronę podrzędną. U góry ekranu kliknij zakładkę <code className="action">Security</code>. Na wyświetlonym dashboardzie zobaczysz, czy Sucuri wykryło problemy z bezpieczeństwem.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png)
+<img className="thumbnail" alt="Dashboard Sucuri z problemami bezpieczeństwa wykrytymi na stronie podrzędnej" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
-In our example, Sucuri tells us that three security issues have been identified. Click `Fix all issues` to resolve all security issues. If you would like to find out more about the issues identified, click the `Security` tab at the top of the interface. A list of security issues is displayed.
+W naszym przykładzie Sucuri informuje o wykryciu trzech problemów z bezpieczeństwem. Kliknij <code className="action">Fix all issues</code>, aby rozwiązać wszystkie problemy. Jeśli chcesz dowiedzieć się więcej o wykrytych problemach, kliknij zakładkę <code className="action">Security</code> u góry interfejsu. Wyświetli się lista problemów z bezpieczeństwem.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-list.png)
+<img className="thumbnail" alt="Lista problemów bezpieczeństwa wykrytych przez Sucuri na stronie podrzędnej" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
-To resolve an issue, identify the corresponding line and click the `Fix` button to the right of the line.
+Aby rozwiązać problem, znajdź odpowiedni wiersz i kliknij przycisk <code className="action">Fix</code> po jego prawej stronie.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png)
+<img className="thumbnail" alt="Problem bezpieczeństwa rozwiązany w Sucuri z dostępnym przyciskiem Unfix" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
-Once the problem has been resolved, you can cancel the changes made by clicking the `Unfix` button.
+Po rozwiązaniu problemu możesz cofnąć wprowadzone zmiany, klikając przycisk <code className="action">Unfix</code>.
 
-## Go further <a id="go-further"></a>
+## Sprawdź również <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Zarządzanie wieloma stronami WordPress za pomocą wtyczki MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Manage customers for your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Zarządzanie informacjami o klientach stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Tworzenie kopii zapasowych stron WordPress za pomocą MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój itp.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/api-webhosting.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/api-webhosting.mdx
@@ -1,1 +1,413 @@
-../../../../en/guides/web-cloud/web-hosting/api-webhosting.mdx
+---
+title: Como criar e gerir uma aplicação web utilizando a API pública da OVHcloud
+description: "Saiba como utilizar a API pública da OVHcloud para criar uma aplicação web: associar domínios, gerir bases de dados e configurar certificados SSL"
+lastUpdated: 2026-08-19
+availableIn: [eu, ca, apac]
+---
+
+import Api from '@components/Api';
+
+## Objetivo
+
+Este guia explica-lhe como utilizar a API pública da OVHcloud para criar e gerir uma aplicação web no seu alojamento. Vai aprender a efetuar as operações essenciais: associar domínios, gerir bases de dados e configurar certificados SSL.
+
+## Requisitos
+
+- Dispor de uma oferta de [alojamento web OVHcloud](/links/web/hosting).
+- Conhecimentos básicos da API REST.
+- Ter acesso à API da OVHcloud. Consulte o nosso guia [Primeiros passos com as API OVHcloud](/guides/manage-and-operate/api/first-steps).
+
+:::warning
+A utilização das API da OVHcloud exige conhecimentos avançados nesta área. Em caso de dificuldade, contacte os [parceiros OVHcloud](/links/partner).
+:::
+
+## Instruções
+
+### Obter as informações do serviço
+
+O primeiro passo consiste em obter o `serviceName`, um identificador único do seu serviço de alojamento web. Vai precisar dele para a maioria das chamadas à API seguintes.
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web"} />
+
+Este comando devolve uma lista dos seus serviços de alojamento web. Cada entrada da lista é um `serviceName`.
+
+**Exemplo de resposta**:
+
+```json
+[
+  "example.cluster01.hosting.ovh.net",
+  "example2.cluster02.hosting.ovh.net"
+]
+```
+
+### Associar um domínio
+
+Associe um domínio ao seu serviço de alojamento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/attachedDomain"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| bypassDNSConfiguration | não | Se estiver ativado, a zona DNS não será atualizada |
+| cdn | não | Indica se o domínio está associado ao CDN do alojamento. Valores permitidos: active┃none |
+| domain | não | Domínio a associar |
+| firewall | não | Indica se a firewall está ativa para este domínio. Valores permitidos: active┃none |
+| ipLocation | não | Define a localização IP associada ao domínio. Valores permitidos: BE┃CA┃CZ┃DE┃ES┃FI┃FR┃IE┃IT┃LT┃NL┃PL┃PT┃UK |
+| ownLog | não | Domínio para separar os logs |
+| path | não | Caminho onde serão armazenados os ficheiros web |
+| runtimeId | não | Identificador da configuração runtime utilizada neste domínio |
+| ssl | não | Opção para ativar o SSL no domínio |
+
+**Exemplo de resposta**:
+
+```json
+{
+ "doneDate": "2024-08-22T08:13:50.740Z",
+ "function": "abuse/close",
+ "id": 0,
+ "lastUpdate": "2024-08-22T08:13:50.740Z",
+ "objectId": "string",
+ "objectType": "Abuse",
+ "startDate": "2024-08-22T08:13:50.740Z",
+ "status": "cancelled"
+}
+```
+
+### Gerar certificados SSL
+
+Configure e faça a gestão dos certificados SSL para proteger o seu site:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/ssl"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| certificate | não | Certificado SSL a instalar |
+| chain | não | Cadeia de certificados utilizada para validar o certificado SSL |
+| key | não | Chave privada associada ao certificado SSL |
+
+**Exemplo de resposta**:
+
+```json
+{
+ "isReportable": false,
+ "provider": "COMODO",
+ "regenerable": false,
+ "status": "created",
+ "taskId": 0,
+ "type": "CUSTOM"
+}
+```
+
+### Gerir as bases de dados
+
+As API de alojamento web da OVHcloud permitem-lhe igualmente gerir as suas bases de dados.
+
+#### Criar uma base de dados
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| capacity | sim | Capacidades da base de dados. Valores: extraSqlPersonal┃local┃privateDatabase┃sqlLocal┃sqlPersonal┃sqlPro |
+| user | sim | Nome de utilizador da base de dados. Deve estar em minúsculas e começar pelo identificador do seu alojamento web |
+| password | não | Palavra-passe da base de dados |
+| quota | não | Espaço atribuído. Valores: 25┃100┃200┃256┃400┃512┃800┃1024 |
+| type | sim | Tipo de base de dados. Valores: mariadb┃mysql┃postgresql┃redis |
+| version | não | Versão da base de dados |
+
+**Exemplo de resposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar as bases de dados existentes
+
+Liste todas as bases de dados associadas ao seu serviço de alojamento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| mode | sim | Valores permitidos: besteffort ┃ classic ┃ module |
+
+**Exemplo de resposta**:
+
+```json
+[
+ "example.mysql.db",
+ "example2.mysql.db"
+]
+```
+
+### Gerir os módulos
+
+#### Obter uma lista de módulos
+
+Obtenha uma lista dos módulos disponíveis que pode instalar no seu alojamento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| active | não | Filtra os módulos ativados ou desativados |
+| branch | não | Filtra os módulos consoante a versão. Valores permitidos: old ┃ stable ┃ testing |
+| latest | não | Filtro que permite exibir os módulos correspondentes à versão mais recente |
+
+**Exemplo de resposta**:
+
+```json
+[
+ 195,
+ 184,
+ 38,
+ 176
+]
+```
+
+#### Obter as informações de um módulo
+
+Obtenha os detalhes de um módulo específico instalado no seu alojamento web:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/moduleList/\{id\}"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| id | sim | Identificador do módulo |
+
+**Exemplo de resposta**:
+
+```json
+{
+ "keywords": [
+   "gallery"
+ ],
+ "adminNameType": "string",
+ "author": "OVH",
+ "branch": "old",
+ "id": 195,
+ "size": {
+   "value": 0,
+   "unit": "B"
+ },
+ "name": "myname",
+ "upgradeFrom": [],
+ "language": [
+   "en",
+   "fr",
+   "de",
+   "es",
+   "pl"
+ ],
+ "version": "1.4.2.2",
+ "active": false,
+ "languageRequirement": {
+   "value": "php",
+   "unit": "supported versions: ''\nnon supported versions: '8+'"
+ },
+ "latest": true
+}
+```
+
+### Instalar um novo módulo
+
+Instale um novo módulo no seu serviço de alojamento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/module"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| moduleId | sim | Identificador do módulo a instalar |
+| adminName | não | Nome do administrador |
+| adminpassword | não | Palavra-passe da conta de administrador |
+| domain | não | Nome de domínio onde o módulo será implementado |
+| language | não | Idioma da instalação do módulo |
+| path | não | Caminho no servidor onde o módulo será instalado |
+| dependencies -> name | não | Nome do serviço dependente |
+| dependencies -> password | não | Palavra-passe do serviço dependente |
+| dependencies -> port | não | Porta de ligação do serviço |
+| dependencies -> prefix | não | Prefixo utilizado na configuração do serviço |
+| dependencies -> server | não | Endereço do servidor do serviço dependente |
+| dependencies -> type | não | Tipo de serviço (ex.: MySQL) |
+| dependencies -> user | não | Nome de utilizador do serviço dependente |
+
+**Exemplo de resposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+### Gerir os utilizadores FTP
+
+Faça a gestão dos utilizadores FTP/SSH do seu alojamento web para facilitar os acessos e as configurações.
+
+#### Criar um novo utilizador FTP/SSH
+
+Crie um novo utilizador FTP ou SSH para aceder ao seu alojamento web:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| home | sim | Diretório principal |
+| login | sim | Nome de utilizador |
+| password | sim | Palavra-passe |
+| sshState | não | Determina o estado do acesso SSH do utilizador. Valores permitidos: active ┃none ┃sftponly |
+
+**Exemplo de resposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar os utilizadores FTP/SSH
+
+Liste todos os utilizadores FTP/SSH existentes no seu serviço de alojamento:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/user"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| home | não | Filtra os utilizadores consoante o respetivo diretório principal |
+| login | não | Filtra os utilizadores consoante o respetivo nome de utilizador |
+
+**Exemplo de resposta**:
+
+```json
+[
+ "user1",
+ "user2",
+ "user3",
+ "user4"
+]
+```
+
+### Restaurar uma base de dados
+
+Crie, liste e restaure backups de bases de dados do seu site.
+
+#### Criar um backup de uma base de dados
+
+Crie um backup da sua base de dados para a restaurar em caso de necessidade:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| name | sim | Nome da base de dados |
+| date | sim | Tipo de backup. Valores permitidos: daily.1┃now┃weekly.1 |
+| sendEmail | não | Se este parâmetro estiver ativado, é enviado um e-mail quando o backup fica disponível |
+
+**Exemplo de resposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+#### Listar os backups de bases de dados disponíveis
+
+Liste todos os backups disponíveis para as suas bases de dados:
+
+<Api version="v1" section="/hosting/web" method="GET" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| name | sim | Nome da base de dados |
+| creationDate.from | não | Filtra os backups criados a partir desta data |
+| creationDate.to | não | Filtra os backups criados até esta data |
+| deletionDate.from | não | Filtra os backups eliminados a partir desta data |
+| deletionDate.to | não | Filtra os backups eliminados até esta data |
+| type | não | Filtra os backups consoante o tipo. Valores permitidos: daily.1┃now┃weekly.1 |
+
+**Exemplo de resposta**:
+
+```json
+[
+ 1,
+ 12
+]
+```
+
+#### Restaurar um backup específico de uma base de dados
+
+Restaure um backup específico da sua base de dados em caso de problema:
+
+<Api version="v1" section="/hosting/web" method="POST" route={"/hosting/web/\{serviceName\}/database/\{name\}/dump/\{id\}/restore"} />
+
+| Parâmetro | Obrigatório | Descrição |
+|---|---|---|
+| serviceName | sim | Nome do serviço |
+| name | sim | Nome da base de dados |
+| id | sim | Identificador do backup |
+
+**Exemplo de resposta**:
+
+```json
+{
+"doneDate": "2024-08-22T09:24:35.206Z",
+"function": "string",
+"id": 0,
+"lastUpdate": "2024-08-22T09:24:35.206Z",
+"objectId": "string",
+"objectType": "Abuse",
+"startDate": "2024-08-22T09:24:35.206Z",
+"status": "cancelled"
+}
+```
+
+## Conclusão
+
+Este guia apresentou-lhe os principais pedidos à API para gerir o seu alojamento web OVHcloud, como a associação de domínios e a gestão de certificados SSL e de bases de dados.
+
+Existem, no entanto, muitas outras chamadas à API disponíveis, que pode explorar consoante as suas necessidades. Para mais opções e funcionalidades, consulte a secção "<ApiLink section="/hosting/web" method="GET" route={"/hosting/web"}>/hosting/web</ApiLink>" da API da OVHcloud.
+
+## Quer saber mais?
+
+[Order a domain name via API](/guides/web-cloud/domains/api-domain-order)
+
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -1,124 +1,118 @@
 ---
-title: "Backing up your WordPress websites with MainWP"
-description: "Find out how to back up and restore your WordPress websites with MainWP"
-lastUpdated: 2024-01-25
+title: Efetuar backups dos seus sites WordPress com MainWP
+description: "Saiba como efetuar backups dos seus sites WordPress e restaurá-los com MainWP e a extensão UpdraftPlus a partir de um único dashboard"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Backing up a website is a vital part of running your business. It offers several advantages:
+O backup de um site é uma prática essencial para a gestão da sua empresa. Oferece várias vantagens:
 
-- **Data security**: Regular backups ensure your website's data is protected in the event of a cyberattack, technical failure or human error.
-- **Protection against update errors**: A backup made before a WordPress plugin or theme is updated allows you to go back in time if an error or version conflict occurs during the update.
-- **Rapid Restore**: In the event of a technical error, the backup can be reverted to a previous version to offer your customers a functional website and business continuity.
-- **Legal Compliance**: Maintaining regular backups may be a regulatory compliance requirement for your organization and may protect you from legal action.
+- **Segurança dos dados**: os backups regulares garantem que os dados do seu site estão protegidos em caso de ciberataque, falha técnica ou erro humano.
+- **Proteção contra erros de atualização**: um backup efetuado antes da atualização do WordPress, de um plugin ou de um tema permite recuar em caso de erro ou de conflito de versões durante a atualização.
+- **Restauro rápido**: em caso de erro técnico, o backup permite voltar a uma versão anterior para oferecer aos seus clientes um site funcional e garantir a continuidade da atividade.
+- **Conformidade legal**: para a sua empresa, manter backups regulares pode corresponder a uma exigência de conformidade regulamentar e proteger-lhe de ações judiciais.
 
-MainWP offers several extensions for backing up your websites.
+O MainWP disponibiliza várias extensões que permitem efetuar backups dos seus sites.
 
-**This guide explains how to back up your WordPress websites with the UpdraftPlus extension.**
+**Este guia explica-lhe como efetuar backups dos seus sites WordPress com a extensão UpdraftPlus.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Dispor de uma [oferta de alojamento Web Cloud](/links/web/hosting).
+- Ter sessão iniciada no seu dashboard MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
 :::
 
-## Instructions
+## Instruções
 
-### Install the UpdraftPlus extension
+### Instalar a extensão UpdraftPlus
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Se nunca instalou uma extensão MainWP, saiba como o fazer [neste guia](/guides/web-cloud/web-hosting/mainwp-general).
 :::
 
-To find all the extensions linked to the backup, go to the [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) section of MainWP. You can also search for an extension by clicking `Extensions` from the MainWP main menu, then `Install Extensions`. Click on the `Backup` tab to view the list of extensions linked to the backup.
+Para encontrar todas as extensões relacionadas com os backups, aceda à secção [backup](https://mainwp.com/mainwp-extensions/extension-category/backup/) do MainWP. Pode igualmente procurar uma extensão clicando em <code className="action">Extensions</code> no menu principal do MainWP e depois em <code className="action">Install Extensions</code>. Clique no separador <code className="action">Backup</code> para apresentar a lista das extensões relacionadas com os backups.
 
-In this example, we choose the free UpdraftPlus extension, but you are free to choose the extension of your choice.
+Neste exemplo, escolhemos a extensão gratuita UpdraftPlus, mas pode escolher a extensão que preferir.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+Depois de selecionar a extensão, clique em <code className="action">Install Selected Extensions</code>.
 
-Once you have selected the extension, click `Install Selected Extensions`.
+No menu principal do MainWP, clique em <code className="action">Extensions</code> e depois em <code className="action">Manage Extensions</code>. É apresentada a extensão UpdraftPlus instalada anteriormente.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed UpdraftPlus extension appears.
+Clique em <code className="action">Enable</code> para ativar a extensão. Se surgir uma mensagem de erro a indicar que a licença não está ativada, basta clicar no botão <code className="action">License</code>. Antes de poder utilizar o UpdraftPlus, deve ativar o plugin UpdraftPlus nos sites subordinados de que pretende efetuar backup.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+### Instalar o plugin UpdraftPlus num site subordinado
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button. Before you can use UpdraftPlus, you must enable the UpdraftPlus plugin on the child sites that you want to back up.
+No menu principal do MainWP, clique em <code className="action">Sites</code> e depois em <code className="action">Install Plugins</code>. Na barra de pesquisa, escreva "UpdraftPlus".
 
-### Install the UpdraftPlus plugin on a child site
+<img className="thumbnail" alt="Campo de pesquisa de plugins MainWP com UpdraftPlus introduzido" src="/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png" loading="lazy" />
 
-In the main menu of MainWP, click `Sites` then `Install Plugins`. In the search bar, type UpdraftPlus.
+Depois de identificar o plugin "UpdraftPlus: WordPress Backup & Migration", clique em <code className="action">Install Plugin</code>. Em seguida, à direita do ecrã, selecione o site subordinado no qual pretende instalar o UpdraftPlus. Clique em <code className="action">Complete Installation</code>. Não se esqueça de assinalar <code className="action">Activate after installation</code>.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/search-updraftplus.png)
+Concluída a instalação, aceda ao menu principal do MainWP. Clique em <code className="action">Sites</code>, <code className="action">Plugins</code> e depois em <code className="action">Manage Plugins</code>. Para verificar que o UpdraftPlus está instalado nos seus sites, selecione os sites subordinados pretendidos, à direita do ecrã. Mais abaixo, no campo de pesquisa <code className="action">Search Options</code>, escreva "UpdraftPlus" e selecione <code className="action">Show Plugins</code>.
 
-Once you have identified the "UpdraftPlus: WordPress Backup & Migration" plugin, click `Install Plugin`. Then, on the right-hand side of the screen, select the child website on which you want to install UpdraftPlus. Click `Complete Installation`. Remember to tick `Activate after installation`.
+<img className="thumbnail" alt="Página Manage Plugins do MainWP filtrada por UpdraftPlus para os sites subordinados" src="/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png" loading="lazy" />
 
-Once the installation is complete, go to the MainWP main menu. Click `Sites`, `Plugins` then `Manage Plugins`. To check that UpdraftPlus is installed on your websites, select the child websites you want, on the right-hand side of the screen. Further down, in the search field `Search Options`, type "UpdraftPlus" then select `Show Plugins`.
+São apresentados a extensão "MainWP UpdraftPlus Extension" e o plugin "UpdraftPlus - Backup/Restore", o que significa que estão corretamente instalados nos sites subordinados em causa.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/show-plugins.png)
+Selecione a extensão "MainWP UpdraftPlus Extension" e o plugin "UpdraftPlus - Backup/Restore" e clique em <code className="action">Install to Selected Site(s)</code> (botão no canto superior direito).
 
-The extension "MainWP UpdraftPlus Extension" and the plugin "UpdraftPlus - Backup/Retore" are displayed, which means that they are correctly installed on the child websites concerned.
+Para se certificar de que os plugins estão ativos no seu site subordinado, clique em <code className="action">Sync Dashboard with Sites</code>, no canto superior direito da interface.
 
-Select the "MainWP UpdraftPlus Extension" and the "UpdraftPlus - Backup/Retore" plugin, then click `Install to Selected Site(s)` (button in the top right-hand corner).
+<img className="thumbnail" alt="Botão Sync Dashboard with Sites no canto superior direito da interface MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png" loading="lazy" />
 
-To ensure that the plugins are enabled on your child website, click `Sync Dashboard with Sites`, in the top right-hand corner of the interface.
+Já pode efetuar backups dos seus sites subordinados com o UpdraftPlus.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/sync-dashboard-sites.png)
+### Efetuar backups com o UpdraftPlus
 
-You can now create backups of your child websites with UpdraftPlus.
+No menu principal do MainWP, clique em <code className="action">Sites</code> e depois em <code className="action">Manage Sites</code>. Clique no site subordinado do qual pretende efetuar o backup e depois no separador <code className="action">UpdraftPlus Backups</code>.
 
-### Create a backup with UpdraftPlus
+No ecrã apresentado, clique em <code className="action">Backup Now</code> e siga as instruções. Para confirmar o backup, clique em <code className="action">Backup Now</code>.
 
-In the main menu of MainWP, click `Sites` then `Manage Sites`. Click the child site for which you want to create a backup, then click the `UpdraftPlus Backups` tab.
+<img className="thumbnail" alt="Janela Backup Now do UpdraftPlus num site subordinado MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/tab-updraftPlus.png)
+Concluído o backup, clique no separador <code className="action">ExistingBackups</code>.
 
-On the screen that pops up, click `Backup Now` and follow the instructions. To confirm the backup, click `Backup Now`.
+<img className="thumbnail" alt="Separador ExistingBackups do UpdraftPlus com o backup acabado de criar" src="/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/backup-now.png)
+É apresentada uma nova linha correspondente ao seu backup. Pode efetuar várias ações sobre o backup, incluindo o restauro.
 
-Once the backup is complete, click the `ExistingBackups` tab.
+### Restaurar uma versão guardada de um site subordinado
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/existing-backup.png)
+No menu principal do MainWP, clique em <code className="action">Extensions</code> e depois em <code className="action">UpdraftPlus</code>. Se clicar em <code className="action">Existing Backups</code>, é apresentada a lista dos seus backups.
 
-A new line will appear, corresponding to your backup. You can perform various actions on your backup, including restoring.
+Para restaurar o seu site, localize a linha correspondente ao seu backup e clique em <code className="action">Restore</code>.
 
-### Restore a backed up version of a child site
+<img className="thumbnail" alt="Linha de backup no UpdraftPlus com o botão Restore" src="/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png" loading="lazy" />
 
-In the MainWP main menu, click `Extensions` then `UpdraftPlus`. If you click `Existing Backups`, a list of your backups will appear.
+É apresentada uma nova janela. Contém várias informações, incluindo a lista dos seus backups.
 
-To restore your website, locate the line corresponding to your backup, then click `Restore`.
+Localize o backup que pretende restaurar e clique em <code className="action">Restore</code>. Verifique a data para evitar qualquer erro.
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restore-backup-line.png)
+<img className="thumbnail" alt="Janela do UpdraftPlus com os backups disponíveis para restauro" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png" loading="lazy" />
 
-A new window will appear. It contains some information, including a list of your backups.
+Selecione os elementos que pretende restaurar e confirme. É apresentada a seguinte mensagem de confirmação:
 
-Identify the backup you want to restore, then click `Restore`. Remember to check the date to avoid any errors.
+<img className="thumbnail" alt="Mensagem a confirmar que o restauro do UpdraftPlus foi concluído com êxito" src="/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png" loading="lazy" />
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-message.png)
+## Quer saber mais? <a name="go-further"></a>
 
-Select the elements you want to restore, then confirm. The following confirmation message is displayed:
+[Gerir vários sites WordPress com o plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-![mainWP backup](/images/assets/screens/other/cms/wordpress/mainwp/restoration-success.png)
+[Gerir as informações dos clientes dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-## Go further <a id="go-further"></a>
+[Melhorar a segurança do seu site com o plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Tutorial - Faça o backup do seu site WordPress](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Restaurar o espaço de armazenamento do alojamento web](/guides/web-cloud/web-hosting/ftp-save-and-backup)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-[Tutorial - Backup your WordPress website](/guides/web-cloud/web-hosting/how-to-backup-your-wordpress)
-
-[Restore your web hosting plan's storage space](/guides/web-cloud/web-hosting/ftp-save-and-backup)
-
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
-
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -1,88 +1,88 @@
 ---
-title: "Managing customer information on your WordPress websites with MainWP"
-description: "Find out how to manage all the customers of your WordPress websites from the MainWP dashboard"
-lastUpdated: 2024-01-25
+title: Gerir as informações dos clientes dos seus sites WordPress com MainWP
+description: "Saiba como gerir todos os clientes dos seus sites WordPress a partir do dashboard MainWP: adicionar, alterar e eliminar as suas informações"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Retaining customers is vital to your company's development. Whether you have one or more websites, it's important to get to know your customers as well as possible in order to retain and satisfy them. With the WordPress MainWP plugin, you can manage your website customers efficiently. As a CRM (Customer Relationship Management) would offer, you can add, delete and update all your customer information, for free, in just a few clicks.
+Fidelizar os clientes é essencial para o desenvolvimento da sua empresa. Quer tenha um ou vários sites, é importante conhecer os seus clientes da melhor forma possível para os fidelizar e satisfazer. O plugin MainWP para WordPress permite-lhe gerir eficazmente os clientes dos seus sites. Tal como um CRM (Customer Relationship Management), permite-lhe adicionar, eliminar e atualizar todas as informações dos seus clientes gratuitamente e em poucos cliques.
 
-**This guide will show you how to manage your website's customers' data efficiently using MainWP.**
+**Este guia explica-lhe como gerir eficazmente os dados dos clientes dos seus sites com MainWP.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard. For more information, please read our guide on [Managing multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general).
+- Dispor de uma [oferta de alojamento Web Cloud](/links/web/hosting).
+- Ter sessão iniciada no seu dashboard MainWP. Para mais informações, consulte o nosso guia [Gerir vários sites WordPress com o plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general).
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
 :::
 
-## Instructions
+## Instruções
 
-In the MainWP main menu, click `Clients`. On the screen that opens, there are three tabs:
+No menu principal do MainWP, clique em <code className="action">Clients</code>. No ecrã que se abre existem três separadores:
 
-- Customers: displays a list of all your customers
-- Add Client: allows you to create new customers
-- Client Fields: allows you to create new fields related to your customers
+- Customers: apresenta a lista de todos os seus clientes
+- Add Client: permite criar novos clientes
+- Client Fields: permite criar novos campos relativos aos seus clientes
 
-### Add a customer
+### Adicionar um cliente
 
-To get started, add your first customer. In the main menu of MainWP, click `Clients` then `Add Client`. In the form that appears, fill in your customer's details. On the right-hand side of the screen, select the websites on which you want to create your new customer, then click `Add Client`.
+Para começar, adicione o seu primeiro cliente. No menu principal do MainWP, clique em <code className="action">Clients</code> e depois em <code className="action">Add Client</code>. No formulário apresentado, preencha os dados do seu cliente. À direita do ecrã, selecione os sites nos quais pretende criar o novo cliente e clique em <code className="action">Add Client</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/add-client.png)
+<img className="thumbnail" alt="Formulário Add Client do MainWP com os dados do cliente preenchidos" src="/images/assets/screens/other/cms/wordpress/mainwp/add-client.png" loading="lazy" />
 
-### View your customers
+### Consultar os seus clientes
 
-In the main menu of MainWP, click `Clients` then `Clients`. A list of all your customers will appear. You can search for a specific customer (in the `Search` field in the top right-hand corner of the table) by entering the value of one of its fields, such as its name.
+No menu principal do MainWP, clique em <code className="action">Clients</code> e depois em <code className="action">Clients</code>. É apresentada a lista de todos os seus clientes. Pode procurar um cliente específico (no campo <code className="action">Search</code>, no canto superior direito da tabela) introduzindo o valor de um dos seus campos, como o nome.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/search-client.png)
+<img className="thumbnail" alt="Lista de clientes MainWP com o campo Search no canto superior direito" src="/images/assets/screens/other/cms/wordpress/mainwp/search-client.png" loading="lazy" />
 
-You can drag and drop the columns of your choice to highlight the relevant information of your customers, such as the email address (column `Customer Email`) or the number of websites to which your customer is attached (column `Websites`).
+Pode arrastar e largar as colunas que pretender para destacar as informações relevantes dos seus clientes, como o endereço de e-mail (coluna <code className="action">Customer Email</code>) ou o número de sites associados ao cliente (coluna <code className="action">Websites</code>).
 
-From this table, you can delete any customer. Select the lines corresponding to the customers you want to delete, click `Bulk actions`, `Delete` then `Apply` to confirm.
+A partir desta tabela pode eliminar qualquer cliente. Selecione as linhas correspondentes aos clientes que pretende eliminar, clique em <code className="action">Bulk actions</code>, <code className="action">Delete</code> e depois em <code className="action">Apply</code> para confirmar.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png)
+<img className="thumbnail" alt="Tabela de clientes MainWP com as opções Bulk actions e Delete" src="/images/assets/screens/other/cms/wordpress/mainwp/delete-client.png" loading="lazy" />
 
-Finally, click `Yes, proceed` to confirm the deletion of the customers.
+Por fim, clique em <code className="action">Yes, proceed</code> para confirmar a eliminação dos clientes.
 
-In the table representing your customers, identify the customer of your choice and click on the `...`.
+Na tabela dos seus clientes, localize o cliente pretendido e clique em <code className="action">...</code>.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/more-client.png)
+<img className="thumbnail" alt="Menu de ações de um cliente na tabela de clientes MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/more-client.png" loading="lazy" />
 
-You can:
+Pode:
 
-- edit customer information (`Edit`)
-- delete the customer (`Delete`)
-- see the websites concerned by your customer (`View Sites`)
+- alterar as informações do cliente (<code className="action">Edit</code>)
+- eliminar o cliente (<code className="action">Delete</code>)
+- consultar os sites associados ao seu cliente (<code className="action">View Sites</code>)
 
-### Create new fields for your customers
+### Criar novos campos para os seus clientes
 
-For each customer, many default fields are present, such as name, email, country, number or links to social networks. If you would like to add specific information that is not present by default, you can add the fields of your choice manually.
-In the main menu of MainWP, click `Clients` then `Clients Fields`. To create a new field, click `New Field`. In the window that appears, enter the name and description for your new field.
+Para cada cliente existem vários campos predefinidos, como o nome, o e-mail, o país, o número ou as ligações para as redes sociais. Se pretender acrescentar informações específicas que não estão presentes por defeito, pode adicionar manualmente os campos pretendidos.
+No menu principal do MainWP, clique em <code className="action">Clients</code> e depois em <code className="action">Clients Fields</code>. Para criar um novo campo, clique em <code className="action">New Field</code>. Na janela apresentada, introduza o nome e a descrição do novo campo.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png)
+<img className="thumbnail" alt="Janela do MainWP para criar um novo campo de cliente" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-client.png" loading="lazy" />
 
-In our example, we create a new "loyalty" field, along with an associated description. To confirm the creation of the new field, click `Save Field`. Now, when creating a new customer, the new "loyalty" field will be available.
+No nosso exemplo, criamos um novo campo "loyalty", com a respetiva descrição. Para confirmar a criação do novo campo, clique em <code className="action">Save Field</code>. A partir de agora, ao criar um novo cliente, o novo campo "loyalty" estará disponível.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png)
+<img className="thumbnail" alt="Formulário Add Client do MainWP com o novo campo loyalty" src="/images/assets/screens/other/cms/wordpress/mainwp/new-field-add-client.png" loading="lazy" />
 
-Once you have created your new customer, go to your customers list. Click the customer you just created. The new "loyalty" field and the corresponding value are displayed.
+Depois de criar o novo cliente, aceda à sua lista de clientes. Clique no cliente que acabou de criar. São apresentados o novo campo "loyalty" e o valor correspondente.
 
-![mainWPClientMngt](/images/assets/screens/other/cms/wordpress/mainwp/details-client.png)
+<img className="thumbnail" alt="Detalhes de um cliente MainWP com o campo loyalty e o respetivo valor" src="/images/assets/screens/other/cms/wordpress/mainwp/details-client.png" loading="lazy" />
 
-## Go further <a id="go-further"></a>
+## Quer saber mais? <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gerir vários sites WordPress com o plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Melhorar a segurança do seu site com o plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Efetuar backups dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -1,185 +1,199 @@
 ---
-title: "Managing multiple WordPress websites with the MainWP plugin"
-description: "Find out how to manage multiple WordPress websites from a single tool with the MainWP plugin"
-lastUpdated: 2024-01-25
+title: Gerir vários sites WordPress com o plugin MainWP
+description: "Saiba como gerir vários sites WordPress a partir de uma única ferramenta com o plugin MainWP: atualizações, extensões e sites subordinados"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Managing multiple websites can be complex and time-consuming. If you manage multiple WordPress websites, you will need to manage the technical maintenance of the websites, plugins and themes updates, or even login credentials. The MainWP plugin for WordPress is an efficient solution for managing multiple WordPress websites from a single dashboard. MainWP allows you to:
+Gerir vários sites pode ser complexo e moroso. Se gere vários sites WordPress, terá de assegurar a manutenção técnica dos sites, as atualizações de plugins e temas, e até as credenciais de acesso. O plugin MainWP para WordPress é uma solução eficaz para gerir vários sites WordPress a partir de um único dashboard. O MainWP permite-lhe:
 
-- control all your websites from a single dashboard
-- update the technical components in one click
-- [manage your customer information](/guides/web-cloud/web-hosting/mainwp-client-management)
-- download extensions to perform multiple tasks
+- controlar todos os seus sites a partir de um único dashboard
+- atualizar os componentes técnicos com um clique
+- [gerir as informações dos seus clientes](/guides/web-cloud/web-hosting/mainwp-client-management)
+- descarregar extensões para executar múltiplas tarefas
 
-**Find out how to use the MainWP dashboard to manage multiple WordPress websites.**
+**Saiba como utilizar o dashboard MainWP para gerir vários sites WordPress.**
 
 :::info
-In this guide, we have chosen the MainWP plugin. Other similar solutions exist, you are of course free to choose the plugin you want.
+Neste guia escolhemos o plugin MainWP. Existem outras soluções semelhantes, pelo que pode escolher livremente o plugin que preferir.
+
 :::
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, in the `Web Cloud` section.
-- Access to the WordPress administration interface.
+- Dispor de uma [oferta de alojamento Web Cloud](/links/web/hosting).
+- Ter acesso à interface de administração do WordPress.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
 :::
 
-## Instructions
+{/* CP-NAV-START:web-hosting */}
+---
 
-If you are not already logged in, access the administration interface of your one-click module for which you want to install the MainWP dashboard.
+### Acesso à Área de Cliente OVHcloud
 
-![mainWP](/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png)
+- **Ligação direta:** <ManagerLink to="/#/web/hosting">Alojamentos</ManagerLink>
+- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Alojamentos</code> > Selecione o seu alojamento web
 
-Enter your login and password to log in. The WordPress dashboard appears.
+---
+{/* CP-NAV-END:web-hosting */}
 
-### Install the MainWP plugin 
+## Instruções
 
-Go to the main WordPress menu, on the left-hand side of the screen, and click `Plugins` then `Add New Plugin`.
+Se ainda não tiver sessão iniciada, aceda à interface de administração do módulo "1 clique" no qual pretende instalar o dashboard MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png)
+<img className="thumbnail" alt="Área de Cliente OVHcloud com a lista dos módulos 1 clique" src="/images/assets/screens/control-panel/product-selection/web-cloud/web-hosting/1-click-modules/access-the-module-s-administration-interface.png" loading="lazy" />
 
-A list of the most popular WordPress plugins is displayed. In the top right-hand corner of the search bar, type "MainWP", then confirm. Among the results, several plugins offered by "MainWP" are displayed. Install the following two plugins:
+Introduza o seu nome de utilizador e a sua palavra-passe para iniciar sessão. É apresentado o dashboard do WordPress.
+
+### Instalar o plugin MainWP
+
+Aceda ao menu principal do WordPress, à esquerda do ecrã, e clique em <code className="action">Plugins</code> e depois em <code className="action">Add New Plugin</code>.
+
+<img className="thumbnail" alt="Menu do WordPress com a entrada Plugins e a opção Add New Plugin" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-plugin.png" loading="lazy" />
+
+É apresentada uma lista dos plugins WordPress mais populares. Na barra de pesquisa, no canto superior direito, escreva "MainWP" e confirme. Entre os resultados são apresentados vários plugins disponibilizados pelo "MainWP". Instale os dois plugins seguintes:
 
 - MainWP Dashboard
 - Child MainWP
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png)
+<img className="thumbnail" alt="Resultados da pesquisa de plugins WordPress com MainWP Dashboard e MainWP Child" src="/images/assets/screens/other/cms/wordpress/mainwp/plugins-mainwp-result.png" loading="lazy" />
 
-MainWP Dashboard is the main plugin you can use to manage your websites from a single dashboard.<br />
-MainWP Child enables you to connect your WordPress website (also called a "child site") to the MainWP Dashboard.
+O MainWP Dashboard é o plugin principal que permite gerir os seus sites a partir de um único dashboard.
+
+O MainWP Child permite ligar o seu site WordPress (também designado por "site subordinado") ao MainWP Dashboard.
 
 :::warning
-An error may occur if you install MainWP Child first. Make sure to install MainWP Dashboard **before** MainWP Child.
+Pode ocorrer um erro se instalar primeiro o MainWP Child. Certifique-se de que instala o MainWP Dashboard **antes** do MainWP Child.
+
 :::
 
-Once you have installed both plugins, please remember to enable them in order to use them.
-Once the two plugins are installed and enabled, the following warning message will appear at the top of your screen:
+Depois de instalar os dois plugins, não se esqueça de os ativar para os poder utilizar.
+Depois de instalados e ativados os dois plugins, é apresentada a seguinte mensagem de aviso na parte superior do ecrã:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png)
+<img className="thumbnail" alt="Mensagem de aviso a solicitar a ligação do site subordinado ao MainWP Dashboard" src="/images/assets/screens/other/cms/wordpress/mainwp/warning-message-child.png" loading="lazy" />
 
-This message informs you that you have just activated the MainWP Child plugin, and that you now need to connect your child website to the MainWP Dashboard. For security reasons, disable the MainWP Child plugin if you do not want to connect your child website now. Reactivate the MainWP Child plugin when you are ready to connect your WordPress website to the MainWP dashboard.
+Esta mensagem informa-o de que acabou de ativar o plugin MainWP Child e de que deve agora ligar o seu site subordinado ao MainWP Dashboard. Por motivos de segurança, desative o plugin MainWP Child se não pretender ligar já o seu site subordinado. Volte a ativá-lo quando estiver pronto para ligar o seu site WordPress ao dashboard MainWP.
 
-### Connect a child site to the MainWP dashboard
+### Ligar um site subordinado ao dashboard MainWP
 
-In the main menu on the left, click `Sites`, then `Add New`. The following screen appears:
+No menu principal à esquerda, clique em <code className="action">Sites</code> e depois em <code className="action">Add New</code>. É apresentado o seguinte ecrã:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png)
+<img className="thumbnail" alt="Formulário MainWP para adicionar um novo site subordinado" src="/images/assets/screens/other/cms/wordpress/mainwp/add-new-site.png" loading="lazy" />
 
-Enter the URL of the child site you want to connect to the MainWP dashboard. Just below, select the button to indicate that you have installed and activated the MainWP Child plugin on your child website. The following two new fields are displayed:
+Introduza o URL do site subordinado que pretende ligar ao dashboard MainWP. Logo abaixo, selecione o botão que indica que instalou e ativou o plugin MainWP Child no seu site subordinado. São apresentados os dois novos campos seguintes:
 
-- `Administrator username`: log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, then go to the `Web Cloud` section. Select the web hosting plan concerned, and click the `1-click modules` tab. In the table that pops up, identify the row that corresponds to your 1-click module. Your admin name is in the `Login` column.
-- `Site title`: enter the value you want. If you connect many child websites, remember to enter an explicit site title.
+- `Administrator username`: inicie sessão na sua <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> e aceda à secção <code className="action">Web Cloud</code>. Selecione o alojamento web em causa e clique no separador <code className="action">Módulos "1 clique"</code>. Na tabela apresentada, localize a linha correspondente ao seu módulo. O nome de administrador encontra-se na coluna <code className="action">Nome de utilizador</code>.
+- `Site title`: introduza o valor pretendido. Se ligar muitos sites subordinados, indique um título de site explícito.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site.png)
+<img className="thumbnail" alt="Formulário de adição de site MainWP com o nome de administrador preenchido" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site.png" loading="lazy" />
 
-When all the fields of the form are filled in, click the `Add Site` button below the form to confirm. If there are no errors, you will receive the following confirmation message, confirming that your child site is now connected to the MainWP dashboard:
+Quando todos os campos do formulário estiverem preenchidos, clique no botão <code className="action">Add Site</code> por baixo do formulário para confirmar. Se não existir qualquer erro, receberá a seguinte mensagem de confirmação, indicando que o seu site subordinado está agora ligado ao dashboard MainWP:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png)
+<img className="thumbnail" alt="Mensagem a confirmar que o site subordinado está ligado ao dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/add-site-success-message.png" loading="lazy" />
 
-To check that your child website is available in the MainWP dashboard, click `Sites` in the main menu on the left-hand side, then `Manage Sites`.
+Para verificar que o seu site subordinado está disponível no dashboard MainWP, clique em <code className="action">Sites</code> no menu principal à esquerda e depois em <code className="action">Manage Sites</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png)
+<img className="thumbnail" alt="Página Manage Sites do MainWP com a lista dos sites subordinados ligados" src="/images/assets/screens/other/cms/wordpress/mainwp/sites-dashboard.png" loading="lazy" />
 
-In our example, the website "my website" will appear in the list of child sites connected to the MainWP dashboard. You can add as many child sites as you want.
+No nosso exemplo, o site "my website" é apresentado na lista dos sites subordinados ligados ao dashboard MainWP. Pode adicionar tantos sites subordinados quantos pretender.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png)
+<img className="thumbnail" alt="Vista em grelha do MainWP com todos os sites subordinados ligados" src="/images/assets/screens/other/cms/wordpress/mainwp/grid-all-sites.png" loading="lazy" />
 
 :::info
-Remember to install the MainWP child plugin on each child site that you want to connect to the MainWP dashboard.
+Não se esqueça de instalar o plugin MainWP Child em cada site subordinado que pretenda ligar ao dashboard MainWP.
+
 :::
 
-### Manage software updates from the MainWP dashboard
+### Gerir as atualizações a partir do dashboard MainWP
 
-If you use several plugins and themes for your websites, you may encounter errors due to the different versions. With the MainWP dashboard, you can manage the following updates in one place:
+Se utiliza vários plugins e temas nos seus sites, podem ocorrer erros devido às diferentes versões. O dashboard MainWP permite-lhe gerir num único local as seguintes atualizações:
 
 - WordPress
 - Plugins
-- Themes
-- Translations
+- Temas
+- Traduções
 
-In the main menu on the left, click `Sites` then `Updates`. The following screen appears:
+No menu principal à esquerda, clique em <code className="action">Sites</code> e depois em <code className="action">Updates</code>. É apresentado o seguinte ecrã:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png)
+<img className="thumbnail" alt="Página Updates do MainWP com as atualizações de plugins e temas disponíveis" src="/images/assets/screens/other/cms/wordpress/mainwp/updates-screen.png" loading="lazy" />
 
-At the top of the interface, the tabs indicate that a plugin and four themes are available to update. Click on the tab of your choice to view the available updates. In our example, if you click on the `Themes Updates` tab, you will see a list of the four themes affected by the updates.
+Na parte superior da interface, os separadores indicam que existem um plugin e quatro temas disponíveis para atualização. Clique no separador pretendido para consultar as atualizações disponíveis. No nosso exemplo, ao clicar no separador <code className="action">Themes Updates</code>, verá a lista dos quatro temas abrangidos pelas atualizações.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png)
+<img className="thumbnail" alt="Separador Themes Updates do MainWP com os quatro temas a atualizar" src="/images/assets/screens/other/cms/wordpress/mainwp/update-themes.png" loading="lazy" />
 
-If you want to update several themes (or all the themes at the same time), select the corresponding lines (by ticking the box to the left of each line) then click `Update Selected Themes`.
-The following confirmation message appears, indicating the sites where the previously selected themes will be updated.
+Se pretender atualizar vários temas (ou todos os temas em simultâneo), selecione as linhas correspondentes (assinalando a caixa à esquerda de cada linha) e clique em <code className="action">Update Selected Themes</code>.
+É apresentada a seguinte mensagem de confirmação, que indica os sites nos quais os temas selecionados anteriormente serão atualizados.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png)
+<img className="thumbnail" alt="Mensagem de confirmação com os sites nos quais os temas selecionados serão atualizados" src="/images/assets/screens/other/cms/wordpress/mainwp/update-confirmation-message.png" loading="lazy" />
 
-In our example, the selected themes will be updated for the websites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" and "blog 3". Click `Yes, proceed` to confirm. The progress window appears. It will close when the updates are complete.
+No nosso exemplo, os temas selecionados serão atualizados nos sites "www.example.fr", "www.example2.ovh", "blog 1", "blog 2" e "blog 3". Clique em <code className="action">Yes, proceed</code> para confirmar. É apresentada a janela de progresso, que se fecha quando as atualizações estiverem concluídas.
 
-Do the same to update WordPress, your plugins or your translations.
+Proceda da mesma forma para atualizar o WordPress, os seus plugins ou as suas traduções.
 
-### Extensions
+### Extensões
 
-MainWP offers native features, such as software update management or [customer information management](/guides/web-cloud/web-hosting/mainwp-client-management). However, MainWP becomes even more powerful thanks to its many extensions, offering a wide range of features.
+O MainWP oferece funcionalidades nativas, como a gestão das atualizações ou a [gestão das informações dos clientes](/guides/web-cloud/web-hosting/mainwp-client-management). No entanto, o MainWP torna-se ainda mais potente graças às suas numerosas extensões, que oferecem uma vasta gama de funcionalidades.
 
-There are different [extension categories](https://mainwp.com/mainwp-extensions/), such as Administrative, Backup, Analytics, Security, etc. For each of the categories, there are three different types of extensions:
+Existem diferentes [categorias de extensões](https://mainwp.com/mainwp-extensions/), como Administrative, Backup, Analytics ou Security. Para cada categoria existem três tipos diferentes de extensões:
 
-- Free: free extensions developed by MainWP
-- Professional: premium extensions developed by MainWP
-- .Org: free extensions developed by a third-party publisher
+- Free: extensões gratuitas desenvolvidas pelo MainWP
+- Professional: extensões pagas desenvolvidas pelo MainWP
+- .Org: extensões gratuitas desenvolvidas por um editor externo
 
-Before you can install an extension, go to [MainWP.com](https://mainwp.com/my-account/) to create your account.
+Antes de poder instalar uma extensão, crie a sua conta em [MainWP.com](https://mainwp.com/my-account/).
 
-#### Order an extension
+#### Encomendar uma extensão
 
-Once you have created your MainWP account, go to the [MainWP.com extensions section](https://mainwp.com/mainwp-extensions/). For our example, we choose the free UpdraftPlus extension. Click the UpdraftPlus extension.
+Depois de criar a sua conta MainWP, aceda à [secção de extensões do MainWP.com](https://mainwp.com/mainwp-extensions/). Para o nosso exemplo, escolhemos a extensão gratuita UpdraftPlus. Clique na extensão UpdraftPlus.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png)
+<img className="thumbnail" alt="Ficha da extensão UpdraftPlus na página de extensões do MainWP.com" src="/images/assets/screens/other/cms/wordpress/mainwp/updraftPlus-card.png" loading="lazy" />
 
-A page dedicated to the extension will appear. Click `Get the free Bundle`, then `Proceed to checkout`. You do not need to enter your payment details as this extension is free. Enter only the required information. Tick the required buttons, then finish by clicking `Place order`.
+É apresentada uma página dedicada à extensão. Clique em <code className="action">Get the free Bundle</code> e depois em <code className="action">Proceed to checkout</code>. Não precisa de introduzir os seus dados de pagamento, dado que esta extensão é gratuita. Introduza apenas as informações necessárias. Assinale as caixas necessárias e termine clicando em <code className="action">Place order</code>.
 
-You will now need to retrieve the API key corresponding to your MainWP username, which will enable you to log in to the MainWP dashboard to download the extensions of your choice.
+Terá agora de obter a chave API correspondente ao seu nome de utilizador MainWP, que lhe permitirá iniciar sessão no dashboard MainWP para descarregar as extensões pretendidas.
 
-#### Enter the API key
+#### Introduzir a chave API
 
-Go to [your MainWP account](https://mainwp.com/my-account/my-api-keys/) then copy the API key.
+Aceda à [sua conta MainWP](https://mainwp.com/my-account/my-api-keys/) e copie a chave API.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png)
+<img className="thumbnail" alt="Página da conta MainWP com a chave API a copiar" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-mainwp.png" loading="lazy" />
 
-Go back to the MainWP dashboard and click on `Extensions` in the main menu on the left. In the top right-hand corner of the screen that appears, click `Install and Activate Extensions`.
+Regresse ao dashboard MainWP e clique em <code className="action">Extensions</code> no menu principal à esquerda. No canto superior direito do ecrã apresentado, clique em <code className="action">Install and Activate Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png)
+<img className="thumbnail" alt="Página Extensions do MainWP com o botão Install and Activate Extensions" src="/images/assets/screens/other/cms/wordpress/mainwp/install-activate-extensions.png" loading="lazy" />
 
-In the `Enter your MainWP API Key` field, paste the API key you have previously copied, tick the `Remember MainWP Main API Key` box and click `Validate my MainWP Main API Key`. If there are no errors, the following confirmation message is displayed:
+No campo <code className="action">Enter your MainWP API Key</code>, cole a chave API copiada anteriormente, assinale a caixa <code className="action">Remember MainWP Main API Key</code> e clique em <code className="action">Validate my MainWP Main API Key</code>. Se não existir qualquer erro, é apresentada a seguinte mensagem de confirmação:
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png)
+<img className="thumbnail" alt="Mensagem a confirmar que a chave API MainWP é válida" src="/images/assets/screens/other/cms/wordpress/mainwp/API-key-valid.png" loading="lazy" />
 
-Finally, click `Install Extension` to install the extensions of your choice.
+Por fim, clique em <code className="action">Install Extension</code> para instalar as extensões pretendidas.
 
-#### Install an extension
+#### Instalar uma extensão
 
-After clicking `Install Extensions`, a window will appear with a list of available extensions, sorted by category. In our example, we choose the free "UpdraftPlus" extension from the Backups category. After selecting UpdraftPlus, click `Install Selected Extensions`.
+Depois de clicar em <code className="action">Install Extensions</code>, é apresentada uma janela com a lista das extensões disponíveis, ordenadas por categoria. No nosso exemplo, escolhemos a extensão gratuita "UpdraftPlus" da categoria Backups. Depois de selecionar o UpdraftPlus, clique em <code className="action">Install Selected Extensions</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png)
+<img className="thumbnail" alt="Lista de extensões MainWP com o UpdraftPlus selecionado na categoria Backups" src="/images/assets/screens/other/cms/wordpress/mainwp/install-updraftPlus.png" loading="lazy" />
 
-Once the installation is complete, UpdraftPlus is available in the list of extensions for your MainWP dashboard.
+Concluída a instalação, o UpdraftPlus fica disponível na lista de extensões do seu dashboard MainWP.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png)
+<img className="thumbnail" alt="UpdraftPlus na lista de extensões do dashboard MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/extensions-dashboard-updraftPlus.png" loading="lazy" />
 
-Click `Enable` to enable the extension. If an error message indicates that the license is not activated, simply click the `License` button.
+Clique em <code className="action">Enable</code> para ativar a extensão. Se surgir uma mensagem de erro a indicar que a licença não está ativada, basta clicar no botão <code className="action">License</code>.
 
-## Go further <a id="go-further"></a>
+## Quer saber mais? <a name="go-further"></a>
 
-[Manage your website's customer information with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gerir as informações dos clientes dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Improve your website's security with MainWP](/guides/web-cloud/web-hosting/mainwp-security)
+[Melhorar a segurança do seu site com o plugin MainWP para WordPress](/guides/web-cloud/web-hosting/mainwp-security)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Efetuar backups dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -1,97 +1,97 @@
 ---
-title: "Improving your website's security with the MainWP plugin for WordPress"
-description: "Find out how to control the security of your websites from a single interface using MainWP"
-lastUpdated: 2024-01-25
+title: Melhorar a segurança do seu site com o plugin MainWP para WordPress
+description: "Saiba como controlar a segurança dos seus sites a partir de uma única interface com MainWP e a extensão Sucuri: análises e correções"
+lastUpdated: 2026-08-19
 availableIn: [eu, ca, apac]
 ---
 
-## Objective
+## Objetivo
 
-Maintaining the security of your websites is crucial for the development of your brand. Optimum security for your websites can protect your company's data, as well as your customers' data, thereby preserving your company's image and trust. With extensions to the WordPress MainWP plugin, you can control the security of your websites from a single interface.
+Manter a segurança dos seus sites é fundamental para o desenvolvimento da sua marca. Uma segurança otimizada dos seus sites permite proteger os dados da sua empresa e os dos seus clientes, preservando assim a imagem e a confiança depositada na sua empresa. Com as extensões do plugin MainWP para WordPress, pode controlar a segurança dos seus sites a partir de uma única interface.
 
-**This guide will show you how to improve website security via the MainWP dashboard**
+**Este guia explica-lhe como melhorar a segurança do seu site a partir do dashboard MainWP.**
 
-## Requirements
+## Requisitos
 
-- A [Web Cloud hosting plan](/links/web/hosting).
-- Access to your MainWP dashboard.
+- Dispor de uma [oferta de alojamento Web Cloud](/links/web/hosting).
+- Ter sessão iniciada no seu dashboard MainWP.
 
 [[fragment:support-scope]]
 
 :::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
 :::
 
-## Instructions
+## Instruções
 
-### Install the Sucuri extension
+### Instalar a extensão Sucuri
 
 :::info
-If you have never installed a MainWP extension, you can find out how to install one in [this guide](/guides/web-cloud/web-hosting/mainwp-general).
+Se nunca instalou uma extensão MainWP, saiba como o fazer [neste guia](/guides/web-cloud/web-hosting/mainwp-general).
 :::
 
-To find all the security-related extensions, go to the [security](https://mainwp.com/mainwp-extensions/extension-category/security/) section of MainWP. You can also search for an extension by clicking `Extensions` in the MainWP main menu, then `Install Extensions`.
+Para encontrar todas as extensões relacionadas com a segurança, aceda à secção [security](https://mainwp.com/mainwp-extensions/extension-category/security/) do MainWP. Pode igualmente procurar uma extensão clicando em <code className="action">Extensions</code> no menu principal do MainWP e depois em <code className="action">Install Extensions</code>.
 
-Click on the `Security` tab to view the list of security-related extensions. In this example, we choose the free Sucuri extension, but you are free to choose the extension of your choice. Once you have selected the extension, click `Install Selected Extensions`.
+Clique no separador <code className="action">Security</code> para apresentar a lista das extensões relacionadas com a segurança. Neste exemplo, escolhemos a extensão gratuita Sucuri, mas pode escolher a extensão que preferir. Depois de selecionar a extensão, clique em <code className="action">Install Selected Extensions</code>.
 
-In the MainWP main menu, click `Extensions` then `Manage Extensions`. The previously installed Sucuri extension appears.
+No menu principal do MainWP, clique em <code className="action">Extensions</code> e depois em <code className="action">Manage Extensions</code>. É apresentada a extensão Sucuri instalada anteriormente.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png)
+<img className="thumbnail" alt="Extensão Sucuri na página Manage Extensions do MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-extension.png" loading="lazy" />
 
-If you have not already done so, click `Enable`, then `License` to use the extension.
+Se ainda não o fez, clique em <code className="action">Enable</code> e depois em <code className="action">License</code> para utilizar a extensão.
 
-### Perform a security scan
+### Efetuar uma análise de segurança
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click on the `Security` tab.
+No menu principal do MainWP, clique em <code className="action">Sites</code> e selecione o site subordinado pretendido. Na parte superior do ecrã, clique no separador <code className="action">Security</code>.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png)
+<img className="thumbnail" alt="Separador Security de um site subordinado MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/security-tab.png" loading="lazy" />
 
-To perform a security scan on your website, click `Scan Website`.
+Para efetuar uma análise de segurança do seu site, clique em <code className="action">Scan Website</code>.
 
-![mainWP](/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png)
+<img className="thumbnail" alt="Scanner do Sucuri com o botão Scan Website num site subordinado MainWP" src="/images/assets/screens/other/cms/wordpress/mainwp/sucuri-scanner.png" loading="lazy" />
 
-Once the security scan is complete, a new line will appear, corresponding to the security scan report.
+Depois de concluída a análise de segurança, é apresentada uma nova linha correspondente ao relatório da análise.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png)
+<img className="thumbnail" alt="Nova linha correspondente ao relatório da análise de segurança do Sucuri" src="/images/assets/screens/other/cms/wordpress/mainwp/report-security-line.png" loading="lazy" />
 
-Click `Show Report` to view the security report.
+Clique em <code className="action">Show Report</code> para consultar o relatório de segurança.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png)
+<img className="thumbnail" alt="Detalhe do relatório da análise de segurança do Sucuri para um site subordinado" src="/images/assets/screens/other/cms/wordpress/mainwp/security-report-details.png" loading="lazy" />
 
-The security scan report provides a lot of important information about the security of your website:
+O relatório da análise de segurança fornece muitas informações importantes sobre a segurança do seu site:
 
-- presence of viruses and malicious software
-- anomaly detection
-- dangerous links
-- SPAM attempts
+- presença de vírus e software malicioso
+- deteção de anomalias
+- ligações perigosas
+- tentativas de spam
 - etc.
 
-Remember to carry out regular security scans. With Sucuri, you can enable a reminder. At the bottom of the list of your security reports, click on the dropdown list to the right of `Remind me if I don't scan my child site for`. For example, if you choose `1 week`, Sucuri will remind you every week to carry out a security scan.
+Não se esqueça de efetuar análises de segurança regulares. Com o Sucuri, pode ativar um lembrete. Por baixo da lista dos seus relatórios de segurança, clique na lista pendente à direita de <code className="action">Remind me if I don't scan my child site for</code>. Por exemplo, se escolher <code className="action">1 week</code>, o Sucuri lembrá-lo-á todas as semanas de efetuar uma análise de segurança.
 
-### Identify and resolve security issues
+### Identificar e resolver os problemas de segurança
 
-In the main menu of MainWP, click `Sites` then select the child site of your choice. At the top of the screen, click the `Security` tab. On the dashboard that pops up, you can see if any security issues have been identified by Sucuri.
+No menu principal do MainWP, clique em <code className="action">Sites</code> e selecione o site subordinado pretendido. Na parte superior do ecrã, clique no separador <code className="action">Security</code>. No dashboard apresentado, pode ver se o Sucuri detetou problemas de segurança.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png)
+<img className="thumbnail" alt="Dashboard do Sucuri com os problemas de segurança detetados num site subordinado" src="/images/assets/screens/other/cms/wordpress/mainwp/security-overview.png" loading="lazy" />
 
-In our example, Sucuri tells us that three security issues have been identified. Click `Fix all issues` to resolve all security issues. If you would like to find out more about the issues identified, click the `Security` tab at the top of the interface. A list of security issues is displayed.
+No nosso exemplo, o Sucuri indica que foram detetados três problemas de segurança. Clique em <code className="action">Fix all issues</code> para resolver todos os problemas de segurança. Se pretender saber mais sobre os problemas detetados, clique no separador <code className="action">Security</code> na parte superior da interface. É apresentada uma lista dos problemas de segurança.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-list.png)
+<img className="thumbnail" alt="Lista dos problemas de segurança detetados pelo Sucuri num site subordinado" src="/images/assets/screens/other/cms/wordpress/mainwp/security-list.png" loading="lazy" />
 
-To resolve an issue, identify the corresponding line and click the `Fix` button to the right of the line.
+Para resolver um problema, localize a linha correspondente e clique no botão <code className="action">Fix</code> à direita da linha.
 
-![mainWP security](/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png)
+<img className="thumbnail" alt="Problema de segurança resolvido no Sucuri com o botão Unfix disponível" src="/images/assets/screens/other/cms/wordpress/mainwp/security-unfix.png" loading="lazy" />
 
-Once the problem has been resolved, you can cancel the changes made by clicking the `Unfix` button.
+Depois de resolvido o problema, pode anular as alterações efetuadas clicando no botão <code className="action">Unfix</code>.
 
-## Go further <a id="go-further"></a>
+## Quer saber mais? <a name="go-further"></a>
 
-[Manage multiple WordPress websites with the MainWP plugin](/guides/web-cloud/web-hosting/mainwp-general)
+[Gerir vários sites WordPress com o plugin MainWP](/guides/web-cloud/web-hosting/mainwp-general)
 
-[Manage customers for your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
+[Gerir as informações dos clientes dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-client-management)
 
-[Backing up your websites with MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
+[Efetuar backups dos seus sites WordPress com MainWP](/guides/web-cloud/web-hosting/mainwp-backup)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
+Para serviços especializados (referenciação, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Join our [community of users](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
## Context

SK2765 — missing translations on the Web Hosting guides.

## Translations added

| Guide | Locales | Source |
|---|---|---|
| `api-webhosting` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `mainwp-backup` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `mainwp-client-management` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `mainwp-general` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |
| `mainwp-security` | de, es, it, pl, pt | EN (de/pl) · FR (es/it/pt) |

Two different starting points:

- the five `api-webhosting` targets were **symlinks to the EN file**; they become real translations (type change `T` in the diff), so future edits to the EN guide will need to be propagated manually to those locales;
- the four `mainwp-*` targets were **English copies of an older revision** (`lastUpdated: 2024-01-25`, line counts diverging from the current EN); they are rewritten from today's EN rather than partially resynchronised.

## Fixes applied to the EN and FR sources, then propagated

- **Alt text** — the 41 screenshots carried generic, duplicated alt attributes (`mainWP` ×19, `mainWP backup` ×8, `mainWP security` ×7, `mainWPClientMngt` ×7). All rewritten to describe what each capture actually shows, in the 7 locales, within the 5-15 word range and with no duplicates left.
- **`mainwp-general`** — the `<br/>` used as a paragraph break replaced with a real blank line.
- **Typography** — curly quotes and spaces before colons removed in EN, non-breaking spaces added in FR, `SPAM` lowercased, and the FR `Modules en 1 clic` label aligned on the Manager value `Modules 1 clic`.
- **Meta descriptions** — the 35 descriptions ran from 71 to 104 characters against a 120-155 target; all rewritten and quoted, since they now contain a colon and would otherwise break the frontmatter parsing.
- **Prose** — 15 rewordings on the EN and FR sources (circumlocutions, nominalisations, navigation verbs) plus a comma splice in the `mainwp-general` callout.
- `lastUpdated` bumped on all 35 files.

## Verification

- **MDX compilation**: the 35 files compile with the build's own compiler.
- **Manager buttons**: the 4 OVHcloud labels reconciled **28/28** across the 7 locales against the Manager repository — `navigation_left_hosting`, `hosting_dashboard_one_click_modules`, `hosting_tab_FTP_multiftp_table_header_login`, and `Web Cloud` verbatim. The full navigation path is covered, not just the leaf. A cross-check confirms no label from one locale leaked into another. The remaining 679 buttons belong to MainWP, WordPress, UpdraftPlus and Sucuri, which have no localised UI and stay in English.
- **API tags**: the 13 `<Api>` operations of `api-webhosting` exist in both the EU and CA schemas, so no `regions` prop is needed.
- **External links**: all 6 fetched, 200.
- Structural parity with EN **30/30**, proofread pre-pass at 0, `content:lint` and `sidebar:validate` green, 35/35 frontmatter parse.
