### PR TITLE
docs(vps): fix leftover French placeholders in Nextcloud and OpenClaw guides

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -108,7 +108,7 @@ cat ~/openclaw/data/openclaw.json | grep '"token":'
 
 Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=YOUR_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -108,7 +108,7 @@ cat ~/openclaw/data/openclaw.json | grep '"token":'
 
 Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=YOUR_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -108,7 +108,7 @@ cat ~/openclaw/data/openclaw.json | grep '"token":'
 
 Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=YOUR_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -108,7 +108,7 @@ cat ~/openclaw/data/openclaw.json | grep '"token":'
 
 Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=YOUR_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -124,7 +124,7 @@ docker compose up -d
 
 ### Step 5: Accessing Nextcloud <a name="step5"></a>
 
-In your browser, open [http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080).
+In your browser, open [http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080).
 
 On first access:
 

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-openclaw.mdx
@@ -108,7 +108,7 @@ cat ~/openclaw/data/openclaw.json | grep '"token":'
 
 Open your browser and go to: `http://127.0.0.1:18789`.
 
-*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN`*
+*Tip: If the interface remains disconnected, you can force the connection by using your token directly in the URL: `http://127.0.0.1:18789/?token=YOUR_GATEWAY_TOKEN`*
 
 The rest takes place in the **Overview** menu: enter your **Gateway Token** to log in.
 


### PR DESCRIPTION
## Summary

Two batches of leftover French placeholders in English-text VPS guides (found by a repository-wide scan for French tokens in non-FR locales):

**1. Nextcloud beginner guide — `IPv4_DE_VOTRE_VPS` (6 locales: en, de, es, it, pl, pt)**

Step 5 tells the reader to open `[http://IPv4_DE_VOTRE_VPS:8080](...)` — "DE VOTRE VPS" is French for "of your VPS", while the same guide's Step 1 defines and uses the placeholder `IPv4_OF_YOUR_VPS` (`ssh ubuntu@IPv4_OF_YOUR_VPS`). A reader cannot know what to substitute, and copy-pasting the literal string fails.

Fix: align Step 5 with the token the guide already introduced:

```diff
-[http://IPv4_DE_VOTRE_VPS:8080](http://IPv4_DE_VOTRE_VPS:8080)
+[http://IPv4_OF_YOUR_VPS:8080](http://IPv4_OF_YOUR_VPS:8080)
```

FR keeps its own consistent French token (`ssh ubuntu@IPv4_DE_VOTRE_VPS`) and is untouched.

**2. OpenClaw agent guide — `VOTRE_GATEWAY_TOKEN` (5 locales: de, es, it, pl, pt)**

The connection tip uses `` `http://127.0.0.1:18789/?token=VOTRE_GATEWAY_TOKEN` `` — again French ("your gateway token") inside otherwise English text that already uses English-style placeholders (`YOUR_VPS_IP`, "enter your **Gateway Token**").

Fix: `token=VOTRE_GATEWAY_TOKEN` → `token=YOUR_GATEWAY_TOKEN`.

EN and FR copies of the OpenClaw guide are newer full-length rewrites without this tip and are untouched.

## Checks

- [x] Repository-wide scan: no `VOTRE` left in en/de/es/it/pl/pt docs after this change
- [x] Replacement token in each file matches that file's own established convention
- [x] `git diff --check` clean; 11 files changed, one line per file
- [x] No content or translation changes beyond the placeholder tokens

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
