### PR TITLE
docs(vps): refresh EOL images in the WordPress Docker guide

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -106,7 +106,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -163,12 +163,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -107,7 +107,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -164,12 +164,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -106,7 +106,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -163,12 +163,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -109,7 +109,7 @@ Copiez et collez la configuration suivante dans le fichier `docker-compose.yml` 
 ```sh
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -166,12 +166,12 @@ Si vous le souhaitez, vous pouvez utiliser une autre image Docker.
 
 ### Utiliser une image Docker spécifique
 
-Dirigez-vous dans la [section WordPress de Docker Hub](https://hub.docker.com/_/wordpress) et identifiez l'image qui correspond à vos besoins. Par exemple, si vous choisissez d'utiliser l'image `wordpress:5-php7.4-fpm`, vous devrez modifier votre fichier `docker-compose.yml` avec un éditeur de texte. Une fois le fichier ouvert, trouvez la section du service `wordpress` et modifiez la ligne `image:` pour utiliser le tag spécifique de l'image `wordpress:5-php7.4-fpm` que vous avez choisi. Par exemple :
+Dirigez-vous dans la [section WordPress de Docker Hub](https://hub.docker.com/_/wordpress) et identifiez l'image qui correspond à vos besoins. Par exemple, si vous choisissez d'utiliser l'image `wordpress:php8.3-fpm`, vous devrez modifier votre fichier `docker-compose.yml` avec un éditeur de texte. Une fois le fichier ouvert, trouvez la section du service `wordpress` et modifiez la ligne `image:` pour utiliser le tag spécifique de l'image `wordpress:php8.3-fpm` que vous avez choisi. Par exemple :
 
 ```sh
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -106,7 +106,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -163,12 +163,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -106,7 +106,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -163,12 +163,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-wordpress-docker-on-vps.mdx
@@ -106,7 +106,7 @@ Copy and paste the following configuration into the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.4
     volumes:
       - db_data:/var/lib/mysql
     environment:
@@ -163,12 +163,12 @@ If you wish, you can use another Docker image.
 
 ### Use a specific Docker image
 
-Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:5-php7.4-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:5-php7.4-fpm` image you have chosen. For example:
+Go to the [Docker Hub WordPress section](https://hub.docker.com/_/wordpress) and identify the image that fits your needs. For example, if you choose to use the image `wordpress:php8.3-fpm`, you will need to edit your `docker-compose.yml` file with a text editor. Once the file is open, find the section of the `wordpress` service and modify the line `image:` to use the specific tag of the `wordpress:php8.3-fpm` image you have chosen. For example:
 
 ```yaml
 services:
   wordpress:
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
     container_name: wordpress
 ...
 ```


### PR DESCRIPTION
## Summary

The WordPress Docker guide for VPS used end-of-life images in two places:

1. **`mysql:5.7` in the main Compose stack** — MySQL 5.7 reached EOL on 2023-10-31 and no longer receives security fixes.
2. **`wordpress:5-php7.4-fpm` as the "specific image" example** — both WordPress 5.x and PHP 7.4 are past end of life (PHP 7.4: Nov 2022).

## Changes

All seven locales (en, de, es, fr, it, pl, pt), identical token replacements:

```diff
-    image: mysql:5.7
+    image: mysql:8.4
```

- `8.4` is the current MySQL LTS line (supported until 2032-04 per Oracle's lifecycle) and remains a drop-in replacement for this stack; the guide's `MYSQL_*` environment variables work unchanged.

```diff
-    image: wordpress:5-php7.4-fpm
+    image: wordpress:php8.3-fpm
```

- `wordpress:php8.3-fpm` is an actively published Docker Official Image tag (verified on Docker Hub), and PHP 8.3 is supported upstream until 2027-12.

No other content changes — the surrounding prose that references the example tag was updated with the same token so text and code stay consistent.

## Checks

- [x] Replacement tags verified to exist on Docker Hub (`mysql:8.4`, `wordpress:php8.3-fpm`)
- [x] EOL dates verified via endoflife.date and php.net (MySQL 5.7 → 2023-10-31; PHP 7.4 → 2022-11-28)
- [x] All 7 locale siblings patched consistently (21 insertions, 21 deletions)
- [x] `git diff --check` clean

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
