### PR TITLE
docs(public-cloud): refresh PHP version in MongoDB/Redis connect guides

### DIFF
--- a/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ Vous pouvez trouver un exemple sur le [dépôt d'exemples GitHub](https://github
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une base de données MongoDB active sur votre service Public Cloud Databases OVHcloud (vous pouvez utiliser [ce guide](/guides/public-cloud/databases/getting-started) pour remplir ce prérequis)
 - [Configurer votre instance MongoDB](/guides/public-cloud/databases/mongodb-manage-control-panel) pour accepter les connexions entrantes
-- Un environnement PHP avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec PHP 7.4.
+- Un environnement PHP avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ Comme montré dans le code, nous utilisons **MongoDB\Driver\Manager**. Consultez
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ Vous pouvez trouver un exemple sur le [dépôt d'exemples GitHub](https://github
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une base de données MongoDB active sur votre service Public Cloud Databases OVHcloud (vous pouvez utiliser [ce guide](/guides/public-cloud/databases/getting-started) pour remplir ce prérequis)
 - [Configurer votre instance MongoDB](/guides/public-cloud/databases/mongodb-manage-control-panel) pour accepter les connexions entrantes
-- Un environnement PHP avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec PHP 8.3.
+- Un environnement PHP avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ Comme montré dans le code, nous utilisons **MongoDB\Driver\Manager**. Consultez
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ Vous trouverez un exemple sur le [dépôt d'exemples Github](https://github.com/
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Un service Valkey actif sur votre service OVHcloud Public Cloud Databases ([ce guide](/guides/public-cloud/databases/getting-started) peut vous aider à répondre à ce prérequis)
 - [Configurer votre service Valkey](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) pour qu'il accepte les connexions entrantes
-- Un environnement PHP dans une version stable et disposant d'une connectivité au réseau public (Internet). Ce guide a été réalisé en PHP 8.3.
+- Un environnement PHP dans une version stable et disposant d'une connectivité au réseau public (Internet). Ce guide a été réalisé en PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ Dans votre environnement PHP, essayons une connexion. Pour être sûr d'être bi
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ Vous trouverez un exemple sur le [dépôt d'exemples Github](https://github.com/
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Un service Valkey actif sur votre service OVHcloud Public Cloud Databases ([ce guide](/guides/public-cloud/databases/getting-started) peut vous aider à répondre à ce prérequis)
 - [Configurer votre service Valkey](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) pour qu'il accepte les connexions entrantes
-- Un environnement PHP dans une version stable et disposant d'une connectivité au réseau public (Internet). Ce guide a été réalisé en PHP 7.4.
+- Un environnement PHP dans une version stable et disposant d'une connectivité au réseau public (Internet). Ce guide a été réalisé en PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ Dans votre environnement PHP, essayons une connexion. Pour être sûr d'être bi
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -63,7 +63,7 @@ As shown in the code, we use the **MongoDB\Driver\Manager**. Use the official PH
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
     try {
         // connect to OVHcloud Public Cloud Databases for MongoDB (cluster in version 4.4, MongoDB PHP Extension in 1.8.1)
         $m = new MongoDB\Driver\Manager('mongodb+srv://`<username>`:<password>@mongodb-e49d02ee-o2626ab53.database.cloud.ovh.net/admin?replicaSet=replicaset');

--- a/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.4.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 8.3 used here
+   // PHP version 8.4 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 

--- a/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-connect-php.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A Valkey service running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your Valkey service](/guides/public-cloud/databases/redis-prepare-for-incoming-connections) to accept incoming connections
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
 
 ## Concept
 
@@ -53,7 +53,7 @@ In your PHP environment, let's try a connection. To be sure that we are indeed c
 
 ```php
 <?php
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
 	echo "\nConnection to server ongoing...";
 	$redis = new Redis() or die("Cannot load Redis module in PHP.");
 


### PR DESCRIPTION
## Summary

The MongoDB and Redis PHP connection guides stated *"This guide was made in PHP 7.4"* (plus a matching `// PHP version 7.4 used here` comment inside the sample code). PHP 7.4 reached end of life on **2022-11-28** and no longer receives security fixes, so the guides were pointing readers at a version they should not deploy.

## Changes

Refresh the tested-with statement and the code comment to **PHP 8.3** (upstream support until 2027-12) in all seven locales — 14 files, one line each:

```diff
-- A PHP environment with a stable version and public network connectivity (Internet). This guide was made in PHP 7.4.
+- A PHP environment with a stable version and public network connectivity (Internet). This guide was made using PHP 8.3.
```

```diff
-   // PHP version 7.4 used here
+   // PHP version 8.3 used here
```

FR sentences translated accordingly («réalisé avec PHP 8.3» / «réalisé en PHP 8.3»). The sample code itself is version-agnostic (`MongoDB\Driver\Manager`, phpredis `Redis` class) and works unchanged on modern PHP, so only the version references needed updating.

## Checks

- [x] No `PHP 7.4` remains in either guide in any locale after this change
- [x] PHP 8.3 support window verified via php.net/endoflife.date (security fixes until 2027-12-31)
- [x] Sample code verified to be version-agnostic (no 7.x-only APIs)
- [x] `git diff --check` clean; 14 files changed, +28/−28

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
