### PR TITLE
fix(account): clarify SIRET update does not re-issue past invoices

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -19,7 +19,7 @@ Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil.
 :::warning
 La mise à jour de vos informations depuis votre espace client ne corrige pas les factures déjà émises : elle est prise en compte à partir de votre prochaine facture. Par exemple, un numéro de SIRET mis à jour le 15 septembre sera appliqué à la facture d'octobre, sans réédition de celle de septembre.
 
-Si l'erreur de facturation est imputable à OVHcloud, la facture concernée est corrigée et rééditée par nos équipes, sans action de votre part.
+Si vous estimez que l'erreur de facturation est imputable à OVHcloud, [contactez le support OVHcloud](/links/support-contact). Nos équipes analyseront alors la demande afin de déterminer l'origine de l'erreur. Si celle-ci nous est imputable, la facture concernée sera corrigée et rééditée à l'issue de cette analyse : cette opération ne sera pas automatique.
 :::
 
 ## Prérequis

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -1,7 +1,7 @@
 ---
 title: Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA
 description: Découvrez comment renseigner votre numéro de SIRET pour mettre à jour le taux de TVA de votre compte de facturation OVHcloud
-lastUpdated: 2026-08-12
+lastUpdated: 2026-08-20
 ---
 
 ## Objectif
@@ -10,11 +10,17 @@ lastUpdated: 2026-08-12
 
 Si vous disposez d'un compte de type société, renseigner votre numéro de SIRET met automatiquement à jour les coordonnées de votre entreprise, dont votre taux de TVA.
 
-Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil. Cette démarche permet également de corriger une facture sur laquelle l'une des erreurs suivantes a été renseignée :
+Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil. Cette démarche est notamment nécessaire lorsque l'une des erreurs suivantes a été signalée sur une facture :
 
 - une erreur de taux de TVA (litige 207 – TX_TVA_ERR) ;
 - une erreur de SIRET (litige 207 – SIRET_ERR ; Approuvé Partiellement – 206 – SIRET_ERR) ;
 - une erreur de destinataire (Refusé – 210 – DEST-ERR, cas de multi-société dans un groupe).
+
+:::warning
+La mise à jour de vos informations depuis votre espace client ne corrige pas les factures déjà émises : elle est prise en compte à partir de votre prochaine facture. Par exemple, un numéro de SIRET mis à jour le 15 septembre sera appliqué à la facture d'octobre, sans réédition de celle de septembre.
+
+Si l'erreur de facturation est imputable à OVHcloud, la facture concernée est corrigée et rééditée par nos équipes, sans action de votre part.
+:::
 
 ## Prérequis
 


### PR DESCRIPTION
The objective stated that updating your SIRET allows an existing invoice to be corrected. Per internal billing feedback this is inaccurate for customer-side omissions: the update applies from the next invoice only.

- reframe the error list as what triggers the update, not what it fixes
- add a warning covering both regimes: customer omission applies to the next invoice (no re-issue), OVHcloud-side errors are re-issued by us
- bump lastUpdated