### PR TITLE
docs(managed-kubernetes): refresh EOL nginx:1.7.9 image in volume backup guides

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -330,7 +330,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -409,7 +409,7 @@ nginx-service   LoadBalancer   10.3.39.164   51.210.210.247   80:31734/TCP   3m
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:20 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -420,7 +420,7 @@ Accept-Ranges: bytes
 
 $ curl -I 51.210.210.247
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Tue, 21 Dec 2021 14:16:31 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -70,7 +70,7 @@ spec:
           persistentVolumeClaim:
             claimName: nginx-logs
       containers:
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
           name: nginx
           ports:
             - containerPort: 80
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.7.9
+Server: nginx/1.27.3
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -169,7 +169,7 @@ $ echo $LB_IP
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:32 GMT
 Content-Type: text/html
 Content-Length: 612
@@ -180,7 +180,7 @@ Accept-Ranges: bytes
 
 $ curl -I $LB_IP
 HTTP/1.1 200 OK
-Server: nginx/1.27.3
+Server: nginx/1.7.9
 Date: Mon, 26 Sep 2022 06:56:33 GMT
 Content-Type: text/html
 Content-Length: 612


### PR DESCRIPTION
## Summary

Two Managed Kubernetes backup tutorials deploy a sample nginx server from the `nginx:1.7.9` Docker image — a release from 2014 that is long end of life:

- `backing-up-volumes-stash.mdx` (Stash-based volume backup guide)
- `backup-restore-pv-volume-snapshot.mdx` (volume snapshot restore guide)

The repository already demonstrates the modern replacement: the sibling `backing-up-cluster-velero.mdx` guide uses `nginx:1.27.3` (current stable line) for the same kind of sample workload. This patch aligns both backup guides with it.

## Changes

All seven locales (en, de, es, fr, it, pl, pt), 3 occurrences per file, 42 changed lines total — two token forms updated consistently:

```diff
-        - image: nginx:1.7.9
+        - image: nginx:1.27.3
```

in the Deployment manifest, and the matching transcript headers so the sample output stays internally consistent with the deployed image:

```diff
-Server: nginx/1.7.9
+Server: nginx/1.27.3
```

No other content changes. (The `Last-Modified`/`ETag` values in the same transcripts are left untouched.)

## Checks

- [x] Replacement tag already proven in-repo: `nginx:1.27.3` is used by the sibling velero guide across all locales
- [x] Duplicate research: no open/closed PRs or issues touching these guides or `nginx:1.7.9`
- [x] All 14 files patched consistently (42 insertions, 42 deletions)
- [x] `git diff --check` clean; full diff reviewed and verified to contain only the two version-token forms

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
