### PR TITLE
FIX - WEB - Email - Proofread pass on the email migration guides

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ihre E-Mail-Adresse manuell migrieren
-description: Erfahren Sie hier, wie Sie Ihre E-Mail-Adresse manuell auf eine andere E-Mail-Adresse migrieren.
-lastUpdated: 2026-08-24
+description: Erfahren Sie hier, wie Sie Ihre E-Mail-Adresse manuell auf eine andere E-Mail-Adresse migrieren
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,24 +15,20 @@ Die automatische [Migration](/guides/web-cloud/email-and-collaborative-solutions
 
 **Diese Anleitung erläutert, wie Sie Ihre E-Mail-Adresse manuell migrieren.**
 
-:::warning
-In dieser Anleitung erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen.
-
-Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovhcloud.com/community/en). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. 
-:::
+[[fragment:support-scope]]
 
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel [Exchange](https://www.ovhcloud.com/de/emails-exchange/), [E-Mail Pro](https://www.ovhcloud.com/de/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot).
+- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel [Exchange](/links/web/emails-exchange), [E-Mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) Angebot).
 </Region>
 
 <Region zones={['ca']}>
-- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel [Exchange](https://www.ovhcloud.com/de/emails-exchange/) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot).
+- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel [Exchange](/links/web/emails-exchange) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) Angebot).
 </Region>
 
 <Region zones={['apac']}>
-- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) Angebot).
+- Sie verfügen über einen E-Mail-Dienst bei OVHcloud, wie zum Beispiel MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) Angebot).
 </Region>
 - Sie verfügen über die Login-Daten für die E-Mail-Accounts, die Sie migrieren möchten (Quell-Accounts).
 - Sie verfügen über die Login-Daten der OVHcloud E-Mail-Accounts, auf die Sie die Inhalte übertragen möchten (Ziel-Accounts).
@@ -82,7 +78,7 @@ Die folgenden Anweisungen sind in zwei Teile gegliedert:
 
 ### Outlook
 
