### PR TITLE
docs: add how-to for upgrading OPCP.Core to new release

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -608,7 +608,7 @@
             + [How the Ironic to NetBox synchronisation works](hosted-private-cloud/opcp/netbox-ironic-synchronisation)
             + [How to use Terraform](hosted-private-cloud/opcp/use-terraform)
             + [How to update the backup S3 buckets](hosted-private-cloud/opcp/how-to-update-backup-s3-buckets)
-            + [How to upgrade OPCP.Core](hosted-private-cloud/opcp/how-to-upgrade-opcp)
+            + [How to upgrade OPCP](hosted-private-cloud/opcp/how-to-upgrade-opcp)
         + [Security](hosted-private-cloud-hosted-private-cloud-opcp-security)
             + [IAM rights management](hosted-private-cloud/opcp/iam-rights-management)
         + [CloudStore](hosted-private-cloud-hosted-private-cloud-opcp-cloudstore)

--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -608,6 +608,7 @@
             + [How the Ironic to NetBox synchronisation works](hosted-private-cloud/opcp/netbox-ironic-synchronisation)
             + [How to use Terraform](hosted-private-cloud/opcp/use-terraform)
             + [How to update the backup S3 buckets](hosted-private-cloud/opcp/how-to-update-backup-s3-buckets)
+            + [How to upgrade OPCP.Core](hosted-private-cloud/opcp/how-to-upgrade-opcp)
         + [Security](hosted-private-cloud-hosted-private-cloud-opcp-security)
             + [IAM rights management](hosted-private-cloud/opcp/iam-rights-management)
         + [CloudStore](hosted-private-cloud-hosted-private-cloud-opcp-cloudstore)

