### PR TITLE
chore: Update installation architecture notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the OVHcloud documentation site built with [Rspress](https://rspress.dev/) (v2.0.0-rc), a React-based static site generator. It serves documentation in 7 locales: fr, en, de, es, it, pl, pt.
+This is the OVHcloud documentation site built with [Rspress](https://rspress.dev/) v2 (`@rspress/core` — the pinned range lives in `package.json`), a React-based static site generator. It serves documentation in 7 locales: fr, en, de, es, it, pl, pt.
 
 ## Common Commands
 
@@ -33,7 +33,7 @@ pnpm check  # lint + format with auto-fix
 ### Configuration Split
 - `rspress.config.ts` - Development config, serves all locales from one instance
 - `rspress.config.build.ts` - Production config, used per-locale with `LOCALE` env var
-- `config/shared.ts` - Shared locale definitions and base config
+- `config/shared.ts` - Locale definitions only (the `locales` array + `Locale` type). Deliberately data-only: all build settings live in the two configs above
 - `turbo.json` - Turborepo orchestrates parallel locale builds
 
 ### Text Fragments
@@ -61,7 +61,7 @@ This affects sidebar key matching — see `config/sidebar/index.ts` for details.
 ### Dev Performance
 With 9500+ MDX files, dev SSR is slow (~9s per page). Optimizations applied:
 
-- **`lastUpdated`** - Disabled in dev (runs `git log` per page). Enabled only in production via `process.env.NODE_ENV === 'production'`
+- **`lastUpdated`** - The built-in feature is off (`themeConfig.lastUpdated: false`) in **both** configs, since it runs `git log` per page (80k+ calls). The value comes from `plugins/lastUpdatedFromCache.ts` and is rendered by a custom `LastUpdated` component. The plugin resolves, in order: frontmatter `lastUpdated`/`updated` (read from Rspress's already-parsed `frontmatter`, no disk re-read), then the `.last-updated-cache.json` git cache built by `pnpm build:cache`
 - **Shiki langs** - Removed `markdown` and `mdx` which disable lazy loading
 - Multi-locale and shiki lang count have minimal impact on SSR time
 
@@ -82,7 +82,7 @@ docs/
 config/
   sidebar/            # Sidebar definitions per product category
   nav/                # Navigation with localized external URLs
-  shared.ts           # Locale definitions, shared Rspress config
+  shared.ts           # Locale definitions (data-only)
 
 theme/
   index.tsx           # Theme entry - re-exports from @rspress/core/theme-original with overrides
@@ -180,10 +180,16 @@ The custom theme (`theme/index.tsx`) extends Rspress's original theme:
 - Frontmatter `outline: false` or `sidebar: false` hides those elements
 
 ### Build Process
-1. Turborepo runs `build:{locale}` tasks in parallel
-2. Each locale build uses `rspress.config.build.ts` with `LOCALE` env var
-3. Output goes to `dist/{locale}/`
-4. `pnpm build:combine` merges locale builds into final `dist/`
+1. `pnpm build:cache` generates `.last-updated-cache.json` (see Dev Performance)
+2. Turborepo runs `build:{locale}` tasks in parallel
+3. Each locale build uses `rspress.config.build.ts` with `LOCALE` env var
+4. Output goes to `dist/{locale}/`
+5. `pnpm build:combine` merges locale builds into final `dist/` and generates the sitemaps, sitemap index and `robots.txt`
+
+#### Site origin (SEO / LLM crawlers)
+`rspress.config.build.ts` sets `siteOrigin: 'https://docs.ovhcloud.com'`. It is what makes the `llms: true` output (`llms.txt`, `llms-full.txt`, the per-page `.md` links and the AI-agent hint under the H1) emit absolute rather than relative URLs. **Three copies must stay in sync:** `siteOrigin` here, `SITE_URL` in `scripts/combine-builds.ts`, and the same constant in `theme/components/SEOHead`.
+
+Sitemaps are **not** produced by an Rspress plugin (`@rspress/plugin-sitemap` was dropped) — `scripts/combine-builds.ts` writes one `sitemap.xml` per locale with hreflang alternates, a root sitemap index, `robots.txt`, and promotes the legacy `sitemap-help.xml`.
 
 ## Code Style
 


### PR DESCRIPTION
- Rspress version claim now points at package.json instead of the
  stale v2.0.0-rc
- config/shared.ts described as data-only after #568 removed
  sharedConfig/createLocaleConfig and config/locales/*
- lastUpdated: document the plugin + cache mechanism replacing the
  built-in git log per page
- Build Process: add the build:cache step and a Site origin section
  covering siteOrigin, llms output and the three constants that must
  stay in sync