### PR TITLE
docs: fix anchor typos that break in-page cross-references

### DIFF
--- a/docs/de/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/de/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
@@ -95,7 +95,7 @@ By default, the home directory of your job is located under `/workspace`. It mea
 :::warning
 If you are missing a library or a configuration, you can add it directly in command line of the notebook's **console** as long as you don't need privileged access (root access). Example : `pip install <...>`
 
-For installing specific libraries that require privileged access, you will have to build your own notebook image and use it as a **custom image** at [step 2](#step-2-select-the-notebook-corresponding-to-your-needs) instead of a **preset image**. More information about creating your own Docker image can be found [here](/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image).
+For installing specific libraries that require privileged access, you will have to build your own notebook image and use it as a **custom image** at [step 2](#step-2---select-the-notebook-corresponding-to-your-needs) instead of a **preset image**. More information about creating your own Docker image can be found [here](/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image).
 
 :::
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 

--- a/docs/en/guides/web-cloud/web-hosting/manage-runtime-software-applications.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/manage-runtime-software-applications.mdx
@@ -78,7 +78,7 @@ Enter the information requested in the popup window. Follow the remaining steps 
 |Custom name|Enter a name that will distinguish this runtime environment from any other environments in the OVHcloud Control Panel.|  
 |Runtime environment|Choose the new runtime environment you want.|  
 
-Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multisites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-your-runtime-environment-to-a-multisite).
+Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multisites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-the-runtime-environment-to-a-multisite).
 
 ##### **Node.js**
 
@@ -90,7 +90,7 @@ Once you have entered this information, click <code className="action">Confirm</
 |Application environment|Specify whether it is a "production", "test" or "development" environment. Please keep in mind that development environments behave differently from production and test environments, displaying errors directly in the web interface.|
 |Application launch script|Name the script that will call the Node.js technology.|
 
-Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multisites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-your-runtime-environment-to-a-multisite).
+Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multisites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-the-runtime-environment-to-a-multisite).
 
 <img className="thumbnail" alt="cloudweb" src="/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-nodejs8.png" loading="lazy" />
 
@@ -104,7 +104,7 @@ Once you have entered this information, click <code className="action">Confirm</
 |Application environment|Specify whether it is a "production", "test" or "development" environment. Please keep in mind that development environments behave differently from production and test environments, displaying errors directly in the web interface.|
 |Application launch script|Name the script that will call the Ruby runtime environment.|
 
-Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multi-sites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-your-runtime-environment-to-a-multisite).
+Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multi-sites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-the-runtime-environment-to-a-multisite).
 
 <img className="thumbnail" alt="cloudweb" src="/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-ruby2-6.png" loading="lazy" />
 
@@ -118,7 +118,7 @@ Once you have entered this information, click <code className="action">Confirm</
 |Application environment|Specify whether it is a "production", "test" or "development" environment. Please keep in mind that development environments behave differently from production and test environments, displaying errors directly in the web interface.|
 |Application launch script|Name the script that will call the Python runtime environment.|
 
-Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multi-sites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-your-runtime-environment-to-a-multisite).
+Once you have entered this information, click <code className="action">Confirm</code>. Please ensure that this runtime environment is definitely used by the multi-sites you want. To do this, continue to step three: [Link your runtime environment to a multisite](#step-3-link-the-runtime-environment-to-a-multisite).
 
 <img className="thumbnail" alt="cloudweb" src="/images/assets/screens/control-panel/product-selection/web-cloud/cloud-web/runtime-software-application/modify-a-runtime-software-application-python3.png" loading="lazy" />
 

--- a/docs/es/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/es/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 

--- a/docs/it/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/it/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 

--- a/docs/pl/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/pl/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 

--- a/docs/pt/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
+++ b/docs/pt/guides/public-cloud/ai-machine-learning/ai-s3-compliance.mdx
@@ -228,8 +228,8 @@ ovhai datastore add s3 <ALIAS> <endpoint_url> <region> <my-access-key> <my-secre
 
 You will need to replace:
 - `<alias>` by the name you want to give for your datastore
-- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-a-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
-- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-a-s3-compatible-bucket). **Make sure you use lower case letters.**
+- `<endpoint_url>` by the Endpoint value you have retrieved at the end of [bucket creation step](#create-an-s3-compatible-bucket). This endpoint should start with: *https://s3...*.
+- `<region>` by the region where you have created your bucket. This region is indicated as the `Location` of your bucket, on the last screenshot of the [bucket creation step](#create-an-s3-compatible-bucket). **Make sure you use lower case letters.**
 - `<my-access-key>` by the [access key](#retrieve-user-credentials) of the associated user
 - `my-secret-key` by the [secret key](#retrieve-user-credentials) of the associated user
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
   This annotation is automatically added to the Service if it's not specified when creating. After the Service is created successfully it shouldn't be changed, otherwise the Service won't behave as expected.
 
-  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  If this annotation is specified with a valid cloud load balancer ID when creating Service, the Service is reusing this load balancer rather than creating another one. More details [below](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-services).
 
   If this annotation is specified, the other annotations which define the load balancer features will be ignored.
 


### PR DESCRIPTION
## Summary

Four families of in-page anchor links point at slugs that the site's heading slugger never generates, so the links scroll nowhere. All target slugs were verified against the repository's actual heading slugger (`@rspress/shared` github-slugger).

## Defects and fixes

**1. AI S3 compliance guide — wrong article in slug (2 links × 6 locales: en, de, es, it, pl, pt)**
Heading `Create an S3 compatible bucket` → slug `create-an-s3-compatible-bucket`; links used `#create-a-s3-compatible-bucket`.

```diff
-(#create-a-s3-compatible-bucket)
+(#create-an-s3-compatible-bucket)
```

**2. Web Hosting runtime guide — wrong word in slug (4 links, EN only; other locales lack this TOC)**
Heading `Step 3: Link the runtime environment to a multisite.` → slug `step-3-link-the-runtime-environment-to-a-multisite`; links used `#step-3-link-your-runtime-environment-to-a-multisite`.

**3. AI Training notebooks guide — missing double hyphen from "Step 2 - ..." (1 link, EN only)**
The heading `Step 2 - Select the notebook corresponding to your needs` slugs with a triple hyphen: `step-2---select-the-notebook-corresponding-to-your-needs`; the link used a single hyphen.

**4. MKS Public Cloud Load Balancer guide — missing trailing "s" (1 link × 6 locales: en, de, es, it, pl, pt)**
Heading `Sharing an Octavia LoadBalancer between multiple Kubernetes LoadBalancer Services` → slug ends `-services`; links ended `-service`.

The FR copy of the Load Balancer guide is intentionally untouched to avoid conflicting with the open FR translation PR for the MKS family.

## Checks

- [x] Every new anchor value equals the slug produced by the site's own slugger for the existing heading
- [x] Before/after counts verified per locale; no bad anchors remain on this branch
- [x] `git diff --check` clean (14 files changed, 23 insertions, 23 deletions — one line per affected link)
- [x] No content or translation changes

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
