### PR TITLE
docs(managed-kubernetes): refresh EOL mysql:5.6 image in PVC resize guide

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ Le fichier YAML précédent crée un service qui permet à d'autres pods du clus
 Utilisez maintenant `kubectl` pour créer un client `mysql` à la volée et vous connecter à la base de données :
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 Puis créez simplement une base de données avec une table :
@@ -216,7 +216,7 @@ SHOW TABLES;
 Sur notre exemple de cluster :
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 Lancez à nouveau un client MySQL pour vérifier que vous pouvez toujours lire votre base de données :
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 Un `SHOW DATABASES;` doit vous permettre de voir votre base de données `testingResize` ; vous pouvez la sélectionner et retrouver votre table `anEmptyTable`.
@@ -374,7 +374,7 @@ Un `SHOW DATABASES;` doit vous permettre de voir votre base de données `testing
 Sur notre exemple de cluster :
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -94,7 +94,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.6
+      - image: mysql:8.4
         name: mysql
         env:
           # Use secret in real usage
@@ -169,7 +169,7 @@ Pod Template:
   Labels:  app=mysql
   Containers:
    mysql:
-    Image:      mysql:5.6
+    Image:      mysql:8.4
     Port:       3306/TCP
     Host Port:  0/TCP
     Environment:
@@ -201,7 +201,7 @@ The preceding YAML file creates a service that allows other Pods in the cluster 
 Now we are going to use `kubectl` to create a `mysql` client on the fly to connect to the database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 And then simply create a database with a table:
@@ -216,7 +216,7 @@ SHOW TABLES;
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> CREATE DATABASE testingResize;
@@ -366,7 +366,7 @@ Events:
 So we launch again a MySQL client to verify that we can still read our database:
 
 ```bash
-kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 ```
 
 An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can select it and find our `anEmptyTable` table.
@@ -374,7 +374,7 @@ An `SHOW DATABASES;` should allow us to see our `testingResize` database, we can
 On my example cluster:
 
 ```console
-$ kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+$ kubectl run -it --rm --image=mysql:8.4 --restart=Never mysql-client -- mysql -h mysql -ppassword
 If you don't see a command prompt, try pressing enter.
 
 mysql> SHOW DATABASES;


### PR DESCRIPTION
## Summary

The Managed Kubernetes "Resizing Persistent Volumes" tutorial deployed MySQL from the `mysql:5.6` Docker image throughout. MySQL 5.6 reached end of life on 2021-02-05 and no longer receives security fixes.

This patch replaces the pin with the current LTS line, `mysql:8.4`, **for both the server Deployment and the `mysql-client` pod**. This consistency matters technically: MySQL 8.x defaults to `caching_sha2_password` authentication, which a 5.6-era client does not support — mixing an 8.x server with a 5.6 client would make the tutorial's verification commands fail at the connection step. With server and client refreshed together, every example in the guide runs end-to-end.

## Changes

All seven locales (en, de, es, fr, it, pl, pt), identical token replacements — 6 occurrences per file, 42 changed lines total:

```diff
-      - image: mysql:5.6
+      - image: mysql:8.4
```

covering:

1. the Deployment manifest (`spec.template.spec.containers[0].image`);
2. the `kubectl describe pod` sample output shown to readers;
3. both `kubectl run ... --image=mysql:5.6 ... mysql-client` verification commands (and their repeated console transcripts).

`8.4` is the current MySQL LTS line and remains a drop-in replacement for this stack — the guide's `MYSQL_ROOT_PASSWORD` environment setup and volume mount layout work unchanged. This mirrors the same replacement merged today in the WordPress Docker guide (#627).

No other content changes.

## Checks

- [x] Replacement tag verified on Docker Hub (`library/mysql` tag `8.4` exists and is actively published)
- [x] EOL date verified against public lifecycle data (MySQL 5.6 → 2021-02-05), consistent with the checks performed for #627
- [x] All 7 locale siblings patched consistently (42 insertions, 42 deletions)
- [x] `git diff --check` clean; full diff reviewed and verified to contain only the version-token change across exactly 4 line shapes

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
