### PR TITLE
docs: warn that 301 redirects do not cover HTTPS traffic

### DIFF
--- a/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Anwendungsbeispiele - Domainnamen einer Website ändern
 description: Erfahren Sie hier, wie Sie den Domainnamen einer bestehenden Website ändern
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -134,6 +134,11 @@ Denken Sie daran, sich um Ihr SSL *Sectigo EV*, *Sectigo DV* oder *Custom* Zerti
 
 
 Sobald Ihr alter Domainname von der Website getrennt ist, die auf Ihrem Webhosting-Service läuft, und falls er bei OVHcloud registriert ist, können Sie diesen mithilfe einer [sichtbaren dauerhaften 301-Weiterleitung](/guides/web-cloud/domains/redirect-domain-name) weiterleiten. Dies ermöglicht es Ihren Besuchern, automatisch zu Ihrer Website weitergeleitet zu werden, wobei Ihr neuer Domainname in der Adressleiste/URL ihres Browsers angezeigt wird.
+
+:::warning
+Eine über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> erstellte sichtbare dauerhafte 301-Weiterleitung unterstützt ausschließlich `http://`-Anfragen. Anfragen über `https://` an Ihren alten Domainnamen werden nicht weitergeleitet und gehen daher verloren.
+
+:::
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Sobald Ihr alter Domainname von der Website getrennt ist, die auf Ihrem Webhosti
 :::warning
 Eine über das <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> erstellte sichtbare dauerhafte 301-Weiterleitung unterstützt ausschließlich `http://`-Anfragen. Anfragen über `https://` an Ihren alten Domainnamen werden nicht weitergeleitet und gehen daher verloren.
 
+Um auch `https://`-Anfragen weiterzuleiten, muss die Weiterleitung über Ihr Webhosting und nicht über Ihr Kundencenter eingerichtet werden. Lassen Sie dazu Ihren alten Domainnamen auf Ihrem Webhosting deklariert und nehmen Sie anschließend ein [Umschreiben der URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) in einer `.htaccess`-Datei vor.
+
 :::
 
 ## Weiterführende Informationen <a name="go-further"></a>

--- a/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Once your old domain name is dissociated from your website on your web hosting a
 :::warning
 A permanent visible 301 redirect created from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> only handles `http://` requests. Requests to your old domain name over `https://` will not be redirected and will therefore be lost.
 
+To redirect `https://` requests as well, the redirect must be set up from your web hosting plan rather than from your Control Panel. To do so, keep your old domain name declared on your hosting plan, then apply a [URL rewrite](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) in a `.htaccess` file.
+
 :::
 
 ## Go further <a name="go-further"></a>

--- a/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use cases - How to change the domain of an existing website
 description: Find out how to change the domain name of an existing website
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -134,6 +134,11 @@ Don't forget to take care of your SSL certificate *Sectigo EV*, *Sectigo DV* or 
 
 
 Once your old domain name is dissociated from your website on your web hosting and if it is registered with OVHcloud, you can redirect it using a [permanent visible 301 redirect](/guides/web-cloud/domains/redirect-domain-name). This will allow your visitors to be automatically redirected to your website while seeing your new domain name / URL in the address bar of their browser.
+
+:::warning
+A permanent visible 301 redirect created from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> only handles `http://` requests. Requests to your old domain name over `https://` will not be redirected and will therefore be lost.
+
+:::
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Casos de uso - Cómo cambiar el dominio de un sitio existente
 description: Descubra cómo cambiar el dominio de un sitio existente
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -134,6 +134,11 @@ No olvide contratar su certificado SSL *Sectigo EV*, *Sectigo DV* o *Custom* com
 
 
 Una vez que su antiguo nombre de dominio esté desvinculado del sitio web alojado en su alojamiento web y si está registrado en OVHcloud, podrá redirigirlo mediante una [redirección visible permanente 301](/guides/web-cloud/domains/redirect-domain-name). Esto permitirá que sus visitantes sean redirigidos automáticamente hacia su sitio web y visualicen su nuevo dominio en la barra de direcciones/URL de su navegador.
