### PR TITLE
docs(managed-kubernetes): refresh EOL debian:9-slim image in CloudCasa backup guide

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:12-slim
+        image: debian:13-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -103,14 +103,14 @@ spec:
     spec: 
       containers: 
       - name: date 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["while true; do /bin/date | /usr/bin/tee -a /mnt/date ; /bin/sleep 5; done"] 
         volumeMounts: 
           - mountPath: /mnt 
             name: data-mount 
       - name: sidecar 
-        image: debian:9-slim 
+        image: debian:12-slim
         command: ["/bin/sh","-c"] 
         args: ["/bin/sleep 3600"] 
         securityContext: 


### PR DESCRIPTION
## Summary

The CloudCasa backup/restore tutorial for Managed Kubernetes uses the `debian:9-slim` image in its two sample pods (a `date`-logging pod and a `sleep` sidecar used to inspect restored data). Debian 9 "stretch" is long past end of life: standard support ended 2022-06-30, LTS 2023-06-30, and even paid ELTS ended 2024-06-30.

This replaces the pin with `debian:13-slim` (trixie, the current stable release since 2025-08-09). Both sample pods only run `/bin/sh -c` with `/bin/date`, `sleep`, and `tee` — nothing distribution-sensitive — so the tutorial output remains valid.

## Changes

All seven locales (en, de, es, fr, it, pl, pt), two lines each:

```diff
-        image: debian:9-slim
+        image: debian:13-slim
```

(Trailing whitespace present on those original lines was dropped as part of rewriting them.)

No other content changes.

## Checks

- [x] Replacement tag is in **full** support, not just newer than what it replaces (trixie stable since 2025-08-09; standard security support through mid-2028) — per review feedback
- [x] EOL timeline per Debian release lifecycle (stretch: LTS → 2023-06-30, ELTS → 2024-06-30; bookworm now oldstable, standard security ended 2026-07-11)
- [x] Tag mapping verified on Docker Hub: `13-slim` = `trixie-slim`
- [x] Sample commands verified identical across Debian versions (`/bin/date`, `sleep`, `tee`)
- [x] Duplicate research: no open/closed PRs touching this file or `debian:9-slim`
- [x] All 7 locale siblings patched consistently (14 insertions, 14 deletions across both commits); full diff reviewed
- [x] `git diff --check` clean

## Authorship

If this PR is recreated on an internal repository branch for the CDS check, could you please preserve the original commit authorship or retain @GoXLd as a co-author in the final commit? Thank you!
