### PR TITLE
fix(hosted-private-cloud): hide the KMS CipherTrust Manager guide

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -545,7 +545,6 @@
                 + [Enabling Virtual Machine Encryption with external KMS](hosted-private-cloud/powered-by-vmware/vm-encrypt)
                 + [KMS for VMware on OVHcloud - VM encryption use case scenarios](hosted-private-cloud/powered-by-vmware/vmware-overall-vm-encrypt)
                 + [KMS for VMware on OVHcloud - Configuring VM encryption](hosted-private-cloud/powered-by-vmware/okms-vm-encrypt)
-                + [Mise en route du KMS CipherTrust Manager](hosted-private-cloud/powered-by-vmware/kms-cipher-trust)
             + [Network Security (NSX)](hosted-private-cloud-managed-vmware-security-nsx)
                 + [Distributed Firewall Management in NSX](hosted-private-cloud/powered-by-vmware/nsx-manage-distributed-firewall)
                 + [Gateway Firewall Management in NSX](hosted-private-cloud/powered-by-vmware/nsx-manage-gateway-firewall)

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx

--- a/docs/de/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/de/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,1 +1,0 @@
-../../../../en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mise en route du KMS CipherTrust Manager
 description: Découvrez comment déployer et les premières étapes de configuration du KMS CipherTrust Manager sur un environnement vSphere
-hidden: true
+flag: hidden
 lastUpdated: 2021-11-04
 ---
 

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx

--- a/docs/es/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/es/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,1 +1,0 @@
-../../../../en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx

--- a/docs/fr/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/fr/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,6 +1,7 @@
 ---
 title: Mise en route du KMS CipherTrust Manager
 description: Découvrez comment déployer et les premières étapes de configuration du KMS CipherTrust Manager sur un environnement vSphere
+flag: hidden
 lastUpdated: 2021-11-04
 ---
 

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx

--- a/docs/it/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/it/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,1 +1,0 @@
-../../../../en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx

--- a/docs/pl/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/pl/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,1 +1,0 @@
-../../../../en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/powered-by-vmware/_kms-cipher-trust.mdx

--- a/docs/pt/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
+++ b/docs/pt/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx
@@ -1,1 +1,0 @@
-../../../../en/guides/hosted-private-cloud/powered-by-vmware/kms-cipher-trust.mdx


### PR DESCRIPTION
The guide was deliberately unpublished on the legacy platform, but the migration carried its `hidden: true` frontmatter across as an inert key: nothing in theme/, config/, plugins/ or scripts/ reads frontmatter.hidden. On this platform visibility is controlled by the `_` filename prefix (scripts/lib/page-creator.ts). The guide was therefore live, listed in the sidebar and present in the sitemap with 9 entries, the same as any published guide.

- rename the 7 locale files to _kms-cipher-trust.mdx
- repoint the de/es/it/pl/pt symlinks at the renamed EN file
- replace the inert `hidden: true` with `flag: hidden` (EN) and add it to FR, which carried no flag at all
- drop the entry from config/sidebar/index.md

Matches the convention of the other hidden guides, e.g. _veeam-cloud-connect-migration.mdx. sidebar:validate and sidebar:orphans both pass. Note the URL itself still resolves; `_` removes a page from the sidebar and sitemap but does not unpublish it.