+
+:::warning
+Una redirección visible permanente 301 creada desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> solo admite las peticiones en `http://`. Las peticiones en `https://` dirigidas a su antiguo nombre de dominio no se redirigirán y se perderán.
+
+:::
 
 ## Más información <a name="go-further"></a>
 

--- a/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Una vez que su antiguo nombre de dominio esté desvinculado del sitio web alojad
 :::warning
 Una redirección visible permanente 301 creada desde el <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink> solo admite las peticiones en `http://`. Las peticiones en `https://` dirigidas a su antiguo nombre de dominio no se redirigirán y se perderán.
 
+Para redirigir también las peticiones en `https://`, la redirección debe realizarse desde su alojamiento web y no desde su área de cliente. Para ello, mantenga su antiguo nombre de dominio declarado en su alojamiento y, a continuación, efectúe una [reescritura de URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) mediante un archivo `.htaccess`.
+
 :::
 
 ## Más información <a name="go-further"></a>

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Une fois votre ancien nom de domaine dissocié de votre site web présent sur vo
 :::warning
 Une redirection visible permanente 301 créée depuis l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> ne prend en charge que les requêtes en `http://`. Les requêtes en `https://` vers votre ancien nom de domaine ne seront pas redirigées et seront perdues.
 
+Pour rediriger également les requêtes en `https://`, la redirection doit être réalisée depuis votre hébergement web et non depuis votre espace client. Pour cela, conservez votre ancien nom de domaine déclaré sur votre hébergement, puis effectuez une [réécriture d’URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) à l’aide d’un fichier `.htaccess`.
+
 :::
 
 ## Aller plus loin <a name="go-further"></a>

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cas d’usage - Comment changer le domaine d’un site existant"
 description: "Découvrez comment changer le nom de domaine d’un site existant"
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -134,6 +134,11 @@ N’oubliez pas de vous occuper de votre certificat SSL *Sectigo EV*, *Sectigo D
 
 
 Une fois votre ancien nom de domaine dissocié de votre site web présent sur votre hébergement web et s’il est enregistré chez OVHcloud, vous pourrez rediriger ce dernier à l’aide d’une [redirection visible permanente 301](/guides/web-cloud/domains/redirect-domain-name). Cela permettra à vos visiteurs d’être automatiquement redirigés vers votre site en visualisant votre nouveau domaine dans la barre d’adresse/URL de leur navigateur.
+
+:::warning
+Une redirection visible permanente 301 créée depuis l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> ne prend en charge que les requêtes en `http://`. Les requêtes en `https://` vers votre ancien nom de domaine ne seront pas redirigées et seront perdues.
+
+:::
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Casi d'uso - Come cambiare il dominio di un sito esistente
 description: Questa guida ti mostra come modificare il dominio di un sito esistente
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -133,7 +133,12 @@ Ricordati di occuparti del tuo certificato SSL *Sectigo EV*, *Sectigo DV* o *Cus
 :::
 
 
-Una volta che il vostro vecchio nome di dominio è stato disconnesso dal vostro sito web ospitato sull'hosting e se è registrato presso OVHcloud, potrete reindirizzarlo utilizzando una [redirezione visibile permanente 301](/guides/web-cloud/domains/redirect-domain-name). Questo permetterà ai vostri visitatori di essere automaticamente reindirizzati verso il vostro sito visualizzando il vostro nuovo dominio nella barra degli indirizzi/URL del loro browser.
+Una volta che il vostro vecchio nome di dominio è stato disconnesso dal vostro sito web ospitato sull'hosting e se è registrato presso OVHcloud, potrete reindirizzarlo utilizzando un [reindirizzamento visibile permanente 301](/guides/web-cloud/domains/redirect-domain-name). Questo permetterà ai vostri visitatori di essere automaticamente reindirizzati verso il vostro sito visualizzando il vostro nuovo dominio nella barra degli indirizzi/URL del loro browser.
+
+:::warning
+Un reindirizzamento visibile permanente 301 creato dallo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> supporta esclusivamente le richieste in `http://`. Le richieste in `https://` dirette al tuo vecchio nome di dominio non saranno reindirizzate e andranno perse.
+
+:::
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Una volta che il vostro vecchio nome di dominio è stato disconnesso dal vostro 
 :::warning
 Un reindirizzamento visibile permanente 301 creato dallo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink> supporta esclusivamente le richieste in `http://`. Le richieste in `https://` dirette al tuo vecchio nome di dominio non saranno reindirizzate e andranno perse.
 
