### PR TITLE
docs(public-cloud): refresh Python versions in DB connection guides

### DIFF
--- a/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/de/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed :

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed:
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed:

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/es/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed :

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ Vous trouverez un exemple sur le [dépôt d'exemples Github](https://github.com/
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une base de données MongoDB exécutée sur votre service Public Cloud Databases OVHcloud (ce [guide](/guides/public-cloud/databases/getting-started) peut vous aider à répondre à ce prérequis)
 - [Configurez votre instance MongoDB](/guides/public-cloud/databases/mongodb-manage-control-panel) pour qu'elle accepte les connexions entrantes
-- Un environnement Python dans une version stable disposant d'une connectivité réseau publique (Internet). Ce guide a été réalisé avec Python 3.9.5.
+- Un environnement Python dans une version stable disposant d'une connectivité réseau publique (Internet). Ce guide a été réalisé avec Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Une fois votre environnement Python configuré, exécutez **python --version** d
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 Dans la même console, en tapant **pip list | grep pymongo**, vérifiez que **pymongo** est correctement installé :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-Dans notre cas, nous trouvons **Python 3.9.5**, et **PyMongo 4.2**. D'après la matrice de compatibilité officielle de MongoDB mentionnée précédemment, nous serons en mesure de nous connecter à des instances MongoDB en versions 4.x, 5.0 et 6.0.
+Dans notre cas, nous trouvons **Python 3.13**, et **PyMongo 4.2**. D'après la matrice de compatibilité officielle de MongoDB mentionnée précédemment, nous serons en mesure de nous connecter à des instances MongoDB en versions 4.x, 5.0 et 6.0.
 Ceci est conforme avec notre instance MongoDB 5.0 actuelle.
 
 ### Configurer votre instance MongoDB pour accepter les connexions entrantes

--- a/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ Dans la même console, en tapant **pip list | grep pymongo**, vérifiez que **py
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-Dans notre cas, nous trouvons **Python 3.13**, et **PyMongo 4.2**. D'après la matrice de compatibilité officielle de MongoDB mentionnée précédemment, nous serons en mesure de nous connecter à des instances MongoDB en versions 4.x, 5.0 et 6.0.
-Ceci est conforme avec notre instance MongoDB 5.0 actuelle.
+Dans notre cas, nous trouvons **Python 3.13**, et **PyMongo 4.17**. D'après la matrice de compatibilité officielle de MongoDB mentionnée précédemment, nous serons en mesure de nous connecter à des instances MongoDB en versions 7.0 et 8.0.
+Ceci est conforme avec notre instance MongoDB 8.0 actuelle.
 
 ### Configurer votre instance MongoDB pour accepter les connexions entrantes
 

--- a/docs/fr/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ Vous trouverez un exemple sur le [dépôt d'exemples GitHub](https://github.com/
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une base de données MySQL fonctionnant sur votre Public Cloud Databases OVHcloud ([ce guide](/guides/public-cloud/databases/getting-started) peut vous aider à répondre à ce prérequis)
 - [Configurez votre instance MySQL](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) pour qu'elle accepte les connexions entrantes
-- Un environnement Python avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec Python 3.9.7.
+- Un environnement Python avec une version stable et une connectivité réseau publique (Internet). Ce guide a été réalisé avec Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Une fois votre environnement Python configuré, lorsque vous exécutez un **pyth
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 Dans la même console, en saisissant **pip list**, vérifiez que **mysql-connector-python** est correctement installé :

--- a/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ Ce tutoriel est conçu pour vous aider autant que possible dans les tâches cour
 
 - Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Un service Public Cloud Databases for PostgreSQL opérationnel.
-- Un environnement Python dans une version stable et une connectivité réseau publique (Internet). Ce tutoriel a été réalisé avec Python 3.9.7.
+- Un environnement Python dans une version stable et une connectivité réseau publique (Internet). Ce tutoriel a été réalisé avec Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ Ce tutoriel est conçu pour vous aider autant que possible dans les tâches cour
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail prend en charge Python 3.7, 3.8, 3.9 et 3.10.
+Wagtail nécessite Python 3.10 ou supérieur (les versions récentes exigent Python 3.10+ ; consultez la [documentation officielle](https://docs.wagtail.org/fr/stable/getting_started/index.html) pour la version que vous installez).
 
 :::
 

--- a/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/fr/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ Ce tutoriel est conçu pour vous aider autant que possible dans les tâches cour
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail nécessite Python 3.10 ou supérieur (les versions récentes exigent Python 3.10+ ; consultez la [documentation officielle](https://docs.wagtail.org/fr/stable/getting_started/index.html) pour la version que vous installez).
+Wagtail nécessite Python 3.10 ou supérieur. Consultez la [documentation officielle](https://docs.wagtail.org/en/stable/getting_started/index.html) pour la version que vous installez.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/it/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed :

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/pl/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed :

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -17,7 +17,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A MongoDB database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MongoDB instance](/guides/public-cloud/databases/mongodb-manage-control-panel) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.5.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -56,7 +56,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python --version
-Python 3.9.5
+Python 3.13
 ```
 
 In the same console, by typing **pip list | grep pymongo** check if **pymongo** is correctly installed :
@@ -66,7 +66,7 @@ laptop$ pip list | grep pymongo
 pymongo    4.2.0
 ```
 
-In our case, we can find **Python 3.9.5**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
+In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
 This is compliant with our current MongoDB 5.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections

--- a/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -63,11 +63,11 @@ In the same console, by typing **pip list | grep pymongo** check if **pymongo** 
 
 ```python
 laptop$ pip list | grep pymongo
-pymongo    4.2.0
+pymongo    4.17.0
 ```
 
-In our case, we can find **Python 3.13**, and **PyMongo 4.2**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 4.x, 5.0 and 6.0.
-This is compliant with our current MongoDB 5.0 instance.
+In our case, we can find **Python 3.13**, and **PyMongo 4.17**. Based on the official MongoDB compatibility matrix linked previously, we will be able to connect to MongoDB instances in versions 7.0 and 8.0.
+This is compliant with our current MongoDB 8.0 instance.
 
 ### Configure your MongoDB instance to accept incoming connections
 

--- a/docs/pt/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -18,7 +18,7 @@ You can find an example on the [Github examples repository](https://github.com/o
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
 - A MySQL database running on your OVHcloud Public Cloud Databases ([this guide](/guides/public-cloud/databases/getting-started) can help you to meet this requirement)
 - [Configure your MySQL instance](/guides/public-cloud/databases/mysql-prepare-for-incoming-connections) to accept incoming connections
-- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This guide was made using Python 3.13.
 
 ## Concept
 
@@ -45,7 +45,7 @@ Once your Python environment is set up and you begin executing a **python --vers
 
 ```python
 laptop$ python3 --version
-Python 3.9.7
+Python 3.13
 ```
 
 In the same console, by typing a **pip list**, check if **mysql-connector-python** is correctly installed :

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
+Wagtail requires Python 3.10 or later. Check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing.
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -22,7 +22,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
 - An up and running Public Cloud Database for PostgreSQL.
-- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.9.7.
+- A Python environment with a stable version and public network connectivity (Internet). This tutorial was made using Python 3.12.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -36,7 +36,7 @@ This tutorial is designed to help you as much as possible with common tasks. If 
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::info
-Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
+Wagtail requires Python 3.10 or later (recent versions require 3.10+; check the [official documentation](https://docs.wagtail.org/en/stable/getting_started/index.html) for the version you are installing).
 
 :::
 


### PR DESCRIPTION
## Summary

Three Public Cloud Databases guides stated they were built with Python 3.9.x, which reached **end of life on 2025-10-04** and no longer receives security fixes.

## Changes

All seven locales, one token per occurrence:

**1. `mongodb-connect-python.mdx`** — `Python 3.9.5` → `Python 3.13` (3 occurrences: requirement line, sample `python --version` output, prose referencing the output)

**2. `mysql-connect-python.mdx`** — `Python 3.9.7` → `Python 3.13` (2 occurrences: requirement line, sample output)

**3. `postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx`** — two fixes:
- `Python 3.9.7` → `Python 3.12` (tested-with statement)
- The info box claimed *"Wagtail supports Python 3.7, 3.8, 3.9 and 3.10."* — this predated current Wagtail releases: wagtail 7.x on PyPI declares `requires_python >=3.10`. Rewritten as "Wagtail requires Python 3.10 or later" with a link to the official installation docs (FR sentence translated accordingly).

## Deliberately unchanged

- The AI Notebooks Rasa chatbot guide also mentions "(Python 3.9)", but it pins a real OVHcloud AI Notebooks framework label (`--framework-version conda-py39-cuda11.2-v22-4`) — changing it requires product-side verification of available labels.
- Sample code in all three guides is version-agnostic (PyMongo, mysql-connector-python, Django/Wagtail ORM) and works unchanged on modern Python.

## Checks

- [x] No `Python 3.9.x` remains in the three guides in any locale after this change
- [x] Python EOL dates verified via endoflife.date/python.org; Wagtail requirement verified via PyPI metadata (`requires_python >=3.10`)
- [x] `git diff --check` clean; 21 files changed, +49/−49
- [x] FR sentences translated consistently

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