--- a/docs/de/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/de/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,175 @@
+---
+title: How to upgrade OPCP.Core
+description: Learn how to upgrade your OVHcloud On-Prem Cloud Platform (OPCP), from downloading the artifacts with the opcp-cli to performing the post-deployment checks.
+lastUpdated: 2026-08-19
+---
+
+## Objective
+
+This guide explains how to upgrade your **OVHcloud On-Prem Cloud Platform (OPCP)**: downloading the new artifacts, upgrading the `opcp-cli`, applying the new OPCP release, and validating the platform once the upgrade is complete.
+
+## Requirements
+
+- An operational [OPCP](/links/hosted-private-cloud/onprem-cloud-platform) infrastructure.
+- Administrative (`root`) access to the OPCP control-plane, with `opcp-cli`, `opcp-diag`, `needrestart`, `flux` and `tfctl` installed and configured.
+- Access to the official S3<sup>1</sup> bucket provided for your OPCP delivery, in order to download the `opcp-cli`, the new OPCP bundle, the `RELEASE-NOTES`, and their corresponding `.minisig` signature files.
+
+## Instructions
+
+### 1. Running the pre-deployment checks
+
+On the OPCP control-plane, run `opcp-diag` to confirm the platform is healthy before starting the upgrade:
+
+```bash
+opcp-diag run -p
+```
+
+If any error is reported, check whether it needs to be fixed before going any further.
+
+### 2. Downloading the artifacts
+
+Get access to the official S3 bucket in order to download the latest version of:
+
+- the `opcp-cli`,
+- the new OPCP bundle,
+- the `RELEASE-NOTES` of the versions that will be deployed.
+
+You will also find the corresponding `.minisig` files in the bucket. They are used to check that the downloaded files are not corrupted before upgrading your OPCP product.
+
+:::info
+If you are currently using an OPCP product in AirGap mode, you should have received a read-only user to access this bucket. Refer to [Use Object Storage with S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) to get started with Object Storage.
+:::
+
+Once you have downloaded the required files, push them to one of your OPCP controllers. In HA mode (3 controllers), the artifacts are automatically synchronized between all the controllers, so you do not need to push the files to every controller.
+
+### 3. Reading the RELEASE-NOTES
+
+Some versions require manual actions to prepare services before the upgrade.
+
+Read the `RELEASE-NOTES` carefully, as some actions may be required before the upgrade starts and others after it ends.
+
+### 4. Upgrading the opcp-cli
+
+If mentioned in the `RELEASE-NOTES`, upload the new `opcp-cli` binary and its signature to the remote managed OPCP control-plane.
+
+Then, as `root`, update `opcp-cli`:
+
+```bash
+root@opcp-reg-prd-0-0:~ $ opcp-cli update --bin /home/opcp-admin/opcp-cli-linux-amd64 --signature /home/opcp-admin/opcp-cli-linux-amd64.minisig
+✅ Commande 'update' terminée en 521.528004ms
+
+root@opcp-reg-prd-0-0:~ $ opcp-cli version
+INFO[0000] 👉 Opcp-cli version information
+INFO[0000] Opcp-cli version: v2.4.1
+INFO[0000] Opcp-cli commit: de54e85
+INFO[0000] Opcp-cli build time: 2026-02-05_15:54:16
+INFO[0000] ✅ Commande 'version' terminée en 35.343µs
+```
+
+Remove the uploaded files once the update is confirmed:
+
+```bash
+root@opcp-reg-prd-0-0:~ $ rm /home/ovh/opcp-cli-linux-amd64*
+```
+
+### 5. Upgrading the OPCP artifacts
+
+As `root` on the remote managed OPCP control-plane, open the configuration file and update the versions:
+
+```bash
+opcp-cli config edit
+```
+
+Update the global version and, if required, the specific artifact versions. For example:
+
+```yaml
+opcp-version:
+  global: 1.2.1
+  artifacts:
+    irobox: 1.2.4
+    binaries: 1.2.4
+```
+
+If no specific version is needed, only set the global version:
+
+```yaml
+opcp-version:
+  global: 1.2.4
+```
+
+If required, also update the hardware configuration:
+
+```bash
+opcp-cli config edit --hardware
+```
+
+Then apply the new release:
+
+```bash
+opcp-cli deploy
+```
+
+The following steps can take a lot of time, depending on what is updated in the release:
+
+- extracting Glance images,
+- starting the deployment on the remote nodes,
+- executing the deployment of the control plane, which can take up to 10 minutes.
+
+You can follow the detailed logs in `/var/log/opcp-cli/opcp-cli.log`:
+
+```bash
+tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg
+```
+
+### 6. Performing the final checks
+
+#### Checking if some services need a restart
+
+Use `needrestart` to check whether some services need to be restarted:
+
+```bash
+needrestart -r l
+```
+
+:::warning
+Restarting services can have an impact on the platform. Only proceed if it is required.
+:::
+
+If needed, restart the required services:
+
+```bash
+needrestart -ra
+needrestart
+```
+
+#### Waiting for reconciliation
+
+Wait for the Flux reconciliation to complete and the Terraform runs to finish:
+
+```bash
+flux get all -A --status-selector ready=false
+flux get all -A --status-selector ready=unknown
+tfctl get
+```
+
+If needed, apply a fix. Sometimes you need to relaunch some pods, so be patient.
+
+#### Post-deployment checks
+
+On the OPCP control-plane, run `opcp-diag` again:
+
+```bash
+opcp-diag run -p
+```
+
+If any error is reported, check whether it needs to be fixed.
+
+You can also try to access the UI to confirm that it works properly.
+
+## Go further
+
+If you need training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
+
+Join our [community of users](/links/community).
+
+<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to upgrade OPCP
-description: Learn how to upgrade your OVHcloud On-Prem Cloud Platform (OPCP), from downloading the artifacts with the opcp-cli to performing the post-deployment checks.
-lastUpdated: 2026-08-19
+description: Learn how to upgrade your OVHcloud On-Prem Cloud Platform (OPCP), from downloading the artifacts with the opcp-cli to performing the post-deployment checks
+lastUpdated: 2026-08-27
 ---
 
 ## Objective
@@ -134,13 +134,13 @@ Then apply the new release:
 opcp-cli deploy
 ```
 
-The following steps can take up to 30min, depending on what is updated in the release:
+The following steps can take up to 30 minutes, depending on what is updated in the release:
 
 - extracting Glance images,
 - starting the deployment on the remote nodes,
 - executing the deployment of the control plane, which can take up to 10 minutes.
 
-You can follow the detailed logs in `/var/log/opcp-cli/opcp-cli.log`. To do this, you can open a new terminal window and run:
+You can follow the detailed logs in `/var/log/opcp-cli/opcp-cli.log`. To do this, open a new terminal window and run:
 
 ```bash
 tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to upgrade OPCP.Core
+title: How to upgrade OPCP
 description: Learn how to upgrade your OVHcloud On-Prem Cloud Platform (OPCP), from downloading the artifacts with the opcp-cli to performing the post-deployment checks.
 lastUpdated: 2026-08-19
 ---

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -40,7 +40,41 @@ You will also find the corresponding `.minisig` files in the bucket. They are us
 If you are currently using an OPCP product in AirGap mode, you should have received a read-only user to access this bucket. Refer to [Use Object Storage with S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) to get started with Object Storage.
 :::
 