+Per reindirizzare anche le richieste in `https://`, il reindirizzamento deve essere effettuato dal tuo hosting e non dal tuo Spazio Cliente. A questo scopo, mantieni il tuo vecchio nome di dominio dichiarato sull'hosting, poi effettua una [riscrittura dell'URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) tramite un file `.htaccess`.
+
 :::
 
 ## Per saperne di più <a name="go-further"></a>

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Po odłączeniu starej nazwy domeny od witryny znajdującej się na Twoim serwis
 :::warning
 Trwałe widoczne przekierowanie 301 utworzone w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> obsługuje wyłącznie żądania `http://`. Żądania `https://` kierowane do Twojej starej nazwy domeny nie zostaną przekierowane i zostaną utracone.
 
+Aby przekierować również żądania `https://`, przekierowanie musi zostać wykonane na Twoim hostingu, a nie w Panelu klienta. Zachowaj w tym celu starą nazwę domeny zadeklarowaną na hostingu, a następnie wykonaj [przepisanie adresu URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) w pliku `.htaccess`.
+
 :::
 
 ## Sprawdź również <a name="go-further"></a>

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Przykłady zastosowania - Jak zmienić domenę na istniejącej stronie
 description: Dowiedz się, jak zmienić nazwę domeny na istniejącej stronie
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -134,6 +134,11 @@ Pamiętaj, aby zająć się certyfikatem SSL *Sectigo EV*, *Sectigo DV* lub *Cus
 
 
 Po odłączeniu starej nazwy domeny od witryny znajdującej się na Twoim serwisie internetowym i jeśli jest ona zarejestrowana u OVHcloud, możesz przekierować tę domenę przy użyciu [trwałego widocznego przekierowania 301](/guides/web-cloud/domains/redirect-domain-name). Dzięki temu Twoi odwiedzający zostaną automatycznie przekierowani na Twoją stronę, widząc nową domenę w pasku adresu/URL swojej przeglądarki.
+
+:::warning
+Trwałe widoczne przekierowanie 301 utworzone w <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink> obsługuje wyłącznie żądania `http://`. Żądania `https://` kierowane do Twojej starej nazwy domeny nie zostaną przekierowane i zostaną utracone.
+
+:::
 
 ## Sprawdź również <a name="go-further"></a>
 

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -1,7 +1,7 @@
 ---
 title: Casos de uso - Como alterar o domínio de um site existente
 description: Descubra como alterar o nome de domínio de um site existente
-lastUpdated: 2025-10-28
+lastUpdated: 2026-08-21
 availableIn: [eu, ca, apac]
 ---
 
@@ -133,7 +133,12 @@ Não se esqueça de ocupar o seu certificado SSL *Sectigo EV*, *Sectigo DV* ou *
 :::
 
 
-Assim que o seu antigo nome de domínio estiver dissociado do seu site web no seu alojamento web e se estiver registado na OVHcloud, poderá redirecioná-lo com uma [redirecionamento permanente visível 301](/guides/web-cloud/domains/redirect-domain-name). Isto permitirá que os seus visitantes sejam automaticamente redirecionados para o seu site, visualizando o seu novo domínio na barra de endereços/URL do seu navegador.
+Assim que o seu antigo nome de domínio estiver dissociado do seu site web no seu alojamento web e se estiver registado na OVHcloud, poderá reencaminhá-lo com um [reencaminhamento permanente visível 301](/guides/web-cloud/domains/redirect-domain-name). Isto permitirá que os seus visitantes sejam automaticamente redirecionados para o seu site, visualizando o seu novo domínio na barra de endereços/URL do seu navegador.
+
+:::warning
+Um reencaminhamento permanente visível 301 criado a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> só suporta os pedidos em `http://`. Os pedidos em `https://` destinados ao seu antigo nome de domínio não serão reencaminhados e serão perdidos.
+
+:::
 
 ## Quer saber mais? <a name="go-further"></a>
 

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx
@@ -138,6 +138,8 @@ Assim que o seu antigo nome de domínio estiver dissociado do seu site web no se
 :::warning
 Um reencaminhamento permanente visível 301 criado a partir da <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink> só suporta os pedidos em `http://`. Os pedidos em `https://` destinados ao seu antigo nome de domínio não serão reencaminhados e serão perdidos.
 
