### PR TITLE
docs(vps): refresh EOL mariadb:10.6 image in NextCloud beginner guide

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/es/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Créez le fichier `docker-compose.yml` :
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/it/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pl/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:

--- a/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
+++ b/docs/pt/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-beginner.mdx
@@ -90,7 +90,7 @@ Create the `docker-compose.yml` file:
 ```yaml
 services:
   db:
-    image: mariadb:10.6
+    image: mariadb:11
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:


### PR DESCRIPTION
## Summary

The beginner NextCloud-on-VPS tutorial deploys its database from the `mariadb:10.6` Docker image. MariaDB 10.6 reached end of life on **2026-07-06** and no longer receives maintenance or security fixes.

This replaces the pin with `mariadb:11` — the exact tag already used by the sibling [advanced guide](https://github.com/ovh/ovhcloud-docs/blob/develop/docs/en/guides/bare-metal-cloud/virtual-private-servers/install-nextcloud-on-vps-advanced.mdx) of the same NextCloud-on-VPS family, which keeps the two tutorials consistent.

## Why this is a safe replacement

- This is a **fresh-installation tutorial**: the Compose stack creates a new volume, so no data migration or upgrade path applies.
- The service's options (`--transaction-isolation=READ-COMMITTED --binlog-format=ROW`, `MYSQL_*` environment variables) are all valid unchanged for the 11.x line — and are in fact the same settings the advanced guide runs on `mariadb:11`.
- `mariadb:11` is an actively maintained Docker Official Image tag.

## Changes

All seven locales (en, de, es, fr, it, pl, pt), one line each:

```diff
-    image: mariadb:10.6
+    image: mariadb:11
```

No other content changes.

## Checks

- [x] Replacement tag verified against the sibling advanced guide already merged upstream (`mariadb:11`)
- [x] EOL date per MariaDB engineering lifecycle (10.6 → 2026-07-06)
- [x] Duplicate research: no open/closed PRs touching this file or `mariadb:10.6`
- [x] All 7 locale siblings patched consistently (7 insertions, 7 deletions); full diff reviewed — single changed-line shape
- [x] `git diff --check` clean

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