-Once you have downloaded the required files, push them to one of your OPCP controllers. In HA mode (3 controllers), the artifacts are automatically synchronized between all the controllers, so you do not need to push the files to every controller.
+Once the `s3cmd` command is configured, you can list the artifacts to download:
+
+```bash
+s3cmd ls
+2026-08-14 16:19  s3://opcp-distribution-gra
+
+s3cmd ls s3://opcp-distribution-gra
+                          DIR  s3://opcp-distribution-gra/bundle/
+                          DIR  s3://opcp-distribution-gra/opcp-cli/
+                          DIR  s3://opcp-distribution-gra/opcp-controller-debian-image/
+
+s3cmd ls s3://opcp-distribution-gra/opcp-cli/v3.1.21/
+2026-07-15 14:38    186822902  s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64
+2026-07-15 14:38          312  s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64.minisig
+
+s3cmd ls s3://opcp-distribution-gra/bundle/3.0.6/
+2026-07-16 14:49  12045479079  s3://opcp-distribution-gra/bundle/3.0.6/opcp-binaries-3.0.6.tar.gz
+2026-07-16 14:49          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-binaries-3.0.6.tar.gz.minisig
+2026-07-16 14:50   2333361766  s3://opcp-distribution-gra/bundle/3.0.6/opcp-glance-images-3.0.6.tar.gz
+2026-07-16 14:50          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-glance-images-3.0.6.tar.gz.minisig
+2026-07-16 14:50      2608231  s3://opcp-distribution-gra/bundle/3.0.6/opcp-helm-charts-3.0.6.tar.gz
+2026-07-16 14:50          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-helm-charts-3.0.6.tar.gz.minisig
+2026-07-16 15:01  16121324032  s3://opcp-distribution-gra/bundle/3.0.6/opcp-images-3.0.6.tar
+2026-07-16 15:01          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-images-3.0.6.tar.minisig
+2026-07-16 15:01      2451332  s3://opcp-distribution-gra/bundle/3.0.6/opcp-irobox-3.0.6.tar.gz
+2026-07-16 15:01          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-irobox-3.0.6.tar.gz.minisig
+2026-07-16 15:02    968468765  s3://opcp-distribution-gra/bundle/3.0.6/opcp-packages-3.0.6.tar.gz
+2026-07-16 15:02          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-packages-3.0.6.tar.gz.minisig
+
+s3cmd get s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64
+download: 's3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64' -> './opcp-cli-linux-amd64'  [1 of 1]
+ 186822902 of 186822902   100% in   11s    15.98 MB/s  done
+```
+
+Once you have downloaded the required files, push them to one of your OPCP controllers, under the `/home/opcp-admin` path. In HA mode (3 controllers), the artifacts are automatically synchronized between all the controllers, so you do not need to push the files to every controller.
 
 ### 3. Reading the RELEASE-NOTES
 
@@ -56,14 +90,21 @@ Then, as `root`, update `opcp-cli`:
 
 ```bash
 root@opcp-reg-prd-0-0:~ $ opcp-cli update --bin /home/opcp-admin/opcp-cli-linux-amd64 --signature /home/opcp-admin/opcp-cli-linux-amd64.minisig
-✅ Commande 'update' terminée en 521.528004ms
+✅ Command 'update' completed in 521.528004ms
 
 root@opcp-reg-prd-0-0:~ $ opcp-cli version
-INFO[0000] 👉 Opcp-cli version information
-INFO[0000] Opcp-cli version: v2.4.1
-INFO[0000] Opcp-cli commit: de54e85
-INFO[0000] Opcp-cli build time: 2026-02-05_15:54:16
-INFO[0000] ✅ Commande 'version' terminée en 35.343µs
+opcp-cli version
+Opcp-cli version: v3.1.21
+Opcp-cli commit: 4c11635
+Opcp-cli build time: 2026-07-13_15:15:23
+
+Deployed artifacts:
+  images          configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:28:08Z      deployed-at: 2026-07-16T12:47:52Z
+  packages        configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:27:28Z      deployed-at: 2026-07-16T12:48:00Z
+  binaries        configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:31:36Z      deployed-at: 2026-07-16T12:50:05Z
+  helm-charts     configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:28:07Z      deployed-at: 2026-07-16T12:50:06Z
+  glance-images   configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:27:36Z      deployed-at: 2026-07-16T12:55:16Z
+  irobox          configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:26:28Z      deployed-at: 2026-08-26T08:47:18Z
 ```
 
 Remove the uploaded files once the update is confirmed:
@@ -80,27 +121,11 @@ As `root` on the remote managed OPCP control-plane, open the configuration file 
 opcp-cli config edit
 ```
 
-Update the global version and, if required, the specific artifact versions. For example:
+Update the global version. For example:
 
 ```yaml
 opcp-version:
