### PR TITLE
docs(storage): fix dead Go further anchor in HA-NAS snapshots API guide

### DIFF
--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -167,7 +167,7 @@ Um Ihren Snapshot wiederherzustellen, kopieren Sie diesen aus dem `.zfs`-Dateipf
 
 Zusätzliche Hilfe finden Sie unter "[Weiterführende Informationen](#gofurther)".
 
-## Weiterführende Informationen
+## Weiterführende Informationen <a name="gofurther"></a>
 
 [NAS via NFS-Freigabe mounten](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -162,7 +162,7 @@ To restore your snapshot, copy it from the `.zfs` file path to the new directory
 
 You can find more information in the [Go further](#gofurther) section of this guide.
 
-## Go further
+## Go further <a name="gofurther"></a>
 
 [Mount your NAS via NFS share](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -167,7 +167,7 @@ Para restaurar el snapshot, cópielo desde la ruta de acceso del archivo `.zfs` 
 
 Para más información, consulte el apartado [Más información](#gofurther) de esta guía.
 
-## Más información
+## Más información <a name="gofurther"></a>
 
 [Montar un NAS mediante NFS](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -162,7 +162,7 @@ Pour restaurer votre snapshot, copiez-le depuis le chemin d'accès du fichier `.
 
 Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 
-## Aller plus loin
+## Aller plus loin <a name="gofurther"></a>
 
 [Montez votre NAS via un partage NFS](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -167,7 +167,7 @@ Per ripristinare lo Snapshot, copia dal percorso di accesso del file `.zfs` alla
 
 Per maggiori informazioni consulta la sezione [Per saperne di più](#gofurther) su questa guida.
 
-## Per saperne di più
+## Per saperne di più <a name="gofurther"></a>
 
 [Eseguire il mount di un NAS tramite NFS](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -167,7 +167,7 @@ Aby przywrócić snapshot, skopiuj go ze ścieżki dostępu pliku `.zfs` do nowe
 
 Więcej informacji znajduje się w sekcji [Sprawdź również](#gofurther) ten przewodnik.
 
-## Sprawdź również
+## Sprawdź również <a name="gofurther"></a>
 
 [Montowanie przestrzeni dyskowej NAS przy użyciu protokołu NFS](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -167,7 +167,7 @@ Para restaurar a sua snapshot, copie-a a partir do caminho de acesso do ficheiro
 
 Para mais informações, aceda à secção [Quer saber mais](#gofurther).
 
-## Quer saber mais?
+## Quer saber mais? <a name="gofurther"></a>
 
 [Montar um NAS através de NFS](/guides/storage-and-backup/file-storage/ha-nas/nas-nfs)
 


### PR DESCRIPTION
## Summary

The HA-NAS "Managing snapshots via API" guide contains an in-page cross-reference `[Go further](#gofurther)`, but no `#gofurther` anchor exists in **any** locale: the final section heading is localized in six locales (`Weiterführende Informationen`, `Más información`, `Aller plus loin`, `Per saperne di più`, `Sprawdź również`, `Quer saber mais?`), so the auto-generated slug never matches the English-style anchor. Even in English, the slug of `Go further` is `go-further`, not `gofurther`.

Reader effect: clicking the link at the end of the instructions scrolls nowhere (dead link) — verified against the site's own heading-slugger (`@rspress/shared` github-slugger): `slug("Weiterführende Informationen") = weiterführende-informationen`, etc.

## Changes

Add an explicit `<a name="gofurther"></a>` to the final heading line in all seven locales, one line per file:

```diff
-## Go further
+## Go further <a name="gofurther"></a>
```

This matches the convention already used in sibling storage guides (e.g. `netapp-control-panel.mdx`: `## Go further <a name="gofurther"></a>`), and keeps the anchor stable regardless of future heading re-translations.

## Checks

- [x] Before: 1 dead `(#gofurther)` link per locale, 0 definitions in all 7 locales
- [x] After: 1 link + 1 definition per locale; all slugs of localized headings verified with the repository's actual Rspress slugger
- [x] `git diff --check` clean (7 files changed, 7 insertions, 7 deletions)
- [x] No content or translation changes

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
