### PR TITLE
fix: Correct locale-availability route keys on Windows

### DIFF
--- a/scripts/build-locale-availability.ts
+++ b/scripts/build-locale-availability.ts
@@ -46,8 +46,11 @@ for (const loc of LOCALES) {
   if (!fs.existsSync(dir)) continue;
   for (const f of walk(dir)) {
     if (!isResolvable(f)) continue;
-    const rel = f
-      .replace(`${path.join(ROOT, 'docs', loc)}/`, '')
+    // path.relative, not a string replace: path.join yields `\` on Windows.
+    const rel = path
+      .relative(path.join(ROOT, 'docs', loc), f)
+      .split(path.sep)
+      .join('/')
       .replace(/\.mdx$/, '');
     perLocale[loc].add(rel);
     union.add(rel);


### PR DESCRIPTION
- Current path emits absolute `C:\…` keys, so `LOCALE_AVAILABILITY` never matches and the language switcher's 404 fallback is silently disabled on every Windows dev machine.
-> Use path.relative + split(path.sep), as sidebar-validate already does. (No effect on production build, only enables local testing.)