-  global: 1.2.1
-  artifacts:
-    irobox: 1.2.4
-    binaries: 1.2.4
-```
-
-If no specific version is needed, only set the global version:
-
-```yaml
-opcp-version:
-  global: 1.2.4
-```
-
-If required, also update the hardware configuration:
-
-```bash
-opcp-cli config edit --hardware
+  global: 3.0.6
 ```
 
 Then apply the new release:
@@ -109,13 +134,13 @@ Then apply the new release:
 opcp-cli deploy
 ```
 
-The following steps can take a lot of time, depending on what is updated in the release:
+The following steps can take up to 30min, depending on what is updated in the release:
 
 - extracting Glance images,
 - starting the deployment on the remote nodes,
 - executing the deployment of the control plane, which can take up to 10 minutes.
 
-You can follow the detailed logs in `/var/log/opcp-cli/opcp-cli.log`:
+You can follow the detailed logs in `/var/log/opcp-cli/opcp-cli.log`. To do this, you can open a new terminal window and run:
 
 ```bash
 tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg

--- a/docs/en/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
@@ -74,6 +74,7 @@ To find the right guide for your needs:
         { title: 'How the Ironic to NetBox synchronisation works', link: '/guides/hosted-private-cloud/opcp/netbox-ironic-synchronisation' },
         { title: 'How to use Terraform', link: '/guides/hosted-private-cloud/opcp/use-terraform' },
         { title: 'How to update the backup S3 buckets', link: '/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets' },
+        { title: 'How to upgrade OPCP.Core', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
       ],
     },
     {

--- a/docs/en/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
@@ -74,7 +74,7 @@ To find the right guide for your needs:
         { title: 'How the Ironic to NetBox synchronisation works', link: '/guides/hosted-private-cloud/opcp/netbox-ironic-synchronisation' },
         { title: 'How to use Terraform', link: '/guides/hosted-private-cloud/opcp/use-terraform' },
         { title: 'How to update the backup S3 buckets', link: '/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets' },
-        { title: 'How to upgrade OPCP.Core', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
+        { title: 'How to upgrade OPCP', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
       ],
     },
     {

--- a/docs/es/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/es/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comment mettre à jour OPCP"
-description: "Découvrez comment mettre à jour votre OVHcloud On-Prem Cloud Platform (OPCP), du téléchargement des artefacts avec l’opcp-cli aux vérifications post-déploiement."
-lastUpdated: 2026-08-19
+description: "Découvrez comment mettre à jour votre OVHcloud On-Prem Cloud Platform (OPCP), du téléchargement des artefacts aux vérifications post-déploiement"
+lastUpdated: 2026-08-27
 ---
 
 ## Objectif
@@ -24,7 +24,7 @@ Sur le plan de contrôle OPCP, lancez `opcp-diag` pour confirmer que la platefor
 opcp-diag run -p
 ```
 
-Si une erreur est signalée, vérifiez s’il est nécessaire de la corriger avant d’aller plus loin.
+Si une erreur est signalée, vérifiez si elle doit être corrigée avant d’aller plus loin.
 
 ### 2. Télécharger les artefacts
 
@@ -37,10 +37,10 @@ Obtenez un accès au bucket S3 officiel afin de télécharger la dernière versi
 Vous trouverez également les fichiers `.minisig` correspondants dans le bucket. Ils permettent de vérifier que les fichiers téléchargés ne sont pas corrompus avant de mettre à jour votre produit OPCP.
 
 :::info
-Si vous utilisez actuellement un produit OPCP en mode AirGap, vous devriez avoir reçu un utilisateur en lecture seule pour accéder à ce bucket. Consultez [Utiliser le stockage objet avec S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) pour démarrer avec le stockage objet.
+Si vous utilisez actuellement un produit OPCP en mode AirGap, vous devriez avoir reçu un utilisateur en lecture seule pour accéder à ce bucket. Consultez [Utiliser Object Storage avec S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) pour démarrer avec Object Storage.
 :::
 
-Une fois la configuration de la commande `s3cmd` terminée, vous pouvez lister les artifacts à télécharger :
+Une fois la configuration de la commande `s3cmd` terminée, vous pouvez lister les artefacts à télécharger :
 
 ```bash
 s3cmd ls
@@ -90,7 +90,7 @@ Puis, en tant que `root`, mettez à jour `opcp-cli` :
 
 ```bash
 root@opcp-reg-prd-0-0:~ $ opcp-cli update --bin /home/opcp-admin/opcp-cli-linux-amd64 --signature /home/opcp-admin/opcp-cli-linux-amd64.minisig
