### PR TITLE
docs(data-analytics): repoint dead Checking reference in advanced configuration guide

### DIFF
--- a/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -47,7 +47,7 @@ Depending on the engine, some settings may already be defined.
 :::info
 Once the advanced configuration has been submitted, it is not possible to reset it to initial values. It is only possible to update the values, so we recommend that you take note of the initial values before changing them.
 
-See the [Checking](#checking) section below.
+To verify the values you submitted, see the [Get the existing advanced configuration](#get-the-existing-advanced-configuration) section below.
 
 :::
 

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -47,7 +47,7 @@ Selon le moteur, certains paramètres peuvent déjà être définis.
 :::info
 Une fois la configuration avancée soumise, il n'est pas possible de la réinitialiser à ses valeurs initiales. Il est uniquement possible de mettre à jour les valeurs ; nous vous recommandons donc de noter les valeurs initiales avant de les modifier.
 
-Consultez la section [Vérification](#checking) ci-dessous.
+Pour vérifier les valeurs soumises, consultez la section [Obtenir la configuration avancée existante](#obtenir-la-configuration-avancée-existante) ci-dessous.
 
 :::
 


### PR DESCRIPTION
## Summary

In the Public Cloud Analytics "advanced configuration" guide, the info box links to a `[Checking](#checking)` section that **does not exist in this guide** — the anchor scrolls nowhere. The reference was inherited from the sibling Managed Databases guide (`databases/advanced-configuration.mdx`), which does have a `### Checking` section; the analytics adaptation never carried it.

Affected: EN and FR (the only locales that contain the sentence; de/es/it/pl/pt don't have it).

## Changes

Repoint the reference to this guide's own existing section that serves exactly the "verify what you submitted" purpose — "Get the existing advanced configuration" (re-run the retrieval call and compare the response):

```diff
-See the [Checking](#checking) section below.
+To verify the values you submitted, see the [Get the existing advanced configuration](#get-the-existing-advanced-configuration) section below.
```

FR:

```diff
-Consultez la section [Vérification](#checking) ci-dessous.
+Pour vérifier les valeurs soumises, consultez la section [Obtenir la configuration avancée existante](#obtenir-la-configuration-avancée-existante) ci-dessous.
```

Both target slugs verified with the repository's actual heading slugger (`@rspress/shared` github-slugger): `get-the-existing-advanced-configuration` and `obtenir-la-configuration-avancée-existante`.

Alternative considered: porting the whole `### Checking` section from the databases guide (pgAdmin screenshots don't apply to Kafka/OpenSearch/Grafana engines), which would need product-specific content decisions — left out of this minimal fix.

## Checks

- [x] Before: `#checking` has no target in either file; after: both links resolve to existing headings
- [x] `git diff --check` clean (2 files changed, 2 insertions, 2 deletions)
- [x] No invented content — the target section already exists in both files

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
