### PR TITLE
docs(hosted-private-cloud): add missing Step 3.9 anchors in IPsec guide

### DIFF
--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ Dans ce guide, nous devons réaliser une partie de l'installation sur le cluster
 &emsp;&emsp;[Etape 2.9.1 Changement du mot de passe par défaut de **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Etape 2.9.2 Ajout d'une règle pour autoriser l'administration à distance à partir d'une adresse publique](#addadminrule)<br />
 [Etape 3 Configuration de la passerelle en France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Etape 3.1 Téléchargement des sources pour l'installation de pfsense](#downloadsources-fr)<br />
+&ensp;&ensp;[Etape 3.1 Téléchargement des sources pour l'installation de pfsense](#downloadsourcesfr)<br />
 &ensp;&ensp;[Etape 3.2 Création de la machine virtuelle **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;&ensp;[Etape 3.3 Arrêt de la machine virtuelle **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;&ensp;[Etape 3.4 Récupération de l'adresse publique sur l'espace client OVHcloud](#getpublicaddressfr)<br />

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -53,7 +53,7 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &emsp;&emsp;[Step 2.9.1 Changing the default password for **pfSense**](#changepassword)<br />
 &emsp;&emsp;[Step 2.9.2 Adding a rule to allow remote administration from a public address](#addadminrule)<br />
 [Step 3 Gateway configuration in France](#configuregatewayfrance)<br />
-&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsources)<br />
+&ensp;&ensp;[Step 3.1 Downloading sources for pfsense installation](#downloadsourcesfr)<br />
 &ensp;[Step 3.2 Creating the virtual machine **GW-PFSENSE**](#createvmpfsensefr)<br />
 &ensp;[Step 3.3 Shutting down the virtual machine **OVH-GATEWAY**](#shutdownovhgatewayfr)<br />
 &ensp;[Step 3.4 Retrieving the public address on the OVHcloud Control Panel](#getpublicaddressfr)<br />
@@ -62,8 +62,8 @@ In this guide, we will carry out part of the installation on the cluster in Cana
 &ensp;[Step 3.7 Ejecting pfSense CDROM from virtual machine **GW-PFSENSE**](#pfsenseremovecdromfr)<br />
 &ensp;[Step 3.8 Configure pfSense IP addresses through the console](#configureippfsensefr)<br />
 &ensp;&ensp;[Step 3.9 Configuring certain options through the Web interface](#configurepfsenseoptionsfr)<br />
-&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepassworden)<br />
-&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminruleen)<br />
+&emsp;&emsp;[Step 3.9.1 Changing the default password for **pfSense**](#changepasswordfr)<br />
+&emsp;&emsp;[Step 3.9.2 Adding a rule to allow remote administration from a public address](#addadminrulefr)<br />
 [Step 4 Setting up IPsec VPN](#configurevpnipsec)<br />
 &ensp;[Step 4.1 Setting Up the site in Canada](#ipseccanada)<br />
 &emsp;&emsp;[Step 4.1.1 Setting up IPsec VPN in France](#paramipsectofrance)<br />
@@ -697,7 +697,7 @@ Then click <code className="action">SIGN IN</code>.
 <img className="thumbnail" alt="WEB Configure pfsense 01" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/05-configure-pfsense01-fr.png" loading="lazy" />
 
 <a name="changepasswordfr"></a>
-##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
+##### **Step 3.9.1 Change the pfSense default password**
 
 From the <code className="action">System</code> menu, choose <code className="action">User Manager</code>.
 
@@ -716,7 +716,7 @@ Confirm the changes by clicking <code className="action">Save</code> at the bott
 <img className="thumbnail" alt="Change Password 03" src="/images/hosted-private-cloud/nutanix-on-ovhcloud/44-ipsec-interconnection/06-change-password04.png" loading="lazy" />.
 
 <a name="addadminrulefr"></a>
-##### **Step 3.9.2 Add a rule to allow remote administration from a public address.** <a name="addadminruleen"></a>
+##### **Step 3.9.2 Add a rule to allow remote administration from a public address.**
 
 Go to the <code className="action">Firewall</code> menu and choose <code className="action">Rules</code>.
 


### PR DESCRIPTION
## Summary

In the Nutanix/IPsec interconnection guide, the guide table of contents links the France-side steps as `#changepassworden` and `#addadminruleen`, but no anchors with those names exist anywhere in the guide.

As a result:

- both TOC entries silently jump to the **Canada**-side sections (`#changepassword` / `#addadminrule`);
- the France sections (Step 3.9.1 "Change the pfSense default password" and Step 3.9.2 "Add a rule to allow remote administration from a public address") are unreachable from the TOC.

## Changes

Add explicit `<a name>` anchors to the two France-side headings in six locales (en, de, es, it, pl, pt), 2 lines per file inside existing heading lines:

```diff
-##### **Step 3.9.1 Change the pfSense default password**
+##### **Step 3.9.1 Change the pfSense default password** <a name="changepassworden"></a>
```

This matches the convention already used throughout this exact guide (the sibling France steps carry explicit anchors like `<a name="changepasswordfr"></a>`, `<a name="addadminrulefr"></a>`, and the Canada sections use `<a name="changepassword"></a>`).

The FR locale is intentionally untouched: it already uses plain anchor names that resolve correctly.

## Checks

- [x] Before: `#changepassworden` / `#addadminruleen` had no matching anchor definition in any of the 6 locales
- [x] After: every `-en` TOC link resolves to a definition; Step 2.9.x and Step 3.9.x now jump to their own sections
- [x] `git diff --check` clean (6 files changed, 12 insertions, 12 deletions)
- [x] No content changes — only inline anchor additions to existing heading lines

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
