### PR TITLE
docs(i18n): exclude personal VoIP and internet access hardware from FR support scope

### DIFF
--- a/config/fragments.ts
+++ b/config/fragments.ts
@@ -62,6 +62,8 @@ Lors de l’utilisation des guides OVHcloud, veuillez tenir compte des points su
   - Les systèmes d’exploitation et les interfaces utilisateur (Windows, Debian, Plesk, etc.).
   - Tout autre logiciel tiers (clients FTP, logiciels de messagerie, etc.).
   - Les services proposés par d’autres fournisseurs (DNS, API, interfaces utilisateur, etc.).
+  - Le matériel personnel utilisé avec nos services VoIP (téléphone IP, iPBX, etc.).
+  - Le matériel personnel utilisé avec nos offres d’accès internet (modem, routeur, etc.).
 
 Pour recevoir l’assistance appropriée en cas de problème, suivez ces recommandations :
 


### PR DESCRIPTION
Add two sub-bullets to the FR support-scope fragment stating that personally owned hardware used with OVHcloud VoIP services (IP phone, iPBX) and internet access offers (modem, router) falls outside the technical support perimeter.

FR only: VoIP and internet access are France-market products, so the other six locales are unchanged.