### PR TITLE
fix(managed-kubernetes): repoint FR in-page anchors to translated headings

### DIFF
--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -343,7 +343,7 @@ Valeurs autorisées : `octavia` = Load Balancer Public Cloud, `iolb` = Loadbalan
 
   Cette annotation est automatiquement ajoutée au Service si elle n'est pas spécifiée lors de la création. Une fois le Service créé avec succès, elle ne doit pas être modifiée, sous peine que le Service ne se comporte pas comme attendu.
 
-  Si cette annotation est spécifiée avec un ID de load balancer cloud valide lors de la création du Service, le Service réutilise ce load balancer plutôt que d'en créer un nouveau. Plus de détails [ci-dessous](#sharing-an-octavia-loadbalancer-between-multiple-kubernetes-loadbalancer-service).
+  Si cette annotation est spécifiée avec un ID de load balancer cloud valide lors de la création du Service, le Service réutilise ce load balancer plutôt que d'en créer un nouveau. Plus de détails [ci-dessous](#partager-un-loadbalancer-octavia-entre-plusieurs-services-loadbalancer-kubernetes).
 
   Si cette annotation est spécifiée, les autres annotations définissant les fonctionnalités du load balancer seront ignorées.
 
@@ -555,7 +555,7 @@ Error syncing load balancer: failed to ensure load balancer: Network is not matc
 
 Consultez le guide : [Comment définir un GatewayIP sur un Subnet OpenStack](/guides/public-cloud/network-services/update-subnet-properties).
 
-Si vous ne souhaitez pas déployer de routeur OpenStack dans votre subnet (par exemple, si vous gérez votre propre routeur), vous devez configurer le `LoadBalancerSubnetId` de votre cluster MKS. [Plus d'informations ici](#network-prerequisite-to-expose-your-load-balancers-publicly).
+Si vous ne souhaitez pas déployer de routeur OpenStack dans votre subnet (par exemple, si vous gérez votre propre routeur), vous devez configurer le `LoadBalancerSubnetId` de votre cluster MKS. [Plus d'informations ici](#prérequis-réseau-pour-exposer-vos-load-balancers-publiquement).
 
 ### Network is not matching requirements for Public LoadBalancer: Cannot deploy an OpenStack Router
 
@@ -565,7 +565,7 @@ Lorsque vous essayez de déployer un LoadBalancer public, vous devez disposer d'
 Error syncing load balancer: failed to ensure load balancer: Network is not matching requirement for Public LoadBalancer (cannot deploy an OpenStack Router)
 ```
 
-Dans votre cas, le GatewayIP est déjà utilisé par autre chose et nous ne pouvons pas déployer de routeur OpenStack pour votre LoadBalancer public. Si vous n'êtes pas en mesure de libérer l'IP (par exemple, si elle est utilisée par un routeur que vous avez déployé), vous devez configurer le `LoadBalancerSubnetId` de votre cluster MKS. [Plus d'informations ici](#network-prerequisite-to-expose-your-load-balancers-publicly)
+Dans votre cas, le GatewayIP est déjà utilisé par autre chose et nous ne pouvons pas déployer de routeur OpenStack pour votre LoadBalancer public. Si vous n'êtes pas en mesure de libérer l'IP (par exemple, si elle est utilisée par un routeur que vous avez déployé), vous devez configurer le `LoadBalancerSubnetId` de votre cluster MKS. [Plus d'informations ici](#prérequis-réseau-pour-exposer-vos-load-balancers-publiquement)
 
 ## Convention de nommage des ressources
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/migrate-iolb-to-public-cloud-loadbalancer.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/migrate-iolb-to-public-cloud-loadbalancer.mdx
@@ -69,7 +69,7 @@ Si vous tentez une mise à niveau sans avoir migré au préalable, une erreur se
 :::
 
 
-Il existe deux méthodes pour passer d'un [Load Balancer pour Managed Kubernetes](/links/public-cloud/load-balancer-kubernetes) à un [Load Balancer Public Cloud](/links/public-cloud/load-balancer) : vous pouvez soit **[migrer](#migration)**, soit **[remplacer](#replacement)** votre Load Balancer.
+Il existe deux méthodes pour passer d'un [Load Balancer pour Managed Kubernetes](/links/public-cloud/load-balancer-kubernetes) à un [Load Balancer Public Cloud](/links/public-cloud/load-balancer) : vous pouvez soit **[migrer](#migration)**, soit **[remplacer](#remplacement)** votre Load Balancer.
 
 Votre Service Load Balancer existant utilisant [Load Balancer for Kubernetes](/links/public-cloud/load-balancer-kubernetes) devrait comporter l'annotation suivante :
 
@@ -79,7 +79,7 @@ annotations:
 ```
 
 :::danger
-Chacune des deux méthodes décrites ci-dessous ([migration](#migration) ou [remplacement](#replacement)) nécessite un changement DNS pour lequel une propagation DNS de 24 à 48 heures est requise **avant** d'effectuer la migration.
+Chacune des deux méthodes décrites ci-dessous ([migration](#migration) ou [remplacement](#remplacement)) nécessite un changement DNS pour lequel une propagation DNS de 24 à 48 heures est requise **avant** d'effectuer la migration.
 
 Par conséquent, veuillez **lire l'intégralité de ce guide** (et notamment la section « Comment effectuer un changement DNS ? ») avant de procéder aux étapes ci-dessous.
 :::


### PR DESCRIPTION
The FR translation of the Managed Kubernetes family (#613) localised the headings but left five in-page links pointing at the previous English slugs, so they scroll nowhere.

expose-applications-using-load-balancer.mdx
- #sharing-an-octavia-... -> #partager-un-loadbalancer-octavia-...
- #network-prerequisite-... -> #prerequis-reseau-... (2 links)

migrate-iolb-to-public-cloud-loadbalancer.mdx
- #replacement -> #remplacement (2 links)

Target slugs verified with the repository's own @rspress/shared slugger. A sweep of all 91 real files touched by #613 shows no dead anchors remain.