### PR TITLE
docs(hosted-private-cloud): translate EN KMS CipherTrust guide from French

### DIFF
--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,113 +1,113 @@
 ---
-title: Mise en route du KMS CipherTrust Manager
-description: Découvrez comment déployer et les premières étapes de configuration du KMS CipherTrust Manager sur un environnement vSphere
+title: Getting started with the KMS CipherTrust Manager
+description: Find out how to deploy the KMS CipherTrust Manager and perform its first configuration steps on a vSphere environment
 hidden: true
 lastUpdated: 2021-11-04
 ---
 
-## Objectif
+## Objective
 
-Vous trouverez dans ce guide les différentes étapes permettant la configuration du Key Management System (**KMS**) CipherTrust de Thales dans l'interface vSphere de votre Hosted Private Cloud.
+This guide walks you through the steps required to configure the Thales CipherTrust Key Management System (**KMS**) in the vSphere interface of your Hosted Private Cloud.
 
-**Découvrez comment configuer un KMS Thales CipherTust.**
+**Find out how to set up a Thales CipherTrust KMS.**
 
-## Prérequis
+## Requirements
 
-* Disposer d'un service [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/)
-* Être connecté à l'[interface vSphere](/guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connection) de votre service Hosted Private Cloud
-* Avoir une adresse IP par instance de KMS
-* Avoir les fichiers du modèle OVF présents sur votre poste de travail
-* Avoir une clé publique SSH
-* Avoir récupéré l'OVA [KMS CipherTrust Manager](https://ovh.to/W2gBYe)
+* An [OVHcloud Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/) service
+* Access to the [vSphere interface](/guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connection) of your Hosted Private Cloud service
+* One IP address per KMS instance
+* The OVF template files available on your workstation
+* An SSH public key
+* The [KMS CipherTrust Manager](https://ovh.to/W2gBYe) OVA downloaded
 
 :::info
-Dans les étapes ci-dessous, nous utiliserons les informations suivantes :
+The steps below use the following information:
 
-*	portgroup vSphere : ADM
-*	sous-réseau local : 192.0.2.64/28
+*	vSphere portgroup: ADM
+*	local subnet: 192.0.2.64/28
 
 :::
 
-## En pratique 
+## Instructions
 
-### Installer les OVA CipherTrust Manager
+### Installing the CipherTrust Manager OVA
 
-* Connectez-vous au vCenter avec un compte permettant le déploiement d'un modèle OVF.
+* Log in to vCenter with an account that is allowed to deploy an OVF template.
 
 ![Deploy OVF Template](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_01.png)
 
-* Dirigez-vous dans le menu `Hôte et cluster`, puis sélectionnez le cluster.
-* Cliquez sur `Actions` > `Déployer un modèle OVF`.
-* Suivez les étapes d'installation :
+* Go to the `Hosts and Clusters` menu, then select the cluster.
+* Click `Actions` > `Deploy OVF Template`.
+* Follow the installation wizard:
 
 ![Select an OVF template](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_02.png)
 
-* Sélectionnez les fichiers locaux liés au modèle OVA `610-000612-005_SW_VMware_CipherTrust_Manager_v2.4.0_RevA.ova`.
-* Cliquez sur le bouton `Next`.
+* Select the local files of the OVA template `610-000612-005_SW_VMware_CipherTrust_Manager_v2.4.0_RevA.ova`.
+* Click the `Next` button.
 
 ![Select a name and folder](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_03.png)
 
-* Renseignez le nom de la machine virtuelle. Le nom doit être différent pour chaque instance. Ici, nous l'appellerons **KMS_01_master**.
-* Sélectionnez le datacenter où sera placé la machine virtuelle.
-* Cliquez sur le bouton `Next`.
+* Enter the name of the virtual machine. The name must be different for each instance. In this guide, we will use **KMS_01_master**.
+* Select the datacenter in which the virtual machine will be placed.
+* Click the `Next` button.
 
 ![Select a compute resource](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_04.png)
 
-* Sélectionnez la ressource de calcul (compute resource), ici **Cluster1**.
-* Cliquez sur le bouton `Next`.
+* Select the compute resource, here **Cluster1**.
+* Click the `Next` button.
 
 ![Review details](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_05.png)
 
-* Vérifiez les informations.
-* Cliquez sur le bouton `Next`.
+* Verify the information.
+* Click the `Next` button.
 
 ![Select storage](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_06.png)
 
-* Sélectionnez le périphérique de stockage.
-* Cliquez sur le bouton `Next`.
+* Select the storage device.
+* Click the `Next` button.
 
 ![Select networks](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_07.png)
 
-* Sélectionnez le réseau approprié, ici **ADM**.
-* Cliquez sur le bouton `Next`.
+* Select the appropriate network, here **ADM**.
+* Click the `Next` button.
 
 ![Ready to complete](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_ova_08.png)
 
-* Vérifiez les informations liées au déploiement.
-* Cliquez sur le bouton `Finish`.
+* Verify the deployment information.
+* Click the `Finish` button.
 
-Une fois la machine virtuelle déployée :
+Once the virtual machine is deployed:
 
 ![Edit settings](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_01.png)
 
-* Sélectionnez la machine virtuelle.
-* Cliquez sur `Edit Settings`.
+* Select the virtual machine.
+* Click `Edit Settings`.
 
 ![Add New Device](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_02.png)
 
-* Dans l'onglet **Virtual Hardware**, cliquez sur `Add New Device`.
-* Sélectionner **CD/DVD Drive**.
+* In the **Virtual Hardware** tab, click `Add New Device`.
+* Select **CD/DVD Drive**.
 
 ![New CD/DVD Drive](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_03.png)
 
-* Validez avec le bouton `OK`.
+* Confirm with the `OK` button.
 
-Configuration de la machine virtuelle :
+Configuring the virtual machine:
 
 ![Edit vApp Options](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_04.png)
 
-* Allez dans l'onglet **Configure**.
-* Dans le menu de gauche **vApp Options**.
-* Cliquez sur `Edit...`.
+* Go to the **Configure** tab.
+* In the left-hand menu, open **vApp Options**.
+* Click `Edit...`.
 
 ![Enable vApp options](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_05.png)
 
-* Vérifiez que **Enable vApp options** est bien coché.
-* Allez dans l'onglet **OVF Details**.
-* Cochez **ISO images**.
-* Cliquez sur `OK`.
+* Verify that **Enable vApp options** is checked.
+* Go to the **OVF Details** tab.
+* Check **ISO images**.
+* Click `OK`.
 
-Preparez le fichier cloud.init selon le modèle suivant.
+Prepare the cloud.init file using the following template.
 
 ```
 #cloud-config
@@ -122,120 +122,119 @@ keysecure:
       dns1: 192.0.2.65
 ```
 
-Attention : 
+Warning:
 
-* Ce fichier ne doit pas contenir de tabulation, seuls les espaces sont acceptés.
-* Toutes les valeurs entre « < » et « > » doivent être remplacées par les bonnes valeurs.
+* This file must not contain any tab characters; only spaces are accepted.
+* All values between `<` and `>` must be replaced with the correct values.
 
-Modifiez le fichier cloud.init en base 64. Exemple : 
+Convert the cloud.init file to base 64. Example:
 
 ```sh
 openssl base64 -A -in cloud.init -out cloudb64.init
 ```
 
 :::warning
-La chaine en base 64 doit être sur une seule ligne pour le reste de l'opération.
+The base 64 string must remain on a single line for the rest of this procedure.
 :::
 
-Finalisation de la configuration de la machine virtuelle :
+Finalizing the virtual machine configuration:
 
 ![Add vApp Properties](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_06.png)
 
-* Dirigez-vous sur l'onglet **Configure**.
-* Dans le menu de gauche **vApp Options**.
-* Puis dans la section **Properties**, cliquez sur `ADD`.
+* Go to the **Configure** tab.
+* In the left-hand menu, open **vApp Options**.
+* Then, in the **Properties** section, click `ADD`.
 
 ![New property](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_08.png)
 
-* Dans l'onglet **General**, définissez le label à **user-data**.
+* In the **General** tab, set the label to **user-data**.
 
 ![default value](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_10.png)
 
-* Dans l'onglet **Type**, saisissez dans **Default value**, la chaine en base 64.
-* Cliquez sur `SAVE` pour valider.
+* In the **Type** tab, enter the base 64 string in **Default value**.
+* Click `SAVE` to confirm.
 
-Démarrez la machine virtuelle et vérifiez qu'à l'issue du démarrage l'adresse IP configurée est bien présente.
+Start the virtual machine and verify that the configured IP address is present after startup.
 
-Repétez les étapes pour la seconde instance **KMS_01_slave**
+Repeat these steps for the second instance, **KMS_01_slave**.
 
-A l'issue de ces étapes, les différentes instances doivent être visibles. Exemple : 
+After completing these steps, all instances should be visible. Example:
 
 ![KMS_01_master](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_11.png)
 
 ![KMS_01_slave](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_vm_12.png)
 
-### Pré-configurer chaque instance
+### Pre-configuring each instance
 
 :::warning
-Il est important que la clé SSH ainsi que les mots de passe définis dans les différentes instances soient identiques.
+It is important that the SSH key and the passwords defined for all instances are identical.
 :::
 
 ![Add SSH Public Key](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_getting_started_01.png)
 
-Première authentification au KMS :
+First authentication on the KMS:
 
-* Connectez-vous sur l'appliance : [192.0.2.68](https://192.0.2.68/).
-* Renseignez la clé SSH publique.
-* Cliquez sur `ADD`.
+* Log in to the appliance: [192.0.2.68](https://192.0.2.68/).
+* Provide the SSH public key.
+* Click `ADD`.
 
 :::info
-L'insertion peut prendre quelques minutes afin que les microservices puissent se lancer.
+The insertion may take a few minutes while the microservices start.
 :::
 
 ![Default log in](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_getting_started_02.png)
 
-Authentification :
+Authentication:
 
-* Depuis la fenêtre, renseignez les mots de passe par défaut :
-    * Username : **admin**
-    * Password : **admin**
-* Cliquez sur `Log In`.
+* In the window that opens, enter the default passwords:
+    * Username: **admin**
+    * Password: **admin**
+* Click `Log In`.
 
 ![Change password](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_getting_started_03.png)
 
-Une nouvelle fenêtre apparaît pour renouveler le mot de passe.
+A new window opens to renew the password.
 
-* Current Password : **admin**
-* New Password : NouveauMotDePasse
-* Retype New Password : NouveauMotDePasse
-* Cliquez sur `Change Password`.
+* Current Password: **admin**
+* New Password: YourNewPassword
+* Retype New Password: YourNewPassword
+* Click `Change Password`.
 
 ![Log In](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_getting_started_04.png)
 
-Utilisez le nouveau mot de passe pour vous authentifier.
+Use the new password to authenticate.
 
 ![cipher trust manager](/images/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust/kms_cipher_trust_getting_started_05.png)
 
-L'instance de KMS est prête a être utilisée.
+The KMS instance is now ready to be used.
 
-### Activer la licence KMS
+### Activating the KMS license
 
-Dans le cadre de l'installation, deux types de licences sont à installer :
+Two types of licenses need to be installed as part of the setup:
 
-1. Virtual CipherTrust Manager : licence propre à une instance
-    * Il faudra activer les licences unitairement pour chaque instance à l'aide du "Key Manager Lock Code".
-    * L'installation devra être réalisée par appliance.
-2. KMIP : licence pour les clients KMIP
-    * Activation de la licence en fonction du besoin. L'activation est réalisée à l'aide du "Connector Lock Code".
-    * L'installation devra être réalisée une seule fois avant d'être propagée sur les membres du cluster.
+1. Virtual CipherTrust Manager: license specific to one instance
+    * You will need to activate the licenses individually for each instance using the "Key Manager Lock Code".
+    * Installation must be performed per appliance.
+2. KMIP: license for KMIP clients
+    * License activation depends on your needs. Activation is performed using the "Connector Lock Code".
+    * Installation must be performed only once before being propagated to the cluster members.
 
-Afin de réaliser l'activation et l'installation des licences, connectez-vous sur chacune des instances du client.
+To activate and install the licenses, log in to each of the customer's instances.
 
-* Dirigez-vous dans `Admin Settings` > `Licensing` > `Lock Codes`, puis récupérez :
+* Go to `Admin Settings` > `Licensing` > `Lock Codes`, then retrieve:
     * Key Manager Lock Code
     * Connector Lock Code
-    * Récupérez le(s) document(s) livré(s) par Thales concernant la commande de licences.
-* Transmettez ces informations au support OVHcloud.
+    * Retrieve the document(s) delivered by Thales regarding the license order.
+* Send this information to OVHcloud support.
 
 :::info
-*	Le Key Manager Lock Code est à utiliser pour l'activation de la licence de l'appliance virtuelle.
-*	Le Connector Lock Code est à utiliser pour les licences de connecteur comme KMIP.
+*	The Key Manager Lock Code is used to activate the virtual appliance license.
+*	The Connector Lock Code is used for connector licenses such as KMIP.
 
 :::
 
-Votre KMS est désormais prêt à etre utilisé.
+Your KMS is now ready to be used.
 
-## Aller plus loin
+## Go further
 
-Échangez avec notre [communauté d'utilisateurs](/links/community).
-
+Join our [community of users](/links/community).


### PR DESCRIPTION
## Summary

The English copy of the KMS CipherTrust Manager guide (`docs/en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx`) carried the French source content: the title ("Mise en route du KMS CipherTrust Manager"), the description, and ~70 prose lines in French ("Cliquez sur le bouton `Next`", "Renseignez le nom de la machine virtuelle…").

Because `de`, `es`, `it`, `pl` and `pt` are symlinks to this file, five locales rendered French text under their own locale, and even the EN page was largely French.

## Changes

Translate all prose to English. Everything else is preserved 1:1 (verified programmatically against the original):

- frontmatter keys unchanged; only `title`/`description` translated; `hidden` flag and `lastUpdated` untouched;
- all 23 image paths identical;
- both code blocks byte-identical (`#cloud-config` template, `openssl base64` command);
- admonition counts identical (3 × `:::info`, 2 × `:::warning`);
- internal link to the vSphere connection guide and `/links/community` preserved;
- example value `NouveauMotDePasse` became `YourNewPassword`.

The FR sibling keeps its own French copy and is not modified.

## Checks

- [x] Structure parity script: images/fences/admonitions/links counts match the original exactly
- [x] Zero French-accent characters remain in the file
- [x] `git diff --check` clean; 1 file changed
- [x] No factual, structural or image changes

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