-✅ Commande 'update' terminée en 521.528004ms
+✅ Command 'update' completed in 521.528004ms
 
 root@opcp-reg-prd-0-0:~ $ opcp-cli version
 opcp-cli version
@@ -134,13 +134,13 @@ Appliquez ensuite la nouvelle version :
 opcp-cli deploy
 ```
 
-Les étapes suivantes peuvent prendre jusqu'à 30min, selon ce qui est mis à jour dans la version :
+Les étapes suivantes peuvent prendre jusqu'à 30 minutes, selon ce qui est mis à jour dans la version :
 
 - extraction des images Glance,
 - démarrage du déploiement sur les nœuds distants,
 - exécution du déploiement du plan de contrôle, qui peut prendre jusqu’à 10 minutes.
 
-Vous pouvez suivre les journaux détaillés dans `/var/log/opcp-cli/opcp-cli.log`. Pour cela, vous pouvez ouvrir une nouvelle fenêtre de terminal et exécuter :
+Vous pouvez suivre les journaux détaillés dans `/var/log/opcp-cli/opcp-cli.log`. Pour cela, ouvrez une nouvelle fenêtre de terminal et exécutez :
 
 ```bash
 tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg
@@ -177,7 +177,7 @@ flux get all -A --status-selector ready=unknown
 tfctl get
 ```
 
-Si nécessaire, appliquez un correctif. Il est parfois nécessaire de relancer certains pods : soyez patient.
+Si nécessaire, appliquez un correctif. Vous devez parfois relancer certains pods : soyez patient.
 
 #### Vérifications post-déploiement
 
@@ -187,7 +187,7 @@ Sur le plan de contrôle OPCP, relancez `opcp-diag` :
 opcp-diag run -p
 ```
 