-Wenn Sie einen OVHcloud [Exchange E-Mail-Account](https://www.ovhcloud.com/de/emails/hosted-exchange/) haben, können Sie diesen direkt im PST-Format über das Kundencenter exportieren.
+Wenn Sie einen OVHcloud [Exchange E-Mail-Account](/links/web/emails-hosted-exchange) haben, können Sie diesen direkt im PST-Format über das Kundencenter exportieren.
 
 Im Tab <code className="action">E-Mail-Accounts</code> Ihres Exchange-Dienstes klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf <code className="action">...</code> und dann auf <code className="action">In PST-Format exportieren</code>.
 
@@ -281,7 +277,7 @@ Im nächsten Schritt benennen Sie Ihr Profil und identifizieren Sie den Ordner, 
 
 Wenn Sie die Import-Schritte befolgt haben, überprüfen Sie, ob Ihre Elemente auf dem Server vorhanden sind.
 
-Loggen Sie sich im [Webmail](https://www.ovhcloud.com/de/mail/) ein.
+Loggen Sie sich im [Webmail](/links/web/email) ein.
 
 In Ihrem Posteingang und in der linken Spalte finden Sie die Ordner und E-Mails Ihrer gesicherten E-Mail-Adresse.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Umzug zu Exchange, Email Pro oder Zimbra
 description: Migrieren Sie Ihren MX Plan E-Mail-Account zu Exchange, Email Pro oder Zimbra und behalten Sie Ihre Nachrichten, Kontakte und Ordner
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -34,14 +34,14 @@ Wenn Ihre E-Mails nur lokal gespeichert sind (POP-Konfiguration oder lokales Arc
 
 ## Voraussetzungen
 
-- Sie verfügen über einen MX Plan E-Mail-Account (als eigenständige Lösung oder als Teil eines [OVHcloud Webhosting Angebots](https://www.ovhcloud.com/de/web-hosting/)).
+- Sie verfügen über einen MX Plan E-Mail-Account (als eigenständige Lösung oder als Teil eines [OVHcloud Webhosting Angebots](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Sie verfügen über einen [Exchange](https://www.ovhcloud.com/de/emails/hosted-exchange/), [E-Mail Pro](https://www.ovhcloud.com/de/emails/email-pro/) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/).
+- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](/links/web/emails-zimbra).
 </Region>
 
 <Region zones={['ca']}>
-- Sie verfügen über einen [Exchange](https://www.ovhcloud.com/de/emails/hosted-exchange/) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt).
+- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt).
 </Region>
 
 - **Sie haben keine Weiterleitungen für die MX Plan E-Mail-Accounts aktiviert, die Sie migrieren möchten.**
@@ -83,7 +83,7 @@ Unabhängig von der gewählten Migrationsmethode empfehlen wir Ihnen dringend, I
 
 Die E-Mail Pro und Exchange Lösungen verfügen über eine gemeinsame Basis für Funktionen. Je nach Verwendungszweck bestehen jedoch Unterschiede. Wenn Sie eine Exchange Account auswählen, verfügen Sie über alle kollaborativen Funktionen wie die Synchronisation des Kalenders und der Kontakte. Die E-Mail Pro Lösung bietet ebenfalls einige dieser Funktionen, diese sind jedoch auf die Verwendung über das Webmail beschränkt.
 
-Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](https://www.ovhcloud.com/de/emails/) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in E-Mail Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
+Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](/links/web/emails) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in E-Mail Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
 
 ### Schritt 2: E-Mail Pro oder Exchange Accounts bestellen
 
@@ -267,7 +267,7 @@ Um die Konfiguration zu ändern, klicken Sie auf das rote Symbol und führen Sie
 
 ### Schritt 5: Migrierte E-Mail-Accounts verwenden
 
-Verwenden Sie nun Ihre migrierten E-Mail-Accounts. OVHcloud stellt dazu eine Online-Anwendung (*Web App*) zur Verfügung, die über [Webmail](https://www.ovhcloud.com/de/mail/) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
+Verwenden Sie nun Ihre migrierten E-Mail-Accounts. OVHcloud stellt dazu eine Online-Anwendung (*Web App*) zur Verfügung, die über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
 
 Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) eingerichtet haben, müssen Sie diesen erneut konfigurieren. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert. Weitere Informationen finden Sie in den jeweiligen Anleitungen zu [E-Mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) und [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan). Auch wenn Sie den Account nicht sofort neu konfigurieren können, ist der Zugriff über die Online-Anwendung weiterhin möglich.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts zwischen OVHcloud-Plattformen migrieren
 description: Migrieren Sie E-Mail-Accounts zwischen zwei OVHcloud-Plattformen (Exchange, Email Pro, MX Plan), ohne Nachrichten, Kontakte oder Ordner zu verlieren
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ Um eine MX Plan Lösung nach Exchange zu migrieren, folgen Sie unserer Anleitung
 
 ## Voraussetzungen
 
-- Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](https://www.ovhcloud.com/de/emails/hosted-exchange/) oder [E-Mail Pro](https://www.ovhcloud.com/de/emails/email-pro/) oder [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/) Accounts.
-- Sie verfügen über eine "**Ziel-Plattform**": [Exchange](https://www.ovhcloud.com/de/emails/hosted-exchange/), [E-Mail Pro](https://www.ovhcloud.com/de/emails/email-pro/) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](https://www.ovhcloud.com/de/web-hosting/) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
+- Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](/links/web/emails-hosted-exchange) oder [E-Mail Pro](/links/web/email-pro) oder [Zimbra](/links/web/emails-zimbra) Accounts.
+- Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -176,7 +176,7 @@ Um die Konfiguration zu ändern, klicken Sie auf das rote Feld und führen Sie d
 
 ### Migrierte E-Mail-Adressen verwenden
 
-Sie können nun Ihre migrierten E-Mail-Adressen verwenden. OVHcloud stellt dazu einen Web-Client (*Web App*) zur Verfügung, der über [Webmail](https://www.ovhcloud.com/de/mail/) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
+Sie können nun Ihre migrierten E-Mail-Adressen verwenden. OVHcloud stellt dazu einen Web-Client (*Web App*) zur Verfügung, der über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
 
 Wenn Sie einen der migrierten Accounts auf einem lokalen E-Mail-Client eingerichtet haben (Outlook, Thunderbird, etc.), muss er erneut konfiguriert werden. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert.
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts mit dem OVHcloud Mail Migrator migrieren
 description: Migrieren Sie Ihre E-Mail-Accounts mit dem OVHcloud Mail Migrator (OMM) zu OVHcloud, inklusive Nachrichten, Kontakten und Kalendern
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Voraussetzungen
 
 <Region zones={['eu']}>
-- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: [Zimbra](https://www.ovhcloud.com/de/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/de/emails-exchange/), [E-Mail Pro](https://www.ovhcloud.com/de/emails/email-pro/) oder eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](https://www.ovhcloud.com/de/web-hosting/)).
+- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [E-Mail Pro](/links/web/email-pro) oder eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: [Exchange](https://www.ovhcloud.com/de/emails-exchange/) oder eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](https://www.ovhcloud.com/de/web-hosting/)).
+- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: [Exchange](/links/web/emails-exchange) oder eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](https://www.ovhcloud.com/de/web-hosting/)).
+- Sie haben einen externen E-Mail-Dienst oder einen Dienst von OVHcloud: eine MX Plan Lösung (als MX Plan Angebot oder enthalten in einem [OVHcloud Webhosting Angebot](/links/web/hosting)).
 </Region>
 
 - Sie verfügen über die Login-Daten für die Quell-Accounts, die Sie migrieren möchten.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Manually migrate your email address
 description: How to migrate your email address manually to another email address
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,24 +15,20 @@ You can [migrate an email address automatically](/guides/web-cloud/email-and-col
 
 **Find out how to migrate your email address manually.**
 
-:::warning
-This guide will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation. If you experience any difficulties carrying out these operations, please get in touch with a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/), and/or discuss your issues with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot assist you in this regard.
-
-:::
-
+[[fragment:support-scope]]
 
 ## Requirements
 
 <Region zones={['eu']}>
-- An email service with OVHcloud, such as an [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/), [Email Pro](https://www.ovhcloud.com/en-gb/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/) or MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](https://www.ovhcloud.com/en-gb/web-hosting/))
+- An email service with OVHcloud, such as an [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) or MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](/links/web/hosting))
 </Region>
 
 <Region zones={['ca']}>
-- An email service with OVHcloud, such as an [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/) or MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](https://www.ovhcloud.com/en-gb/web-hosting/))
+- An email service with OVHcloud, such as an [Exchange](/links/web/emails-exchange) or MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](/links/web/hosting))
 </Region>
 
 <Region zones={['apac']}>
-- An email service with OVHcloud, such as an MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](https://www.ovhcloud.com/en-gb/web-hosting/))
+- An email service with OVHcloud, such as an MX Plan solution (via the MX Plan or included in an [OVHcloud web hosting solution](/links/web/hosting))
 </Region>
 
 - Access to the email accounts you want to migrate (the source accounts)
@@ -83,7 +79,7 @@ The following instructions are divided into two parts:
 
 ### Outlook
 
-If you have an [OVHcloud Exchange email account](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/), you can export it directly in PST format via the OVHcloud Control Panel.
+If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
 Once on your Exchange service page, in the <code className="action">Email accounts</code> tab, click the <code className="action">...</code> button to the right of the email account you want to export, then <code className="action">Export in PST format</code>.
 
@@ -282,7 +278,7 @@ In the next step, name your profile and identify the folder where the profile wi
 
 When you have done the necessary steps by following the import instructions, make sure that your items are present on the server.
 
-Log in to [webmail](https://www.ovhcloud.com/en-gb/mail/).
+Log in to [webmail](/links/web/email).
 
 In your inbox and the left-hand column, you will find the folders and emails for your saved email address.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrate to Exchange, Email Pro or Zimbra
 description: Migrate your MX Plan email account to an Exchange, Email Pro or Zimbra offer while keeping your messages, contacts and folders
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -35,14 +35,14 @@ If your emails are only stored locally (POP configuration or local archiving), y
 
 ## Requirements
 
-- An MX Plan email account (as MX Plan standalone or included in an OVHcloud [Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- An MX Plan email account (as MX Plan standalone or included in an OVHcloud [Web Hosting plan](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- An [Exchange](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/en-gb/emails/email-pro/) or [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/) service with at least one unconfigured account (which will appear as "@configureme.me").
+- An [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) or [Zimbra](/links/web/emails-zimbra) service with at least one unconfigured account (which will appear as "@configureme.me").
 </Region>
 
 <Region zones={['ca']}>
-- An [Exchange](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/) service with at least one unconfigured account (which will appear as "@configureme.me").
+- An [Exchange](/links/web/emails-hosted-exchange) service with at least one unconfigured account (which will appear as "@configureme.me").
 </Region>
 
 - **No redirections set on the MX Plan email account you want to migrate**.
@@ -84,7 +84,7 @@ Whatever migration method you use, we strongly recommend backing up your mailbox
 
 Email Pro and Exchange solutions have a common feature base. However, there are differences in use cases. By choosing an Exchange account, you get all the collaborative features, such as calendars and contact synchronisation. The Email Pro solution offers a few advanced features as well, but they are limited to webmail use only.
 
-It is important to choose the solution you would like to migrate your MX Plan email accounts to before initiating the process. To help you decide, the [OVHcloud professional email solutions page](https://www.ovhcloud.com/en-gb/emails/) offers a detailed comparison of the available services. You can also manage a mixed solution and use one or more Email Pro and Exchange accounts for the same domain name. Furthermore, if you need to migrate multiple accounts, we recommend that you set up a migration plan.
+It is important to choose the solution you would like to migrate your MX Plan email accounts to before initiating the process. To help you decide, the [OVHcloud professional email solutions page](/links/web/emails) offers a detailed comparison of the available services. You can also manage a mixed solution and use one or more Email Pro and Exchange accounts for the same domain name. Furthermore, if you need to migrate multiple accounts, we recommend that you set up a migration plan.
 
 ### Step 2: Ordering your Email Pro or Exchange accounts
 
@@ -106,7 +106,7 @@ Before starting your migration, you will need to identify the version of the MX 
 The email technology of your MX Plan offer may vary depending on the date of activation of your offer or if a migration has recently taken place. This technology is particularly distinguished by the interface of its webmail. To identify it from your control panel, follow these steps:
 
 1. The <code className="action">General information</code> tab is selected by default.
-1. Note the technology used under the mention **Webmail** in the `Subscription` box.
+1. Note the technology used under the mention **webmail** in the `Subscription` box.
 
 <img className="thumbnail" alt="MX Plan subscription panel showing the Webmail technology in the OVHcloud Control Panel" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -264,11 +264,11 @@ If you have just migrated or modified a DNS record for your domain, it may take 
 :::
 
 
-To modify the configuration, click on the red badge and perform the requested operation. This operation requires a propagation time of 4 to 24 hours maximum before it is fully effective.
+To modify the configuration, click on the red badge and complete the requested operation. This operation requires a propagation time of 4 to 24 hours maximum before it is fully effective.
 
 ### Step 5: Using your migrated email accounts
 
-Now, you can start using your migrated email accounts. To do this, OVHcloud offers an online interface (*web app*), available here: [Webmail](https://www.ovhcloud.com/en-gb/mail/). You will need to enter your email credentials.
+Now, you can start using your migrated email accounts. To do this, OVHcloud offers an online interface (*web app*), available here: [webmail](/links/web/email). You will need to enter your email credentials.
 
 If you have configured one of the migrated accounts on an email client (such as Outlook), you must set it up again. The login details for the OVHcloud server have changed following the migration. To help you make changes, please read the respective guides in the [Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) and [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan) guide sections. Even if you are unable to reconfigure the account immediately, access via the online application is still possible.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts between OVHcloud platforms
 description: Migrate email accounts between two OVHcloud platforms (Exchange, Email Pro or MX Plan) without losing your messages, contacts or folders
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ To migrate an MX Plan solution to an Exchange platform, please follow our guide 
 
 ## Requirements
 
-- A **"source"** platform with configured [Exchange](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/) or [Email Pro](https://www.ovhcloud.com/en-gb/emails/email-pro/) accounts or [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/).
-- A "**destination**" platform with [Exchange](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/en-gb/emails/email-pro/) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](https://www.ovhcloud.com/en-gb/web-hosting/)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+- A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) or [Email Pro](/links/web/email-pro) accounts or [Zimbra](/links/web/emails-zimbra).
+- A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -149,7 +149,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 The migration time depends on the amount of data to migrate to your new account. This may vary from a few minutes to several hours.
 
 :::warning
-After the migration, verify that all of your elements are present by logging into webmail at [Webmail](/links/web/email). **Do not delete or reset your original account until you have confirmed that everything has been migrated correctly** — once the original account is deleted, any items that were not migrated will be permanently lost.
+After the migration, verify that all of your elements are present by logging into webmail at [webmail](/links/web/email). **Do not delete or reset your original account until you have confirmed that everything has been migrated correctly** — once the original account is deleted, any items that were not migrated will be permanently lost.
 :::
 
 Once the migration is complete, you can keep or delete the original account with the temporary name.
@@ -170,11 +170,11 @@ If you have just migrated or modified a DNS record for your domain, it may take 
 :::
 
 
-To modify the configuration, click on the red box and carry out the requested operation. It can take between 4 and a maximum of 24 hours for DNS changes to propagate fully.
+To modify the configuration, click on the red box and complete the requested operation. It can take between 4 and a maximum of 24 hours for DNS changes to propagate fully.
 
 ### Use your migrated email addresses
 
-Now, you can start using your migrated email addresses. To do this, OVHcloud offers a web client (_web app_), available here [Webmail](https://www.ovhcloud.com/en-gb/mail/). You will need to enter your email credentials.
+Now, you can start using your migrated email addresses. To do this, OVHcloud offers a web client (_web app_), available here [webmail](/links/web/email). You will need to enter your email credentials.
 
 If you have configured one of the migrated accounts on a local email client (e.g. Outlook, Thunderbird), you will need to configure it again. The login details for the OVHcloud server have changed following the migration.
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts via OVHcloud Mail Migrator
 description: Migrate your email accounts to OVHcloud with the OVHcloud Mail Migrator (OMM), transferring messages, contacts and calendars
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Requirements
 
 <Region zones={['eu']}>
-- An external email service or one from OVHcloud, such as a [Zimbra](https://www.ovhcloud.com/en-gb/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/), [Email Pro](https://www.ovhcloud.com/en-gb/emails/email-pro/) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- An external email service or one from OVHcloud, such as a [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- An external email service or one from OVHcloud, such as an [Exchange](https://www.ovhcloud.com/en-gb/emails-exchange/) offer or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- An external email service or one from OVHcloud, such as MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](https://www.ovhcloud.com/en-gb/web-hosting/)).
+- An external email service or one from OVHcloud, such as MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
 </Region>
 
 - Login details for the email accounts you want to migrate (the source accounts).
@@ -83,7 +83,7 @@ Before starting your migration, it is important to know the 3 types of accounts 
 
 - **OVHcloud**: The `Autodetect` option is recommended if you need to migrate an account hosted on one of the OVHcloud email offers. If you have a large number of OVHcloud email accounts, select one of the following offers: `MX plan`, `Email Pro`, `Exchange` or `Zimbra`. You will be asked to connect to the OVHcloud account associated with the offer concerned by the migration. For more information, see the section "[Migrate via a connection to the OVHcloud customer account](#sso-migration)".
 - **Others**: They refer to email services outside of OVHcloud. You will find a non-exhaustive list of email services supported by OMM. If the type of service of your email account is not listed, use the `IMAP` or `POP` protocols, which are compatible with most email servers.
-- **Importing files**: It is possible to migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the <code className="action">Browse your files</code> button.
+- **Importing files**: You can migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the <code className="action">Browse your files</code> button.
 
 <img className="thumbnail" alt="Creating a new migration in the OVHcloud Mail Migrator, step 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
@@ -169,7 +169,7 @@ When you select one of these offers, follow the steps below:
 
 
 :::warning
-It is possible to disconnect current accesses from an OVHcloud Control Panel by clicking on <code className="action">Log out</code>, then under `OVHcloud account ID`, click on <code className="action">Log out of the account</code>.
+You can disconnect current accesses from an OVHcloud Control Panel by clicking on <code className="action">Log out</code>, then under `OVHcloud account ID`, click on <code className="action">Log out of the account</code>.
 
 <img className="thumbnail" alt="Migrating through the OVHcloud account connection in OMM, step 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar manualmente una dirección de correo electrónico
 description: Cómo migrar manualmente su dirección de correo a otra dirección de correo
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Requisitos
 
 <Region zones={['eu']}>
-- Disponer de un servicio de correo en OVHcloud, como una solución [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/), [Email Pro](https://www.ovhcloud.com/es-es/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de un servicio de correo en OVHcloud, como una solución [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Disponer de un servicio de correo en OVHcloud, como una solución [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de un servicio de correo en OVHcloud, como una solución [Exchange](/links/web/emails-exchange) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Disponer de un servicio de correo en OVHcloud, como una solución MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de un servicio de correo en OVHcloud, como una solución MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)).
 </Region>
 - Disponer del nombre de usuario y la contraseña de las cuentas de correo electrónico que quiera migrar (las cuentas de origen).
 - Disponer del nombre de usuario y la contraseña de las cuentas de correo electrónico de OVHcloud que recibirán los datos que se migran (las cuentas de destino).
@@ -78,7 +78,7 @@ Las instrucciones siguientes se dividen en dos partes:
 
 ### Outlook
 
-Si tiene una cuenta de correo [Exchange de OVHcloud](https://www.ovhcloud.com/es-es/emails/hosted-exchange/), puede exportarla directamente en formato PST desde el área de cliente.
+Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
 Una vez en la página de su servicio Exchange, en la pestaña <code className="action">Cuentas de correo</code>, haga clic en el botón <code className="action">...</code> a la derecha de la cuenta de correo que quiera exportar y luego en <code className="action">Exportar en formato PST</code>.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar a Exchange, Email Pro o Zimbra
 description: Migre su cuenta de correo MX Plan a una oferta Exchange, Email Pro o Zimbra conservando sus mensajes, contactos y carpetas
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -34,14 +34,14 @@ Si sus correos electrónicos están almacenados únicamente de forma local (conf
 
 ## Requisitos
 
-- Disponer de una cuenta MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Disponer de una cuenta MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Tener un servicio [Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/es-es/emails/email-pro/) con al menos una cuenta no configurada (que aparecerá como "@configureme.me") o [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/).
+- Tener un servicio [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) con al menos una cuenta no configurada (que aparecerá como "@configureme.me") o [Zimbra](/links/web/emails-zimbra).
 </Region>
 
 <Region zones={['ca']}>
-- Tener un servicio [Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) con al menos una cuenta no configurada (que aparecerá como "@configureme.me").
+- Tener un servicio [Exchange](/links/web/emails-hosted-exchange) con al menos una cuenta no configurada (que aparecerá como "@configureme.me").
 </Region>
 
 - **No haber configurado ninguna redirección en la dirección de correo MX Plan que quiera migrar**.
@@ -83,7 +83,7 @@ Sea cual sea el método de migración, le recomendamos encarecidamente que haga 
 
 Las soluciones Email Pro y Exchange disponen de una base de funcionalidades común. Sin embargo, existen diferencias en los casos de uso. Eligiendo una dirección Exchange, dispondrá de todas las funciones colaborativas, como la sincronización del calendario y de los contactos. La solución Email Pro ofrece algunas, pero estas están limitadas a su uso únicamente a través de un webmail.
 
-Por lo tanto, es importante conocer a qué solución quiere migrar sus direcciones de correo MX Plan. Si necesita ayuda, consulte la página de [soluciones de correo electrónico profesionales de OVHcloud](https://www.ovhcloud.com/es-es/emails/), que ofrece una comparativa detallada de los productos. Es posible combinar las soluciones y utilizar una o más cuentas Email Pro y Exchange para un mismo dominio. Si quiere migrar varias cuentas, le recomendamos que establezca un plan de migración.
+Por lo tanto, es importante conocer a qué solución quiere migrar sus direcciones de correo MX Plan. Si necesita ayuda, consulte la página de [soluciones de correo electrónico profesionales de OVHcloud](/links/web/emails), que ofrece una comparativa detallada de los productos. Es posible combinar las soluciones y utilizar una o más cuentas Email Pro y Exchange para un mismo dominio. Si quiere migrar varias cuentas, le recomendamos que establezca un plan de migración.
 
 ### Etapa 2: Pedir sus cuentas Email Pro o Exchange
 
@@ -105,7 +105,7 @@ Antes de realizar la migración, deberá identificar la versión del MX Plan des
 La tecnología de correo de su oferta MX Plan puede variar según la fecha de activación de su oferta o si ha tenido lugar recientemente una migración. Esta tecnología se distingue especialmente por la interfaz de su webmail. Para identificarla desde su área de cliente, siga estos pasos:
 
 1. El apartado <code className="action">Información general</code> se selecciona por defecto.
-1. Anote la tecnología utilizada bajo la mención **Webmail** en el recuadro `Suscripción`.
+1. Anote la tecnología utilizada bajo la mención **webmail** en el recuadro `Suscripción`.
 
 <img className="thumbnail" alt="Panel de suscripción de MX Plan que muestra la tecnología Webmail en el área de cliente de OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -173,7 +173,7 @@ Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de corr
 El tiempo de migración dependerá de cuánto contenido quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
 :::warning
-Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [Webmail OVHcloud](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
+Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [webmail OVHcloud](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
 :::
 
 Una vez realizada la migración, puede conservar o eliminar la cuenta original con el nombre provisional.
@@ -265,7 +265,7 @@ Para modificar la configuración, haga clic en el botón rojo y realice la opera
 
 ### Etapa 5: Utilizar sus direcciones de correo migradas
 
-Ya puede utilizar las direcciones de correo electrónico migradas. Para ello, OVHcloud pone a su disposición una aplicación online (_web app_) disponible en la dirección [Webmail](https://www.ovhcloud.com/es-es/mail/). Introduzca las claves de su dirección de correo electrónico.
+Ya puede utilizar las direcciones de correo electrónico migradas. Para ello, OVHcloud pone a su disposición una aplicación online (_web app_) disponible en la dirección [webmail](/links/web/email). Introduzca las claves de su dirección de correo electrónico.
 
 Si ha configurado alguna de las cuentas migradas en un cliente de correo (p. ej. Outlook), deberá volver a configurarlas. La información de conexión al servidor de OVHcloud ha cambiado tras la migración. Para más información, consulte nuestra guía en las secciones relativas a [Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) y [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan). Si no puede reconfigurar la cuenta de forma inmediata, siempre es posible acceder a través de la aplicación online.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo entre plataformas de OVHcloud
 description: Migre cuentas de correo entre dos plataformas de OVHcloud (Exchange, Email Pro, MX Plan) sin perder sus mensajes, contactos ni carpetas
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ Para migrar una solución MX Plan a una plataforma Exchange, consulte nuestra gu
 
 ## Requisitos
 
-- Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/) o [Email Pro](https://www.ovhcloud.com/es-es/emails/email-pro/) o [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/).
-- Disponer de una plataforma de **"destino"** con cuentas [Exchange](https://www.ovhcloud.com/es-es/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/es-es/emails/email-pro/) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+- Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) o [Zimbra](/links/web/emails-zimbra).
+- Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -149,7 +149,7 @@ Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de corr
 El tiempo de migración dependerá de la cantidad de datos que quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
 :::warning
-Una vez realizada la migración, compruebe que todos sus elementos se encuentren conectándose al webmail en la dirección [Webmail](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
+Una vez realizada la migración, compruebe que todos sus elementos se encuentren conectándose al webmail en la dirección [webmail](/links/web/email). **No elimine su dirección de origen hasta que haya confirmado que todo se ha migrado correctamente.** Una vez eliminada la dirección de origen, los elementos que no se hayan migrado se perderán de forma permanente.
 :::
 
 Una vez realizada la migración, podrá conservar o eliminar la cuenta de origen con el nombre provisional.
@@ -176,7 +176,7 @@ Para modificar la configuración, haga clic en la etiqueta roja y realice la ope
 
 ### Utilizar las direcciones de correo migradas
 
-Ya puede utilizar las direcciones de correo electrónico migradas. Para ello, OVHcloud pone a su disposición una aplicación online (_web app_) disponible en la dirección [Webmail](https://www.ovhcloud.com/es-es/mail/). Introduzca las claves de su dirección de correo electrónico.
+Ya puede utilizar las direcciones de correo electrónico migradas. Para ello, OVHcloud pone a su disposición una aplicación online (_web app_) disponible en la dirección [webmail](/links/web/email). Introduzca las claves de su dirección de correo electrónico.
 
 Si ha configurado una de las cuentas migradas en un cliente de correo (p.ej.: Outlook, Thunderbird), deberá volver a configurarlo. La información de conexión al servidor de OVHcloud ha cambiado tras la migración.
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo electrónico con OVHcloud Mail Migrator
 description: Migre sus cuentas de correo a OVHcloud con OVHcloud Mail Migrator (OMM), transfiriendo mensajes, contactos y calendarios
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Requisitos
 
 <Region zones={['eu']}>
-- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Zimbra](https://www.ovhcloud.com/es-es/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/), [Email Pro](https://www.ovhcloud.com/es-es/emails/email-pro/) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Exchange](/links/web/emails-exchange) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Tener un servicio de correo electrónico externo o en OVHcloud, como MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](https://www.ovhcloud.com/es-es/web-hosting/)).
+- Tener un servicio de correo electrónico externo o en OVHcloud, como MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](/links/web/hosting)).
 </Region>
 
 - Tener los identificadores relacionados con las cuentas de correo electrónico que desea migrar (las cuentas de correo electrónico de origen).
@@ -206,7 +206,7 @@ Si se produce un error durante la migración, se le proporcionará un enlace al 
 
 
 :::warning
-Una vez finalizada la migración, conéctese a la cuenta de destino y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) están presentes; para una dirección de correo de OVHcloud, utilice el [Webmail OVHcloud](/links/web/email). **No elimine la cuenta de origen hasta que haya confirmado que todo se ha migrado correctamente**, ya que de lo contrario los elementos que no se hayan migrado se perderán de forma permanente.
+Una vez finalizada la migración, conéctese a la cuenta de destino y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) están presentes; para una dirección de correo de OVHcloud, utilice el [webmail OVHcloud](/links/web/email). **No elimine la cuenta de origen hasta que haya confirmado que todo se ha migrado correctamente**, ya que de lo contrario los elementos que no se hayan migrado se perderán de forma permanente.
 :::
 
 ## Más información

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrar una cuenta de correo MX Plan
 description: Migre una cuenta de correo MX Plan a una cuenta Zimbra de OVHcloud y reasigne su dirección para completar el cambio
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu]
 ---
 
@@ -146,7 +146,7 @@ Utilice las opciones de exportación de su cliente de correo electrónico. En nu
 ### 2 - Eliminar la cuenta MX Plan original y reasignar su dirección a la cuenta Zimbra <a name="step2"></a>
 
 :::warning
-Antes de eliminar su cuenta MX Plan original, conéctese al [Webmail OVHcloud](/links/web/email) y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) se han migrado a la cuenta Zimbra. Una vez eliminada la cuenta original, los elementos que no se hayan migrado se perderán de forma permanente.
+Antes de eliminar su cuenta MX Plan original, conéctese al [webmail OVHcloud](/links/web/email) y compruebe que todos sus elementos (correos, carpetas, contactos, calendarios) se han migrado a la cuenta Zimbra. Una vez eliminada la cuenta original, los elementos que no se hayan migrado se perderán de forma permanente.
 :::
 
 #### 2.1 - Eliminación de la antigua dirección de correo electrónico MX Plan <a name="step21"></a>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer manuellement votre adresse e-mail
 description: Découvrez comment migrer manuellement votre adresse e-mail vers une autre adresse e-mail
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -24,15 +24,15 @@ Nous vous recommandons de faire appel à un [partenaire spécialisé](https://ma
 ## Prérequis
 
 <Region zones={['eu']}>
-- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre [Exchange](https://www.ovhcloud.com/fr/emails-exchange/), [Email Pro](https://www.ovhcloud.com/fr/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre [Exchange](https://www.ovhcloud.com/fr/emails-exchange/) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre [Exchange](/links/web/emails-exchange) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail chez OVHcloud, tel qu'une offre MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 - Disposer des identifiants relatifs aux comptes e-mail que vous souhaitez migrer (les comptes source).
 - Disposer des identifiants relatifs aux comptes e-mail OVHcloud qui reçoivent les données migrées (les comptes de destination).
@@ -73,7 +73,7 @@ Dans un premier temps, vérifiez si la migration automatique est possible par no
 
 Dans ce guide nous avons réalisé les opérations sur les 3 logiciels de messagerie les plus utilisés, **Outlook**, **Mail** sur Mac OS et **Thunderbird**.
 
-Les instructions qui suivent sont décomposées en deux parties :
+Les instructions qui suivent sont décomposées en deux parties :
 
 - **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte. Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Nous vous recommandons néanmoins d'utiliser le système d'exportation de votre logiciel de messagerie.
 
@@ -81,7 +81,7 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 ### Outlook
 
-Si vous possédez un compte e-mail [Exchange OVHcloud](https://www.ovhcloud.com/fr/emails/hosted-exchange/), il est possible de l'exporter directement au format PST depuis l'espace client.
+Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), vous pouvez l'exporter directement au format PST depuis l'espace client.
 
 Une fois sur la page de votre service Exchange, dans l'onglet <code className="action">Comptes e-mail</code>, cliquez sur le bouton <code className="action">...</code> à droite du compte e-mail à exporter, puis sur <code className="action">Exporter au format PST</code>.
 
@@ -259,7 +259,7 @@ La fenêtre suivante vous affiche les profils existants. Cliquez sur <code class
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration/thunderbird-profil-create01.png" loading="lazy" />
     
-    À l’étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
+    À l’étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration/thunderbird-profil-create02.png" loading="lazy" />
     
@@ -280,7 +280,7 @@ La fenêtre suivante vous affiche les profils existants. Cliquez sur <code class
 
 Lorsque vous avez fait le nécessaire en suivant les instructions d'importation, vérifiez que vos éléments sont bien présents sur le serveur.
 
-Connectez-vous au [webmail](https://www.ovhcloud.com/fr/mail/).
+Connectez-vous au [webmail](/links/web/email).
 
 Vous retrouverez dans votre boite de réception et dans la colonne de gauche les dossiers et e-mails de votre adresse e-mail sauvegardée.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrer vers Exchange, Email Pro ou Zimbra
 description: Migrez votre compte e-mail MX Plan vers une offre Exchange, Email Pro ou Zimbra en conservant vos messages, contacts et dossiers
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -10,11 +10,11 @@ import { Region } from '@components/Zone';
 ## Objectif
 
 <Region zones={['eu']}>
-OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dans une offre d'hébergement web), Email Pro, Exchange et Zimbra. Celles-ci bénéficient de fonctionnalités propres et peuvent s'adapter à plusieurs usages. Vos besoins évoluent ? OVHcloud met à votre disposition un outil de migration vous permettant de passer d'une solution à une autre.
+OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dans une offre d'hébergement web), Email Pro, Exchange et Zimbra. Celles-ci bénéficient de fonctionnalités propres et peuvent s'adapter à plusieurs usages. Vos besoins évoluent ? OVHcloud met à votre disposition un outil de migration vous permettant de passer d'une solution à une autre.
 </Region>
 
 <Region zones={['ca']}>
-OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dans une offre d'hébergement web) et Exchange. Celles-ci bénéficient de fonctionnalités propres et peuvent s'adapter à plusieurs usages. Vos besoins évoluent ? OVHcloud met à votre disposition un outil de migration vous permettant de passer d'une solution à une autre.
+OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dans une offre d'hébergement web) et Exchange. Celles-ci bénéficient de fonctionnalités propres et peuvent s'adapter à plusieurs usages. Vos besoins évoluent ? OVHcloud met à votre disposition un outil de migration vous permettant de passer d'une solution à une autre.
 </Region>
 
 <Region zones={['eu']}>
@@ -36,14 +36,14 @@ Si vos e-mails sont uniquement enregistrés en local (configuration en POP ou ar
 
 ## Prérequis
 
-- Disposer d'une adresse e-mail MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'une adresse e-mail MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Disposer d'un service [Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/fr/emails/email-pro/) avec au minimum un compte non configuré (qui apparaîtra sous la forme « @configureme.me ») ou [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/).
+- Disposer d'un service [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) avec au minimum un compte non configuré (qui apparaîtra sous la forme « @configureme.me ») ou [Zimbra](/links/web/emails-zimbra).
 </Region>
 
 <Region zones={['ca']}>
-- Disposer d'un service [Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/) avec au minimum un compte non configuré (qui apparaîtra sous la forme « @configureme.me »).
+- Disposer d'un service [Exchange](/links/web/emails-hosted-exchange) avec au minimum un compte non configuré (qui apparaîtra sous la forme « @configureme.me »).
 </Region>
 
 - **Ne pas avoir paramétré de redirection sur l'adresse e-mail MX Plan que vous souhaitez migrer**.
@@ -76,18 +76,18 @@ Si vos e-mails sont uniquement enregistrés en local (configuration en POP ou ar
 {/* CP-NAV-END:web-mx-plan */}
 
 :::tip
-Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
 :::
 
 ## En pratique
 
-### Étape 1 : Délimiter votre projet
+### Étape 1 : Délimiter votre projet
 
 Les solutions Email Pro et Exchange disposent d'une base de fonctionnalités commune. Néanmoins, des différences subsistent selon les cas d'utilisation. En choisissant une adresse Exchange, vous disposez de la totalité des fonctions collaboratives, comme la synchronisation du calendrier et des contacts. La solution Email Pro, quant à elle, en propose quelques-unes mais celles-ci sont limitées à une utilisation via un webmail uniquement.
 
-Avant de poursuivre, il est donc important de savoir vers quelle offre vous souhaitez migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](https://www.ovhcloud.com/fr/emails/) qui propose un comparatif détaillé des offres. Vous avez la possibilité de cumuler les solutions et donc d'utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
+Avant de poursuivre, il est donc important de savoir vers quelle offre vous souhaitez migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](/links/web/emails) qui propose un comparatif détaillé des offres. Vous pouvez cumuler les solutions et donc d'utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
 
-### Étape 2 : Commander vos comptes Email Pro ou Exchange
+### Étape 2 : Commander vos comptes Email Pro ou Exchange
 
 Cette étape est facultative si vous disposez déjà d'un service Exchange ou Email Pro vers lequel vous effectuez cette migration.
 
@@ -99,15 +99,15 @@ Une fois le compte commandé, laissez-le sous la forme « @configureme.me » dan
 :::
 
 
-### Étape 3 : Réaliser la migration
+### Étape 3 : Réaliser la migration
 
 Avant de débuter votre migration, il vous faudra identifier la version du MX Plan depuis lequel vous migrez.
 
 :::info
-La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l’identifier depuis votre espace client, suivez ces étapes :
+La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l’identifier depuis votre espace client, suivez ces étapes :
 
 1. L’onglet <code className="action">Informations générales</code> est sélectionné par défaut.
-1. Relevez la technologie utilisée sous la mention **Webmail** dans l’encadré `Abonnement`.
+1. Relevez la technologie utilisée sous la mention **webmail** dans l’encadré `Abonnement`.
 
 <img className="thumbnail" alt="Panneau d'abonnement MX Plan affichant la technologie Webmail dans l'espace client OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -150,7 +150,7 @@ La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**, **Cré
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
+1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme MX Plan, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
@@ -170,14 +170,14 @@ Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme
 
 3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
-Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Pour plus d'informations sur OMM, consultez notre guide « [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) ».
 
 <img className="thumbnail" alt="Configuration du compte MX Plan pour la migration dans l'espace client OVHcloud, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account03.png" loading="lazy" />
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
 :::warning
-Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail OVHcloud](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [webmail OVHcloud](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
 :::
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
@@ -204,9 +204,9 @@ Pour plus d'information sur les changements de contacts, consultez notre guide p
 :::
 
 
-La migration peut être effectuée depuis deux interfaces :<br/>
+La migration peut être effectuée depuis deux interfaces :<br/>
 
-- **celle de l'assistant de configuration Hosted Exchange**, uniquement si vous venez de commander un service Hosted Exchange et que vous n'avez encore rien paramétré sur ce dernier ;
+- **celle de l'assistant de configuration Hosted Exchange**, uniquement si vous venez de commander un service Hosted Exchange et que vous n'avez encore rien paramétré sur ce dernier ;
 - **celle du MX Plan**, dès que vous êtes en possession d'un service Email Pro ou Exchange (déjà configuré ou non) et d'une adresse MX Plan que vous souhaitez migrer.
 
 > Pour rappel, avant de débuter la migration, assurez-vous qu'aucune **redirection** ou qu'aucun **répondeur** ne soient paramétrés sur votre MX Plan.
@@ -227,7 +227,7 @@ Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les mes
 
 L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
 
-Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
+Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaissent à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
 #### **Migration depuis l'interface MX Plan**
 
@@ -235,7 +235,7 @@ Pour réaliser la migration depuis cette interface, rendez-vous dans la section 
 
 <img className="thumbnail" alt="Accès à l'outil de migration depuis l'interface MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
-Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur <code className="action">Suivant</code>. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur <code className="action">Suivant</code> pour poursuivre l'opération.
+Dans la fenêtre, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur <code className="action">Suivant</code>. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur <code className="action">Suivant</code> pour poursuivre l'opération.
 
 Si vous ne possédez pas de compte « libre », un bouton <code className="action">Commander des comptes</code> apparaîtra. Suivez les étapes, puis patientez le temps que les comptes soient installés pour effectuer de nouveau la manipulation.
 
@@ -245,7 +245,7 @@ Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voule
 
 </Region>
 
-### Étape 4 : Vérifier ou modifier la configuration de votre domaine
+### Étape 4 : Vérifier ou modifier la configuration de votre domaine
 
 À cette étape, vos adresses e-mail doivent déjà être migrées et fonctionnelles. Par sécurité, nous vous invitons à vous assurer que la configuration de votre domaine est correcte en consultant votre espace client.
 
@@ -267,9 +267,9 @@ Si vous venez juste de réaliser la migration ou de modifier un enregistrement D
 
 Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. Cette dernière nécessite un temps de propagation de 4 à 24 heures maximum avant d’être pleinement effective.
 
-### Étape 5 : Utiliser vos adresses e-mail migrées
+### Étape 5 : Utiliser vos adresses e-mail migrées
 
-Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [Webmail](https://www.ovhcloud.com/fr/mail/). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
 
 Si vous avez configuré l'un des comptes migrés sur un client de messagerie (comme Outlook), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration. Pour vous aider dans vos manipulations, consultez notre documentation depuis les sections des guides consacrées à [Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) et [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/landing-page-microsoft-exchange). Si vous n'êtes pas en mesure de reconfigurer le compte dans l'immédiat, l'accès via l'applicatif en ligne est toujours possible.
 
@@ -285,7 +285,7 @@ Après une migration, n'hésitez pas à explorer l'ensemble des dossiers et sous
 
 ### Migrer Manuellement
 
-Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvelle offre e-mail OVHcloud en utilisant uniquement votre logiciel de messagerie. Appuyez-vous de notre guide [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration). Nous vous préconisons toutefois de n'utiliser cette méthode que lorsque les méthodes principales ne sont pas possibles.
+Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvelle offre e-mail OVHcloud en utilisant uniquement votre logiciel de messagerie. Appuyez-vous de notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) ». Nous vous préconisons toutefois de n'utiliser cette méthode que lorsque les méthodes principales ne sont pas possibles.
 
 ## Aller plus loin
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -85,7 +85,7 @@ Quelle que soit la méthode de migration, nous vous recommandons vivement de sau
 
 Les solutions Email Pro et Exchange disposent d'une base de fonctionnalités commune. Néanmoins, des différences subsistent selon les cas d'utilisation. En choisissant une adresse Exchange, vous disposez de la totalité des fonctions collaboratives, comme la synchronisation du calendrier et des contacts. La solution Email Pro, quant à elle, en propose quelques-unes mais celles-ci sont limitées à une utilisation via un webmail uniquement.
 
-Avant de poursuivre, il est donc important de savoir vers quelle offre vous souhaitez migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](/links/web/emails) qui propose un comparatif détaillé des offres. Vous pouvez cumuler les solutions et donc d'utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
+Avant de poursuivre, il est donc important de savoir vers quelle offre vous souhaitez migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](/links/web/emails) qui propose un comparatif détaillé des offres. Vous pouvez cumuler les solutions et donc utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
 
 ### Étape 2 : Commander vos comptes Email Pro ou Exchange
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail entre plateformes OVHcloud
 description: Migrez des comptes e-mail entre deux plateformes OVHcloud (Exchange, Email Pro, MX Plan) sans perdre vos messages, contacts ni dossiers
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -11,11 +11,11 @@ import { Region } from '@components/Zone';
 ## Objectif
 
 <Region zones={['eu']}>
-Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra. Vous trouverez dans ce guide un processus de migration en deux phases :
+Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra. Vous trouverez dans ce guide un processus de migration en deux phases :
 </Region>
 
 <Region zones={['ca']}>
-Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange vers une autre plateforme Exchange ou MX Plan. Vous trouverez dans ce guide un processus de migration en deux phases :
+Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange vers une autre plateforme Exchange ou MX Plan. Vous trouverez dans ce guide un processus de migration en deux phases :
 </Region>
 
 1. **Configurer la plateforme de destination**.
@@ -25,11 +25,11 @@ Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange
 
 :::info
 <Region zones={['eu']}>
-Pour migrer une solution MX Plan vers une plateforme Exchange ou Email Pro, nous vous invitons à suivre notre guide [Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+Pour migrer une solution MX Plan vers une plateforme Exchange ou Email Pro, nous vous invitons à suivre notre guide « [Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel) ».
 </Region>
 
 <Region zones={['ca']}>
-Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous invitons à suivre notre guide [Migrer une adresse e-mail MX Plan vers un compte Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel).
+Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous invitons à suivre notre guide « [Migrer une adresse e-mail MX Plan vers un compte Exchange](/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel) ».
 </Region>
 
 :::
@@ -45,8 +45,8 @@ Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous inviton
 
 ## Prérequis
 
-- Disposer d'une plateforme **« source »** avec des comptes [Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/) ou [Email Pro](https://www.ovhcloud.com/fr/emails/email-pro/) configurés ou [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/).
-- Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](https://www.ovhcloud.com/fr/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/fr/emails/email-pro/) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+- Disposer d'une plateforme **« source »** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou [Email Pro](/links/web/email-pro) configurés ou [Zimbra](/links/web/emails-zimbra).
+- Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -76,7 +76,7 @@ Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous inviton
 {/* CP-NAV-END:web-mx-plan */}
 
 :::tip
-Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
 :::
 
 ## En pratique
@@ -102,7 +102,7 @@ La migration de vos comptes e-mail se fera en 3 grandes étapes, **Renommer** le
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="email-migration" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform03.mp4" />
 
 :::warning
-Cas particuliers :
+Cas particuliers :
 
 - Si vous devez migrer **un compte Exchange ou Zimbra PRO** vers un compte **Email Pro** ou **Zimbra STARTER**, vous devez vous assurer que vos comptes e-mail n'excèdent pas les 10 Go (Email Pro) ou 15 Go (Zimbra STARTER). Les fonctions collaboratives, la synchronisation des calendriers et contacts ne sont pas présentes sur Email Pro ou Zimbra STARTER et ne peuvent pas être migrées.
 - Si vous devez migrer **un compte Exchange, Email Pro ou Zimbra** vers un compte **MX Plan**, vous devez vous assurer que votre compte e-mail n'excède pas les 5 Go. Les fonctions collaboratives, la synchronisation des calendriers et contacts ne sont pas présentes sur MX Plan et ne peuvent pas être migrées.
@@ -112,7 +112,7 @@ Cas particuliers :
 
 #### Renommer
 
-Renommez le compte e-mail à migrer avec un nom provisoire (exemple : pour migrer le compte e-mail *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
+Renommez le compte e-mail à migrer avec un nom provisoire (exemple : pour migrer le compte e-mail *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme e-mail, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
@@ -129,7 +129,7 @@ Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme
 #### Migrer
 
 :::warning
-Seules les données de vos comptes e-mail seront migrées (e-mails, contacts, calendriers, règles de boîte de réception, etc.). Les fonctionnalités liées à votre plateforme devront être recréées sur la nouvelle plateforme :
+Seules les données de vos comptes e-mail seront migrées (e-mails, contacts, calendriers, règles de boîte de réception, etc.). Les fonctionnalités liées à votre plateforme devront être recréées sur la nouvelle plateforme :
 
 - [Alias](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections) 
 - [Délégations de droits](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/permissions-delegation) 
@@ -142,14 +142,14 @@ Seules les données de vos comptes e-mail seront migrées (e-mails, contacts, ca
 
 Migrez le compte e-mail « source » vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
-Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud).
+Pour plus d'informations sur OMM, consultez notre guide « [Migrer des comptes e-mail via OVHcloud Mail Migrator](/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud) ».
 
 <img className="thumbnail" alt="Migration du compte e-mail avec OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform06.png" loading="lazy" />
 
 Le délai de migration dépend de la quantité de données à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
 :::warning
-Vérifiez, après la migration, que vous retrouvez tous vos éléments en vous connectant au webmail à l'adresse [Webmail](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
+Vérifiez, après la migration, que vous retrouvez tous vos éléments en vous connectant au webmail à l'adresse [webmail](/links/web/email). **Ne supprimez pas votre adresse d'origine tant que vous n'avez pas confirmé que tout a bien été migré** : une fois l'adresse supprimée, les éléments non migrés seront définitivement perdus.
 :::
 
 Une fois la migration effectuée, vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire.
@@ -174,9 +174,9 @@ Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la ma
 
 ### Utiliser vos adresses e-mail migrées
 
-Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [Webmail](https://www.ovhcloud.com/fr/mail/). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
 
-Si vous avez configuré l'un des comptes migrés sur un client de messagerie (exemple : Outlook, Thunderbird), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration.
+Si vous avez configuré l'un des comptes migrés sur un client de messagerie (exemple : Outlook, Thunderbird), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration.
 
 :::info
 Vous pouvez également migrer manuellement des adresses e-mail vers OVHcloud en utilisant notre outil [OVHcloud Mail Migrator (OMM)](/links/web/omm). Pour cela, vous devez être en possession des informations (utilisateur, mot de passe, serveurs) de l'e-mail source et de l'e-mail de destination.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail via OVHcloud Mail Migrator
 description: Migrez vos comptes e-mail vers OVHcloud avec OVHcloud Mail Migrator (OMM), avec transfert des messages, contacts et agendas
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,22 +20,22 @@ import { Region } from '@components/Zone';
 ## Prérequis
 
 <Region zones={['eu']}>
-- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Zimbra](https://www.ovhcloud.com/fr/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/fr/emails-exchange/), [Email Pro](https://www.ovhcloud.com/fr/emails/email-pro/) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Exchange](https://www.ovhcloud.com/fr/emails-exchange/) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Exchange](/links/web/emails-exchange) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Disposer d'un service e-mail externe ou chez OVHcloud, tel que MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](https://www.ovhcloud.com/fr/web-hosting/)).
+- Disposer d'un service e-mail externe ou chez OVHcloud, tel que MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 </Region>
 
 - Disposer des identifiants relatifs aux comptes e-mail que vous souhaitez migrer (les comptes e-mail source).
 - Disposer des identifiants relatifs aux comptes e-mail de destination.
 
 :::tip
-Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
 :::
 
 ## En pratique
@@ -50,8 +50,8 @@ Avant de lancer une migration, il est nécessaire de créer un projet. Ce projet
 
 Cliquez sur <code className="action">Nouvelle migration</code> pour débuter la création de votre projet.
 
-**Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui servira à recevoir les identifiants et les notifications de suivi de vos migrations. Il est déconseillé de renseigner une des adresses e-mail qui sera migrée dans votre projet.
-**Mot de passe du projet** : Saisissez un mot de passe qui servira à vous connecter à votre projet. Il doit contenir au moins 10 caractères et inclure au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule.
+**Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui servira à recevoir les identifiants et les notifications de suivi de vos migrations. Il est déconseillé de renseigner une des adresses e-mail qui sera migrée dans votre projet.
+**Mot de passe du projet** : Saisissez un mot de passe qui servira à vous connecter à votre projet. Il doit contenir au moins 10 caractères et inclure au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule.
 **Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
 Cliquez sur <code className="action">Créer mon projet</code> pour lancer la création du projet.
@@ -61,7 +61,7 @@ Sur l'adresse e-mail de contact du projet, vous recevrez un e-mail de confirmati
 <img className="thumbnail" alt="Création d'un projet de migration dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-project-01.png" loading="lazy" />
 
 :::info
-En cas d’inactivité pendant 60 jours, le projet de migration et toutes les données associées seront automatiquement supprimés.
+En cas d'inactivité pendant 60 jours, le projet de migration et toutes les données associées seront automatiquement supprimés.
 :::
 
 
@@ -77,42 +77,42 @@ Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'a
 
 <img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
-Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
+Sur la nouvelle page qui s'affiche, renseignez les informations de connexion du compte source et du compte de destination pour planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
 Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 
-- **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
-- **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
-- **Importation de fichiers** : Il est possible de migrer le contenu de fichiers PST, ICS, CSV et XML Rules via OMM vers un compte e-mail de destination. Lorsque cette fonction est sélectionnée, il suffit de glisser-déposer votre document dans la zone prévue à cet effet ou de parcourir votre terminal via le bouton <code className="action">Parcourir vos fichiers</code>.
+- **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
+- **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
+- **Importation de fichiers** : Vous pouvez migrer le contenu de fichiers PST, ICS, CSV et XML Rules via OMM vers un compte e-mail de destination. Lorsque cette fonction est sélectionnée, il suffit de glisser-déposer votre document dans la zone prévue à cet effet ou de parcourir votre terminal via le bouton <code className="action">Parcourir vos fichiers</code>.
 
 <img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-03.png" loading="lazy" />
 
-Complétez les informations selon le type de compte :
+Complétez les informations selon le type de compte :
 
 - **Compte source**
-    - **Type de compte** : Sélectionnez le type de compte source.
-    - **E-mail** : Saisissez l'adresse e-mail du compte source.
-    - **Mot de passe** : Saisissez le mot de passe du compte source.
-    - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail que vous souhaitez migrer.
-    - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
-    - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail source.
-    - **Platform** *(selon le type)* : Sélectionnez la plateforme associée au compte e-mail source.
-    - **Service** *(selon le type)* : Sélectionnez le service associé au compte e-mail source.
-    - **Paramètres avancés** > **Identifiant du compte de délégation** *(selon le type)* : Lorsque le compte e-mail que vous migrez est un compte partagé, vous devez renseigner l'adresse e-mail du compte administrateur sur ce compte de délégation.<br/><br/>
+    - **Type de compte** : Sélectionnez le type de compte source.
+    - **E-mail** : Saisissez l'adresse e-mail du compte source.
+    - **Mot de passe** : Saisissez le mot de passe du compte source.
+    - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail que vous souhaitez migrer.
+    - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
+    - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail source.
+    - **Platform** *(selon le type)* : Sélectionnez la plateforme associée au compte e-mail source.
+    - **Service** *(selon le type)* : Sélectionnez le service associé au compte e-mail source.
+    - **Paramètres avancés** > **Identifiant du compte de délégation** *(selon le type)* : Lorsque le compte e-mail que vous migrez est un compte partagé, vous devez renseigner l'adresse e-mail du compte administrateur sur ce compte de délégation.<br/><br/>
 
 - **Compte de destination**
-    - **Type de compte** : Sélectionnez le type de compte de destination.
-    - **E-mail** : Saisissez l'adresse e-mail de destination.
-    - **Mot de passe** : Saisissez le mot de passe associé au compte de destination.
-    - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail de destination.
-    - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
-    - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail de destination.
-    - **Platform** *(selon le type)* : Sélectionnez la plateforme associée au compte e-mail de destination.
-    - **Service** *(selon le type)* : Sélectionnez le service associé au compte e-mail de destination.
-    - **Paramètres avancés** > **Identifiant du compte de délégation** *(selon le type)* : Lorsque le compte e-mail de destination est un compte partagé, vous devez renseigner l'adresse e-mail du compte administrateur sur ce compte de délégation.<br/><br/>
+    - **Type de compte** : Sélectionnez le type de compte de destination.
+    - **E-mail** : Saisissez l'adresse e-mail de destination.
+    - **Mot de passe** : Saisissez le mot de passe associé au compte de destination.
+    - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail de destination.
+    - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
+    - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail de destination.
+    - **Platform** *(selon le type)* : Sélectionnez la plateforme associée au compte e-mail de destination.
+    - **Service** *(selon le type)* : Sélectionnez le service associé au compte e-mail de destination.
+    - **Paramètres avancés** > **Identifiant du compte de délégation** *(selon le type)* : Lorsque le compte e-mail de destination est un compte partagé, vous devez renseigner l'adresse e-mail du compte administrateur sur ce compte de délégation.<br/><br/>
 
-- **Début du transfert** : Vous pouvez lancer la migration `Immédiatement` ou cocher `Plus tard` pour la reporter. La migration différée vous permet de la déclencher automatiquement à une date et une heure que vous définissez.
-- **Données à transférer** : En fonction du type de compte e-mail que vous migrez et du compte de destination, cette section vous indiquera les différents types de données qui sont prises en charge lors de la migration. Cela dépend du compte source et du compte de destination.
+- **Début du transfert** : Vous pouvez lancer la migration `Immédiatement` ou cocher `Plus tard` pour la reporter. La migration différée vous permet de la déclencher automatiquement à une date et une heure que vous définissez.
+- **Données à transférer** : En fonction du type de compte e-mail que vous migrez et du compte de destination, cette section vous indiquera les différents types de données qui sont prises en charge lors de la migration. Cela dépend du compte source et du compte de destination.
 
 <img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 3" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-04.png" loading="lazy" />
 
@@ -121,7 +121,7 @@ Si vous migrez un compte disposant de fonctionnalités que le compte destination
 :::
 
 
-Une fois les paramètres des comptes source et destination complétés, cliquez sur :
+Une fois les paramètres des comptes source et destination complétés, cliquez sur :
 
 - <code className="action">Migrer et ajouter un autre compte</code> si vous souhaitez ajouter une autre migration dans la liste de votre projet.
 - <code className="action">Migrer mon compte</code> pour lancer la migration paramétrée et revenir à l'accueil du projet.
@@ -132,7 +132,7 @@ Lors d'une migration vers ou depuis un compte OVHcloud, vous pouvez sélectionne
 
 <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-00.png" loading="lazy" />
 
-Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
+Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 
 <Tabs>
   <Tab label="Étape 1">
@@ -141,7 +141,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
     <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 2" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-01.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 2">
-    Connectez-vous au compte client OVHcloud :
+    Connectez-vous au compte client OVHcloud :
     
     - Saisissez l'identifiant ou l'adresse e-mail associé(e) au compte OVHcloud, saisissez le mot de passe correspondant et cliquez sur <code className="action">Se connecter</code> ;
     - ou cliquez sur <code className="action">Continuer</code> si vous étiez déjà identifié.
@@ -159,9 +159,9 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
     <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 4" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-03.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 4">
-    - Vous serez à présent en mesure de sélectionner vos services et comptes à l'aide de menus déroulants. Cela facilite la recherche des éléments et permet d'éviter les erreurs de saisie. Il est toutefois nécessaire de saisir le mot de passe associé au compte e-mail sélectionné.
+    - Vous pouvez sélectionner vos services et comptes à l'aide de menus déroulants. Cela facilite la recherche des éléments et permet d'éviter les erreurs de saisie. Il est toutefois nécessaire de saisir le mot de passe associé au compte e-mail sélectionné.
     
-    Exemple avec un service Zimbra :
+    Exemple avec un service Zimbra :
     
     <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 5" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-04.png" loading="lazy" />
   </Tab>
@@ -169,7 +169,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 
 
 :::warning
-Il est possible de déconnecter les accès en cours depuis un espace client OVHcloud en cliquant sur <code className="action">Se déconnecter</code>, puis sous la mention `Identifiant OVHcloud` cliquez sur <code className="action">Se déconnecter du compte</code>.
+Vous pouvez déconnecter les accès en cours depuis un espace client OVHcloud en cliquant sur <code className="action">Se déconnecter</code>, puis sous la mention `Identifiant OVHcloud` cliquez sur <code className="action">Se déconnecter du compte</code>.
 
 <img className="thumbnail" alt="Migration via la connexion au compte OVHcloud dans OMM, étape 6" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-sso-05.png" loading="lazy" />
 :::
@@ -177,7 +177,7 @@ Il est possible de déconnecter les accès en cours depuis un espace client OVHc
 
 ### Suivre un projet de migration <a name="follow-migration"></a>
 
-Il existe deux moyens pour accéder au suivi de projet de migration :
+Il existe deux moyens pour accéder au suivi de projet de migration :
 
 - Dans l'e-mail reçu lors de la création de votre projet, vous trouverez un lien qui vous permet d'accéder à la page de connexion du projet avec l'`Identifiant du projet` prérempli. Seul le `Mot de passe du projet` est à saisir.
 - Depuis la page d'accueil d'[OMM](/links/web/omm), cliquez sur <code className="action">Suivre une migration</code>. Saisissez ensuite votre `Identifiant du projet` et votre `Mot de passe du projet`.
@@ -188,7 +188,7 @@ Cliquez ensuite sur <code className="action">Se connecter au projet</code> pour 
 
 Depuis cette page, vous retrouvez la liste des migrations en cours ou planifiées. Le statut du projet s'affiche également à droite.
 
-Cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne d'une migration pour afficher les options :
+Cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne d'une migration pour afficher les options :
 
 - <code className="action">Voir plus de détails</code> : Vous êtes renvoyé vers une page vous permettant de suivre la progression d'une migration et de lire le rapport une fois la migration terminée.
 - <code className="action">Annuler la migration</code> : Permet d'annuler la migration en cours. Les éléments déjà migrés seront conservés sur le compte de destination.
@@ -196,7 +196,7 @@ Cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne 
 
 <img className="thumbnail" alt="Suivi de l'avancement d'une migration dans OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-02.png" loading="lazy" />
 
-Exemple de suivi de migration :
+Exemple de suivi de migration :
 
 <img className="thumbnail" alt="Exemple de suivi de migration dans OMM" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-migration-follow-03.png" loading="lazy" />
 
@@ -206,7 +206,7 @@ Si une erreur survient durant la migration, un lien vers le journal des erreurs 
 
 
 :::warning
-Une fois la migration terminée, connectez-vous au compte de destination et vérifiez que vous retrouvez tous vos éléments (e-mails, dossiers, contacts, agendas) — pour une adresse e-mail OVHcloud, utilisez le [Webmail OVHcloud](/links/web/email). **Ne supprimez pas le compte source tant que vous n'avez pas confirmé que tout a bien été migré**, faute de quoi les éléments non migrés seront définitivement perdus.
+Une fois la migration terminée, connectez-vous au compte de destination et vérifiez que vous retrouvez tous vos éléments (e-mails, dossiers, contacts, agendas) — pour une adresse e-mail OVHcloud, utilisez le [webmail OVHcloud](/links/web/email). **Ne supprimez pas le compte source tant que vous n'avez pas confirmé que tout a bien été migré**, faute de quoi les éléments non migrés seront définitivement perdus.
 :::
 
 ## Aller plus loin

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -77,7 +77,7 @@ Pour revenir plus tard sur un projet existant, connectez-vous depuis la page d'a
 
 <img className="thumbnail" alt="Création d'une nouvelle migration dans OVHcloud Mail Migrator, étape 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-omm/omm-create-migration-02.png" loading="lazy" />
 
-Sur la nouvelle page qui s'affiche, renseignez les informations de connexion du compte source et du compte de destination pour planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
+Sur la nouvelle page qui s'affiche, renseignez les informations de connexion du compte source et du compte de destination pour planifier la migration ou la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
 Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrer un compte e-mail MX Plan
 description: Migrez un compte e-mail MX Plan vers un compte Zimbra OVHcloud, puis réattribuez son adresse pour finaliser le changement
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu]
 ---
 
@@ -36,7 +36,7 @@ Si vous souhaitez faire évoluer votre offre e-mail MX Plan vers une offre [Zimb
 </Region>
 
 :::tip
-Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
+Quelle que soit la méthode de migration, nous vous recommandons vivement de sauvegarder votre boîte e-mail au préalable, par précaution contre toute perte de données. Notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration) » explique, étape par étape, comment sauvegarder une boîte e-mail (par exemple via un export au format PST) : réalisez cette sauvegarde avant de démarrer la migration.
 :::
 
 ## En pratique
@@ -45,7 +45,7 @@ Quelle que soit la méthode de migration, nous vous recommandons vivement de sau
 Si votre compte e-mail gère des informations sensibles ou si vous rencontrez des problèmes lors de la migration, nous vous recommandons d'attendre la mise en place de l'outil d'automatisation dans l'espace client OVHcloud.
 :::
 
-La migration d'un compte e-mail MX Plan vers un compte e-mail Zimbra se fait en 2 temps. Pour éviter de couper la réception sur l'adresse e-mail d'origine, il est nécessaire de respecter le processus suivant :
+La migration d'un compte e-mail MX Plan vers un compte e-mail Zimbra se fait en 2 temps. Pour éviter de couper la réception sur l'adresse e-mail d'origine, il est nécessaire de respecter le processus suivant :
 
 1. **[Transférer le contenu du compte MX Plan vers un compte Zimbra](#step1)**
     - [1.1 - Création d'une adresse e-mail Zimbra](#step11)
@@ -69,13 +69,13 @@ Si vous disposez déjà d'une adresse e-mail Zimbra, passez à la [Migration des
 
 Créez dans un premier temps une adresse e-mail avec un nom provisoire. Vous pouvez créer, par exemple, l'adresse `contact2@mydomain.ovh` si vous devez migrer l'adresse `contact@mydomain.ovh`.
 
-Pour créer une adresse e-mail Zimbra, consultez la section « Créer un compte e-mail » de notre guide [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra).
+Pour créer une adresse e-mail Zimbra, consultez la section « Créer un compte e-mail » de notre guide « [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra) ».
 
 #### 1.2 - Migration des e-mails avec OVHcloud Mail Migrator <a name="step12"></a>
 
 Utilisez l'outil de migration [**O**VH **M**ail **M**igrator](/links/web/omm) (**OMM**) pour transférer le contenu du compte MX Plan d'origine vers le nouveau compte de destination Zimbra, en reprenant l'exemple évoqué dans le schéma plus haut.
 
-La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la migration, puis suivre son avancement. Cliquez sur chaque onglet pour afficher les instructions correspondantes.
+La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la migration, puis suivre son avancement. Cliquez sur chaque onglet pour afficher les instructions correspondantes.
 
 <Tabs>
   <Tab label="Étape 1">
@@ -85,8 +85,8 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     <img className="thumbnail" alt="Page d'accueil d'OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-01.png" loading="lazy" />
 
-    - **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui recevra les identifiants et les notifications de suivi. N'utilisez pas une adresse qui sera migrée dans ce projet.
-    - **Mot de passe du projet** : Définissez un mot de passe (10 caractères minimum, avec au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule).
+    - **Adresse e-mail de contact du projet** : Saisissez une adresse e-mail qui recevra les identifiants et les notifications de suivi. N'utilisez pas une adresse qui sera migrée dans ce projet.
+    - **Mot de passe du projet** : Définissez un mot de passe (10 caractères minimum, avec au moins 1 caractère spécial, 1 chiffre, 1 majuscule et 1 minuscule).
     - **Conditions générales** : Cochez la case `J'accepte les conditions générales`.
 
     Cliquez sur <code className="action">Créer mon projet</code>. Vous recevrez un e-mail de confirmation contenant l'identifiant unique du projet.
@@ -100,12 +100,12 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
 
     <img className="thumbnail" alt="Création de la migration de MX Plan vers Zimbra dans OVHcloud Mail Migrator" src="/images/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra/omm-create-migration.png" loading="lazy" />
 
-    - **Compte source** :
-        - **Type de compte** : sous la catégorie `OVHcloud`, choisissez `MX Plan` ou `Auto détection`. Cliquez sur <code className="action">Se connecter</code> pour vous identifier avec votre compte OVHcloud et sélectionner automatiquement le service et l'adresse à migrer (exemple : `contact@mydomain.ovh`). Saisissez ensuite le mot de passe de ce compte e-mail.
-    - **Compte de destination** :
-        - **Type de compte** : sous la catégorie `OVHcloud`, choisissez `Zimbra`. Cliquez sur <code className="action">Se connecter</code> pour vous identifier avec votre compte OVHcloud et sélectionner le service Zimbra et l'adresse de destination (exemple : `contact2@mydomain.ovh`). Saisissez ensuite le mot de passe de ce compte e-mail.
-    - **Données à transférer** : Vérifiez les types de données pris en charge et décochez ceux que vous ne souhaitez pas migrer.
-    - **Début du transfert** : Choisissez `Immédiatement` ou cochez `Plus tard` pour planifier la migration à une date et heure définies.
+    - **Compte source** :
+        - **Type de compte** : sous la catégorie `OVHcloud`, choisissez `MX Plan` ou `Auto détection`. Cliquez sur <code className="action">Se connecter</code> pour vous identifier avec votre compte OVHcloud et sélectionner automatiquement le service et l'adresse à migrer (exemple : `contact@mydomain.ovh`). Saisissez ensuite le mot de passe de ce compte e-mail.
+    - **Compte de destination** :
+        - **Type de compte** : sous la catégorie `OVHcloud`, choisissez `Zimbra`. Cliquez sur <code className="action">Se connecter</code> pour vous identifier avec votre compte OVHcloud et sélectionner le service Zimbra et l'adresse de destination (exemple : `contact2@mydomain.ovh`). Saisissez ensuite le mot de passe de ce compte e-mail.
+    - **Données à transférer** : Vérifiez les types de données pris en charge et décochez ceux que vous ne souhaitez pas migrer.
+    - **Début du transfert** : Choisissez `Immédiatement` ou cochez `Plus tard` pour planifier la migration à une date et heure définies.
 
     Cliquez sur <code className="action">Migrer mon compte</code> pour lancer la migration.
 
@@ -114,12 +114,12 @@ La migration avec OMM se déroule en 3 étapes : créer un projet, configurer la
   <Tab label="Étape 3">
     **Suivre la migration**
 
-    Deux méthodes vous permettent d'accéder au suivi de votre projet de migration :
+    Deux méthodes vous permettent d'accéder au suivi de votre projet de migration :
 
     - Depuis l'e-mail reçu lors de la création du projet, via le lien fourni (l'identifiant du projet y est prérempli).
-    - Depuis la page d'accueil d'[OMM](/links/web/omm) : cliquez sur <code className="action">Suivre une migration</code>, saisissez votre `Identifiant du projet` et votre `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
+    - Depuis la page d'accueil d'[OMM](/links/web/omm) : cliquez sur <code className="action">Suivre une migration</code>, saisissez votre `Identifiant du projet` et votre `Mot de passe du projet`, puis cliquez sur <code className="action">Se connecter au projet</code>.
 
-    Depuis la page du projet, cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne de votre migration pour afficher les options :
+    Depuis la page du projet, cliquez sur le bouton <code className="action">⋮</code> à droite de la ligne de votre migration pour afficher les options :
 
     - <code className="action">Voir plus de détails</code> : Suivez la progression de la migration et consultez le rapport une fois terminée.
     - <code className="action">Annuler la migration</code> : Annule la migration en cours. Les éléments déjà migrés sont conservés sur le compte de destination.
@@ -146,12 +146,12 @@ Utilisez les options d'export de votre client de messagerie. Vous trouverez, dan
 ### 2 - Supprimer le compte MX Plan d'origine et réassigner son adresse au compte Zimbra <a name="step2"></a>
 
 :::warning
-Avant de supprimer votre compte MX Plan d'origine, connectez-vous au [Webmail OVHcloud](/links/web/email) et vérifiez que tous vos éléments (e-mails, dossiers, contacts, agendas) ont bien été migrés vers le compte Zimbra. Une fois le compte d'origine supprimé, les éléments non migrés seront définitivement perdus.
+Avant de supprimer votre compte MX Plan d'origine, connectez-vous au [webmail OVHcloud](/links/web/email) et vérifiez que tous vos éléments (e-mails, dossiers, contacts, agendas) ont bien été migrés vers le compte Zimbra. Une fois le compte d'origine supprimé, les éléments non migrés seront définitivement perdus.
 :::
 
 #### 2.1 - Suppression de l'ancienne adresse e-mail MX Plan <a name="step21"></a>
 
-Pour supprimer l'adresse e-mail MX Plan (exemple : `contact@mydomain.ovh`), suivez notre guide « [Supprimer un compte e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account) ».
+Pour supprimer l'adresse e-mail MX Plan (exemple : `contact@mydomain.ovh`), suivez notre guide « [Supprimer un compte e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account) ».
 
 :::warning
 Si vous migrez depuis un compte MX Plan utilisant le webmail Zimbra, attendez 5 minutes que la suppression soit effective avant de renommer le second compte e-mail.
@@ -163,7 +163,7 @@ Dans votre espace client OVHcloud, accédez à votre service Zimbra et renommez 
 
 ### Conclusion <a name="conclusion"></a>
 
-Votre compte e-mail est maintenant migré vers Zimbra. Pour finaliser la configuration, consultez les guides ci-dessous :
+Votre compte e-mail est maintenant migré vers Zimbra. Pour finaliser la configuration, consultez les guides ci-dessous :
 
 - [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
 - [Configurer votre adresse e-mail Zimbra sur un logiciel de messagerie](/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps)

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migra manualmente il tuo indirizzo email
 description: Come migrare manualmente il tuo indirizzo email verso un altro indirizzo email
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di un servizio email OVHcloud, come [Exchange](https://www.ovhcloud.com/it/emails-exchange/), [Email Pro](https://www.ovhcloud.com/it/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/it/emails/zimbra-emails/) o MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/))
+- Disporre di un servizio email OVHcloud, come [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](/links/web/hosting))
 </Region>
 
 <Region zones={['ca']}>
-- Disporre di un servizio email OVHcloud, come [Exchange](https://www.ovhcloud.com/it/emails-exchange/) o MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/))
+- Disporre di un servizio email OVHcloud, come [Exchange](/links/web/emails-exchange) o MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](/links/web/hosting))
 </Region>
 
 <Region zones={['apac']}>
-- Disporre di un servizio email OVHcloud, come MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/))
+- Disporre di un servizio email OVHcloud, come MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](/links/web/hosting))
 </Region>
 - Disporre delle credenziali relative agli account e-mail da migrare
 - Disporre delle credenziali relative agli account e-mail OVHcloud che ricevono i dati migrati (gli account di destinazione).
@@ -78,7 +78,7 @@ Le seguenti istruzioni sono suddivise in due parti:
 
 ### Outlook
 
-Se disponi di un account e-mail [Exchange OVHcloud](https://www.ovhcloud.com/it/emails/hosted-exchange/), è possibile esportarlo direttamente in formato PST dallo Spazio Cliente.
+Se disponi di un account e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), è possibile esportarlo direttamente in formato PST dallo Spazio Cliente.
 
 Una volta nella pagina del tuo servizio Exchange, nella scheda <code className="action">Account e-mail</code>, clicca sul pulsante <code className="action">...</code> a destra dell'account da esportare e poi su <code className="action">Esporta in formato PST</code>.
 
@@ -277,7 +277,7 @@ Allo step successivo, assegna un nome al tuo profilo e identifica la cartella in
 
 Verifica che i tuoi elementi siano presenti sul server quando hai effettuato l'operazione giusta seguendo le istruzioni d'importazione.
 
-Accedi alla [Webmail](https://www.ovhcloud.com/it/mail/).
+Accedi alla [webmail](/links/web/email).
 
 Nella casella di ricezione e nella colonna di sinistra, troverai le cartelle e le email del tuo indirizzo email salvato.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrare verso Exchange, Email Pro o Zimbra
 description: Migra il tuo account email MX Plan verso un'offerta Exchange, Email Pro o Zimbra mantenendo messaggi, contatti e cartelle
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -34,14 +34,14 @@ Se le tue e-mail sono conservate localmente (configurazione POP o archivio local
 
 ## Prerequisiti
 
-- Disporre di un account email MX Plan (incluso in una soluzione di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un account email MX Plan (incluso in una soluzione di [hosting Web OVHcloud](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Disporre di un servizio [Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/) o [Email Pro](https://www.ovhcloud.com/it/emails/email-pro/) con almeno un account non configurato (che apparirà nel formato "@configureme.me").
+- Disporre di un servizio [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) con almeno un account non configurato (che apparirà nel formato "@configureme.me").
 </Region>
 
 <Region zones={['ca']}>
-- Disporre di un servizio [Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/) con almeno un account non configurato (che apparirà nel formato "@configureme.me").
+- Disporre di un servizio [Exchange](/links/web/emails-hosted-exchange) con almeno un account non configurato (che apparirà nel formato "@configureme.me").
 </Region>
 
 - **Non aver configurato un reindirizzamento sull'indirizzo email MX Plan che vuoi migrare**.
@@ -83,7 +83,7 @@ Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di esegui
 
 Le soluzioni Email Pro ed Exchange dispongono di una base di funzionalità comune. Permangono, tuttavia, differenze a seconda dei casi di utilizzo. Scegliendo un indirizzo Exchange, disporrete di tutte le funzioni collaborative, come la sincronizzazione del calendario e dei contatti. Email Pro, invece, ne propone alcune ma sono limitate all'utilizzo esclusivamente via Webmail.
 
-Prima di proseguire, è importante sapere verso quale offerta vuoi migrare i tuoi indirizzi email MX Plan. Per maggiori informazioni, consulta la pagina delle [soluzioni email professionali di OVHcloud](https://www.ovhcloud.com/it/emails/) che propone un confronto dettagliato delle offerte. Puoi cumulare le soluzioni e quindi utilizzare per uno stesso dominio uno o più account Email Pro ed Exchange. In caso di migrazione di più account, ti consigliamo di impostare un piano di migrazione.
+Prima di proseguire, è importante sapere verso quale offerta vuoi migrare i tuoi indirizzi email MX Plan. Per maggiori informazioni, consulta la pagina delle [soluzioni email professionali di OVHcloud](/links/web/emails) che propone un confronto dettagliato delle offerte. Puoi cumulare le soluzioni e quindi utilizzare per uno stesso dominio uno o più account Email Pro ed Exchange. In caso di migrazione di più account, ti consigliamo di impostare un piano di migrazione.
 
 ### Passaggio 2: Ordina i tuoi account Email Pro o Exchange
 
@@ -105,7 +105,7 @@ Prima di avviare la migrazione, dovrai identificare la versione del MX Plan dal 
 La tecnologia e-mail della vostra offerta MX Plan può variare in base alla data di attivazione della vostra offerta o se una migrazione è avvenuta di recente. Questa tecnologia si distingue in particolare per l'interfaccia del suo webmail. Per identificarla dal vostro Spazio Cliente, seguite questi passaggi:
 
 1. La scheda <code className="action">Informazioni generali</code> è selezionata per impostazione predefinita.
-1. Individuate la tecnologia utilizzata sotto la dicitura **Webmail** nell'area `Abbonamento`.
+1. Individuate la tecnologia utilizzata sotto la dicitura **webmail** nell'area `Abbonamento`.
 
 <img className="thumbnail" alt="Pannello dell'abbonamento MX Plan che mostra la tecnologia Webmail nello Spazio Cliente OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -175,7 +175,7 @@ Per maggiori informazioni su OMM, consulta la guida [Migrare account email via O
 Il tempo di migrazione dipende dalla quantità di contenuto da migrare verso il nuovo account. che può variare da pochi minuti a diverse ore.
 
 :::warning
-Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla [Webmail OVHcloud](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
+Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla [webmail OVHcloud](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
 :::
 
 Dopo la migrazione è possibile conservare o eliminare l'account di origine.
@@ -267,7 +267,7 @@ Per modificare la configurazione, clicca sulla casellina rossa e esegui l'operaz
 
 ### Passaggio 5: Utilizza i tuoi account email migrati
 
-A questo punto non ti resta che utilizzare i tuoi account email migrati. OVHcloud mette a disposizione un'applicazione online (_Web app_) accessibile all'indirizzo [Webmail](https://www.ovhcloud.com/it/mail/). inserendo le credenziali associate al tuo indirizzo email.
+A questo punto non ti resta che utilizzare i tuoi account email migrati. OVHcloud mette a disposizione un'applicazione online (_Web app_) accessibile all'indirizzo [webmail](/links/web/email). inserendo le credenziali associate al tuo indirizzo email.
 
 Se hai configurato uno degli account migrati su un client di posta elettronica (come Outlook), è necessario impostarlo nuovamente. Le informazioni di connessione al server OVHcloud sono cambiate in seguito alla migrazione. Per maggiori informazioni sulle operazioni da effettuare, consulta la nostra documentazione nelle sezioni delle guide dedicate a [Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) e [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan). Se non sei in grado di riconfigurare l'account nell'immediato, l'accesso tramite l'applicazione online è sempre possibile.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrare account email tra piattaforme OVHcloud
 description: Migra account email tra due piattaforme OVHcloud (Exchange, Email Pro, MX Plan) senza perdere messaggi, contatti e cartelle
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ Per migrare una soluzione MX Plan verso una piattaforma Exchange, consulta la gu
 
 ## Prerequisiti
 
-- Disporre di una piattaforma **"sorgente"** con conti [Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/) o [Email Pro](https://www.ovhcloud.com/it/emails/email-pro/) configurati o [Zimbra](https://www.ovhcloud.com/it/emails/zimbra-emails/).
-- Disporre di una piattaforma di **"destinazione"** con account [Exchange](https://www.ovhcloud.com/it/emails/hosted-exchange/), [Email Pro](https://www.ovhcloud.com/it/emails/email-pro/) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](https://www.ovhcloud.com/it/web-hosting/)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
+- Disporre di una piattaforma **"sorgente"** con conti [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) configurati o [Zimbra](/links/web/emails-zimbra).
+- Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -149,7 +149,7 @@ Per maggiori informazioni su OMM, consulta la guida [Migrare account email via O
 Il tempo di migrazione dipende dalla quantità di dati da migrare verso il nuovo account. che può variare da pochi minuti a diverse ore.
 
 :::warning
-Una volta completata la migrazione, verifica di trovare tutti i tuoi elementi accedendo alla Webmail all'indirizzo Web [Webmail](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
+Una volta completata la migrazione, verifica di trovare tutti i tuoi elementi accedendo alla webmail all'indirizzo Web [webmail](/links/web/email). **Non eliminare l'indirizzo di origine prima di aver verificato che tutto sia stato migrato correttamente.** Una volta eliminato l'indirizzo di origine, gli elementi non migrati andranno persi in modo definitivo.
 :::
 
 Una volta completata la migrazione, puoi conservare o eliminare l'account di origine con il nome provvisorio.
@@ -174,7 +174,7 @@ Per modificare la configurazione, clicca sulla pastiglia rossa e effettua la man
 
 ### Utilizza i tuoi account email migrati
 
-A questo punto non ti resta che utilizzare i tuoi account email migrati. OVHcloud mette a disposizione un'applicazione online (_Web app_) accessibile all'indirizzo [Webmail](https://www.ovhcloud.com/it/mail/). inserendo le credenziali associate al tuo indirizzo email.
+A questo punto non ti resta che utilizzare i tuoi account email migrati. OVHcloud mette a disposizione un'applicazione online (_Web app_) accessibile all'indirizzo [webmail](/links/web/email). inserendo le credenziali associate al tuo indirizzo email.
 
 Se hai configurato uno degli account migrati su un client di posta (ad esempio: Outlook, Thunderbird), è necessario impostarlo di nuovo. Le informazioni di connessione al server OVHcloud sono cambiate in seguito alla migrazione.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrare account email tramite OVHcloud Mail Migrator
 description: Migra i tuoi account email verso OVHcloud con OVHcloud Mail Migrator (OMM), inclusi messaggi, contatti e calendari
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Prerequisiti
 
 <Region zones={['eu']}>
-- Disporre di un servizio email esterno o su OVHcloud, come un'offerta [Zimbra](https://www.ovhcloud.com/it/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/it/emails-exchange/), [Email Pro](https://www.ovhcloud.com/it/emails/email-pro/) o MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un servizio email esterno o su OVHcloud, come un'offerta [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) o MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Disporre di un servizio email esterno o su OVHcloud, come un'offerta [Exchange](https://www.ovhcloud.com/it/emails-exchange/) o MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un servizio email esterno o su OVHcloud, come un'offerta [Exchange](/links/web/emails-exchange) o MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Disporre di un servizio email esterno o su OVHcloud, come MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](https://www.ovhcloud.com/it/web-hosting/)).
+- Disporre di un servizio email esterno o su OVHcloud, come MX Plan (tramite l'offerta MX Plan singola o inclusa in un'offerta di [hosting web OVHcloud](/links/web/hosting)).
 </Region>
 
 - Disporre delle credenziali relativi agli account email che si desidera migrare (gli account email sorgente).
@@ -206,7 +206,7 @@ Se si verifica un errore durante la migrazione, ti verrà fornito un link al reg
 
 
 :::warning
-Una volta completata la migrazione, accedi all'account di destinazione e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano presenti; per un indirizzo email OVHcloud, utilizza la [Webmail OVHcloud](/links/web/email). **Non eliminare l'account di origine prima di aver verificato che tutto sia stato migrato correttamente**, altrimenti gli elementi non migrati andranno persi in modo definitivo.
+Una volta completata la migrazione, accedi all'account di destinazione e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano presenti; per un indirizzo email OVHcloud, utilizza la [webmail OVHcloud](/links/web/email). **Non eliminare l'account di origine prima di aver verificato che tutto sia stato migrato correttamente**, altrimenti gli elementi non migrati andranno persi in modo definitivo.
 :::
 
 ## Per saperne di più

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrare un account email MX Plan
 description: Migra un account email MX Plan verso un account Zimbra OVHcloud, poi riassegna il suo indirizzo per completare il passaggio
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu]
 ---
 
@@ -146,7 +146,7 @@ Utilizza le opzioni di esportazione del tuo client di posta elettronica. Nella n
 ### 2 - Eliminare l'account MX Plan originale e riassegnare il suo indirizzo all'account Zimbra <a name="step2"></a>
 
 :::warning
-Prima di eliminare il tuo account MX Plan originale, accedi alla [Webmail OVHcloud](/links/web/email) e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano stati migrati sull'account Zimbra. Una volta eliminato l'account originale, gli elementi non migrati andranno persi in modo definitivo.
+Prima di eliminare il tuo account MX Plan originale, accedi alla [webmail OVHcloud](/links/web/email) e verifica che tutti i tuoi elementi (email, cartelle, contatti, calendari) siano stati migrati sull'account Zimbra. Una volta eliminato l'account originale, gli elementi non migrati andranno persi in modo definitivo.
 :::
 
 #### 2.1 - Eliminazione del vecchio indirizzo e-mail MX Plan <a name="step21"></a>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Ręczna migracja Twojego konta e-mail
 description: Dowiedz się, jak ręcznie przenieść Twoje konto e-mail na inny adres e-mail
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](https://www.ovhcloud.com/pl/emails-exchange/), [E-mail Pro](https://www.ovhcloud.com/pl/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](https://www.ovhcloud.com/pl/web-hosting/))
+- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
 </Region>
 
 <Region zones={['ca']}>
-- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](https://www.ovhcloud.com/pl/emails-exchange/) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](https://www.ovhcloud.com/pl/web-hosting/))
+- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
 </Region>
 
 <Region zones={['apac']}>
-- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](https://www.ovhcloud.com/pl/web-hosting/))
+- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
 </Region>
 - Posiadanie danych dostępowych do kont e-mail, które chcesz przenieść (konta źródłowe)
 - Posiadanie danych dostępowych do kont e-mail OVHcloud, na które przeniesione zostaną dane (konta docelowe)
@@ -78,7 +78,7 @@ Poniższe instrukcje są podzielone na dwie części:
 
 ### Outlook
 
-Jeśli posiadasz konto e-mail [Exchange OVHcloud](https://www.ovhcloud.com/pl/emails/hosted-exchange/), możesz je wyeksportować bezpośrednio w formacie PST w Panelu klienta.
+Jeśli posiadasz konto e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), możesz je wyeksportować bezpośrednio w formacie PST w Panelu klienta.
 
 Po przejściu do strony usługi Exchange, w karcie <code className="action">Konta e-mail</code> kliknij przycisk <code className="action">...</code> po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję <code className="action">Eksportuj w formacie PST</code>.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migracja do Exchange, Email Pro lub Zimbra
 description: Zmigruj konto e-mail MX Plan do oferty Exchange, Email Pro lub Zimbra, zachowując wiadomości, kontakty i foldery
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -34,14 +34,14 @@ Jeśli Twoje e-maile są zapisane lokalnie (konfiguracja POP lub archiwizacja lo
 
 ## Wymagania początkowe
 
-- Posiadanie konta e-mail MX Plan (w ramach pakietu MX Plan lub zawartego w pakiecie [hostingowym OVHcloud](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadanie konta e-mail MX Plan (w ramach pakietu MX Plan lub zawartego w pakiecie [hostingowym OVHcloud](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Posiadanie usługi [Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/), [E-mail Pro](https://www.ovhcloud.com/pl/emails/email-pro/) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/).
+- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](/links/web/emails-zimbra).
 </Region>
 
 <Region zones={['ca']}>
-- Posiadanie usługi [Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me").
+- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me").
 </Region>
 
 - **Nie skonfigurowałeś przekierowania na adres e-mail MX Plan, który chcesz przenieść**.
@@ -83,7 +83,7 @@ Niezależnie od wybranej metody migracji zdecydowanie zalecamy wcześniejsze wyk
 
 Rozwiązania E-mail Pro i Exchange mają wspólną bazę funkcjonalności. Niemniej jednak nadal występują różnice w zależności od zastosowania. Wybierając adres Exchange, dysponujesz wszystkimi funkcjami do pracy zespołowej, takimi jak synchronizacja kalendarza i kontaktów. Niektóre z nich są dostępne w ofercie E-mail Pro, ale są one ograniczone do korzystania wyłącznie z poczty webmail.
 
-Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](https://www.ovhcloud.com/pl/emails/), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont E-mail Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
+Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](/links/web/emails), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont E-mail Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
 
 ### Etap 2: Zamów konta E-mail Pro lub Exchange
 
@@ -105,7 +105,7 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 Technologia e-maila oferty MX Plan może się różnić w zależności od daty aktywacji oferty lub jeśli niedawno miała miejsce migracja. Ta technologia różni się m.in. wyglądem interfejsu webmaila. Aby ją zidentyfikować w panelu klienta, wykonaj poniższe kroki:
 
 1. Zazwyczaj wybrany jest zakładka <code className="action">Informacje ogólne</code>.
-1. Zanotuj technologię używaną pod hasłem **Webmail** w sekcji `Abonament`.
+1. Zanotuj technologię używaną pod hasłem **webmail** w sekcji `Abonament`.
 
 <img className="thumbnail" alt="Panel subskrypcji MX Plan pokazujący technologię webmail w Panelu klienta OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -175,7 +175,7 @@ Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym 
 Czas migracji zależy od ilości treści, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
 :::warning
-Po przeprowadzeniu migracji sprawdź, czy odnajdujesz swoje elementy, logując się do [Webmail OVHcloud](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+Po przeprowadzeniu migracji sprawdź, czy odnajdujesz swoje elementy, logując się do [webmail OVHcloud](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
 :::
 
 Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, używając tymczasowej nazwy.
@@ -267,13 +267,13 @@ Aby zmienić konfigurację, kliknij czerwony przycisk i wykonaj żądaną operac
 
 ### Etap 5: Korzystać z migrowanych kont e-mail
 
-Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [Webmail](https://www.ovhcloud.com/pl/mail/). Wpisz dane dostępowe do Twojego konta e-mail.
+Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [webmail](/links/web/email). Wpisz dane dostępowe do Twojego konta e-mail.
 
 Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (np. Outlook), należy ponownie skonfigurować to konto. Dane do logowania do serwera OVHcloud zmieniły się po migracji. Aby pomóc Ci w przeprowadzeniu operacji, zapoznaj się z naszą dokumentacją w sekcjach przewodników dotyczących [E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) i [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan). Jeśli nie jesteś w stanie zmienić konfiguracji konta w tej chwili, dostęp przez aplikację online jest zawsze możliwy.
 
 ### Organizacja zawartości Twoich kont e-mail po migracji <a name="content-after-migration"></a>
 
-Podczas pierwszego logowania do nowego konta e-mail migrowane treści mogą być częściowo ukryte. Aby wyświetlić wszystkie elementy, w interfejsie Webmail kliknij strzałkę obok `Skrzynki odbiorczej`, aby wyświetlić podfoldery. Powinna pojawić się przeniesiona zawartość Twojego starego konta e-mail.
+Podczas pierwszego logowania do nowego konta e-mail migrowane treści mogą być częściowo ukryte. Aby wyświetlić wszystkie elementy, w interfejsie webmail kliknij strzałkę obok `Skrzynki odbiorczej`, aby wyświetlić podfoldery. Powinna pojawić się przeniesiona zawartość Twojego starego konta e-mail.
 
 <img className="thumbnail" alt="Przeglądanie zmigrowanych folderów i e-maili w webmailu OVHcloud" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/owa_migrate_content.png" loading="lazy" />
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migracja kont e-mail między platformami OVHcloud
 description: Migruj konta e-mail między dwiema platformami OVHcloud (Exchange, Email Pro, MX Plan) bez utraty wiadomości, kontaktów i folderów
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ Aby przenieść rozwiązanie MX Plan na platformę Exchange, zapoznaj się z nas
 
 ## Wymagania początkowe
 
-- Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/) lub [E-mail Pro](https://www.ovhcloud.com/pl/emails/email-pro/) lub [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/).
-- Posiadanie platformy **"docelowej"** z kontami [Exchange](https://www.ovhcloud.com/pl/emails/hosted-exchange/), [E-mail Pro](https://www.ovhcloud.com/pl/emails/email-pro/) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](https://www.ovhcloud.com/pl/web-hosting/)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
+- Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](/links/web/emails-hosted-exchange) lub [E-mail Pro](/links/web/email-pro) lub [Zimbra](/links/web/emails-zimbra).
+- Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -149,7 +149,7 @@ Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym 
 Czas migracji zależy od ilości danych, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
 :::warning
-Po przeprowadzeniu migracji sprawdź, czy wszystkie Twoje dane znajdują się na stronie WWW pod linkiem [Webmail](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+Po przeprowadzeniu migracji sprawdź, czy wszystkie Twoje dane znajdują się na stronie WWW pod linkiem [webmail](/links/web/email). **Nie usuwaj swojego pierwotnego adresu, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane.** Po usunięciu pierwotnego adresu elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
 :::
 
 Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe używając tymczasowej nazwy.
@@ -174,7 +174,7 @@ Aby zmienić konfigurację, kliknij czerwony przycisk i wykonaj żądaną operac
 
 ### Korzystanie z migrowanych kont e-mail
 
-Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [Webmail](https://www.ovhcloud.com/pl/mail/). Wpisz dane dostępowe do Twojego konta e-mail.
+Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [webmail](/links/web/email). Wpisz dane dostępowe do Twojego konta e-mail.
 
 Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (na przykład: Outlook, Thunderbird), należy ponownie skonfigurować ustawienia. Dane do logowania do serwera OVHcloud zmieniły się po migracji.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrowanie kont e-mailowych za pomocą OVHcloud Mail Migrator
 description: Przenieś konta e-mail do OVHcloud za pomocą OVHcloud Mail Migrator (OMM), w tym wiadomości, kontakty i kalendarze
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Wymagania początkowe
 
 <Region zones={['eu']}>
-- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](https://www.ovhcloud.com/pl/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/pl/emails-exchange/), [E-mail Pro](https://www.ovhcloud.com/pl/emails/email-pro/) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Exchange](https://www.ovhcloud.com/pl/emails-exchange/) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Exchange](/links/web/emails-exchange) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, taki jak MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](https://www.ovhcloud.com/pl/web-hosting/)).
+- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, taki jak MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
 </Region>
 
 - Posiadaj dane logowania do kont e-mailowych, które chcesz przenieść (konta źródłowe).
@@ -206,7 +206,7 @@ Jeśli podczas migracji wystąpi błąd, link do logu błędu zostanie wyświetl
 
 
 :::warning
-Po zakończeniu migracji zaloguj się na konto docelowe i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) są obecne — w przypadku adresu e-mail OVHcloud skorzystaj z [Webmail OVHcloud](/links/web/email). **Nie usuwaj konta źródłowego, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane**, w przeciwnym razie elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+Po zakończeniu migracji zaloguj się na konto docelowe i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) są obecne — w przypadku adresu e-mail OVHcloud skorzystaj z [webmail OVHcloud](/links/web/email). **Nie usuwaj konta źródłowego, dopóki nie potwierdzisz, że wszystko zostało poprawnie zmigrowane**, w przeciwnym razie elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
 :::
 
 ## Sprawdź również

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migracja konta e-mail MX Plan
 description: Zmigruj konto e-mail MX Plan na konto Zimbra OVHcloud, a następnie ponownie przypisz jego adres, aby zakończyć zmianę
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu]
 ---
 
@@ -146,7 +146,7 @@ Skorzystaj z opcji eksportu w programie pocztowym. W naszym przewodniku "[Ręczn
 ### 2 - Usunięcie pierwotnego konta MX Plan i przypisanie jego adresu do konta Zimbra <a name="step2"></a>
 
 :::warning
-Przed usunięciem pierwotnego konta MX Plan zaloguj się do [Webmail OVHcloud](/links/web/email) i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) zostały zmigrowane na konto Zimbra. Po usunięciu pierwotnego konta elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
+Przed usunięciem pierwotnego konta MX Plan zaloguj się do [webmail OVHcloud](/links/web/email) i sprawdź, czy wszystkie Twoje elementy (wiadomości, foldery, kontakty, kalendarze) zostały zmigrowane na konto Zimbra. Po usunięciu pierwotnego konta elementy, które nie zostały zmigrowane, zostaną bezpowrotnie utracone.
 :::
 
 #### 2.1 - Usunięcie starego adresu e-mail MX Plan <a name="step21"></a>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar manualmente o seu endereço de e-mail
 description: Saiba como migrar manualmente um endereço de e-mail para outro endereço de e-mail
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Requisitos
 
 <Region zones={['eu']}>
-- Ter um serviço de e-mail na OVHcloud, como uma oferta [Exchange](https://www.ovhcloud.com/pt/emails-exchange/), [E-mail Pro](https://www.ovhcloud.com/pt/emails/email-pro/), [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Ter um serviço de e-mail na OVHcloud, como uma oferta [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Ter um serviço de e-mail na OVHcloud, como uma oferta [Exchange](https://www.ovhcloud.com/pt/emails-exchange/) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Ter um serviço de e-mail na OVHcloud, como uma oferta [Exchange](/links/web/emails-exchange) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Ter um serviço de e-mail na OVHcloud, como uma oferta MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Ter um serviço de e-mail na OVHcloud, como uma oferta MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
 </Region>
 - Ter dados de acesso relativos às contas de e-mail que pretende migrar (as contas de origem).
 - Ter dados de acesso relativos às contas de e-mail OVHcloud que recebem os dados migrados (as contas de destino).
@@ -78,7 +78,7 @@ As instruções que se seguem dividem - se em duas partes:
 
 ### Outlook
 
-Se possui uma conta de e-mail [Exchange OVHcloud](https://www.ovhcloud.com/pt/emails/hosted-exchange/), é possível exportá-la diretamente para o formato PST a partir da Área de Cliente.
+Se possui uma conta de e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), é possível exportá-la diretamente para o formato PST a partir da Área de Cliente.
 
 Uma vez na página do serviço Exchange, no separador <code className="action">Contas de e-mail</code>, clique no botão <code className="action">...</code> à direita da conta de e-mail a exportar e, a seguir, em <code className="action">Exportar para o formato PST</code>.
 
@@ -277,7 +277,7 @@ Na etapa seguinte, dê um nome ao seu perfil e identifique a pasta na qual será
 
 Quando tiver feito o necessário seguindo as instruções de importação, verifique se os seus elementos estão presentes no servidor.
 
-Ligue-se ao [webmail](https://www.ovhcloud.com/pt/mail/).
+Ligue-se ao [webmail](/links/web/email).
 
 Na caixa de entrada e na coluna da esquerda, irá encontrar as pastas e os e-mails do seu endereço de e-mail guardado.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar para Exchange, Email Pro ou Zimbra
 description: Migre a sua conta de e-mail MX Plan para uma oferta Exchange, Email Pro ou Zimbra mantendo mensagens, contactos e pastas
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -34,14 +34,14 @@ Se os seus e-mails estiverem apenas armazenados localmente (configuração em PO
 
 ## Requisitos
 
-- Ter um endereço de e-mail MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Ter um endereço de e-mail MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
 
 <Region zones={['eu']}>
-- Dispor de um serviço [Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/), [E-mail Pro](https://www.ovhcloud.com/pt/emails/email-pro/) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/).
+- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](/links/web/emails-zimbra).
 </Region>
 
 <Region zones={['ca']}>
-- Dispor de um serviço [Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me").
+- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me").
 </Region>
 
 - **Não ter configurado um reencaminhamento para o endereço de e-mail MX Plan que pretende migrar.**
@@ -83,7 +83,7 @@ Seja qual for o método de migração, recomendamos vivamente que faça previame
 
 As soluções E-mail Pro e Exchange dispõem de uma base de funcionalidades comum. No entanto, subsistem diferenças consoante os casos de utilização. Ao escolher um endereço Exchange, dispõe da totalidade das funções colaborativas, como a sincronização do calendário e dos contactos. A solução E-mail Pro, por sua vez, propõe algumas, mas estas estão limitadas a uma utilização apenas através de um webmail.
 
-Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](https://www.ovhcloud.com/pt/emails/) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas E-mail Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
+Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](/links/web/emails) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas E-mail Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
 
 ### Etapa 2: Encomendar as suas contas E-mail Pro ou Exchange
 
@@ -105,7 +105,7 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 A tecnologia de e-mail da sua oferta MX Plan pode variar consoante a data de ativação da sua oferta ou se uma migração ocorreu recentemente. Esta tecnologia distingue-se, nomeadamente, pela interface do seu webmail. Para a identificar a partir do seu Área de Cliente OVHcloud, siga estes passos:
 
 1. O separador <code className="action">Informações gerais</code> está selecionado por defeito.
-1. Registe a tecnologia utilizada sob a menção **Webmail** no quadro `Subscrição`.
+1. Registe a tecnologia utilizada sob a menção **webmail** no quadro `Subscrição`.
 
 <img className="thumbnail" alt="Painel de subscrição do MX Plan a mostrar a tecnologia Webmail na Área de Cliente OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -175,7 +175,7 @@ Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mai
 O tempo de migração depende da quantidade de conteúdo a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
 :::warning
-Após a migração, verifique que encontra os seus elementos ao aceder ao [Webmail OVHcloud](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+Após a migração, verifique que encontra os seus elementos ao aceder ao [webmail OVHcloud](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
 :::
 
 Pode conservar ou eliminar a conta de origem com o nome provisório após esta migração.
@@ -267,7 +267,7 @@ Para alterar a configuração, clique na etiqueta vermelha e execute a operaçã
 
 ### Etapa 5: Utilizar os seus endereços de e-mail migrados
 
-Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [Webmail](https://www.ovhcloud.com/pt/mail/). Introduza os dados de acesso relativos ao seu endereço de e-mail.
+Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [webmail](/links/web/email). Introduza os dados de acesso relativos ao seu endereço de e-mail.
 
 Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), deve configurá-la novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração. Para o ajudar nas suas operações, consulte o nosso manual através das secções dos guias [E-mail Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) e [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/landing-page-mx-plan). Se não consegue reconfigurar a conta de forma imediata, o acesso através da aplicação online é sempre possível.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail entre plataformas OVHcloud
 description: Migre contas de e-mail entre duas plataformas OVHcloud (Exchange, Email Pro, MX Plan) sem perder mensagens, contactos ou pastas
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca]
 ---
 
@@ -45,8 +45,8 @@ Para migrar uma solução MX Plan para uma plataforma Exchange, sugerimos que si
 
 ## Requisitos
 
-- Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/) ou [E-mail Pro](https://www.ovhcloud.com/pt/emails/email-pro/) ou [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/).
-- Ter uma plataforma de **"destino"** com contas [Exchange](https://www.ovhcloud.com/pt/emails/hosted-exchange/), [E-mail Pro](https://www.ovhcloud.com/pt/emails/email-pro/) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
+- Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](/links/web/emails-hosted-exchange) ou [E-mail Pro](/links/web/email-pro) ou [Zimbra](/links/web/emails-zimbra).
+- Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -149,7 +149,7 @@ Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mai
 O tempo de migração depende da quantidade de dados a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
 :::warning
-Depois da migração, verifique que encontra todos os seus elementos ao aceder ao webmail [Webmail](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+Depois da migração, verifique que encontra todos os seus elementos ao aceder ao webmail [webmail](/links/web/email). **Não elimine o seu endereço de origem enquanto não tiver confirmado que tudo foi corretamente migrado.** Depois de eliminado o endereço de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
 :::
 
 Depois de efetuar a migração, pode conservar ou eliminar a conta de origem com o nome provisório.
@@ -174,7 +174,7 @@ Para modificar a configuração, clique na pastilha vermelha e realize a manipul
 
 ### Utilizar os endereços de e-mail migrados
 
-Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [Webmail](https://www.ovhcloud.com/pt/mail/). Introduza os dados de acesso relativos ao seu endereço de e-mail.
+Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [webmail](/links/web/email). Introduza os dados de acesso relativos ao seu endereço de e-mail.
 
 Se configurou uma das contas migradas num cliente de e-mail (exemplo: Outlook, Thunderbird), deve configurá-lo novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração.
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/omm-migrate-email-account-to-ovhcloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail com o OVHcloud Mail Migrator
 description: Migre as suas contas de e-mail para a OVHcloud com o OVHcloud Mail Migrator (OMM), incluindo mensagens, contactos e calendários
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu, ca, apac]
 ---
 
@@ -20,15 +20,15 @@ import { Region } from '@components/Zone';
 ## Requisitos
 
 <Region zones={['eu']}>
-- Dispor de um serviço de e-mail externo ou da OVHcloud, tais como uma oferta [Zimbra](https://www.ovhcloud.com/pt/emails/zimbra-emails/), [Exchange](https://www.ovhcloud.com/pt/emails-exchange/), [E-mail Pro](https://www.ovhcloud.com/pt/emails/email-pro/) ou MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de um serviço de e-mail externo ou da OVHcloud, tais como uma oferta [Zimbra](/links/web/emails-zimbra), [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro) ou MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['ca']}>
-- Dispor de um serviço de e-mail externo ou da OVHcloud, tais como uma oferta [Exchange](https://www.ovhcloud.com/pt/emails-exchange/) ou MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de um serviço de e-mail externo ou da OVHcloud, tais como uma oferta [Exchange](/links/web/emails-exchange) ou MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)).
 </Region>
 
 <Region zones={['apac']}>
-- Dispor de um serviço de e-mail externo ou da OVHcloud, tal como MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](https://www.ovhcloud.com/pt/web-hosting/)).
+- Dispor de um serviço de e-mail externo ou da OVHcloud, tal como MX Plan (via oferta MX Plan única ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)).
 </Region>
 
 - Dispor das credenciais das contas de e-mail que pretende migrar (as contas de e-mail fonte).
@@ -206,7 +206,7 @@ Se ocorrer um erro durante a migração, será fornecido um link para o registo 
 
 
 :::warning
-Uma vez concluída a migração, aceda à conta de destino e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) estão presentes — para um endereço de e-mail OVHcloud, utilize o [Webmail OVHcloud](/links/web/email). **Não elimine a conta de origem enquanto não tiver confirmado que tudo foi corretamente migrado**, caso contrário os elementos que não tenham sido migrados serão perdidos de forma permanente.
+Uma vez concluída a migração, aceda à conta de destino e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) estão presentes — para um endereço de e-mail OVHcloud, utilize o [webmail OVHcloud](/links/web/email). **Não elimine a conta de origem enquanto não tiver confirmado que tudo foi corretamente migrado**, caso contrário os elementos que não tenham sido migrados serão perdidos de forma permanente.
 :::
 
 ## Quer saber mais?

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zimbra - Migrar uma conta de e-mail MX Plan
 description: Migre uma conta de e-mail MX Plan para uma conta Zimbra da OVHcloud e reatribua o seu endereço para concluir a mudança
-lastUpdated: 2026-08-24
+lastUpdated: 2026-08-25
 availableIn: [eu]
 ---
 
@@ -146,7 +146,7 @@ Utilize as opções de exportação do seu cliente de e-mail. No nosso manual "[
 ### 2 - Eliminar a conta MX Plan de origem e reatribuir o seu endereço à conta Zimbra <a name="step2"></a>
 
 :::warning
-Antes de eliminar a sua conta MX Plan de origem, aceda ao [Webmail OVHcloud](/links/web/email) e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) foram migrados para a conta Zimbra. Depois de eliminada a conta de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
+Antes de eliminar a sua conta MX Plan de origem, aceda ao [webmail OVHcloud](/links/web/email) e verifique que todos os seus elementos (e-mails, pastas, contactos, calendários) foram migrados para a conta Zimbra. Depois de eliminada a conta de origem, os elementos que não tenham sido migrados serão perdidos de forma permanente.
 :::
 
 #### 2.1 - Eliminação do antigo endereço de e-mail MX Plan <a name="step21"></a>


### PR DESCRIPTION
Follow-up to #637, stacked on it because both touch the same 33 files. **Merge #637 first.**

A full `/proofread` of the five email migration guides across all seven locales — pre-existing debt, unrelated to the OMM work in #637.

## What changed

**207 hardcoded marketing URLs centralised.** `https://www.ovhcloud.com/{locale}/…` replaced with the `/links/web/*` keys that already existed for them: `hosting`, `email-pro`, `emails-hosted-exchange`, `emails-exchange`, `emails-zimbra`, `email`, `emails`. These URLs drift apart every time a guide is copied between locale trees; the shortlink resolves per locale at build.

**Shared support-scope fragment in English and German.** The five other locales already used `[[fragment:support-scope]]`; English and German still carried the legacy hand-written warning, so the reference language was the one lagging. The fragment covers everything the old block said and adds the Help Centre and partner portal pointers.

**Typography and terminology.** French non-breaking spaces before colons (73), chevrons on guide citations (6), two stray curly apostrophes, lowercase `webmail` in six locales (41) — German excluded, where the capital is required for a common noun — and a stray trailing period on one German `description`.

**Twelve wording fixes in English and French.** Circumlocutions, a future tense in a procedural step, and a relative clause describing what the reader already sees.

## Deliberately not included

- **33 lines still use `<br>` in prose.** Several carry two consecutive tags inside list items, where the blank line the rule prescribes would end the list item — the same reason table cells are exempt. Needs a manual pass, not a scripted one.
- **7 `support-levels` URLs.** No `/links` key exists, and `config/links.ts` is generated. The fix belongs in `base/links/` plus a `convert-links.ts` run.
- **French "Email Pro".** `data/terminology/translations.csv` says `E-mail Pro` for French, but the corpus says `Email Pro` 452 times against 4. Six of seven locales agree with the CSV; French is the lone outlier. That is a product naming decision.

## Tooling bug worth fixing separately

`prepass.py` enforces a hardcoded "Email Pro, no hyphen in all languages" rule instead of reading `translations.csv`, which gives `E-mail Pro` for fr/pl/pt and `E-Mail Pro` for de. On this batch, **84 of its 315 findings were false positives** that would have corrupted correct Polish and Portuguese product names. `rules.common.md` line 66 carries the same error.

## Validation

`content:lint`, plus a full build of all seven locales. Fragment expansion verified in the rendered HTML (no surviving token). Outside the two fragment files, the diff is +217/−217 — no line added or removed.
