### PR TITLE
SK-2669 - WEB - Email - Align the OMM guides with the current Mail Migrator

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ihre E-Mail-Adresse manuell migrieren
 description: Erfahren Sie hier, wie Sie Ihre E-Mail-Adresse manuell auf eine andere E-Mail-Adresse migrieren.
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Ziel
 
-Die automatische [Migration](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) einer E-Mail-Adresse ist über unseren [OVHcloud Mail Migrator](https://omm.ovhcloud.com/) möglich. Sie können Ihre E-Mail-Adresse auch manuell über einen E-Mail-Client migrieren.
+Die automatische [Migration](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) einer E-Mail-Adresse ist über unseren [OVHcloud Mail Migrator](/links/web/omm) möglich. Sie können Ihre E-Mail-Adresse auch manuell über einen E-Mail-Client migrieren.
 
 **Diese Anleitung erläutert, wie Sie Ihre E-Mail-Adresse manuell migrieren.**
 
@@ -67,7 +67,7 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 ## In der praktischen Anwendung
 
 :::info
-Überprüfen Sie zunächst, ob die automatische Migration mit unserem [OVHcloud Mail Migrator](https://omm.ovhcloud.com/) möglich ist. Lesen Sie hierzu die Anleitung [E-Mail-Accounts über den OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Überprüfen Sie zunächst, ob die automatische Migration mit unserem [OVHcloud Mail Migrator](/links/web/omm) möglich ist. Lesen Sie hierzu die Anleitung [E-Mail-Accounts über den OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Umzug zu Exchange, Email Pro oder Zimbra
 description: Migrieren Sie Ihren MX Plan E-Mail-Account zu Exchange, Email Pro oder Zimbra und behalten Sie Ihre Nachrichten, Kontakte und Ordner
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -166,7 +166,7 @@ Klicken Sie im Tab <code className="action">E-Mail-Accounts</code> Ihrer E-Mail 
 
 <img className="thumbnail" alt="Konfiguration des MX Plan-Kontos für die Migration im OVHcloud Kundencenter, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migrieren** des Accounts mithilfe unseres OMM-Tools ([OVHcloud Mail Migrator](https://omm.ovhcloud.com/)) auf das Konto Ihrer neuen Plattform.
+3\. **Migrieren** des Accounts mithilfe unseres OMM-Tools ([OVHcloud Mail Migrator](/links/web/omm)) auf das Konto Ihrer neuen Plattform.
 
 Weitere Informationen zu OMM finden Sie in unserer Anleitung [E-Mail-Accounts über OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts zwischen OVHcloud-Plattformen migrieren
 description: Migrieren Sie E-Mail-Accounts zwischen zwei OVHcloud-Plattformen (Exchange, Email Pro, MX Plan), ohne Nachrichten, Kontakte oder Ordner zu verlieren
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Nur die Daten Ihrer E-Mail Accounts werden migriert (E-Mails, Kontakte, Kalender
 :::
 
 
-Migrieren Sie den Quell-E-Mail-Account mithilfe unseres Tools [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator) auf das Konto Ihrer neuen Plattform.
+Migrieren Sie den Quell-E-Mail-Account mithilfe unseres Tools [OMM](/links/web/omm) (OVHcloud Mail Migrator) auf das Konto Ihrer neuen Plattform.
 
 Weitere Informationen zu OMM finden Sie in unserer Anleitung "[E-Mail-Accounts über den OVHcloud Mail Migrator migrieren](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud)".
 
@@ -181,7 +181,7 @@ Sie können nun Ihre migrierten E-Mail-Adressen verwenden. OVHcloud stellt dazu 
 Wenn Sie einen der migrierten Accounts auf einem lokalen E-Mail-Client eingerichtet haben (Outlook, Thunderbird, etc.), muss er erneut konfiguriert werden. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert.
 
 :::info
-Sie können auch externe E-Mail-Adressen zu OVHcloud migrieren, indem Sie unseren [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/) verwenden. Hierzu benötigen Sie die Login-Daten (Benutzer, Passwort, Server) der Quell- und Ziel-Accounts.
+Sie können auch externe E-Mail-Adressen zu OVHcloud migrieren, indem Sie unseren [OVHcloud Mail Migrator (OMM)](/links/web/omm) verwenden. Hierzu benötigen Sie die Login-Daten (Benutzer, Passwort, Server) der Quell- und Ziel-Accounts.
 
 :::
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -70,7 +70,7 @@ Das Migrationsprojekt und die damit verbundenen Daten werden nach 60 Tagen Inakt
 Sobald Ihr Projekt erstellt ist, werden Sie automatisch angemeldet und zur Startseite Ihres Projekts weitergeleitet, von der aus Sie Ihre erste Migration starten können.
 
 :::info
-Um später zu einem bestehenden Projekt zurückzukehren, melden Sie sich über die Startseite von [OMM](/links/web/omm) an, wie im Abschnitt [Migrationsprojekt-Status verfolgen](#follow-migration) beschrieben.
+Um später zu einem bestehenden Projekt zurückzukehren, melden Sie sich über die Startseite von [OMM](/links/web/omm) an, wie im Abschnitt "[Migrationsprojekt-Status verfolgen](#follow-migration)" beschrieben.
 :::
 
 - Klicken Sie auf <code className="action">New migration</code> oben links in der Tabelle.
@@ -177,8 +177,8 @@ Sie können die aktiven Zugriffe zum OVHcloud Kundencenter durch Klicken auf <co
 
 Es gibt zwei Möglichkeiten, den Status zu verfolgen:
 
-- Über die E-Mail, die Sie beim Erstellen Ihres Projekts erhalten haben. Sie finden einen Link, der Ihnen den Zugang zur Projektseite mit der `Project ID` ermöglicht. Nur das `Project Password` muss eingegeben werden.
-- Auf der Startseite von [OMM](/links/web/omm) klicken Sie auf <code className="action">Track a migration</code>. Geben Sie Ihre `Project ID` und Ihr `Project Password` ein.
+- Über die E-Mail, die Sie beim Erstellen Ihres Projekts erhalten haben. Sie finden einen Link, der Ihnen den Zugang zur Projektseite mit der `Project ID` ermöglicht. Nur das `Project password` muss eingegeben werden.
+- Auf der Startseite von [OMM](/links/web/omm) klicken Sie auf <code className="action">Track a migration</code>. Geben Sie Ihre `Project ID` und Ihr `Project password` ein.
 
 Klicken Sie anschließend auf <code className="action">Connect to project</code>, um zur Startseite des Projekts zu gelangen und Ihre Migrationen zu verfolgen.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Um später zu einem bestehenden Projekt zurückzukehren, melden Sie sich über d
 
 - Klicken Sie auf <code className="action">New migration</code> oben links in der Tabelle.
 
-<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Eine neue Seite wird angezeigt, auf der Sie die Zugangsdaten für den Quell-Account und den Ziel-Accounts eingeben können, um die Migration zu planen oder direkt zu starten. Der Inhalt des **Source Account** wird zum **Destination Account** migriert.
 
@@ -85,7 +85,7 @@ Bevor Sie Ihre Migration starten, ist es wichtig, die 3 Arten von Accounts zu ke
 - **Others**: E-Mail-Dienste, die außerhalb von OVHcloud abgeschlossen wurden. Eine nicht erschöpfende Liste der von OMM unterstützten E-Mail-Dienste wird angezeigt. Wenn Ihr E-Mail-Account-Typ nicht aufgelistet ist, verwenden Sie die Protokolle `IMAP` oder `POP`, die mit den meisten E-Mail-Servern kompatibel sind.
 - **Importing files**: Es ist möglich, den Inhalt von PST-, ICS-, CSV- und XML-Dateien über OMM zu einem Ziel-E-Mail-Account zu migrieren. Wenn diese Funktion ausgewählt wird, genügt es, Ihre Datei in das Feld zu ziehen oder über den Button <code className="action">Browse your files</code> Ihre Dateien zu durchsuchen.
 
-<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Füllen Sie die Informationen entsprechend des Accounttyps aus:
 
@@ -112,7 +112,7 @@ Füllen Sie die Informationen entsprechend des Accounttyps aus:
 - **Start of Transfers**: Sie können die Migration unmittelbar über `Immediately` starten oder `Later` ankreuzen, um die Migration zu verschieben. Eine verschobene Migration ermöglicht es, Datum und Uhrzeit des Starts zu definieren.
 - **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accounts zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Account ab.
 
-<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Wenn Sie einen Account migrieren, der Funktionen hat, die der Ziel-Account nicht hat, müssen Sie die Elemente, die von OMM nicht migriert werden können, eigenständig sichern. Konsultieren Sie unsere Anleitung "[Manuelles Migrieren Ihrer E-Mail-Adresse](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -182,7 +182,7 @@ Es gibt zwei Möglichkeiten, den Status zu verfolgen:
 
 Klicken Sie anschließend auf <code className="action">Connect to project</code>, um zur Startseite des Projekts zu gelangen und Ihre Migrationen zu verfolgen.
 
-<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Anmeldung an einem Migrationsprojekt im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Auf dieser Seite finden Sie die Liste der laufenden oder geplanten Migrationen. Der Status des Projekts wird ebenfalls rechts angezeigt.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts mit dem OVHcloud Mail Migrator migrieren
 description: Migrieren Sie Ihre E-Mail-Accounts mit dem OVHcloud Mail Migrator (OMM) zu OVHcloud, inklusive Nachrichten, Kontakten und Kalendern
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Ziel
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) ist ein von OVHcloud entwickeltes Tool, das den Bedarf nach Reversibilität abdeckt. Sie können damit E-Mail-Accounts auf Ihre OVHcloud E-Mail-Accounts oder einen externen E-Mail-Dienst migrieren. Dabei können verschiedene Inhalte wie E-Mails, Kontakte, Kalender und Aufgaben übertragen werden, sofern diese mit Ihren E-Mail-Accounts kompatibel sind.
+[OVHcloud Mail Migrator](/links/web/omm) ist ein von OVHcloud entwickeltes Tool, das den Bedarf nach Reversibilität abdeckt. Sie können damit E-Mail-Accounts auf Ihre OVHcloud E-Mail-Accounts oder einen externen E-Mail-Dienst migrieren. Dabei können verschiedene Inhalte wie E-Mails, Kontakte, Kalender und Aufgaben übertragen werden, sofern diese mit Ihren E-Mail-Accounts kompatibel sind.
 
 **Diese Anleitung erklärt, wie Sie Ihre E-Mail-Accounts mit unserem OVHcloud Mail Migrator-Tool zu OVHcloud migrieren können.**
 
@@ -40,7 +40,7 @@ Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, I
 
 ## In der praktischen Anwendung
 
-Um auf OMM zuzugreifen, verwenden Sie die Adresse: [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/)
+Um auf OMM zuzugreifen, verwenden Sie die Adresse: [https://omm.ovhcloud.com/](/links/web/omm)
 
 <img className="thumbnail" alt="Startseite des OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ Das Migrationsprojekt und die damit verbundenen Daten werden nach 60 Tagen Inakt
 
 ### Migration erstellen <a name="create-migration"></a>
 
-Sobald Ihr Projekt erstellt ist, melden Sie sich wie folgt an:
+Sobald Ihr Projekt erstellt ist, melden Sie sich über die Startseite von [OMM](/links/web/omm) wie folgt an:
 
 - Klicken Sie auf <code className="action">Track a migration</code>.
 - Geben Sie die `Project ID` ein, die Sie per E-Mail erhalten haben.
@@ -182,7 +182,7 @@ Sie können die aktiven Zugriffe zum OVHcloud Kundencenter durch Klicken auf <co
 Es gibt zwei Möglichkeiten, den Status zu verfolgen:
 
 - Über die E-Mail, die Sie beim Erstellen Ihres Projekts erhalten haben. Sie finden einen Link, der Ihnen den Zugang zur Projektseite mit der `Project ID` ermöglicht. Nur das `Project Password` muss eingegeben werden.
-- Auf der Startseite von OMM klicken Sie auf <code className="action">Track a migration</code>. Geben Sie Ihre `Project ID` und Ihr `Project Password` ein.
+- Auf der Startseite von [OMM](/links/web/omm) klicken Sie auf <code className="action">Track a migration</code>. Geben Sie Ihre `Project ID` und Ihr `Project Password` ein.
 
 Klicken Sie anschließend auf <code className="action">Connect to project</code>, um zur Startseite des Projekts zu gelangen und Ihre Migrationen zu verfolgen.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Klicken Sie auf <code className="action">New migration</code>, um mit der Erstel
 
 **E-Mail-Adresse des Projekt-Kontakts**: Geben Sie eine E-Mail-Adresse ein, die zum Empfang der Zugangsdaten und der Benachrichtigungen zu Ihren Migrationen verwendet wird. Es wird nicht empfohlen, eine der E-Mail-Adressen einzugeben, die in Ihrem Projekt migriert werden.
 **Projekt-Passwort**: Geben Sie ein Passwort ein, das zur Anmeldung in Ihr Projekt verwendet wird. Es muss mindestens 10 Zeichen enthalten, darunter mindestens 1 Sonderzeichen, 1 Zahl, 1 Großbuchstabe und 1 Kleinbuchstabe.
+**Nutzungsbedingungen**: Aktivieren Sie das Kontrollkästchen `I agree to the terms and conditions`.
 
 Klicken Sie auf <code className="action">Create my project</code>, um die Erstellung des Projekts zu starten.
 
@@ -66,16 +67,11 @@ Das Migrationsprojekt und die damit verbundenen Daten werden nach 60 Tagen Inakt
 
 ### Migration erstellen <a name="create-migration"></a>
 
-Sobald Ihr Projekt erstellt ist, melden Sie sich über die Startseite von [OMM](/links/web/omm) wie folgt an:
+Sobald Ihr Projekt erstellt ist, werden Sie automatisch angemeldet und zur Startseite Ihres Projekts weitergeleitet, von der aus Sie Ihre erste Migration starten können.
 
-- Klicken Sie auf <code className="action">Track a migration</code>.
-- Geben Sie die `Project ID` ein, die Sie per E-Mail erhalten haben.
-- Geben Sie das `Project password` ein, das Sie bei der Erstellung festgelegt haben.
-- Klicken Sie auf <code className="action">Connect to project</code>, um abzuschließen.
-
-<img className="thumbnail" alt="Erstellen einer neuen Migration im OVHcloud Mail Migrator, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Sie befinden sich nun auf der Startseite des Projekts, von der aus Sie Ihre erste Migration starten können.
+:::info
+Um später zu einem bestehenden Projekt zurückzukehren, melden Sie sich über die Startseite von [OMM](/links/web/omm) an, wie im Abschnitt [Migrationsprojekt-Status verfolgen](#follow-migration) beschrieben.
+:::
 
 - Klicken Sie auf <code className="action">New migration</code> oben links in der Tabelle.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - MX Plan E-Mail-Account migrieren
 description: Migrieren Sie einen MX Plan E-Mail-Account zu einem OVHcloud Zimbra-Account und weisen Sie dessen Adresse anschließend neu zu
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
 
     - **Project contact email address**: Geben Sie eine E-Mail-Adresse ein, die die Zugangsdaten und Tracking-Benachrichtigungen erhält. Verwenden Sie keine Adresse, die in diesem Projekt migriert werden soll.
     - **Project password**: Legen Sie ein Passwort fest (mindestens 10 Zeichen, mit mindestens 1 Sonderzeichen, 1 Zahl, 1 Großbuchstaben und 1 Kleinbuchstaben).
+    - **Nutzungsbedingungen**: Aktivieren Sie das Kontrollkästchen `I agree to the terms and conditions`.
 
     Klicken Sie auf <code className="action">Create my project</code>. Sie erhalten eine Bestätigungs-E-Mail mit der eindeutigen Projekt-ID.
   </Tab>
   <Tab label="Schritt 2">
-    **Am Projekt anmelden und Migration erstellen**
+    **Migration erstellen**
 
-    Klicken Sie auf der Startseite von [OMM](/links/web/omm) auf <code className="action">Track a migration</code>, geben Sie die `Project identifier` und das `Project password` ein und klicken Sie anschließend auf <code className="action">Log in to the project</code>.
+    Nach der Erstellung des Projekts werden Sie automatisch angemeldet und zur Startseite Ihres Projekts weitergeleitet. Wenn Sie später dorthin zurückkehren, klicken Sie auf der Startseite von [OMM](/links/web/omm) auf <code className="action">Track a migration</code>, geben Sie die `Project ID` und das `Project password` ein und klicken Sie anschließend auf <code className="action">Connect to project</code>.
 
-    Klicken Sie dann auf <code className="action">New migration</code>, um Ihre Migration zu konfigurieren:
+    Klicken Sie auf <code className="action">New migration</code>, um Ihre Migration zu konfigurieren:
 
     <img className="thumbnail" alt="Erstellen der Migration von MX Plan zu Zimbra im OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ Die Migration mit OMM erfolgt in 3 Schritten: Erstellen eines Projekts, Konfigur
     Es gibt zwei Möglichkeiten, den Fortschritt Ihres Migrationsprojekts zu verfolgen:
 
     - Über die beim Erstellen des Projekts erhaltene E-Mail, über den angegebenen Link (die Projekt-ID ist bereits vorausgefüllt).
-    - Über die Startseite von [OMM](/links/web/omm): Klicken Sie auf <code className="action">Track a migration</code>, geben Sie Ihre `Project identifier` und Ihr `Project password` ein und klicken Sie dann auf <code className="action">Log in to the project</code>.
+    - Über die Startseite von [OMM](/links/web/omm): Klicken Sie auf <code className="action">Track a migration</code>, geben Sie Ihre `Project ID` und Ihr `Project password` ein und klicken Sie dann auf <code className="action">Connect to project</code>.
 
     Klicken Sie auf der Projektseite rechts neben Ihrer Migrationszeile auf die Schaltfläche <code className="action">⋮</code>, um die Optionen anzuzeigen:
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Manually migrate your email address
 description: How to migrate your email address manually to another email address
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Objective
 
-You can [migrate an email address automatically](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) via our [OVHcloud Mail Migrator](https://omm.ovhcloud.com/) tool. You can also migrate your email address manually using an email client.
+You can [migrate an email address automatically](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) via our [OVHcloud Mail Migrator](/links/web/omm) tool. You can also migrate your email address manually using an email client.
 
 **Find out how to migrate your email address manually.**
 
@@ -68,7 +68,7 @@ This guide will show you how to use one or more OVHcloud solutions with external
 ## Instructions
 
 :::info
-First of all, check if automatic migration is possible using our [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). To do this, please use our guide on [Migrating email accounts with OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+First of all, check if automatic migration is possible using our [OVHcloud Mail Migrator](/links/web/omm). To do this, please use our guide on [Migrating email accounts with OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrate to Exchange, Email Pro or Zimbra
 description: Migrate your MX Plan email account to an Exchange, Email Pro or Zimbra offer while keeping your messages, contacts and folders
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -167,7 +167,7 @@ In the <code className="action">Email accounts</code> tab for your Email Pro or 
 
 <img className="thumbnail" alt="Configuring the MX Plan account for migration in the Control Panel, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migrate** the MX Plan account to your new platform account using our [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator) tool.
+3\. **Migrate** the MX Plan account to your new platform account using our [OMM](/links/web/omm) (OVHcloud Mail Migrator) tool.
 
 For more information on OMM, please read our guide on [Migrating email accounts via the OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts between OVHcloud platforms
 description: Migrate email accounts between two OVHcloud platforms (Exchange, Email Pro or MX Plan) without losing your messages, contacts or folders
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Only the data of your email accounts will be migrated (emails, contacts, calenda
 :::
 
 
-Migrate the source email account to your new platform account using our [OMM](https://omm.ovhcloud.com/) tool (OVHcloud Mail Migrator).
+Migrate the source email account to your new platform account using our [OMM](/links/web/omm) tool (OVHcloud Mail Migrator).
 
 For more information on OMM, please read our guide on [Migrating email accounts via the OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -179,7 +179,7 @@ Now, you can start using your migrated email addresses. To do this, OVHcloud off
 If you have configured one of the migrated accounts on a local email client (e.g. Outlook, Thunderbird), you will need to configure it again. The login details for the OVHcloud server have changed following the migration.
 
 :::info
-You can also manually migrate external email addresses to OVHcloud by using our [OVHcloud Mail Migrator](https://omm.ovhcloud.com/) tool (OMM). To do this, you must have the login details (user, password, servers) of the source email and the destination email.
+You can also manually migrate external email addresses to OVHcloud by using our [OVHcloud Mail Migrator](/links/web/omm) tool (OMM). To do this, you must have the login details (user, password, servers) of the source email and the destination email.
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -70,7 +70,7 @@ If there is no activity for 60 days, the migration project and all associated da
 Once your project is created, you are automatically logged in and redirected to your project homepage, from which you can start your first migration.
 
 :::info
-To return to an existing project later on, log in from the [OMM](/links/web/omm) homepage as described in the [Follow a migration project](#follow-migration) section.
+To return to an existing project later, log in from the [OMM](/links/web/omm) homepage as described in the "[Follow a migration project](#follow-migration)" section.
 :::
 
 - Click on <code className="action">New migration</code> in the top left of the table.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ To return to an existing project later on, log in from the [OMM](/links/web/omm)
 
 - Click on <code className="action">New migration</code> in the top left of the table.
 
-<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 On the new page that appears, enter the connection information of the source account and the destination account to schedule the migration or to start it immediately. To recall, the content of the **source account** will be migrated to the **destination account**.
 
@@ -85,7 +85,7 @@ Before starting your migration, it is important to know the 3 types of accounts 
 - **Others**: They refer to email services outside of OVHcloud. You will find a non-exhaustive list of email services supported by OMM. If the type of service of your email account is not listed, use the `IMAP` or `POP` protocols, which are compatible with most email servers.
 - **Importing files**: It is possible to migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the <code className="action">Browse your files</code> button.
 
-<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete the information according to the type of account:
 
@@ -114,7 +114,7 @@ Complete the information according to the type of account:
 - **Start of transfer**: You can start the migration `Immediately` or check `Later` to postpone it. The deferred migration allows you to start it automatically at a date and time you define.
 - **Data to transfer**: Depending on the type of email account you are migrating and the destination account, this section will indicate the different types of data that are supported during the migration. This depends on the source account and the destination account.
 
-<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 If you are migrating an account that has features the destination account does not have, **you will need to save by your means the items that cannot be migrated by OMM**. To help you, refer to our guide "[Manually migrate your email address](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -184,7 +184,7 @@ There are two ways to access the migration project tracking:
 
 Click on <code className="action">Connect to project</code> to access the project homepage and follow your migrations.
 
-<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Logging in to a migration project in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 From this page, you will find the list of ongoing or scheduled migrations. The project status also appears on the right.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts via OVHcloud Mail Migrator
 description: Migrate your email accounts to OVHcloud with the OVHcloud Mail Migrator (OMM), transferring messages, contacts and calendars
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Objective
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to OVHcloud email addresses or an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
+[OVHcloud Mail Migrator](/links/web/omm) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to OVHcloud email addresses or an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
 
 **Find out how to migrate your email accounts to OVHcloud using our OVHcloud Mail Migrator tool.**
 
@@ -40,7 +40,7 @@ Whatever migration method you use, we strongly recommend backing up your mailbox
 
 ## Instructions
 
-To access OMM, go to [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+To access OMM, go to [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="OVHcloud Mail Migrator home page" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ If there is no activity for 60 days, the migration project and all associated da
 
 ### Create a new migration <a name="create-migration"></a>
 
-Once your project is created, log in to it from the [OMM](https://omm.ovhcloud.com/) homepage:
+Once your project is created, log in to it from the [OMM](/links/web/omm) homepage:
 
 - Click on <code className="action">Track a migration</code>.
 - Enter the `Project ID` received by email.
@@ -184,7 +184,7 @@ It is possible to disconnect current accesses from an OVHcloud Control Panel by 
 There are two ways to access the migration project tracking:
 
 - In the email received when you created your project, you will find a link that allows you to access the project login page with the `Project ID` pre-filled. Only the `Project password` needs to be entered.
-- From the [OMM](https://omm.ovhcloud.com/) homepage, click on <code className="action">Track a migration</code>. Then enter your `Project ID` and your `Project password`.
+- From the [OMM](/links/web/omm) homepage, click on <code className="action">Track a migration</code>. Then enter your `Project ID` and your `Project password`.
 
 Click on <code className="action">Connect to project</code> to access the project homepage and follow your migrations.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Click on <code className="action">New migration</code> to begin creating your pr
 
 **Project contact email**: Enter an email address that will be used to receive the credentials and the tracking notifications of your migrations. It is not recommended to enter one of the email addresses that will be migrated in your project.
 **Project password**: Enter a password that will be used to connect to your project. It must contain at least 10 characters and include at least 1 special character, 1 digit, 1 uppercase and 1 lowercase letter.
+**Terms and conditions**: Tick the `I agree to the terms and conditions` box.
 
 Click on <code className="action">Create my project</code> to start creating the project.
 
@@ -66,16 +67,11 @@ If there is no activity for 60 days, the migration project and all associated da
 
 ### Create a new migration <a name="create-migration"></a>
 
-Once your project is created, log in to it from the [OMM](/links/web/omm) homepage:
+Once your project is created, you are automatically logged in and redirected to your project homepage, from which you can start your first migration.
 
-- Click on <code className="action">Track a migration</code>.
-- Enter the `Project ID` received by email.
-- Enter the `Project password` you set at its creation.
-- Click on <code className="action">Connect to project</code> to complete.
-
-<img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-You are now on the project homepage, which will allow you to start your first migration.
+:::info
+To return to an existing project later on, log in from the [OMM](/links/web/omm) homepage as described in the [Follow a migration project](#follow-migration) section.
+:::
 
 - Click on <code className="action">New migration</code> in the top left of the table.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -94,7 +94,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
   <Tab label="Step 2">
     **Create the migration**
 
-    Once the project is created, you are automatically logged in and redirected to your project homepage. If you come back to it later, click <code className="action">Track a migration</code> from the [OMM](/links/web/omm) homepage, enter the `Project ID` and `Project password`, then click <code className="action">Connect to project</code>.
+    Once your project is created, you are automatically logged in and redirected to your project homepage. If you come back to it later, click <code className="action">Track a migration</code> from the [OMM](/links/web/omm) homepage, enter the `Project ID` and `Project password`, then click <code className="action">Connect to project</code>.
 
     Click <code className="action">New migration</code> to configure your migration:
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrate an MX Plan email account
 description: Migrate an MX Plan email account to an OVHcloud Zimbra account, then reassign its address to complete the switch
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
 
     - **Project contact email address**: Enter an email address that will receive the login credentials and tracking notifications. Do not use an address that will be migrated in this project.
     - **Project password**: Set a password (minimum 10 characters, with at least 1 special character, 1 number, 1 uppercase and 1 lowercase letter).
+    - **Terms and conditions**: Tick the `I agree to the terms and conditions` box.
 
     Click <code className="action">Create my project</code>. You will receive a confirmation email containing the unique project identifier.
   </Tab>
   <Tab label="Step 2">
-    **Log in to the project and create the migration**
+    **Create the migration**
 
-    From the [OMM](/links/web/omm) homepage, click <code className="action">Track a migration</code>, enter the `Project identifier` and `Project password`, then click <code className="action">Log in to the project</code>.
+    Once the project is created, you are automatically logged in and redirected to your project homepage. If you come back to it later, click <code className="action">Track a migration</code> from the [OMM](/links/web/omm) homepage, enter the `Project ID` and `Project password`, then click <code className="action">Connect to project</code>.
 
-    Then click <code className="action">New migration</code> to configure your migration:
+    Click <code className="action">New migration</code> to configure your migration:
 
     <img className="thumbnail" alt="Creating the MX Plan to Zimbra migration in the OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ The migration with OMM is carried out in 3 steps: create a project, configure th
     Two methods allow you to track your migration project:
 
     - Via the email received when the project was created, using the link provided (the project identifier is pre-filled).
-    - From the [OMM](/links/web/omm) homepage: click <code className="action">Track a migration</code>, enter your `Project identifier` and `Project password`, then click <code className="action">Log in to the project</code>.
+    - From the [OMM](/links/web/omm) homepage: click <code className="action">Track a migration</code>, enter your `Project ID` and `Project password`, then click <code className="action">Connect to project</code>.
 
     From the project page, click the <code className="action">⋮</code> button to the right of your migration line to display the options:
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar manualmente una dirección de correo electrónico
 description: Cómo migrar manualmente su dirección de correo a otra dirección de correo
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Objetivo
 
-[Es posible migrar automáticamente](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) una cuenta de correo a través de nuestra herramienta [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). También puede migrar su cuenta de correo electrónico manualmente a través de los programas de correo.
+[Es posible migrar automáticamente](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) una cuenta de correo a través de nuestra herramienta [OVHcloud Mail Migrator](/links/web/omm). También puede migrar su cuenta de correo electrónico manualmente a través de los programas de correo.
 
 **Esta guía explica cómo migrar manualmente una dirección de correo electrónico.**
 
@@ -63,7 +63,7 @@ import { Region } from '@components/Zone';
 ## Procedimiento
 
 :::info
-En primer lugar, compruebe si nuestra herramienta [OVHcloud Mail Migrator](https://omm.ovhcloud.com/) permite la migración automática. Para ello, consulte la guía [Migrar cuentas de correo electrónico a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+En primer lugar, compruebe si nuestra herramienta [OVHcloud Mail Migrator](/links/web/omm) permite la migración automática. Para ello, consulte la guía [Migrar cuentas de correo electrónico a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar a Exchange, Email Pro o Zimbra
 description: Migre su cuenta de correo MX Plan a una oferta Exchange, Email Pro o Zimbra conservando sus mensajes, contactos y carpetas
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -164,7 +164,7 @@ En la pestaña <code className="action">Cuentas de correo</code> de su plataform
 
 <img className="thumbnail" alt="Configurar la cuenta de MX Plan para la migración en el área de cliente, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migre** la cuenta MX Plan a la cuenta de su nueva plataforma utilizando nuestra herramienta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+3\. **Migre** la cuenta MX Plan a la cuenta de su nueva plataforma utilizando nuestra herramienta [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de correo a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo entre plataformas de OVHcloud
 description: Migre cuentas de correo entre dos plataformas de OVHcloud (Exchange, Email Pro, MX Plan) sin perder sus mensajes, contactos ni carpetas
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Solo se migrarán los datos de sus cuentas de correo (correo electrónico, conta
 :::
 
 
-Migre la cuenta de correo de origen a la cuenta de su nueva plataforma utilizando nuestra herramienta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+Migre la cuenta de correo de origen a la cuenta de su nueva plataforma utilizando nuestra herramienta [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de correo a través de OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -181,7 +181,7 @@ Ya puede utilizar las direcciones de correo electrónico migradas. Para ello, OV
 Si ha configurado una de las cuentas migradas en un cliente de correo (p.ej.: Outlook, Thunderbird), deberá volver a configurarlo. La información de conexión al servidor de OVHcloud ha cambiado tras la migración.
 
 :::info
-También puede migrar manualmente direcciones de correo a OVHcloud utilizando nuestra herramienta [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/). Para ello, debe disponer de la información (usuario, contraseña, servidores) del correo de origen y del correo electrónico de destino.
+También puede migrar manualmente direcciones de correo a OVHcloud utilizando nuestra herramienta [OVHcloud Mail Migrator (OMM)](/links/web/omm). Para ello, debe disponer de la información (usuario, contraseña, servidores) del correo de origen y del correo electrónico de destino.
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Para volver más tarde a un proyecto existente, conéctese desde la página de i
 
 - Haga clic en <code className="action">New migration</code> en la parte superior izquierda de la tabla.
 
-<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 En la nueva página que aparece, introduzca las informaciones de conexión de la cuenta de origen y de la cuenta de destino para programar la migración o iniciarla inmediatamente. Para recordar, el contenido del **source account** se migrará al **destination account**.
 
@@ -85,7 +85,7 @@ Antes de comenzar su migración, es importante conocer bien los 3 tipos de cuent
 - **Others**: Se trata de servicios de correo electrónico contratados fuera de OVHcloud. Una lista no exhaustiva de servicios de correo electrónico compatibles con OMM está disponible. Si el tipo de servicio de su cuenta de correo electrónico no aparece en esta lista, utilice los protocolos `IMAP` o `POP`, compatibles con la mayoría de los servidores de correo electrónico.
 - **Importing files**: Es posible migrar el contenido de archivos PST, ICS, CSV y XML Rules a través de OMM a una cuenta de correo electrónico de destino. Cuando se selecciona esta función, basta con arrastrar y soltar su documento en la zona correspondiente o navegar por su terminal mediante el botón <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete las informaciones según el tipo de cuenta:
 
@@ -114,7 +114,7 @@ Complete las informaciones según el tipo de cuenta:
 - **Start of transfer**: Puede iniciar la migración `Immediately` o marcar `Later` para posponerla. La migración diferida le permite iniciarla automáticamente en una fecha y hora que usted defina.
 - **Data to transfer**: Según el tipo de cuenta de correo electrónico que migre y la cuenta de destino, esta sección le indicará los diferentes tipos de datos que se admiten durante la migración. Esto depende de la cuenta de origen y la cuenta de destino.
 
-<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestra guía "[Migrar manualmente su dirección de correo electrónico](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -184,7 +184,7 @@ Existen dos maneras de acceder al seguimiento del proyecto de migración:
 
 Haga clic después en <code className="action">Connect to project</code> para acceder a la página de inicio del proyecto y seguir sus migraciones.
 
-<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Conexión a un proyecto de migración en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Desde esta página, encontrará la lista de las migraciones en curso o programadas. El estado del proyecto también se muestra a la derecha.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Haga clic en <code className="action">New migration</code> para comenzar la crea
 
 **Dirección de correo electrónico de contacto del proyecto**: Introduzca una dirección de correo electrónico que servirá para recibir los identificadores y las notificaciones de seguimiento de sus migraciones. No se recomienda introducir una de las direcciones de correo electrónico que se migrarán en su proyecto.
 **Contraseña del proyecto**: Introduzca una contraseña que servirá para conectarse a su proyecto. Debe contener al menos 10 caracteres y incluir al menos 1 carácter especial, 1 número, 1 mayúscula y 1 minúscula.
+**Condiciones generales**: Marque la casilla `I agree to the terms and conditions`.
 
 Haga clic en <code className="action">Create my project</code> para iniciar la creación del proyecto.
 
@@ -66,16 +67,11 @@ En caso de inactividad durante 60 días, el proyecto de migración y todos los d
 
 ### Crear una nueva migración <a name="create-migration"></a>
 
-Una vez creado su proyecto, conéctese a él desde la página de inicio de [OMM](/links/web/omm):
+Una vez creado su proyecto, se conectará automáticamente y será redirigido a la página de inicio del proyecto, desde la cual podrá iniciar su primera migración.
 
-- Haga clic en <code className="action">Track a migration</code>.
-- Introduzca el `Project ID` recibido por correo electrónico.
-- Introduzca la `Project password` que definió al crearlo.
-- Haga clic en <code className="action">Connect to project</code> para finalizar.
-
-<img className="thumbnail" alt="Crear una nueva migración en OVHcloud Mail Migrator, paso 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Ahora está en la página de inicio del proyecto, desde la cual podrá iniciar su primera migración.
+:::info
+Para volver más tarde a un proyecto existente, conéctese desde la página de inicio de [OMM](/links/web/omm) siguiendo la sección [Seguir un proyecto de migración](#follow-migration).
+:::
 
 - Haga clic en <code className="action">New migration</code> en la parte superior izquierda de la tabla.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -70,7 +70,7 @@ En caso de inactividad durante 60 días, el proyecto de migración y todos los d
 Una vez creado su proyecto, se conectará automáticamente y será redirigido a la página de inicio del proyecto, desde la cual podrá iniciar su primera migración.
 
 :::info
-Para volver más tarde a un proyecto existente, conéctese desde la página de inicio de [OMM](/links/web/omm) siguiendo la sección [Seguir un proyecto de migración](#follow-migration).
+Para volver más tarde a un proyecto existente, conéctese desde la página de inicio de [OMM](/links/web/omm) siguiendo la sección "[Seguir un proyecto de migración](#follow-migration)".
 :::
 
 - Haga clic en <code className="action">New migration</code> en la parte superior izquierda de la tabla.

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo electrónico con OVHcloud Mail Migrator
 description: Migre sus cuentas de correo a OVHcloud con OVHcloud Mail Migrator (OMM), transfiriendo mensajes, contactos y calendarios
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Objetivo
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) es una herramienta creada por OVHcloud que responde a la necesidad de reversibilidad. Permite migrar sus cuentas de correo electrónico a sus direcciones de correo electrónico de OVHcloud o a un servicio de correo electrónico externo. El proceso admite diferentes tipos de contenido, como correos electrónicos, contactos, calendarios y tareas, siempre que estos sean compatibles con sus direcciones de correo electrónico.
+[OVHcloud Mail Migrator](/links/web/omm) es una herramienta creada por OVHcloud que responde a la necesidad de reversibilidad. Permite migrar sus cuentas de correo electrónico a sus direcciones de correo electrónico de OVHcloud o a un servicio de correo electrónico externo. El proceso admite diferentes tipos de contenido, como correos electrónicos, contactos, calendarios y tareas, siempre que estos sean compatibles con sus direcciones de correo electrónico.
 
 **Descubra cómo migrar sus cuentas de correo electrónico a OVHcloud con nuestra herramienta OVHcloud Mail Migrator.**
 
@@ -40,7 +40,7 @@ Sea cual sea el método de migración, le recomendamos encarecidamente que haga 
 
 ## Procedimiento
 
-Para acceder a OMM, vaya a la dirección [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+Para acceder a OMM, vaya a la dirección [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="Página de inicio de OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ En caso de inactividad durante 60 días, el proyecto de migración y todos los d
 
 ### Crear una nueva migración <a name="create-migration"></a>
 
-Una vez creado su proyecto, conéctese a él desde la página de inicio de [OMM](https://omm.ovhcloud.com/):
+Una vez creado su proyecto, conéctese a él desde la página de inicio de [OMM](/links/web/omm):
 
 - Haga clic en <code className="action">Track a migration</code>.
 - Introduzca el `Project ID` recibido por correo electrónico.
@@ -184,7 +184,7 @@ Es posible desconectar los accesos en curso desde un área de cliente de OVHclou
 Existen dos maneras de acceder al seguimiento del proyecto de migración:
 
 - En el correo electrónico recibido durante la creación de su proyecto, encontrará un enlace que le permite acceder a la página de conexión del proyecto con el `Project ID` prellenado. Solo el `Project password` debe introducirse.
-- Desde la página de inicio de [OMM](https://omm.ovhcloud.com/), haga clic en <code className="action">Track a migration</code>. Introduzca después su `Project ID` y su `Project password`.
+- Desde la página de inicio de [OMM](/links/web/omm), haga clic en <code className="action">Track a migration</code>. Introduzca después su `Project ID` y su `Project password`.
 
 Haga clic después en <code className="action">Connect to project</code> para acceder a la página de inicio del proyecto y seguir sus migraciones.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrar una cuenta de correo MX Plan
 description: Migre una cuenta de correo MX Plan a una cuenta Zimbra de OVHcloud y reasigne su dirección para completar el cambio
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
 
     - **Project contact email address**: Introduzca una dirección de correo electrónico que recibirá las credenciales de acceso y las notificaciones de seguimiento. No utilice una dirección que vaya a migrarse en este proyecto.
     - **Project password**: Defina una contraseña (mínimo 10 caracteres, con al menos 1 carácter especial, 1 número, 1 mayúscula y 1 minúscula).
+    - **Condiciones generales**: Marque la casilla `I agree to the terms and conditions`.
 
     Haga clic en <code className="action">Create my project</code>. Recibirá un correo electrónico de confirmación con el identificador único del proyecto.
   </Tab>
   <Tab label="Paso 2">
-    **Conectarse al proyecto y crear la migración**
+    **Crear la migración**
 
-    Desde la página de inicio de [OMM](/links/web/omm), haga clic en <code className="action">Track a migration</code>, introduzca el `Project identifier` y la `Project password`, y haga clic en <code className="action">Log in to the project</code>.
+    Una vez creado el proyecto, se conectará automáticamente y será redirigido a la página de inicio de su proyecto. Si vuelve a él más tarde, haga clic en <code className="action">Track a migration</code> desde la página de inicio de [OMM](/links/web/omm), introduzca el `Project ID` y la `Project password`, y haga clic en <code className="action">Connect to project</code>.
 
-    A continuación, haga clic en <code className="action">New migration</code> para configurar su migración:
+    Haga clic en <code className="action">New migration</code> para configurar su migración:
 
     <img className="thumbnail" alt="Crear la migración de MX Plan a Zimbra en OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ La migración con OMM se realiza en 3 pasos: crear un proyecto, configurar la mi
     Hay dos métodos para acceder al seguimiento de su proyecto de migración:
 
     - Desde el correo electrónico recibido al crear el proyecto, mediante el enlace proporcionado (el identificador del proyecto aparece rellenado previamente).
-    - Desde la página de inicio de [OMM](/links/web/omm): haga clic en <code className="action">Track a migration</code>, introduzca su `Project identifier` y su `Project password`, y haga clic en <code className="action">Log in to the project</code>.
+    - Desde la página de inicio de [OMM](/links/web/omm): haga clic en <code className="action">Track a migration</code>, introduzca su `Project ID` y su `Project password`, y haga clic en <code className="action">Connect to project</code>.
 
     Desde la página del proyecto, haga clic en el botón <code className="action">⋮</code> a la derecha de la línea de su migración para ver las opciones:
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -67,7 +67,7 @@ Nous vous recommandons de faire appel à un [partenaire spécialisé](https://ma
 ## En pratique
 
 :::info
-Dans un premier temps, vérifiez si la migration automatique est possible par notre outil [OVHcloud Mail Migrator](/links/web/omm). Pour cela, aidez-vous du guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Dans un premier temps, vérifiez si la migration automatique est possible par notre outil [OVHcloud Mail Migrator](/links/web/omm). Pour cela, aidez-vous du guide « [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) ».
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer manuellement votre adresse e-mail
 description: Découvrez comment migrer manuellement votre adresse e-mail vers une autre adresse e-mail
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Objectif
 
-[La migration automatique](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) d’une adresse e-mail est possible via notre outil [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Vous pouvez également migrer manuellement votre adresse e-mail par le biais des logiciels de messagerie.
+[La migration automatique](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) d’une adresse e-mail est possible via notre outil [OVHcloud Mail Migrator](/links/web/omm). Vous pouvez également migrer manuellement votre adresse e-mail par le biais des logiciels de messagerie.
 
 **Découvrez comment migrer manuellement votre adresse e-mail.**
 
@@ -67,7 +67,7 @@ Nous vous recommandons de faire appel à un [partenaire spécialisé](https://ma
 ## En pratique
 
 :::info
-Dans un premier temps, vérifiez si la migration automatique est possible par notre outil [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Pour cela, aidez-vous du guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Dans un premier temps, vérifiez si la migration automatique est possible par notre outil [OVHcloud Mail Migrator](/links/web/omm). Pour cela, aidez-vous du guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrer vers Exchange, Email Pro ou Zimbra
 description: Migrez votre compte e-mail MX Plan vers une offre Exchange, Email Pro ou Zimbra en conservant vos messages, contacts et dossiers
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -168,7 +168,7 @@ Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme
 
 <img className="thumbnail" alt="Configuration du compte MX Plan pour la migration dans l'espace client OVHcloud, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail entre plateformes OVHcloud
 description: Migrez des comptes e-mail entre deux plateformes OVHcloud (Exchange, Email Pro, MX Plan) sans perdre vos messages, contacts ni dossiers
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Seules les données de vos comptes e-mail seront migrées (e-mails, contacts, ca
 :::
 
 
-Migrez le compte e-mail « source » vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+Migrez le compte e-mail « source » vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -179,7 +179,7 @@ Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, 
 Si vous avez configuré l'un des comptes migrés sur un client de messagerie (exemple : Outlook, Thunderbird), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration.
 
 :::info
-Vous pouvez également migrer manuellement des adresses e-mail vers OVHcloud en utilisant notre outil [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/). Pour cela, vous devez être en possession des informations (utilisateur, mot de passe, serveurs) de l'e-mail source et de l'e-mail de destination.
+Vous pouvez également migrer manuellement des adresses e-mail vers OVHcloud en utilisant notre outil [OVHcloud Mail Migrator (OMM)](/links/web/omm). Pour cela, vous devez être en possession des informations (utilisateur, mot de passe, serveurs) de l'e-mail source et de l'e-mail de destination.
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'a
 
 - Cliquez sur <code className="action">Nouvelle migration</code> en haut à gauche du tableau.
 
-<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
@@ -85,7 +85,7 @@ Avant de commencer votre migration, il est important de bien connaître les 3 ty
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
 - **Importation de fichiers** : Il est possible de migrer le contenu de fichiers PST, ICS, CSV et XML Rules via OMM vers un compte e-mail de destination. Lorsque cette fonction est sélectionnée, il suffit de glisser-déposer votre document dans la zone prévue à cet effet ou de parcourir votre terminal via le bouton <code className="action">Parcourir vos fichiers</code>.
 
-<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complétez les informations selon le type de compte :
 
@@ -114,7 +114,7 @@ Complétez les informations selon le type de compte :
 - **Début du transfert** : Vous pouvez lancer la migration `Immédiatement` ou cocher `Plus tard` pour la reporter. La migration différée vous permet de la déclencher automatiquement à une date et une heure que vous définissez.
 - **Données à transférer** : En fonction du type de compte e-mail que vous migrez et du compte de destination, cette section vous indiquera les différents types de données qui sont prises en charge lors de la migration. Cela dépend du compte source et du compte de destination.
 
-<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) ».
@@ -184,7 +184,7 @@ Il existe deux moyens pour accéder au suivi de projet de migration :
 
 Cliquez ensuite sur <code className="action">Se connecter au projet</code> pour accéder à la page d'accueil du projet et suivre vos migrations.
 
-<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion à un projet de migration dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Depuis cette page, vous retrouvez la liste des migrations en cours ou planifiées. Le statut du projet s'affiche également à droite.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail via OVHcloud Mail Migrator
 description: Migrez vos comptes e-mail vers OVHcloud avec OVHcloud Mail Migrator (OMM), avec transfert des messages, contacts et agendas
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Objectif
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) est un outil créé par OVHcloud qui répond au besoin de réversibilité. Il permet de migrer vos comptes e-mail vers vos adresses e-mail OVHcloud ou un service e-mail externe. Le processus prend en charge différents types de contenus, tels que les e-mails, les contacts, les calendriers et les tâches, tant que ces derniers sont compatibles avec vos adresses e-mail.
+[OVHcloud Mail Migrator](/links/web/omm) est un outil créé par OVHcloud qui répond au besoin de réversibilité. Il permet de migrer vos comptes e-mail vers vos adresses e-mail OVHcloud ou un service e-mail externe. Le processus prend en charge différents types de contenus, tels que les e-mails, les contacts, les calendriers et les tâches, tant que ces derniers sont compatibles avec vos adresses e-mail.
 
 **Découvrez comment migrer vos comptes e-mail vers OVHcloud grâce à notre outil OVHcloud Mail Migrator.**
 
@@ -40,7 +40,7 @@ Quelle que soit la méthode de migration, nous vous recommandons vivement de sau
 
 ## En pratique
 
-Pour accéder à OMM, rendez-vous sur l'adresse [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+Pour accéder à OMM, rendez-vous sur l'adresse [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="Page d'accueil d'OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ En cas d’inactivité pendant 60 jours, le projet de migration et toutes les do
 
 ### Créer une nouvelle migration <a name="create-migration"></a>
 
-Une fois votre projet créé, connectez-vous à celui-ci depuis la page d'accueil d'[OMM](https://omm.ovhcloud.com/) :
+Une fois votre projet créé, connectez-vous à celui-ci depuis la page d'accueil d'[OMM](/links/web/omm) :
 
 - Cliquez sur <code className="action">Suivre une migration</code>.
 - Saisissez l'`Identifiant du projet` reçu par e-mail.
@@ -184,7 +184,7 @@ Il est possible de déconnecter les accès en cours depuis un espace client OVHc
 Il existe deux moyens pour accéder au suivi de projet de migration :
 
 - Dans l'e-mail reçu lors de la création de votre projet, vous trouverez un lien qui vous permet d'accéder à la page de connexion du projet avec l'`Identifiant du projet` prérempli. Seul le `Mot de passe du projet` est à saisir.
-- Depuis la page d'accueil d'[OMM](https://omm.ovhcloud.com/), cliquez sur <code className="action">Suivre une migration</code>. Saisissez ensuite votre `Identifiant du projet` et votre `Mot de passe du projet`.
+- Depuis la page d'accueil d'[OMM](/links/web/omm), cliquez sur <code className="action">Suivre une migration</code>. Saisissez ensuite votre `Identifiant du projet` et votre `Mot de passe du projet`.
 
 Cliquez ensuite sur <code className="action">Se connecter au projet</code> pour accéder à la page d'accueil du projet et suivre vos migrations.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,7 +52,7 @@ Cliquez sur <code className="action">Nouvelle migration</code> pour débuter la 
 
 **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui servira à recevoir les identifiants et les notifications de suivi de vos migrations. Il est déconseillé de renseigner une des adresses e-mail qui sera migrée dans votre projet.
 **Mot de passe du projet** : Saisissez un mot de passe qui servira à vous connecter à votre projet. Il doit contenir au moins 10 caractères et inclure au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule.
-**Conditions générales** : Cochez la case `J'accepte les conditions générales`.
+**Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
 Cliquez sur <code className="action">Créer mon projet</code> pour lancer la création du projet.
 
@@ -67,10 +67,10 @@ En cas d’inactivité pendant 60 jours, le projet de migration et toutes les do
 
 ### Créer une nouvelle migration <a name="create-migration"></a>
 
-Une fois votre projet créé, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet, qui vous permettra de lancer votre première migration.
+Une fois votre projet créé, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet, d'où vous lancez votre première migration.
 
 :::info
-Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'accueil d'[OMM](/links/web/omm) en suivant la section [Suivre un projet de migration](#follow-migration).
+Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'accueil d'[OMM](/links/web/omm) comme décrit dans la rubrique « [Suivre un projet de migration](#follow-migration) ».
 :::
 
 - Cliquez sur <code className="action">Nouvelle migration</code> en haut à gauche du tableau.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Cliquez sur <code className="action">Nouvelle migration</code> pour débuter la 
 
 **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui servira à recevoir les identifiants et les notifications de suivi de vos migrations. Il est déconseillé de renseigner une des adresses e-mail qui sera migrée dans votre projet.
 **Mot de passe du projet** : Saisissez un mot de passe qui servira à vous connecter à votre projet. Il doit contenir au moins 10 caractères et inclure au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule.
+**Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
 Cliquez sur <code className="action">Créer mon projet</code> pour lancer la création du projet.
 
@@ -66,16 +67,11 @@ En cas d’inactivité pendant 60 jours, le projet de migration et toutes les do
 
 ### Créer une nouvelle migration <a name="create-migration"></a>
 
-Une fois votre projet créé, connectez-vous à celui-ci depuis la page d'accueil d'[OMM](/links/web/omm) :
+Une fois votre projet créé, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet, qui vous permettra de lancer votre première migration.
 
-- Cliquez sur <code className="action">Suivre une migration</code>.
-- Saisissez l'`Identifiant du projet` reçu par e-mail.
-- Saisissez le `Mot de passe du projet` que vous avez défini à sa création.
-- Cliquez sur <code className="action">Se connecter au projet</code> pour terminer.
-
-<img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lancer votre première migration.
+:::info
+Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'accueil d'[OMM](/links/web/omm) en suivant la section [Suivre un projet de migration](#follow-migration).
+:::
 
 - Cliquez sur <code className="action">Nouvelle migration</code> en haut à gauche du tableau.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -87,16 +87,16 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     - **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui recevra les identifiants et les notifications de suivi. N'utilisez pas une adresse qui sera migrée dans ce projet.
     - **Mot de passe du projet** : Définissez un mot de passe (10 caractères minimum, avec au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule).
-    - **Conditions générales** : Cochez la case `J'accepte les conditions générales`.
+    - **Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
     Cliquez sur <code className="action">Créer mon projet</code>. Vous recevrez un e-mail de confirmation contenant l'identifiant unique du projet.
   </Tab>
   <Tab label="Étape 2">
     **Créer la migration**
 
-    Après la création du projet, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet. Si vous y revenez plus tard, cliquez sur <code className="action">Suivre une migration</code> depuis la page d'accueil d'[OMM](/links/web/omm), saisissez l'`Identifiant du projet` et le `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
+    Une fois le projet créé, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet. Si vous y revenez plus tard, cliquez sur <code className="action">Suivre une migration</code> depuis la page d'accueil d'[OMM](/links/web/omm), saisissez l'`Identifiant du projet` et le `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
 
-    Cliquez sur <code className="action">Nouvelle migration</code> pour paramétrer votre migration :
+    Cliquez sur <code className="action">Nouvelle migration</code> pour paramétrer votre migration :
 
     <img className="thumbnail" alt="Création de la migration de MX Plan vers Zimbra dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrer un compte e-mail MX Plan
 description: Migrez un compte e-mail MX Plan vers un compte Zimbra OVHcloud, puis réattribuez son adresse pour finaliser le changement
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     - **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui recevra les identifiants et les notifications de suivi. N'utilisez pas une adresse qui sera migrée dans ce projet.
     - **Mot de passe du projet** : Définissez un mot de passe (10 caractères minimum, avec au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule).
+    - **Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
     Cliquez sur <code className="action">Créer mon projet</code>. Vous recevrez un e-mail de confirmation contenant l'identifiant unique du projet.
   </Tab>
   <Tab label="Étape 2">
-    **Se connecter au projet et créer la migration**
+    **Créer la migration**
 
-    Depuis la page d'accueil d'[OMM](/links/web/omm), cliquez sur <code className="action">Suivre une migration</code>, saisissez l'`Identifiant du projet` et le `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
+    Après la création du projet, vous êtes automatiquement connecté et redirigé vers la page d'accueil de votre projet. Si vous y revenez plus tard, cliquez sur <code className="action">Suivre une migration</code> depuis la page d'accueil d'[OMM](/links/web/omm), saisissez l'`Identifiant du projet` et le `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
 
-    Cliquez ensuite sur <code className="action">Nouvelle migration</code> pour paramétrer votre migration :
+    Cliquez sur <code className="action">Nouvelle migration</code> pour paramétrer votre migration :
 
     <img className="thumbnail" alt="Création de la migration de MX Plan vers Zimbra dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migra manualmente il tuo indirizzo email
 description: Come migrare manualmente il tuo indirizzo email verso un altro indirizzo email
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Obiettivo
 
-[La migrazione automatica](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) di un indirizzo email è possibile tramite il nostro tool [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Inoltre, è possibile migrare manualmente il tuo indirizzo email tramite client di posta.
+[La migrazione automatica](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) di un indirizzo email è possibile tramite il nostro tool [OVHcloud Mail Migrator](/links/web/omm). Inoltre, è possibile migrare manualmente il tuo indirizzo email tramite client di posta.
 
 **Questa guida ti mostra come migrare manualmente il tuo indirizzo email.**
 
@@ -63,7 +63,7 @@ import { Region } from '@components/Zone';
 ## Procedura
 
 :::info
-Per prima cosa, verifica che la migrazione automatica sia possibile utilizzando il nostro tool [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Per effettuare questa operazione, consulta la guida [Migrare account e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Per prima cosa, verifica che la migrazione automatica sia possibile utilizzando il nostro tool [OVHcloud Mail Migrator](/links/web/omm). Per effettuare questa operazione, consulta la guida [Migrare account e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrare verso Exchange, Email Pro o Zimbra
 description: Migra il tuo account email MX Plan verso un'offerta Exchange, Email Pro o Zimbra mantenendo messaggi, contatti e cartelle
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -166,7 +166,7 @@ Nella scheda <code className="action">Account email</code> della tua piattaforma
 
 <img className="thumbnail" alt="Configurazione dell'account MX Plan per la migrazione nello Spazio Cliente, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migra** l'account MX Plan verso l'account della tua nuova piattaforma con l'aiuto del nostro tool [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+3\. **Migra** l'account MX Plan verso l'account della tua nuova piattaforma con l'aiuto del nostro tool [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Per maggiori informazioni su OMM, consulta la guida [Migrare account email via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrare account email tra piattaforme OVHcloud
 description: Migra account email tra due piattaforme OVHcloud (Exchange, Email Pro, MX Plan) senza perdere messaggi, contatti e cartelle
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Verranno migrati solo i dati dei tuoi account email (email, contatti, calendari,
 :::
 
 
-Migra l'account email "sorgente" verso l'account della tua nuova piattaforma con l'aiuto del nostro tool [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+Migra l'account email "sorgente" verso l'account della tua nuova piattaforma con l'aiuto del nostro tool [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Per maggiori informazioni su OMM, consulta la guida [Migrare account email via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -179,7 +179,7 @@ A questo punto non ti resta che utilizzare i tuoi account email migrati. OVHclou
 Se hai configurato uno degli account migrati su un client di posta (ad esempio: Outlook, Thunderbird), è necessario impostarlo di nuovo. Le informazioni di connessione al server OVHcloud sono cambiate in seguito alla migrazione.
 
 :::info
-Inoltre, è possibile migrare manualmente indirizzi email verso OVHcloud utilizzando il nostro tool [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/). Per farlo, è necessario disporre delle informazioni (utente, password, server) dell'email sorgente e dell'email di destinazione.
+Inoltre, è possibile migrare manualmente indirizzi email verso OVHcloud utilizzando il nostro tool [OVHcloud Mail Migrator (OMM)](/links/web/omm). Per farlo, è necessario disporre delle informazioni (utente, password, server) dell'email sorgente e dell'email di destinazione.
 
 :::
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Per tornare in seguito a un progetto esistente, accedi dalla pagina iniziale di 
 
 - Clicca su <code className="action">New migration</code> in alto a sinistra del tavolo.
 
-<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Nella nuova pagina che appare, inserisci le informazioni di accesso dell'account sorgente e dell'account di destinazione per pianificare la migrazione o avviarla immediatamente. Ricorda, il contenuto dal **source account** verrà migrato verso al **destination account**.
 
@@ -85,7 +85,7 @@ Prima di iniziare la tua migrazione, è importante conoscere bene i 3 tipi di ac
 - **Others**: Si tratta di servizi email sottoscritti fuori da OVHcloud. È disponibile un elenco non esaustivo di servizi email supportati da OMM. Se il tipo di servizio del tuo account email non è incluso, utilizza i protocolli `IMAP` o `POP`, compatibili con la maggior parte dei server email.
 - **Importing files**: È possibile migrare il contenuto di file PST, ICS, CSV e XML Rules tramite OMM verso un account email di destinazione. Quando questa funzione è selezionata, basta trascinare e rilasciare il tuo documento nell'area dedicata o esplorare il tuo terminale tramite il pulsante <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Completa le informazioni in base al tipo di account:
 
@@ -114,7 +114,7 @@ Completa le informazioni in base al tipo di account:
 - **Start of transfer**: Puoi avviare la migrazione `Immediately` o selezionare `Later` per rimandarla. La migrazione differita ti permette di attivarla automaticamente a una data e un'ora che definisci.
 - **Data to transfer**: In base al tipo di account email che stai migrando e all'account di destinazione, questa sezione ti indicherà i diversi tipi di dati supportati durante la migrazione. Questo dipende dall'account sorgente e dall'account di destinazione.
 
-<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Se stai migrando un account che dispone di funzionalità che l'account di destinazione non possiede, **sarà necessario salvare autonomamente gli elementi che non potranno essere migrati da OMM**. Per aiutarti, consulta la nostra guida "[Migrare manualmente la tua email](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -184,7 +184,7 @@ Esistono due modi per accedere al monitoraggio del progetto di migrazione:
 
 Clicca quindi su <code className="action">Connect to project</code> per accedere alla pagina iniziale del progetto e seguire le tue migrazioni.
 
-<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Accesso a un progetto di migrazione in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Da questa pagina, troverai l'elenco delle migrazioni in corso o pianificate. Lo stato del progetto viene visualizzato anche a destra.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrare account email tramite OVHcloud Mail Migrator
 description: Migra i tuoi account email verso OVHcloud con OVHcloud Mail Migrator (OMM), inclusi messaggi, contatti e calendari
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Obiettivo
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) è uno strumento sviluppato da OVHcloud che risponde al bisogno di reversibilità. Consente di migrare i tuoi account email verso le tue email OVHcloud o un servizio email esterno. Il processo supporta diversi tipi di contenuti, come email, contatti, calendari e compiti, purché siano compatibili con le tue email.
+[OVHcloud Mail Migrator](/links/web/omm) è uno strumento sviluppato da OVHcloud che risponde al bisogno di reversibilità. Consente di migrare i tuoi account email verso le tue email OVHcloud o un servizio email esterno. Il processo supporta diversi tipi di contenuti, come email, contatti, calendari e compiti, purché siano compatibili con le tue email.
 
 **Scopri come migrare i tuoi account email su OVHcloud utilizzando il nostro strumento OVHcloud Mail Migrator.**
 
@@ -40,7 +40,7 @@ Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di esegui
 
 ## Procedura
 
-Per accedere a OMM, vai all'indirizzo [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+Per accedere a OMM, vai all'indirizzo [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="Pagina iniziale di OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ In caso di inattività per 60 giorni, il progetto di migrazione e tutti i dati a
 
 ### Creare una nuova migrazione <a name="create-migration"></a>
 
-Una volta creato il tuo progetto, accedi a esso dalla pagina iniziale di [OMM](https://omm.ovhcloud.com/):
+Una volta creato il tuo progetto, accedi a esso dalla pagina iniziale di [OMM](/links/web/omm):
 
 - Clicca su <code className="action">Track a migration</code>.
 - Inserisci il `Project ID` ricevuto via email.
@@ -184,7 +184,7 @@ Quando si seleziona una di queste offerte, segui le seguenti fasi:
 Esistono due modi per accedere al monitoraggio del progetto di migrazione:
 
 - Nell'email ricevuta al momento della creazione del tuo progetto, troverai un link che ti permette di accedere alla pagina di accesso del progetto con il `Project ID` precompilato. Solo la `Project password` deve essere inserita.
-- Dalla pagina iniziale di [OMM](https://omm.ovhcloud.com/), clicca su <code className="action">Track a migration</code>. Inserisci successivamente il tuo `Project ID` e la tua `Project password`.
+- Dalla pagina iniziale di [OMM](/links/web/omm), clicca su <code className="action">Track a migration</code>. Inserisci successivamente il tuo `Project ID` e la tua `Project password`.
 
 Clicca quindi su <code className="action">Connect to project</code> per accedere alla pagina iniziale del progetto e seguire le tue migrazioni.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -70,7 +70,7 @@ In caso di inattività per 60 giorni, il progetto di migrazione e tutti i dati a
 Una volta creato il tuo progetto, l'accesso avviene automaticamente e sei reindirizzato alla pagina iniziale del progetto, da cui potrai avviare la tua prima migrazione.
 
 :::info
-Per tornare in seguito a un progetto esistente, accedi dalla pagina iniziale di [OMM](/links/web/omm) seguendo la sezione [Seguire un progetto di migrazione](#follow-migration).
+Per tornare in seguito a un progetto esistente, accedi dalla pagina iniziale di [OMM](/links/web/omm) seguendo la sezione "[Seguire un progetto di migrazione](#follow-migration)".
 :::
 
 - Clicca su <code className="action">New migration</code> in alto a sinistra del tavolo.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Clicca su <code className="action">New migration</code> per iniziare la creazion
 
 **Project contact email**: Inserisci un indirizzo email che servirà a ricevere le credenziali e le notifiche di monitoraggio delle tue migrazioni. Non è consigliabile inserire uno degli indirizzi email che saranno migrati nel tuo progetto.
 **Project password**: Inserisci una password che servirà a connettersi al tuo progetto. Deve contenere almeno 10 caratteri e includere almeno 1 carattere speciale, 1 numero, 1 maiuscola e 1 minuscola.
+**Terms and conditions**: Seleziona la casella `I agree to the terms and conditions`.
 
 Clicca su <code className="action">Create my project</code> per avviare la creazione del progetto.
 
@@ -66,16 +67,11 @@ In caso di inattività per 60 giorni, il progetto di migrazione e tutti i dati a
 
 ### Creare una nuova migrazione <a name="create-migration"></a>
 
-Una volta creato il tuo progetto, accedi a esso dalla pagina iniziale di [OMM](/links/web/omm):
+Una volta creato il tuo progetto, l'accesso avviene automaticamente e sei reindirizzato alla pagina iniziale del progetto, da cui potrai avviare la tua prima migrazione.
 
-- Clicca su <code className="action">Track a migration</code>.
-- Inserisci il `Project ID` ricevuto via email.
-- Inserisci la `Project password` definita al momento della sua creazione.
-- Clicca su <code className="action">Connect to project</code> per completare.
-
-<img className="thumbnail" alt="Creazione di una nuova migrazione in OVHcloud Mail Migrator, passaggio 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Ora sei sulla pagina iniziale del progetto che ti permetterà di avviare la tua prima migrazione.
+:::info
+Per tornare in seguito a un progetto esistente, accedi dalla pagina iniziale di [OMM](/links/web/omm) seguendo la sezione [Seguire un progetto di migrazione](#follow-migration).
+:::
 
 - Clicca su <code className="action">New migration</code> in alto a sinistra del tavolo.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrare un account email MX Plan
 description: Migra un account email MX Plan verso un account Zimbra OVHcloud, poi riassegna il suo indirizzo per completare il passaggio
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
 
     - **Project contact email address**: Inserisci un indirizzo e-mail che riceverà le credenziali di accesso e le notifiche di monitoraggio. Non utilizzare un indirizzo che verrà migrato in questo progetto.
     - **Project password**: Definisci una password (minimo 10 caratteri, con almeno 1 carattere speciale, 1 cifra, 1 lettera maiuscola e 1 lettera minuscola).
+    - **Terms and conditions**: Seleziona la casella `I agree to the terms and conditions`.
 
     Clicca su <code className="action">Create my project</code>. Riceverai un'e-mail di conferma contenente l'identificativo unico del progetto.
   </Tab>
   <Tab label="Step 2">
-    **Accedere al progetto e creare la migrazione**
+    **Creare la migrazione**
 
-    Dalla pagina principale di [OMM](/links/web/omm), clicca su <code className="action">Track a migration</code>, inserisci l'`Project identifier` e la `Project password`, poi clicca su <code className="action">Log in to the project</code>.
+    Una volta creato il progetto, l'accesso avviene automaticamente e sei reindirizzato alla pagina principale del tuo progetto. Se vi torni in seguito, clicca su <code className="action">Track a migration</code> dalla pagina principale di [OMM](/links/web/omm), inserisci il `Project ID` e la `Project password`, poi clicca su <code className="action">Connect to project</code>.
 
-    Clicca quindi su <code className="action">New migration</code> per configurare la tua migrazione:
+    Clicca su <code className="action">New migration</code> per configurare la tua migrazione:
 
     <img className="thumbnail" alt="Creazione della migrazione da MX Plan a Zimbra in OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ La migrazione con OMM avviene in 3 step: creare un progetto, configurare la migr
     Hai due metodi per accedere al monitoraggio del tuo progetto di migrazione:
 
     - Dall'e-mail ricevuta al momento della creazione del progetto, tramite il link fornito (l'identificativo del progetto è precompilato).
-    - Dalla pagina principale di [OMM](/links/web/omm): clicca su <code className="action">Track a migration</code>, inserisci il tuo `Project identifier` e la tua `Project password`, poi clicca su <code className="action">Log in to the project</code>.
+    - Dalla pagina principale di [OMM](/links/web/omm): clicca su <code className="action">Track a migration</code>, inserisci il tuo `Project ID` e la tua `Project password`, poi clicca su <code className="action">Connect to project</code>.
 
     Dalla pagina del progetto, clicca sul pulsante <code className="action">⋮</code> a destra della riga della tua migrazione per visualizzare le opzioni:
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ręczna migracja Twojego konta e-mail
 description: Dowiedz się, jak ręcznie przenieść Twoje konto e-mail na inny adres e-mail
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Wprowadzenie
 
-[Automatyczna](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) migracja konta e-mail jest możliwa przy użyciu narzędzia [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Możesz również ręcznie przenieść Twoje konto e-mail za pomocą programu pocztowego.
+[Automatyczna](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) migracja konta e-mail jest możliwa przy użyciu narzędzia [OVHcloud Mail Migrator](/links/web/omm). Możesz również ręcznie przenieść Twoje konto e-mail za pomocą programu pocztowego.
 
 **Dowiedz się, jak przenieść ręcznie Twoje konto e-mail.**
 
@@ -63,7 +63,7 @@ import { Region } from '@components/Zone';
 ## W praktyce
 
 :::info
-Sprawdź najpierw, czy automatyczna migracja jest możliwa przy użyciu narzędzia [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). W tym celu skorzystaj z przewodnika [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Sprawdź najpierw, czy automatyczna migracja jest możliwa przy użyciu narzędzia [OVHcloud Mail Migrator](/links/web/omm). W tym celu skorzystaj z przewodnika [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migracja do Exchange, Email Pro lub Zimbra
 description: Zmigruj konto e-mail MX Plan do oferty Exchange, Email Pro lub Zimbra, zachowując wiadomości, kontakty i foldery
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -166,7 +166,7 @@ W zakładce <code className="action">Konta e-mail</code> na Twojej platformie E-
 
 <img className="thumbnail" alt="Konfigurowanie konta MX Plan do migracji w Panelu klienta, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Przenieś** konto MX Plan na konto nowej platformy za pomocą narzędzia [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+3\. **Przenieś** konto MX Plan na konto nowej platformy za pomocą narzędzia [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym przewodnikiem [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migracja kont e-mail między platformami OVHcloud
 description: Migruj konta e-mail między dwiema platformami OVHcloud (Exchange, Email Pro, MX Plan) bez utraty wiadomości, kontaktów i folderów
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Migracja zostanie przeprowadzona wyłącznie w przypadku danych przypisanych do 
 :::
 
 
-Przenieś konto e-mail "source" na konto Twojej nowej platformy, korzystając z naszego narzędzia [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+Przenieś konto e-mail "source" na konto Twojej nowej platformy, korzystając z naszego narzędzia [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym przewodnikiem [Migracja kont e-mail przez OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -179,7 +179,7 @@ Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostęp
 Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (na przykład: Outlook, Thunderbird), należy ponownie skonfigurować ustawienia. Dane do logowania do serwera OVHcloud zmieniły się po migracji.
 
 :::info
-Możesz również ręcznie przenieść konta e-mail do OVHcloud przy użyciu narzędzia [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/). W tym celu powinieneś posiadać informacje (użytkownik, hasło, serwery) dotyczące źródłowego e-maila i docelowego e-maila.
+Możesz również ręcznie przenieść konta e-mail do OVHcloud przy użyciu narzędzia [OVHcloud Mail Migrator (OMM)](/links/web/omm). W tym celu powinieneś posiadać informacje (użytkownik, hasło, serwery) dotyczące źródłowego e-maila i docelowego e-maila.
 
 :::
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrowanie kont e-mailowych za pomocą OVHcloud Mail Migrator
 description: Przenieś konta e-mail do OVHcloud za pomocą OVHcloud Mail Migrator (OMM), w tym wiadomości, kontakty i kalendarze
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Wprowadzenie
 
-[Narzędzie OVHcloud Mail Migrator](https://omm.ovhcloud.com/) zostało stworzone przez OVHcloud, aby spełnić potrzebę odwracalności. Umożliwia ono migrację kont e-mailowych do adresów e-mail w OVHcloud lub zewnętrznego usługi poczty e-mail. Proces obsługuje różne typy treści, takie jak wiadomości e-mail, kontakty, kalendarze i zadania, o ile są one kompatybilne z Twoimi adresami e-mail.
+[Narzędzie OVHcloud Mail Migrator](/links/web/omm) zostało stworzone przez OVHcloud, aby spełnić potrzebę odwracalności. Umożliwia ono migrację kont e-mailowych do adresów e-mail w OVHcloud lub zewnętrznego usługi poczty e-mail. Proces obsługuje różne typy treści, takie jak wiadomości e-mail, kontakty, kalendarze i zadania, o ile są one kompatybilne z Twoimi adresami e-mail.
 
 **Dowiedz się, jak przenieść swoje konta e-mail do OVHcloud, korzystając z naszego narzędzia OVHcloud Mail Migrator.**
 
@@ -40,7 +40,7 @@ Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wyk
 
 ## W praktyce
 
-Aby uzyskać dostęp do OMM, przejdź na [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+Aby uzyskać dostęp do OMM, przejdź na [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="Strona główna OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ Jeśli nie będzie żadnej aktywności przez 60 dni, projekt migracji i wszystki
 
 ### Tworzenie nowej migracji <a name="create-migration"></a>
 
-Po utworzeniu projektu zaloguj się do niego z [strony głównej OMM](https://omm.ovhcloud.com/):
+Po utworzeniu projektu zaloguj się do niego z [strony głównej OMM](/links/web/omm):
 
 - Kliknij <code className="action">Track a migration</code>.
 - Wprowadź `Project ID` otrzymany przez e-mail.
@@ -184,7 +184,7 @@ Możesz wylogować bieżące połączenia z Panelu klienta OVHcloud, klikając <
 Istnieją dwa sposoby uzyskania dostępu do śledzenia projektu migracji:
 
 - W wiadomości e-mail otrzymanej podczas tworzenia projektu znajdziesz link, który pozwala na dostęp do strony logowania do projektu z wstępnie wypełnionym `Project ID`. Wystarczy wprowadzić `Project password`.
-- Z [strony głównej OMM](https://omm.ovhcloud.com/) kliknij <code className="action">Track a migration</code>. Następnie wprowadź swoje `Project ID` i swoje `Project password`.
+- Z [strony głównej OMM](/links/web/omm) kliknij <code className="action">Track a migration</code>. Następnie wprowadź swoje `Project ID` i swoje `Project password`.
 
 Kliknij <code className="action">Connect to project</code>, aby uzyskać dostęp do strony głównej projektu i śledzić swoje migracje.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Aby wrócić później do istniejącego projektu, zaloguj się ze [strony głów
 
 - Kliknij <code className="action">New migration</code> w lewym górnym rogu tabeli.
 
-<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Na nowej stronie, która się pojawi, wprowadź dane logowania konta źródłowego i konta docelowego, aby zaplanować migrację lub rozpocząć ją od razu. Dla przypomnienia, zawartość **source account** zostanie przeniesiona do **destination account**.
 
@@ -85,7 +85,7 @@ Przed rozpoczęciem migracji ważne jest, aby wiedzieć o trzech typach kont, kt
 - **Others**: Są to usługi poczty e-mail subskrybowane poza OVHcloud. Dostępna jest niekompletna lista usług poczty e-mail obsługiwanych przez OMM. Jeśli typ usługi Twojego konta e-mail nie znajduje się na liście, użyj protokołów `IMAP` lub `POP`, kompatybilnych z większością serwerów poczty e-mail.
 - **Importing files**: Możliwe jest przeniesienie zawartości plików PST, ICS, CSV i XML Rules przez OMM do konta poczty e-mail docelowego. Gdy ta funkcja zostanie wybrana, po prostu przeciągnij i upuść swój dokument do wyznaczonej strefy lub przejdź do terminala za pomocą przycisku <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Uzupełnij informacje zgodnie z typem konta:
 
@@ -114,7 +114,7 @@ Uzupełnij informacje zgodnie z typem konta:
 - **Start of transfer**: Możesz rozpocząć migrację `Immediately` lub zaznaczyć `Later`, aby odłożyć ją. Odłożona migracja pozwala na jej automatyczne rozpoczęcie w dniu i godzinie, które określisz.
 - **Data to transfer**: W zależności od typu konta e-mail, którego przenosisz, i konta docelowego, ta sekcja wskazuje różne typy danych obsługiwane podczas migracji. To zależy od konta źródłowego i konta docelowego.
 
-<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Jeśli przenosisz konto, które ma funkcje, których konto docelowe nie posiada, **będziesz musiał samodzielnie zapisać elementy, które nie mogą zostać przeniesione przez OMM**. Aby Ci w tym pomóc, zapoznaj się z naszym przewodnikiem "[Ręczna migracja Twojego konta e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -184,7 +184,7 @@ Istnieją dwa sposoby uzyskania dostępu do śledzenia projektu migracji:
 
 Kliknij <code className="action">Connect to project</code>, aby uzyskać dostęp do strony głównej projektu i śledzić swoje migracje.
 
-<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Logowanie do projektu migracji w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 Na tej stronie znajdziesz listę trwających lub zaplanowanych migracji. Status projektu również pojawia się po prawej stronie.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -70,7 +70,7 @@ Jeśli nie będzie żadnej aktywności przez 60 dni, projekt migracji i wszystki
 Po utworzeniu projektu zostaniesz automatycznie zalogowany i przekierowany na stronę główną projektu, z której możesz rozpocząć pierwszą migrację.
 
 :::info
-Aby wrócić później do istniejącego projektu, zaloguj się ze [strony głównej OMM](/links/web/omm), postępując zgodnie z sekcją [Śledzenie projektu migracji](#follow-migration).
+Aby wrócić później do istniejącego projektu, zaloguj się ze [strony głównej OMM](/links/web/omm), postępując zgodnie z sekcją "[Śledzenie projektu migracji](#follow-migration)".
 :::
 
 - Kliknij <code className="action">New migration</code> w lewym górnym rogu tabeli.

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Kliknij <code className="action">New migration</code>, aby rozpocząć tworzenie
 
 **Adres e-mail kontaktowy projektu**: Wprowadź adres e-mail, który zostanie użyty do otrzymywania danych logowania i powiadomień o śledzeniu Twoich migracji. Nie zaleca się wprowadzania jednego z adresów e-mail, które zostaną przeniesione w ramach projektu.
 **Hasło projektu**: Wprowadź hasło, które zostanie użyte do połączenia się z Twoim projektem. Musi ono zawierać co najmniej 10 znaków i zawierać co najmniej 1 znak specjalny, 1 cyfrę, 1 wielką literę i 1 małą literę.
+**Warunki ogólne**: Zaznacz pole `I agree to the terms and conditions`.
 
 Kliknij <code className="action">Create my project</code>, aby rozpocząć tworzenie projektu.
 
@@ -66,16 +67,11 @@ Jeśli nie będzie żadnej aktywności przez 60 dni, projekt migracji i wszystki
 
 ### Tworzenie nowej migracji <a name="create-migration"></a>
 
-Po utworzeniu projektu zaloguj się do niego z [strony głównej OMM](/links/web/omm):
+Po utworzeniu projektu zostaniesz automatycznie zalogowany i przekierowany na stronę główną projektu, z której możesz rozpocząć pierwszą migrację.
 
-- Kliknij <code className="action">Track a migration</code>.
-- Wprowadź `Project ID` otrzymany przez e-mail.
-- Wprowadź `Project password` ustawione podczas jego tworzenia.
-- Kliknij <code className="action">Connect to project</code>, aby ukończyć.
-
-<img className="thumbnail" alt="Tworzenie nowej migracji w OVHcloud Mail Migrator, krok 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Teraz jesteś na stronie głównej projektu, która pozwoli Ci rozpocząć pierwszą migrację.
+:::info
+Aby wrócić później do istniejącego projektu, zaloguj się ze [strony głównej OMM](/links/web/omm), postępując zgodnie z sekcją [Śledzenie projektu migracji](#follow-migration).
+:::
 
 - Kliknij <code className="action">New migration</code> w lewym górnym rogu tabeli.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migracja konta e-mail MX Plan
 description: Zmigruj konto e-mail MX Plan na konto Zimbra OVHcloud, a następnie ponownie przypisz jego adres, aby zakończyć zmianę
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
 
     - **Project contact email address**: Wpisz adres e-mail, który będzie otrzymywał dane logowania i powiadomienia o postępach. Nie używaj adresu, który będzie migrowany w tym projekcie.
     - **Project password**: Ustaw hasło (co najmniej 10 znaków, w tym co najmniej 1 znak specjalny, 1 cyfra, 1 wielka litera i 1 mała litera).
+    - **Warunki ogólne**: Zaznacz pole `I agree to the terms and conditions`.
 
     Kliknij <code className="action">Create my project</code>. Otrzymasz e-mail z potwierdzeniem zawierający unikalny identyfikator projektu.
   </Tab>
   <Tab label="Krok 2">
-    **Logowanie do projektu i tworzenie migracji**
+    **Tworzenie migracji**
 
-    Na stronie głównej [OMM](/links/web/omm) kliknij <code className="action">Track a migration</code>, wpisz `Project identifier` i `Project password`, a następnie kliknij <code className="action">Log in to the project</code>.
+    Po utworzeniu projektu zostaniesz automatycznie zalogowany i przekierowany na stronę główną projektu. Jeśli wrócisz do niego później, kliknij <code className="action">Track a migration</code> na stronie głównej [OMM](/links/web/omm), wpisz `Project ID` i `Project password`, a następnie kliknij <code className="action">Connect to project</code>.
 
-    Następnie kliknij <code className="action">New migration</code>, aby skonfigurować migrację:
+    Kliknij <code className="action">New migration</code>, aby skonfigurować migrację:
 
     <img className="thumbnail" alt="Tworzenie migracji z MX Plan do Zimbra w OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ Migracja za pomocą OMM przebiega w 3 krokach: tworzenie projektu, konfiguracja 
     Istnieją dwa sposoby śledzenia projektu migracji:
 
     - Za pośrednictwem e-maila otrzymanego podczas tworzenia projektu, korzystając z podanego linku (identyfikator projektu jest wstępnie wypełniony).
-    - Ze strony głównej [OMM](/links/web/omm): kliknij <code className="action">Track a migration</code>, wpisz `Project identifier` i `Project password`, a następnie kliknij <code className="action">Log in to the project</code>.
+    - Ze strony głównej [OMM](/links/web/omm): kliknij <code className="action">Track a migration</code>, wpisz `Project ID` i `Project password`, a następnie kliknij <code className="action">Connect to project</code>.
 
     Na stronie projektu kliknij przycisk <code className="action">⋮</code> po prawej stronie wiersza migracji, aby wyświetlić opcje:
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar manualmente o seu endereço de e-mail
 description: Saiba como migrar manualmente um endereço de e-mail para outro endereço de e-mail
-lastUpdated: 2026-03-30
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 
 ## Objetivo
 
-[A migração automática](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) de um endereço de e-mail é possível através da nossa ferramenta [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Também pode migrar manualmente o seu endereço de e-mail através dos softwares de e-mail.
+[A migração automática](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) de um endereço de e-mail é possível através da nossa ferramenta [OVHcloud Mail Migrator](/links/web/omm). Também pode migrar manualmente o seu endereço de e-mail através dos softwares de e-mail.
 
 **Saiba como migrar manualmente o seu endereço de e-mail.**
 
@@ -63,7 +63,7 @@ import { Region } from '@components/Zone';
 ## Instruções
 
 :::info
-Em primeiro lugar, verifique se a migração automática é possível através da nossa ferramenta [OVHcloud Mail Migrator](https://omm.ovhcloud.com/). Para isso, consulte o guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Em primeiro lugar, verifique se a migração automática é possível através da nossa ferramenta [OVHcloud Mail Migrator](/links/web/omm). Para isso, consulte o guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
 :::
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar para Exchange, Email Pro ou Zimbra
 description: Migre a sua conta de e-mail MX Plan para uma oferta Exchange, Email Pro ou Zimbra mantendo mensagens, contactos e pastas
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -166,7 +166,7 @@ No separador <code className="action">Contas de e-mail</code> da plataforma E-ma
 
 <img className="thumbnail" alt="Configurar a conta MX Plan para migração na Área de Cliente, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account02.png" loading="lazy" />
 
-3\. **Migre** a conta MX Plan para a sua nova plataforma com a nossa ferramenta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+3\. **Migre** a conta MX Plan para a sua nova plataforma com a nossa ferramenta [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail entre plataformas OVHcloud
 description: Migre contas de e-mail entre duas plataformas OVHcloud (Exchange, Email Pro, MX Plan) sem perder mensagens, contactos ou pastas
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca]
 ---
 
@@ -140,7 +140,7 @@ Apenas os dados das suas contas de e-mail serão migrados (e-mails, contactos, c
 :::
 
 
-Migre a conta de e-mail "source" para a sua nova plataforma com a ajuda da nossa ferramenta [OMM](https://omm.ovhcloud.com/) (OVHcloud Mail Migrator).
+Migre a conta de e-mail "source" para a sua nova plataforma com a ajuda da nossa ferramenta [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mail através do OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
 
@@ -179,7 +179,7 @@ Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHc
 Se configurou uma das contas migradas num cliente de e-mail (exemplo: Outlook, Thunderbird), deve configurá-lo novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração.
 
 :::info
-Também pode migrar manualmente endereços de e-mail para a OVHcloud utilizando a nossa ferramenta [OVHcloud Mail Migrator (OMM)](https://omm.ovhcloud.com/). Para isso, deverá dispor das informações (utilizador, palavra-passe, servidores) do e-mail de origem e do e-mail de destino.
+Também pode migrar manualmente endereços de e-mail para a OVHcloud utilizando a nossa ferramenta [OVHcloud Mail Migrator (OMM)](/links/web/omm). Para isso, deverá dispor das informações (utilizador, palavra-passe, servidores) do e-mail de origem e do e-mail de destino.
 
 :::
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail com o OVHcloud Mail Migrator
 description: Migre as suas contas de e-mail para a OVHcloud com o OVHcloud Mail Migrator (OMM), incluindo mensagens, contactos e calendários
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu, ca, apac]
 ---
 
@@ -13,7 +13,7 @@ import { Region } from '@components/Zone';
 
 ## Objetivo
 
-[OVHcloud Mail Migrator](https://omm.ovhcloud.com/) é uma ferramenta criada pela OVHcloud que responde à necessidade de reversibilidade. Permite migrar as suas contas de e-mail para os seus endereços de e-mail da OVHcloud ou para um serviço de e-mail externo. O processo suporta diferentes tipos de conteúdos, tais como e-mails, contactos, calendários e tarefas, desde que estes sejam compatíveis com os seus endereços de e-mail.
+[OVHcloud Mail Migrator](/links/web/omm) é uma ferramenta criada pela OVHcloud que responde à necessidade de reversibilidade. Permite migrar as suas contas de e-mail para os seus endereços de e-mail da OVHcloud ou para um serviço de e-mail externo. O processo suporta diferentes tipos de conteúdos, tais como e-mails, contactos, calendários e tarefas, desde que estes sejam compatíveis com os seus endereços de e-mail.
 
 **Saiba como migrar as suas contas de e-mail para a OVHcloud com a nossa ferramenta OVHcloud Mail Migrator.**
 
@@ -40,7 +40,7 @@ Seja qual for o método de migração, recomendamos vivamente que faça previame
 
 ## Instruções
 
-Para aceder ao OMM, dirija-se ao endereço [https://omm.ovhcloud.com/](https://omm.ovhcloud.com/).
+Para aceder ao OMM, dirija-se ao endereço [https://omm.ovhcloud.com/](/links/web/omm).
 
 <img className="thumbnail" alt="Página inicial do OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-01.png" loading="lazy" />
 
@@ -66,7 +66,7 @@ Em caso de inatividade durante 60 dias, o projeto de migração e todos os dados
 
 ### Criar uma nova migração <a name="create-migration"></a>
 
-Depois de criar o seu projeto, faça login no projeto a partir da página inicial do [OMM](https://omm.ovhcloud.com/):
+Depois de criar o seu projeto, faça login no projeto a partir da página inicial do [OMM](/links/web/omm):
 
 - Clique em <code className="action">Track a migration</code>.
 - Introduza o `Project ID` recebido por e-mail.
@@ -184,7 +184,7 @@ Quando seleciona uma destas ofertas, siga as etapas abaixo:
 Existem duas formas de aceder ao acompanhamento do projeto de migração:
 
 - No e-mail recebido durante a criação do seu projeto, encontrará um link que lhe permite aceder à página de login do projeto com o `Project ID` pré-preenchido. Apenas o `Project password` terá de ser introduzido.
-- A partir da página inicial do [OMM](https://omm.ovhcloud.com/), clique em <code className="action">Track a migration</code>. Introduza depois o seu `Project ID` e o seu `Project password`.
+- A partir da página inicial do [OMM](/links/web/omm), clique em <code className="action">Track a migration</code>. Introduza depois o seu `Project ID` e o seu `Project password`.
 
 Clique depois em <code className="action">Connect to project</code> para aceder à página inicial do projeto e seguir as suas migrações.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -67,10 +67,10 @@ Em caso de inatividade durante 60 dias, o projeto de migração e todos os dados
 
 ### Criar uma nova migração <a name="create-migration"></a>
 
-Depois de criar o seu projeto, é automaticamente ligado e redirecionado para a página inicial do projeto, a partir da qual poderá iniciar a sua primeira migração.
+Depois de criar o seu projeto, a sua sessão é iniciada automaticamente e é redirecionado para a página inicial do projeto, a partir da qual poderá iniciar a sua primeira migração.
 
 :::info
-Para voltar mais tarde a um projeto existente, inicie sessão a partir da página inicial do [OMM](/links/web/omm) seguindo a secção [Seguir um projeto de migração](#follow-migration).
+Para voltar mais tarde a um projeto existente, inicie sessão a partir da página inicial do [OMM](/links/web/omm) seguindo a secção "[Seguir um projeto de migração](#follow-migration)".
 :::
 
 - Clique em <code className="action">New migration</code> no canto superior esquerdo da tabela.

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -52,6 +52,7 @@ Clique em <code className="action">New migration</code> para iniciar a criação
 
 **Project contact email**: Introduza um endereço de e-mail que servirá para receber as credenciais e as notificações de acompanhamento das suas migrações. Não é aconselhável introduzir um dos endereços de e-mail que será migrado no seu projeto.
 **Project password**: Introduza uma palavra-passe que servirá para aceder ao seu projeto. Deve conter pelo menos 10 caracteres e incluir pelo menos 1 caractere especial, 1 dígito, 1 maiúscula e 1 minúscula.
+**Terms and conditions**: Assinale a caixa `I agree to the terms and conditions`.
 
 Clique em <code className="action">Create my project</code> para iniciar a criação do projeto.
 
@@ -66,16 +67,11 @@ Em caso de inatividade durante 60 dias, o projeto de migração e todos os dados
 
 ### Criar uma nova migração <a name="create-migration"></a>
 
-Depois de criar o seu projeto, faça login no projeto a partir da página inicial do [OMM](/links/web/omm):
+Depois de criar o seu projeto, é automaticamente ligado e redirecionado para a página inicial do projeto, a partir da qual poderá iniciar a sua primeira migração.
 
-- Clique em <code className="action">Track a migration</code>.
-- Introduza o `Project ID` recebido por e-mail.
-- Introduza a `Project password` definida na sua criação.
-- Clique em <code className="action">Connect to project</code> para terminar.
-
-<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
-
-Agora está na página inicial do projeto, que lhe permitirá iniciar a sua primeira migração.
+:::info
+Para voltar mais tarde a um projeto existente, inicie sessão a partir da página inicial do [OMM](/links/web/omm) seguindo a secção [Seguir um projeto de migração](#follow-migration).
+:::
 
 - Clique em <code className="action">New migration</code> no canto superior esquerdo da tabela.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -75,7 +75,7 @@ Para voltar mais tarde a um projeto existente, inicie sessão a partir da págin
 
 - Clique em <code className="action">New migration</code> no canto superior esquerdo da tabela.
 
-<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
 Na nova página que aparece, preencha as informações de conexão da conta de origem e da conta de destino para planejar a migração ou iniciá-la imediatamente. Lembre-se de que o conteúdo da **source account** será migrado para o **destination account**.
 
@@ -85,7 +85,7 @@ Antes de iniciar a sua migração, é importante conhecer bem os 3 tipos de cont
 - **Others**: Trata-se de serviços de e-mail subscritos fora da OVHcloud. Uma lista não exaustiva de serviços de e-mail suportados pelo OMM está disponível. Se o tipo de serviço da sua conta de e-mail não estiver lá, utilize os protocolos `IMAP` ou `POP`, compatíveis com a maioria dos servidores de e-mail.
 - **Importing files**: É possível migrar o conteúdo de ficheiros PST, ICS, CSV e XML Rules através do OMM para uma conta de e-mail de destino. Quando esta função é selecionada, basta arrastar e largar o seu documento na área apropriada ou navegar no seu terminal através do botão <code className="action">Browse your files</code>.
 
-<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
 Complete as informações de acordo com o tipo de conta:
 
@@ -114,7 +114,7 @@ Complete as informações de acordo com o tipo de conta:
 - **Start of transfer**: Pode iniciar a migração `Immediately` ou marcar `Later` para a adiar. A migração adiada permite-lhe iniciá-la automaticamente numa data e hora que definir.
 - **Data to transfer**: Consoante o tipo de conta de e-mail que está a migrar e a conta de destino, esta secção indica-lhe os diferentes tipos de dados suportados durante a migração. Isto depende da conta de origem e da conta de destino.
 
-<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
+<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
 :::warning
 Se migrar uma conta com funcionalidades que a conta de destino não possui, **será necessário guardar por sua conta os elementos que não poderão ser migrados pelo OMM**. Para o ajudar, consulte o nosso guia "[Migrar manualmente o seu endereço de e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration)".
@@ -184,7 +184,7 @@ Existem duas formas de aceder ao acompanhamento do projeto de migração:
 
 Clique depois em <code className="action">Connect to project</code> para aceder à página inicial do projeto e seguir as suas migrações.
 
-<img className="thumbnail" alt="Criar uma nova migração no OVHcloud Mail Migrator, passo 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
+<img className="thumbnail" alt="Ligação a um projeto de migração no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-01.png" loading="lazy" />
 
 A partir desta página, encontra a lista das migrações em curso ou programadas. O estado do projeto também aparece à direita.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -94,7 +94,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
   <Tab label="Etapa 2">
     **Criar a migração**
 
-    Depois de criar o projeto, é automaticamente ligado e redirecionado para a página inicial do seu projeto. Se voltar a ele mais tarde, clique em <code className="action">Track a migration</code> a partir da página inicial do [OMM](/links/web/omm), introduza o `Project ID` e a `Project password` e clique em <code className="action">Connect to project</code>.
+    Depois de criar o projeto, a sua sessão é iniciada automaticamente e é redirecionado para a página inicial do seu projeto. Se voltar a ele mais tarde, clique em <code className="action">Track a migration</code> a partir da página inicial do [OMM](/links/web/omm), introduza o `Project ID` e a `Project password` e clique em <code className="action">Connect to project</code>.
 
     Clique em <code className="action">New migration</code> para configurar a sua migração:
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrar uma conta de e-mail MX Plan
 description: Migre uma conta de e-mail MX Plan para uma conta Zimbra da OVHcloud e reatribua o seu endereço para concluir a mudança
-lastUpdated: 2026-07-23
+lastUpdated: 2026-08-24
 availableIn: [eu]
 ---
 
@@ -87,15 +87,16 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
 
     - **Project contact email address**: Introduza um endereço de e-mail que receberá as credenciais de acesso e as notificações de acompanhamento. Não utilize um endereço que irá ser migrado neste projeto.
     - **Project password**: Defina uma palavra-passe (mínimo 10 caracteres, com pelo menos 1 carácter especial, 1 número, 1 maiúscula e 1 minúscula).
+    - **Terms and conditions**: Assinale a caixa `I agree to the terms and conditions`.
 
     Clique em <code className="action">Create my project</code>. Receberá um e-mail de confirmação com o identificador único do projeto.
   </Tab>
   <Tab label="Etapa 2">
-    **Ligar-se ao projeto e criar a migração**
+    **Criar a migração**
 
-    A partir da página inicial do [OMM](/links/web/omm), clique em <code className="action">Track a migration</code>, introduza o `Project identifier` e a `Project password` e clique em <code className="action">Log in to the project</code>.
+    Depois de criar o projeto, é automaticamente ligado e redirecionado para a página inicial do seu projeto. Se voltar a ele mais tarde, clique em <code className="action">Track a migration</code> a partir da página inicial do [OMM](/links/web/omm), introduza o `Project ID` e a `Project password` e clique em <code className="action">Connect to project</code>.
 
-    A seguir, clique em <code className="action">New migration</code> para configurar a sua migração:
+    Clique em <code className="action">New migration</code> para configurar a sua migração:
 
     <img className="thumbnail" alt="Criar a migração do MX Plan para o Zimbra no OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
@@ -116,7 +117,7 @@ A migração com o OMM realiza-se em 3 etapas: criar um projeto, configurar a mi
     Existem dois métodos para aceder ao acompanhamento do seu projeto de migração:
 
     - A partir do e-mail recebido aquando da criação do projeto, através do link fornecido (o identificador do projeto está pré-preenchido).
-    - A partir da página inicial do [OMM](/links/web/omm): clique em <code className="action">Track a migration</code>, introduza o `Project identifier` e a `Project password` e clique em <code className="action">Log in to the project</code>.
+    - A partir da página inicial do [OMM](/links/web/omm): clique em <code className="action">Track a migration</code>, introduza o `Project ID` e a `Project password` e clique em <code className="action">Connect to project</code>.
 
     A partir da página do projeto, clique no botão <code className="action">⋮</code> à direita da linha da sua migração para ver as opções:
 


### PR DESCRIPTION
Follow-up to the OVHcloud Mail Migrator redesign (2025-11-24). Both procedural guides had already been updated to the project-based flow, so this PR covers what the tool changed *since*, plus link and label consistency. Every finding was verified against the live tool and its public changelog, not against memory.

## What changed

**Obsolete login step removed.** OMM 8.61.0 (2026-05-19) connects you automatically and redirects to the project page right after creation. Both guides still sent the reader back to the homepage to re-enter the project ID and password, asking for a login that had already happened. The `Track a migration` path is kept and moved to its real use case: returning to an existing project later.

**Missing mandatory step added.** The project-creation form requires ticking `I agree to the terms and conditions` before the project can be created. Neither guide documented it — though the existing screenshot already showed the box, so the text was the part lagging behind.

**Non-existent UI labels corrected.** In `migrate-mxplan-to-zimbra`, the six non-French locales quoted `Project identifier` and `Log in to the project`. The interface shows `Project ID` and `Connect to project`. Separately, the German OMM guide wrote `Project Password` where the form shows `Project password`, as the six other locales already had it. The French locale quoted the correct French labels throughout.

**OMM link targets normalised.** Hardcoded `https://omm.ovhcloud.com/` targets replaced with the `/links/web/omm` shortlink already declared in `config/links.ts` for all seven locales, so the URL is maintained in one place. The visible address on the "how to access OMM" line is deliberately kept — only the link target changes there.

**German parity restored.** The German OMM guide had two OMM links against four in the six other locales, and its translation had dropped the "from the OMM homepage" mention entirely.

**Image alt texts.** Renumbered after the step removal above (the section previously opened on "step 2"), and the project-login screenshot now describes what it actually shows rather than claiming to be the first step of creating a migration. This also clears a duplicate alt text that predated the branch.

**Proofread pass.** A `/proofread-pr` run on the branch caught three more defects, fixed in the last commit: the newly added section citation was unquoted in all seven locales, although every one of those files already quoted its other in-page citation; the Portuguese wording for being logged in described switching on a device rather than opening a session; and the French lines this branch touched were missing their non-breaking spaces. It also produced five wording fixes in English and French — tense, a redundant filler, and two openings aligned with their sibling guide.

## Guides updated

Email migration: `omm-migrate-email-account-to-ovhcloud`, `migration-platform`, `migration-control-panel`, `manual-email-migration`.
Zimbra: `migrate-mxplan-to-zimbra`.

## Scope & notes

- 7 locales (en, fr, de, es, it, pl, pt) — 35 files, 4 commits.
- Validated with `content:lint`, `sidebar:check`, `overview:validate` (3026 links across 358 files) and a full build of all seven locales. The build matters here: the Zimbra guide uses `<Tabs>`, and `content:lint` compiles nothing.
- A corpus-wide sweep confirms the scope is complete: 49 files mention OMM across the seven locales, and the 14 outside this PR (`faq-emails`, `hosting-migrating-to-ovh`) carry only a cross-reference — no hardcoded URL, no procedure — so they need nothing.
- **Known debt, left for a screenshot pass:** `migration_platform06.png` and `omm-zimbra-01.png` both show the migration form without the `Start of transfer` and `Data to be transferred` sections that the surrounding text describes. `omm-create-migration-04.png`, already in the repo, shows the current form and served as the reference for that comparison. Each stale image is shared by its seven locales, so this is two images to reshoot — which requires an OMM project and real email accounts.
- **Not covered:** OMM 8.61.0 also added resuming a migration from the migration list. That is new content rather than a correction, so it is out of scope here.