-Si une erreur est signalée, vérifiez s’il est nécessaire de la corriger.
+Si une erreur est signalée, vérifiez si elle doit être corrigée.
 
 Vous pouvez également essayer d’accéder à l’interface pour confirmer qu’elle fonctionne correctement.
 

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,175 @@
+---
+title: "Comment mettre à jour OPCP.Core"
+description: "Découvrez comment mettre à jour votre OVHcloud On-Prem Cloud Platform (OPCP), du téléchargement des artefacts avec l’opcp-cli aux vérifications post-déploiement."
+lastUpdated: 2026-08-19
+---
+
+## Objectif
+
+Ce guide explique comment mettre à jour votre **OVHcloud On-Prem Cloud Platform (OPCP)** : téléchargement des nouveaux artefacts, mise à jour de l’`opcp-cli`, application de la nouvelle version OPCP, puis validation de la plateforme une fois la mise à jour terminée.
+
+## Prérequis
+
+- Disposer d’une infrastructure [OPCP](/links/hosted-private-cloud/onprem-cloud-platform) opérationnelle.
+- Disposer d’un accès administrateur (`root`) au plan de contrôle OPCP, avec les outils `opcp-cli`, `opcp-diag`, `needrestart`, `flux` et `tfctl` installés et configurés.
+- Disposer d’un accès au bucket S3<sup>1</sup> officiel fourni pour votre livraison OPCP, afin de télécharger l’`opcp-cli`, le nouveau paquet OPCP, les `RELEASE-NOTES`, ainsi que leurs fichiers de signature `.minisig` correspondants.
+
+## En pratique
+
+### 1. Lancer les vérifications préalables au déploiement
+
+Sur le plan de contrôle OPCP, lancez `opcp-diag` pour confirmer que la plateforme est en bonne santé avant de démarrer la mise à jour :
+
+```bash
+opcp-diag run -p
+```
+
+Si une erreur est signalée, vérifiez s’il est nécessaire de la corriger avant d’aller plus loin.
+
+### 2. Télécharger les artefacts
+
+Obtenez un accès au bucket S3 officiel afin de télécharger la dernière version :
+
+- de l’`opcp-cli`,
+- du nouveau paquet OPCP,
+- des `RELEASE-NOTES` des versions qui seront déployées.
+
+Vous trouverez également les fichiers `.minisig` correspondants dans le bucket. Ils permettent de vérifier que les fichiers téléchargés ne sont pas corrompus avant de mettre à jour votre produit OPCP.
+
+:::info
+Si vous utilisez actuellement un produit OPCP en mode AirGap, vous devriez avoir reçu un utilisateur en lecture seule pour accéder à ce bucket. Consultez [Utiliser le stockage objet avec S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) pour démarrer avec le stockage objet.
+:::
+
+Une fois les fichiers requis téléchargés, transférez-les sur l’un de vos contrôleurs OPCP. En mode HA (3 contrôleurs), les artefacts sont automatiquement synchronisés entre tous les contrôleurs : il n’est donc pas nécessaire de transférer les fichiers sur chacun d’eux.
+
+### 3. Lire les RELEASE-NOTES
+
+Certaines versions nécessitent des actions manuelles pour préparer les services avant la mise à jour.
+
+Lisez attentivement les `RELEASE-NOTES`, car certaines actions peuvent être requises avant le début de la mise à jour et d’autres après sa fin.
+
+### 4. Mettre à jour l’opcp-cli
+
+Si cela est indiqué dans les `RELEASE-NOTES`, téléversez le nouveau binaire `opcp-cli` ainsi que sa signature sur le plan de contrôle OPCP géré à distance.
+
+Puis, en tant que `root`, mettez à jour `opcp-cli` :
+
+```bash
+root@opcp-reg-prd-0-0:~ $ opcp-cli update --bin /home/opcp-admin/opcp-cli-linux-amd64 --signature /home/opcp-admin/opcp-cli-linux-amd64.minisig
+✅ Commande 'update' terminée en 521.528004ms
+
+root@opcp-reg-prd-0-0:~ $ opcp-cli version
+INFO[0000] 👉 Opcp-cli version information
+INFO[0000] Opcp-cli version: v2.4.1
+INFO[0000] Opcp-cli commit: de54e85
+INFO[0000] Opcp-cli build time: 2026-02-05_15:54:16
+INFO[0000] ✅ Commande 'version' terminée en 35.343µs
+```
+
+Supprimez les fichiers téléversés une fois la mise à jour confirmée :
+
+```bash
+root@opcp-reg-prd-0-0:~ $ rm /home/ovh/opcp-cli-linux-amd64*
+```
+
+### 5. Mettre à jour les artefacts OPCP
+
+En tant que `root` sur le plan de contrôle OPCP géré à distance, ouvrez le fichier de configuration et mettez à jour les versions :
+
+```bash
+opcp-cli config edit
+```
+
+Mettez à jour la version globale et, si nécessaire, les versions spécifiques des artefacts. Par exemple :
+
+```yaml
+opcp-version:
+  global: 1.2.1
+  artifacts:
+    irobox: 1.2.4
+    binaries: 1.2.4
+```
+
+Si aucune version spécifique n’est nécessaire, définissez uniquement la version globale :
+
+```yaml
+opcp-version:
+  global: 1.2.4
+```
+
+Si nécessaire, mettez également à jour la configuration matérielle :
+
+```bash
+opcp-cli config edit --hardware
+```
+
+Appliquez ensuite la nouvelle version :
+
+```bash
+opcp-cli deploy
+```
+
+Les étapes suivantes peuvent prendre beaucoup de temps, selon ce qui est mis à jour dans la version :
+
+- extraction des images Glance,
+- démarrage du déploiement sur les nœuds distants,
+- exécution du déploiement du plan de contrôle, qui peut prendre jusqu’à 10 minutes.
+
+Vous pouvez suivre les journaux détaillés dans `/var/log/opcp-cli/opcp-cli.log` :
+
+```bash
+tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg
+```
+
+### 6. Effectuer les vérifications finales
+
+#### Vérifier si certains services nécessitent un redémarrage
+
+Utilisez `needrestart` pour vérifier si certains services doivent être redémarrés :
+
+```bash
+needrestart -r l
+```
+
+:::warning
+Le redémarrage de services peut avoir un impact sur la plateforme. Ne procédez que si cela est nécessaire.
+:::
+
+Si nécessaire, redémarrez les services concernés :
+
+```bash
+needrestart -ra
+needrestart
+```
+
+#### Attendre la réconciliation
+
+Attendez que la réconciliation Flux soit terminée et que les exécutions Terraform soient achevées :
+
+```bash
+flux get all -A --status-selector ready=false
+flux get all -A --status-selector ready=unknown
+tfctl get
+```
+
+Si nécessaire, appliquez un correctif. Il est parfois nécessaire de relancer certains pods : soyez patient.
+
+#### Vérifications post-déploiement
+
+Sur le plan de contrôle OPCP, relancez `opcp-diag` :
+
+```bash
+opcp-diag run -p
+```
+
+Si une erreur est signalée, vérifiez s’il est nécessaire de la corriger.
+
+Vous pouvez également essayer d’accéder à l’interface pour confirmer qu’elle fonctionne correctement.
+
+## Aller plus loin
+
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](/links/professional-services) pour obtenir un devis et faire analyser votre projet par nos experts.
+
+Échangez avec notre [communauté d’utilisateurs](/links/community).
+
+<sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -40,7 +40,41 @@ Vous trouverez également les fichiers `.minisig` correspondants dans le bucket.
 Si vous utilisez actuellement un produit OPCP en mode AirGap, vous devriez avoir reçu un utilisateur en lecture seule pour accéder à ce bucket. Consultez [Utiliser le stockage objet avec S3cmd](/guides/storage-and-backup/object-storage/s3-s3cmd) pour démarrer avec le stockage objet.
 :::
 
