### PR TITLE
fix(mass-translate): correct MKS source defects found while translating to FR

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
@@ -486,7 +486,6 @@ with the following information:
     }
   }
 ```
->
 
 ### Destroy
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-keycloak.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-keycloak.mdx
@@ -354,7 +354,7 @@ $ echo $INGRESS_URL
 135.125.84.194
 ```
 
-If you are using the [OVHcloud Domain name product](https://www.ovhcloud.com/fr/domains/), you can follow this documentation to configure your DNS record to link it to the public IPv4 address associated to your LoadBalancer: [Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit).
+If you are using the [OVHcloud Domain name product](/links/web/domains), you can follow this documentation to configure your DNS record to link it to the public IPv4 address associated to your LoadBalancer: [Editing an OVHcloud DNS zone](/guides/web-cloud/domains/dns-zone-edit).
 
 If you are using an external DNS provider, please configure your domain before reading the rest of this tutorial.
 
@@ -796,6 +796,6 @@ kubectl delete namespaces cert-manager
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/managing-nodes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/managing-nodes.mdx
@@ -530,7 +530,7 @@ Fill the fields to create a new node pool.
     The subsequent node pool configuration steps are described in [Creating a cluster](/guides/public-cloud/containers-orchestration/managed-kubernetes/create-cluster).
     
     :::info
-    To learn more about the flavors of the current OVHcloud range, [refer to this page](https://www.ovhcloud.com/fr/public-cloud/).
+    To learn more about the flavors of the current OVHcloud range, [refer to this page](/links/public-cloud/public-cloud).
 
     :::
 
@@ -813,10 +813,10 @@ Confirm the decision by typing `DELETE` into the field, then click on the <code 
 
 ## Go further
 
-To have an overview of the OVHcloud Managed Kubernetes service, visit the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
+To have an overview of the OVHcloud Managed Kubernetes service, visit the [OVHcloud Managed Kubernetes page](/links/public-cloud/kubernetes).
 
 To deploy your first application on your Kubernetes cluster, we invite you to follow our guides to [configure default settings for `kubectl`](/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl) and to [deploy a Hello World application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -135,7 +135,7 @@ Here, we defined the `ovh-eu` endpoint because we want to call the OVHcloud Euro
 
 * `ovh-eu` for OVHcloud Europe API
 * `ovh-us` for OVHcloud US API
-* `ovh-ca` for OVHcloud North-America API
+* `ovh-ca` for OVHcloud Canada API
 
 Then, define the resources you want to create in a new file called `ovh_kube_cluster_iprestrictions.tf`:
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -813,7 +813,6 @@ Error: not all generators ran successfully
 ```
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
->
 
 ### Test the operator in "dev mode"
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -35,7 +35,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-These commands will add the Kyverno Helm repository to your local Helm chart repository and update the installed chart repositories:
+These commands will add the cert-manager Helm repository to your local Helm chart repository and update the installed chart repositories:
 
 ```console
 $ helm repo add jetstack https://charts.jetstack.io


### PR DESCRIPTION
Surfaced by the FR translation pass; none are translation defects.

- 5 hardcoded ovhcloud.com/fr/ links in the ENGLISH source sent readers to French marketing pages. Replaced with /links/ keys. In-fence example values left untouched (they are config samples).
- install-cert-manager said "add the Kyverno Helm repository" while the command adds jetstack. Copy-paste from install-kyverno.
- stray ">" on its own line rendered an empty `<blockquote>` in deploy-go-operator and automatically-label-taint-node-pool.

docs/fr is deliberately untouched: those files are owned by the translation branch, so the same fixes land there with the translation.