### PR TITLE
docs(bare-metal-cloud): restore faulty-disk marker in mdstat examples

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ Wenn Sie mit diesen Aktionen fertig sind, überprüfen Sie erneut den RAID-Statu
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/de/dedicated/hotswap-software-raid/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/de/dedicated/hotswap-software-raid/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ once you have made these changes, check the RAID status again.
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/gb/en/dedicated/hotswap-raid-soft/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/gb/en/dedicated/hotswap-raid-soft/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -204,11 +204,11 @@ Una vez completada esta operación, vuelva a comprobar el estado del RAID.
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/es/dedicated/hotswap-raid-soft/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/es/dedicated/hotswap-raid-soft/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: <none>

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ root@ns3054662:/home# mdadm --manage /dev/md2 --set-faulty /dev/sdb2
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/fr/dedicated/hotswap-raid-soft/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/fr/dedicated/hotswap-raid-soft/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ Una volta completata l’operazione, verifica nuovamente lo stato del RAID.
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/it/dedicated/hotswap-raid-soft/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/it/dedicated/hotswap-raid-soft/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ Po wykonaniu tych operacji sprawdź ponownie stan macierzy RAID.
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/pl/dedicated/hotswap-raid-soft/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/pl/dedicated/hotswap-raid-soft/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx
@@ -199,11 +199,11 @@ Um vez concluída esta operação, volte a verificar o estado do RAID.
 ```sh
 root@ns3054662:/home# cat /proc/mdstat
 >>> Personalities : [linear] [raid0] [raid1] [raid10] [raid6] [raid5] [raid4] [multipath] [faulty]
->>> md2 : active raid1 sda2[0] sdb2[1](/pt/dedicated/hotswap-raid-software/F)
+>>> md2 : active raid1 sda2[0] sdb2[1](F)
 >>>       3885385728 blocks super 1.2 [2/1] [U_]
 >>>       bitmap: 0/29 pages [0KB], 65536KB chunk
 
->>> md1 : active raid1 sdb1[2](/pt/dedicated/hotswap-raid-software/F) sda1[0]
+>>> md1 : active raid1 sdb1[2](F) sda1[0]
 >>>       20971456 blocks [2/1] [U_]
 
 >>> unused devices: `<none>`


### PR DESCRIPTION
## Summary

In the software RAID hot-swap guide for dedicated servers, the example output of `cat /proc/mdstat` was corrupted during the migration to the new documentation platform: the mdadm faulty-disk marker `(F)` that follows a device index was misinterpreted by a link-conversion pass as Markdown link syntax and glued to the page's legacy `docs.ovh.com` URL.

Current text in all locales, e.g. `docs/en/guides/bare-metal-cloud/dedicated-servers/hotswap-raid-soft.mdx`, line 202:

```sh
>>> md2 : active raid1 sda2[0] sdb2[1](/gb/en/dedicated/hotswap-raid-soft/F)
```

This is impossible `/proc/mdstat` output — the kernel prints the faulty marker simply as `(F)`. The same guide states this two paragraphs later ("The sdb1 and sdb2 have been switched to faulty **(F)**"), so the example currently contradicts its own explanation.

## Evidence

- Archived original page (Wayback Machine snapshot of `docs.ovh.com/gb/en/dedicated/hotswap-raid-soft/`, 2023-03-05) shows the authentic output: `md2 : active raid1 sda2 [0] sdb2 [1](F)` and `md1 : active raid1 sdb1 [2](F) sda1 [0]`.
- Linux kernel admin-guide (`docs.kernel.org/admin-guide/md.html`): a component device can be kicked from the array as `faulty` after a detected fault; the marker appears right after the device index in `/proc/mdstat` output.
- The repository's own migration link validator (`scripts/migrate/validate/links.ts`) classifies such pseudo-targets as `Internal link target not found`.
- A full internal-link scan of current `develop` (10,637 absolute links across 1,685 EN pages) found no unresolved targets except this artifact class.

Notably, each locale carries its own legacy URL prefix (`/gb/en/...`, `/de/dedicated/hotswap-software-raid/F`, `/pt/dedicated/hotswap-raid-software/F`, ...), which confirms the corruption came from per-locale legacy page URLs rather than from the technical content.

## Changes

Restore the authentic kernel output in all seven locale siblings of `hotswap-raid-soft.mdx` (en, de, es, fr, it, pl, pt):

- `sdb2[1](/<legacy-path>/F)` → `sdb2[1](F)`
- `sdb1[2](/<legacy-path>/F) sda1[0]` → `sdb1[2](F) sda1[0]`

14 single-line edits inside code fences; no other content is modified.

## Checks

- [x] `git diff --check` clean (7 files changed, 14 insertions, 14 deletions)
- [x] Repository-wide search for the artifact pattern `\(/[^)]*/F\)` returns 0 occurrences on this branch
- [x] Every patched line compared against the archived original page
- [x] Code fences balanced in all 7 files; all changes are inside existing ```sh fences only

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