-Une fois les fichiers requis téléchargés, transférez-les sur l’un de vos contrôleurs OPCP. En mode HA (3 contrôleurs), les artefacts sont automatiquement synchronisés entre tous les contrôleurs : il n’est donc pas nécessaire de transférer les fichiers sur chacun d’eux.
+Une fois la configuration de la commande `s3cmd` terminée, vous pouvez lister les artifacts à télécharger :
+
+```bash
+s3cmd ls
+2026-08-14 16:19  s3://opcp-distribution-gra
+
+s3cmd ls s3://opcp-distribution-gra
+                          DIR  s3://opcp-distribution-gra/bundle/
+                          DIR  s3://opcp-distribution-gra/opcp-cli/
+                          DIR  s3://opcp-distribution-gra/opcp-controller-debian-image/
+
+s3cmd ls s3://opcp-distribution-gra/opcp-cli/v3.1.21/
+2026-07-15 14:38    186822902  s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64
+2026-07-15 14:38          312  s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64.minisig
+
+s3cmd ls s3://opcp-distribution-gra/bundle/3.0.6/
+2026-07-16 14:49  12045479079  s3://opcp-distribution-gra/bundle/3.0.6/opcp-binaries-3.0.6.tar.gz
+2026-07-16 14:49          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-binaries-3.0.6.tar.gz.minisig
+2026-07-16 14:50   2333361766  s3://opcp-distribution-gra/bundle/3.0.6/opcp-glance-images-3.0.6.tar.gz
+2026-07-16 14:50          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-glance-images-3.0.6.tar.gz.minisig
+2026-07-16 14:50      2608231  s3://opcp-distribution-gra/bundle/3.0.6/opcp-helm-charts-3.0.6.tar.gz
+2026-07-16 14:50          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-helm-charts-3.0.6.tar.gz.minisig
+2026-07-16 15:01  16121324032  s3://opcp-distribution-gra/bundle/3.0.6/opcp-images-3.0.6.tar
+2026-07-16 15:01          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-images-3.0.6.tar.minisig
+2026-07-16 15:01      2451332  s3://opcp-distribution-gra/bundle/3.0.6/opcp-irobox-3.0.6.tar.gz
+2026-07-16 15:01          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-irobox-3.0.6.tar.gz.minisig
+2026-07-16 15:02    968468765  s3://opcp-distribution-gra/bundle/3.0.6/opcp-packages-3.0.6.tar.gz
+2026-07-16 15:02          310  s3://opcp-distribution-gra/bundle/3.0.6/opcp-packages-3.0.6.tar.gz.minisig
+
+s3cmd get s3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64
+download: 's3://opcp-distribution-gra/opcp-cli/v3.1.21/opcp-cli-linux-amd64' -> './opcp-cli-linux-amd64'  [1 of 1]
+ 186822902 of 186822902   100% in   11s    15.98 MB/s  done
+```
+
+Une fois les fichiers requis téléchargés, transférez-les sur l’un de vos contrôleurs OPCP, sous le chemin `/home/opcp-admin`. En mode HA (3 contrôleurs), les artefacts sont automatiquement synchronisés entre tous les contrôleurs : il n’est donc pas nécessaire de transférer les fichiers sur chacun d’eux.
 
 ### 3. Lire les RELEASE-NOTES
 
@@ -59,11 +93,18 @@ root@opcp-reg-prd-0-0:~ $ opcp-cli update --bin /home/opcp-admin/opcp-cli-linux-
 ✅ Commande 'update' terminée en 521.528004ms
 
 root@opcp-reg-prd-0-0:~ $ opcp-cli version