+Para reencaminhar também os pedidos em `https://`, o reencaminhamento deve ser efetuado a partir do seu alojamento web e não a partir da sua Área de Cliente. Para isso, mantenha o seu antigo nome de domínio declarado no seu alojamento e, em seguida, efetue uma [reescrita do URL](/guides/web-cloud/web-hosting/htaccess-url-rewriting-using-mod-rewrite) através de um ficheiro `.htaccess`.
+
 :::
 
 ## Quer saber mais? <a name="go-further"></a>


### PR DESCRIPTION
## Context

Following user feedback (SK2767) on the Web Hosting guide *How to change the domain
name of an existing website*.

Step 3 tells the reader to detach the old domain name and then set up a permanent
visible 301 redirect towards the new one. What it does not say is that this
redirect only ever answers HTTP: the OVHcloud redirection service does not hold a
certificate for the redirected domain, so the TLS handshake fails before any HTTP
301 can be returned. Readers coming from an HTTPS site therefore lose all HTTPS
traffic to their old domain without any warning in the guide.

This limitation is already documented in the guide this step links to
(`web-cloud/domains/redirect-domain-name`), but nothing surfaced it at the point
where the reader actually acts on it.

## Changes

Adds a `:::warning` callout at the end of step 3, in all 7 locales, stating that
the redirect only handles `http://` requests and that `https://` requests to the
old domain are not redirected.

Wording deliberately reuses the terminology of the linked redirection guide rather
than the phrasing from the original feedback, which called it a "DNS 301 redirect"
— a 301 is an HTTP status code, not a DNS mechanism, and that distinction is
precisely why HTTPS breaks here.

| Locale | Guide |
|---|---|
| fr | `docs/fr/guides/web-cloud/web-hosting/how-to-change-the-domain-name-of-an-existing-website.mdx` |
| en | `docs/en/…` |
| de | `docs/de/…` |
| es | `docs/es/…` |
| it | `docs/it/…` |
| pl | `docs/pl/…` |
| pt | `docs/pt/…` |

`lastUpdated` bumped to `2026-08-21` on all 7.

### Drive-by terminology fixes

While translating, two pre-existing inconsistencies surfaced on the line directly
above the new callout:

- **it** — `redirezione` → `reindirizzamento` (0 vs 51 occurrences elsewhere under
  `it/guides/web-cloud/domains/`), with the article corrected for the gender change
  (`una` → `un`).
- **pt** — `redirecionamento` → `reencaminhamento` (2 vs 51 occurrences, pt-PT
  form), verb aligned (`redirecioná-lo` → `reencaminhá-lo`), and a pre-existing
  gender agreement error fixed (`uma redirecionamento` → `um reencaminhamento`).

## Verification

- MDX compiles on all 7 files.
- `biome lint` exits 0 (the single remaining `info` is pre-existing, in `scripts/`).
- Diff-scoped proofread: 0 ERROR; no action buttons, external links, `<Api>` tags
  or zoned tokens introduced; `<ManagerLink>` used without an import, as required
  for named-file globals.
- DE and PT language QA passes applied (compounds, declension, n-Deklination on
  `Domainnamen`; pt-PT vs pt-BR, diacritics).
- All 7 locales are genuine translations (no EN symlinks or fallback copies), so
  no locale is left stale.
- No file deleted or renamed, so no `301.map` entry is required.