-INFO[0000] 👉 Opcp-cli version information
-INFO[0000] Opcp-cli version: v2.4.1
-INFO[0000] Opcp-cli commit: de54e85
-INFO[0000] Opcp-cli build time: 2026-02-05_15:54:16
-INFO[0000] ✅ Commande 'version' terminée en 35.343µs
+opcp-cli version
+Opcp-cli version: v3.1.21
+Opcp-cli commit: 4c11635
+Opcp-cli build time: 2026-07-13_15:15:23
+
+Deployed artifacts:
+  images          configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:28:08Z      deployed-at: 2026-07-16T12:47:52Z
+  packages        configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:27:28Z      deployed-at: 2026-07-16T12:48:00Z
+  binaries        configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:31:36Z      deployed-at: 2026-07-16T12:50:05Z
+  helm-charts     configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:28:07Z      deployed-at: 2026-07-16T12:50:06Z
+  glance-images   configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:27:36Z      deployed-at: 2026-07-16T12:55:16Z
+  irobox          configured: 3.0.6        deployed: 3.0.6        build-time: 2026-07-13T09:26:28Z      deployed-at: 2026-08-26T08:47:18Z
 ```
 
 Supprimez les fichiers téléversés une fois la mise à jour confirmée :
@@ -80,27 +121,11 @@ En tant que `root` sur le plan de contrôle OPCP géré à distance, ouvrez le f
 opcp-cli config edit
 ```
 
-Mettez à jour la version globale et, si nécessaire, les versions spécifiques des artefacts. Par exemple :
+Mettez à jour la version globale. Par exemple :
 
 ```yaml
 opcp-version:
-  global: 1.2.1
-  artifacts:
-    irobox: 1.2.4
-    binaries: 1.2.4
-```
-
-Si aucune version spécifique n’est nécessaire, définissez uniquement la version globale :
-
-```yaml
-opcp-version:
-  global: 1.2.4
-```
-
-Si nécessaire, mettez également à jour la configuration matérielle :
-
-```bash
-opcp-cli config edit --hardware
+  global: 3.0.6
 ```
 
 Appliquez ensuite la nouvelle version :
@@ -109,13 +134,13 @@ Appliquez ensuite la nouvelle version :
 opcp-cli deploy
 ```
 
-Les étapes suivantes peuvent prendre beaucoup de temps, selon ce qui est mis à jour dans la version :
+Les étapes suivantes peuvent prendre jusqu'à 30min, selon ce qui est mis à jour dans la version :
 
 - extraction des images Glance,
 - démarrage du déploiement sur les nœuds distants,
 - exécution du déploiement du plan de contrôle, qui peut prendre jusqu’à 10 minutes.
 
-Vous pouvez suivre les journaux détaillés dans `/var/log/opcp-cli/opcp-cli.log` :
+Vous pouvez suivre les journaux détaillés dans `/var/log/opcp-cli/opcp-cli.log`. Pour cela, vous pouvez ouvrir une nouvelle fenêtre de terminal et exécuter :
 
 ```bash
 tail -F /var/log/opcp-cli/opcp-cli.log | jq .msg

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Comment mettre à jour OPCP.Core"
+title: "Comment mettre à jour OPCP"
 description: "Découvrez comment mettre à jour votre OVHcloud On-Prem Cloud Platform (OPCP), du téléchargement des artefacts avec l’opcp-cli aux vérifications post-déploiement."
 lastUpdated: 2026-08-19
 ---

--- a/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
@@ -74,7 +74,7 @@ Pour trouver le guide adapté à votre besoin :
         { title: 'Fonctionnement de la synchronisation Ironic vers NetBox', link: '/guides/hosted-private-cloud/opcp/netbox-ironic-synchronisation' },
         { title: 'Comment utiliser Terraform', link: '/guides/hosted-private-cloud/opcp/use-terraform' },
         { title: 'Comment mettre à jour les buckets S3 de sauvegarde', link: '/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets' },
-        { title: 'Comment mettre à jour OPCP.Core', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
+        { title: 'Comment mettre à jour OPCP', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
       ],
     },
     {

--- a/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/landing-page-opcp.mdx
@@ -74,6 +74,7 @@ Pour trouver le guide adapté à votre besoin :
         { title: 'Fonctionnement de la synchronisation Ironic vers NetBox', link: '/guides/hosted-private-cloud/opcp/netbox-ironic-synchronisation' },
         { title: 'Comment utiliser Terraform', link: '/guides/hosted-private-cloud/opcp/use-terraform' },
         { title: 'Comment mettre à jour les buckets S3 de sauvegarde', link: '/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets' },
+        { title: 'Comment mettre à jour OPCP.Core', link: '/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp' },
       ],
     },
     {

--- a/docs/it/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/it/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx

--- a/docs/pl/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/pl/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx

--- a/docs/pt/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
+++ b/docs/pt/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/opcp/how-to-upgrade-opcp.mdx


### PR DESCRIPTION
This guide is made for our airgap customer to be able to upgrade the OPCP.Core version by themselves.