### PR TITLE
feat(i18n): clear the FR translation backlog — 56 guides, 8 products

### DIFF
--- a/docs/fr/guides/account-and-service-management/account-information/hds-certification.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/hds-certification.mdx
@@ -1,1 +1,62 @@
-../../../../en/guides/account-and-service-management/account-information/hds-certification.mdx
+---
+title: Certification HDS des produits OVHcloud
+description: Liste des produits OVHcloud couverts par la certification HDS (Hébergement de Données de Santé), avec les normes et versions applicables.
+lastUpdated: 2026-06-02
+---
+
+## Objectif
+
+**Cette page a pour but de présenter les produits couverts par la norme « Hébergement de Données de Santé » (HDS).**
+
+## Normes et versions
+
+Notre certificat actuel est établi conformément à la norme et à la version suivantes :
+
+- HDS v2018
+
+La version 2024 de la certification HDS doit être mise en place en 2024.
+
+## Produits OVHcloud actuellement certifiés
+
+Les clients utilisant des produits HDS doivent souscrire un support Business ou Enterprise. L'option HDS doit être activée dans l'espace client OVHcloud ou demandée aux équipes support.
+
+| **Produit** | **Certifié** | 
+| --- | ---  | 
+| Serveur dédié | oui | 
+| Serveur dédié - 3AZ | oui |
+| Dedicated Pod - SecNumCloud | oui |
+| File Storage | oui | 
+| Block Storage | oui | 
+| Managed Mutualized Virtualization | non | 
+| Managed Dedicated Cloud | oui | 
+| Managed Dedicated Cloud - SecNumCloud | oui | 
+| Public Cloud Instances | oui | 
+| Public Cloud Instances-3AZ | oui | 
+| Managed Containers | oui |
+| Notebooks Interface | oui | 
+| Managed Distributed Computing Cluster | oui |
+| Managed Orchestration | oui |
+| Managed Search engine software platform | oui | 
+| Managed Timeseries | oui | 
+| Managed In Memory Database | oui |
+| Managed Document Database | oui | 
+| Managed Relational Database | oui |
+| Managed Column-Oriented Database | oui | 
+| Managed Message broker | oui | 
+| Object Storage | oui | 
+| Object Storage-3AZ | oui | 
+| Managed OCI artifact Registry | oui | 
+| Cold Storage | oui  | 
+| Managed Log Manager | oui | 
+| Managed Data Visualization | oui | 
+| Managed Web Hosting | oui | 
+| Hosted Mailbox | non | 
+| Managed E-mail Server on Mutualized Infrastructure | non |
+| Managed Dedicated E-mail Infrastructure | oui | 
+| Managed Database System for Web Hosting | non | 
+| Domain Name | oui | 
+| Unified Data Platform | oui | 
+| OVHcloud KMS | oui | 
+| Secret Manager | oui |
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/security-certifications.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/security-certifications.mdx
@@ -1,1 +1,63 @@
-../../../../en/guides/account-and-service-management/account-information/security-certifications.mdx
+---
+title: Certifications ISO 27k des produits OVHcloud
+description: Liste des produits OVHcloud couverts par les normes de la famille ISO/IEC 27k, avec les normes et versions applicables.
+lastUpdated: 2026-06-02
+---
+
+## Objectif
+
+Cette page a pour but de présenter les produits OVHcloud couverts par les normes de la famille ISO/IEC 27k.
+
+## Normes et versions
+
+Nos certificats actuels sont établis conformément aux normes et versions suivantes :
+
+- ISO/IEC 27001:2022
+- ISO/IEC 27017:2015
+- ISO/IEC 27018:2019
+- ISO/IEC 27701:2019
+
+Nous suivons les nouvelles versions des normes ISO27017, ISO27018 et ISO27701 actuellement en cours de révision par l'ISO.
+
+## Produits OVHcloud actuellement certifiés
+
+| **Produit** | **Certifié** | 
+| --- | ---  | 
+| Serveur dédié | oui | 
+| Serveur dédié - 3AZ | oui |
+| Dedicated Pod - SecNumCloud | oui |
+| File Storage | oui | 
+| Block Storage | oui | 
+| Managed Mutualized Virtualization | non | 
+| Managed Dedicated Cloud | oui | 
+| Managed Dedicated Cloud - SecNumCloud | oui | 
+| Public Cloud Instances | oui | 
+| Public Cloud Instances-3AZ | oui | 
+| Managed Containers | oui |
+| Notebooks Interface | oui | 
+| Managed Distributed Computing Cluster | oui |
+| Managed Orchestration | oui |
+| Managed Search engine software platform | oui | 
+| Managed Timeseries | oui | 
+| Managed In Memory Database | oui |
+| Managed Document Database | oui | 
+| Managed Relational Database | oui |
+| Managed Column-Oriented Database | oui | 
+| Managed Message broker | oui | 
+| Object Storage | oui | 
+| Object Storage-3AZ | oui | 
+| Managed OCI artifact Registry | oui | 
+| Cold Storage | oui  | 
+| Managed Log Manager | oui | 
+| Managed Data Visualization | oui | 
+| Managed Web Hosting | oui | 
+| Hosted Mailbox | non | 
+| Managed E-mail Server on Mutualized Infrastructure | non |
+| Managed Dedicated E-mail Infrastructure | oui | 
+| Managed Database System for Web Hosting | non | 
+| Domain Name | oui | 
+| Unified Data Platform | oui | 
+| OVHcloud KMS | oui | 
+| Secret Manager | oui |
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/account-information/security-specification-pci.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/security-specification-pci.mdx
@@ -1,12 +1,12 @@
 ---
-title: Public Cloud Instance security specification
-description: Public Cloud Instance security overview
+title: Spécifications de sécurité des instances Public Cloud
+description: Vue d'ensemble de la sécurité des instances Public Cloud
 lastUpdated: 2025-01-17
 ---
 
-## Objective
+## Objectif
 
-In addition to [the responsibility model for Public Cloud Instance](/guides/public-cloud/compute/responsibility-model-instances), this security fact sheet aims at describing security features and functions associated with the service. It also describes best practices that customers can adopt to secure their instances based on OpenStack technology.
+En complément [du modèle de responsabilité des instances Public Cloud](/guides/public-cloud/compute/responsibility-model-instances), cette fiche de sécurité a pour but de décrire les fonctionnalités et les fonctions de sécurité associées au service. Elle décrit également les bonnes pratiques que les clients peuvent adopter pour sécuriser leurs instances basées sur la technologie OpenStack.
 
 ### 1. Certifications
 
@@ -20,107 +20,107 @@ In addition to [the responsibility model for Public Cloud Instance](/guides/publ
 - CSA type II
 - C5 type II
 
-### 2. Best practices to be deployed on the service
+### 2. Bonnes pratiques à mettre en œuvre sur le service
 
-#### 2.1 Recommendations once the service is delivered
+#### 2.1 Recommandations après la livraison du service
 
-When you sign up for the service, we recommend that you use SSH keys to access your Instance (rather than a login/password) for a better authentication security level for your administrators and to change it regularly. For more information on how to manage your SSH keys, consult this [guide](/guides/public-cloud/compute/creating-ssh-keys).
+Lorsque vous souscrivez le service, nous vous recommandons d'utiliser des clés SSH pour accéder à votre instance (plutôt qu'un couple identifiant/mot de passe) afin d'assurer un meilleur niveau de sécurité d'authentification pour vos administrateurs, et de les changer régulièrement. Pour plus d'informations sur la gestion de vos clés SSH, consultez ce [guide](/guides/public-cloud/compute/creating-ssh-keys).
 
-You can use the user interface and the CLI to perform tasks. You must manage and secure your access to perform certain administrative tasks, as described in this [guide](/guides/public-cloud/compute/getting-started#connect-instance).
+Vous pouvez utiliser l'interface utilisateur et la CLI pour effectuer des tâches. Vous devez gérer et sécuriser vos accès pour effectuer certaines tâches d'administration, comme décrit dans ce [guide](/guides/public-cloud/compute/getting-started#connect-instance).
 
-To filter connections, you must set up a firewall using IPtables.
+Pour filtrer les connexions, vous devez mettre en place un pare-feu à l'aide d'IPtables.
 
-#### 2.2 Vulnerability scans
+#### 2.2 Analyses de vulnérabilités
 
-You are authorized to perform vulnerability scans on the service you have subscribed to. OVHcloud doesn't have to be previously informed.  
-Security measures deployed by OVHcloud (especially network protection) aren't disabled, because such an audit's purpose is to demonstrate a clear vision of the security level of the customer's infrastructure.  
-You are not authorized to use your service to scan other infrastructures.
+Vous êtes autorisé à réaliser des analyses de vulnérabilités sur le service que vous avez souscrit. OVHcloud n'a pas besoin d'en être informé au préalable.  
+Les mesures de sécurité déployées par OVHcloud (notamment la protection réseau) ne sont pas désactivées, car l'objectif d'un tel audit est de donner une vision claire du niveau de sécurité de l'infrastructure du client.  
+Vous n'êtes pas autorisé à utiliser votre service pour analyser d'autres infrastructures.
 
-### 3. Service Level Agreement (SLA)
+### 3. Contrat de niveau de service (SLA)
 
-The SLA varies between 99.9% and 99.999% and differs between offers and ranges. Please refer to the specific terms and conditions of service for more details.
+Le SLA varie entre 99,9 % et 99,999 % et diffère selon les offres et les gammes. Veuillez consulter les conditions particulières de service pour plus de détails.
 
-### 4. Backups
+### 4. Sauvegardes
 
-#### 4.1 Technical backups
+#### 4.1 Sauvegardes techniques
 
-As a part of our resilience plan in the Control Plane, we perform backups to maintain our Service Level Agreement. These technical backups cannot be activated at the customer's request.
+Dans le cadre de notre plan de résilience du control plane, nous réalisons des sauvegardes afin de respecter notre contrat de niveau de service. Ces sauvegardes techniques ne peuvent pas être activées à la demande du client.
 
 
-#### 4.2 Customer data backups
+#### 4.2 Sauvegardes des données client
 
-| **Option** | **Granularity** | **RPO** | **RTO** | **Documentation** |
+| **Option** | **Granularité** | **RPO** | **RTO** | **Documentation** |
 | --- | --- | --- | --- | --- |
-| Backup of an Instance | Instance | Depends on the date of the last backup and the delay of incident resolution | Depends on the size of the Instance | [Backing up an instance](/guides/public-cloud/compute/save-an-instance)<br/>[Backups and restoration](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup) |
+| Sauvegarde d'une instance | Instance | Dépend de la date de la dernière sauvegarde et du délai de résolution de l'incident | Dépend de la taille de l'instance | [Sauvegarder une instance](/guides/public-cloud/compute/save-an-instance)<br/>[Sauvegardes et restauration](/guides/public-cloud/compute/create-restore-a-virtual-server-with-a-backup) |
 
 
 ### 5. Logs
 
-| **Source** | **Content** | **Documentation** |
+| **Source** | **Contenu** | **Documentation** |
 | --- | --- | --- |
-| Control Panel | Logs of interactions made by admin, technical or billing contacts in the Control Panel and services they have access to, using API calls. |- <ApiLink section="/me" method="GET" route={"/me/api/logs/self"} regions={["eu"]}>List of API calls done with your account</ApiLink><br/>- <ApiLink section="/me" method="GET" route={"/me/api/logs/services"} regions={["eu"]}>List of API calls done on services you have access to</ApiLink><br/>- <ApiLink section="/me" method="GET" route={"/me/logs/audit"}>Get your audit logs</ApiLink> |
+| Espace client | Logs des interactions effectuées par les contacts administrateur, technique ou de facturation dans l'espace client et sur les services auxquels ils ont accès, via des appels API. |- <ApiLink section="/me" method="GET" route={"/me/api/logs/self"} regions={["eu"]}>Liste des appels API effectués avec votre compte</ApiLink><br/>- <ApiLink section="/me" method="GET" route={"/me/api/logs/services"} regions={["eu"]}>Liste des appels API effectués sur les services auxquels vous avez accès</ApiLink><br/>- <ApiLink section="/me" method="GET" route={"/me/logs/audit"}>Obtenir vos logs d'audit</ApiLink> |
 
 ### 6. API
 
-| **Name** | **Capacity** | **Documentation** |
+| **Nom** | **Capacité** | **Documentation** |
 | --- | --- | --- |
-| Control Panel and service | Manage customer accounts and services on which each account has access rights. | [Preparing an environment for using the OpenStack API](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)<br/>[Getting started with the OpenStack API](/guides/public-cloud/compute/starting-with-nova)<br/>[API Rate Limits](/guides/public-cloud/cross-functional/api-rate-limits) |
+| Espace client et service | Gérer les comptes clients et les services sur lesquels chaque compte dispose de droits d'accès. | [Préparer un environnement pour utiliser l'API OpenStack](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment)<br/>[Premiers pas avec l'API OpenStack](/guides/public-cloud/compute/starting-with-nova)<br/>[Limites de débit de l'API](/guides/public-cloud/cross-functional/api-rate-limits) |
 
-### 7. Accounts - User
+### 7. Comptes - Utilisateur
 
 #### 7.1 Control plane
 
-Using your customer account on the OVHcloud Control Panel, you are able to manage your service using [three different contacts](/guides/account-and-service-management/account-information/managing-contacts).<br/>
-OVHcloud uses another account with an internal NIC to refer to a customer having subscribed to several services.
+Depuis votre compte client sur l'espace client OVHcloud, vous pouvez gérer votre service à l'aide de [trois contacts différents](/guides/account-and-service-management/account-information/managing-contacts).<br/>
+OVHcloud utilise un autre compte doté d'un NIC interne pour désigner un client ayant souscrit plusieurs services.
 
-To enforce security access to your account on the Control Panel, we recommend activating a [two-factor authentication mechanism](/guides/account-and-service-management/account-information/secure-ovhcloud-account-with-2fa) or [SSO (Single Sign-On) authentication](/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-adfs).
+Pour renforcer la sécurité de l'accès à votre compte sur l'espace client, nous vous recommandons d'activer un [mécanisme d'authentification à deux facteurs](/guides/account-and-service-management/account-information/secure-ovhcloud-account-with-2fa) ou une [authentification SSO (Single Sign-On)](/guides/account-and-service-management/account-information/ovhcloud-account-connect-saml-adfs).
 
-You can create your OpenStack users and define several roles following [this guide](/guides/public-cloud/cross-functional/create-and-delete-a-user) according to your access management policy.
+Vous pouvez créer vos utilisateurs OpenStack et définir plusieurs rôles en suivant [ce guide](/guides/public-cloud/cross-functional/create-and-delete-a-user), conformément à votre politique de gestion des accès.
 
-You have to activate and manage your tokens in order to access the Keystone API by following this [guide](/guides/public-cloud/cross-functional/managing-tokens).
+Vous devez activer et gérer vos tokens afin d'accéder à l'API Keystone, en suivant ce [guide](/guides/public-cloud/cross-functional/managing-tokens).
 
 #### 7.2 Data plane
 
-Once you get your credentials, you can create user accounts on your OS and installed applications.
+Une fois vos identifiants reçus, vous pouvez créer des comptes utilisateurs sur votre OS et sur les applications installées.
 
-### 8. Features and options available at service delivery
+### 8. Fonctionnalités et options disponibles à la livraison du service
 
-#### 8.1 OS hardening and maintenance
+#### 8.1 Durcissement et maintenance de l'OS
 
-Public Cloud Instance is based on OpenStack technology which is managed and maintained by the OVHcloud team.
+Public Cloud Instance repose sur la technologie OpenStack, gérée et maintenue par l'équipe OVHcloud.
 
-OVHcloud provides a large catalog of Operating Systems for Windows and Linux distributions. We are committed to updating our catalogue with the latest releases from editors.
+OVHcloud propose un large catalogue de systèmes d'exploitation pour les distributions Windows et Linux. Nous nous engageons à mettre à jour notre catalogue avec les dernières versions publiées par les éditeurs.
 
-The level of hardening applied refers to the basic version supplied by the editor. For an advanced level of hardening, we recommend that you refer to the guidelines published by each editor.
+Le niveau de durcissement appliqué correspond à la version de base fournie par l'éditeur. Pour un niveau de durcissement avancé, nous vous recommandons de consulter les recommandations publiées par chaque éditeur.
 
-You also have the possibility to import your own image when you deploy your Instance with a supported format. Consult [this guide](/guides/public-cloud/compute/upload-own-image) for more information.
+Vous avez également la possibilité d'importer votre propre image lors du déploiement de votre instance, dans un format pris en charge. Consultez [ce guide](/guides/public-cloud/compute/upload-own-image) pour plus d'informations.
 
-Finally, you remain responsible for monitoring your OS and applying necessary updates, [upgrades](/guides/public-cloud/compute/upgrading-operating-system) and security measures on applications you've installed.
+Enfin, vous restez responsable de la surveillance de votre OS et de l'application des mises à jour, [montées de version](/guides/public-cloud/compute/upgrading-operating-system) et mesures de sécurité nécessaires sur les applications que vous avez installées.
 
-#### 8.2 Network security
+#### 8.2 Sécurité réseau
 
-To activate a private connection, you can use the [vRack option](/guides/public-cloud/network-services/vrack). This option could be activated at the first step when you create your Public Cloud Instance (which is recommended) or after service subscription.
+Pour activer une connexion privée, vous pouvez utiliser l'[option vRack](/guides/public-cloud/network-services/vrack). Cette option peut être activée dès la première étape de la création de votre instance Public Cloud (ce qui est recommandé) ou après la souscription du service.
 
-You should filter and allow necessary connections by using IPtables according to your defined project architecture.
+Il est conseillé de filtrer et d'autoriser uniquement les connexions nécessaires à l'aide d'IPtables, conformément à l'architecture définie pour votre projet.
 
-You can consult these guides to set up your configurations:
+Vous pouvez consulter ces guides pour mettre en place vos configurations :
 
-[Managing firewall rules and port security on networks using OpenStack CLI](/guides/public-cloud/cross-functional/security-group-private-network).
-[Access and security settings in Horizon](/guides/public-cloud/cross-functional/compute-horizon-access-security).
-Network guides.
+[Gérer les règles de pare-feu et la sécurité des ports sur les réseaux à l'aide de la CLI OpenStack](/guides/public-cloud/cross-functional/security-group-private-network).
+[Paramètres d'accès et de sécurité dans Horizon](/guides/public-cloud/cross-functional/compute-horizon-access-security).
+Guides réseau.
 
 
-#### 8.3 HDS option
+#### 8.3 Option HDS
 
-The HDS option can be activated on the service.<br/>
-The subscription to the [Business support level](https://www.ovhcloud.com/fr/support-levels/business/) is mandatory, at least to maintain necessary requirements.
+L'option HDS peut être activée sur le service.<br/>
+La souscription au [niveau de support Business](https://www.ovhcloud.com/fr/support-levels/business/) est obligatoire, au minimum pour maintenir les exigences nécessaires.
 
-### 9. Reversibility
+### 9. Réversibilité
 
-To ensure reversibility on the service, you may follow the [specific reversibility policy](/guides/account-and-service-management/reversibility/public-cloud-reversibility-policy) to import and export your data in complete autonomy.
+Pour garantir la réversibilité du service, vous pouvez suivre la [politique de réversibilité spécifique](/guides/account-and-service-management/reversibility/public-cloud-reversibility-policy) afin d'importer et d'exporter vos données en toute autonomie.
 
-#### 9.1 Erasure of customer data
+#### 9.1 Effacement des données client
 
-Once you have destroyed your Public Cloud project, in the OVHcloud Control Panel, all allocated resources are released.
+Une fois votre projet Public Cloud supprimé dans l'espace client OVHcloud, toutes les ressources allouées sont libérées.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+++ b/docs/fr/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
@@ -1,1 +1,163 @@
-../../../../en/guides/account-and-service-management/responsibility-sharing/file-storage.mdx
+---
+title: Services File Storage - Modèle de responsabilité
+description: Répartition des responsabilités entre OVHcloud et le client pour les solutions NAS-HA et Enterprise File Storage
+lastUpdated: 2024-01-22
+---
+
+Le RACI ci-dessous détaille la répartition des responsabilités entre OVHcloud et le client pour les solutions File Storage suivantes :
+
+- NAS-HA 
+- Enterprise File Storage
+
+Ce modèle de responsabilité partagée contribue à alléger la charge opérationnelle du client.
+
+## Définition du RACI
+
+| Rôles |
+| --- |
+|R : est chargé de réaliser le processus|
+|A : est responsable de la bonne réalisation du processus|
+|C : est consulté pendant le processus|
+|I : est informé des résultats du processus|
+
+### 1. Avant la souscription
+
+#### 1.1. Définir le service en fonction des besoins
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Prendre connaissance des capacités et des limitations des services détaillées dans la documentation OVHcloud | RA | CI |
+| Choisir la localisation du service | RA | I |
+| Dimensionner les services en fonction des besoins | RA | I |
+
+### 2. Mise à disposition du service
+
+#### 2.1. Installer le service
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Produire, acheminer, livrer et maintenir les machines physiques, les machines virtuelles et les bâtiments d'hébergement |  | RA |
+| Acquérir et détenir les licences et les droits d'utilisation des logiciels fournis par OVHcloud |  | RA |
+
+#### 2.2. Modèle de réversibilité
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Importer/exporter les données dans un format pris en charge par l'hyperviseur ou par une distribution compatible NFS  | RA | C |
+
+### 3. Utilisation du service
+
+#### 3.1. Exploitation
+
+##### **3.1.1. Exploitation quotidienne**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Décider de répartir les ressources du service existant | RA | I |
+| Gérer la politique de snapshots| RA | I |
+| Définir une politique de rétention des données conforme aux exigences légales | RA |  |
+| Gérer les volumes de stockage et les listes de contrôle d'accès (ACL) | RA | I |
+
+##### **3.1.2. Gestion des accès**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer les accès à l'espace client OVHcloud et au service de stockage via l'interface utilisateur, l'API et les ACL | RA | I |
+| Gérer les accès physiques des équipes OVHcloud aux infrastructures |  | RA |
+| Gérer les accès logiques des équipes OVHcloud aux infrastructures | I | RA |
+
+##### **3.1.3. Supervision**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Superviser les performances du service, telles que les IOPS et le dimensionnement des volumes (64 Mo/To ou 4000 IOPS/To) pour le service NFS |   | RA |
+| Superviser les performances du service (bande passante, IOPS, dimensionnement des volumes, etc.) | RA | I |
+| Conserver les logs du control plane pour la supervision du service |  | RA |
+
+##### **3.1.4. Stockage**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer le contenu hébergé sur le service de stockage  | RA | I |
+| Gérer la continuité des données (snapshots et/ou sauvegardes)| RA | |
+| Réaliser la maintenance des équipements de stockage et de snapshots sur l'infrastructure de management|  | RA |
+| Gérer le chiffrement des données au repos | RA |  |
+
+##### **3.1.5. Connectivité**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Exploiter les systèmes automatiques de gestion du réseau (architecture, mise en œuvre, maintenance logicielle et matérielle des réseaux publics et privés déployés) | I | RA |
+| Gérer le plan d'adressage IP à l'aide des adresses IP OVHcloud | RA |   |
+
+##### **3.1.6. Gestion**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Fournir l'inventaire des volumes de stockage utilisés | I | RA |
+| Gérer la sécurité des infrastructures de management (API, espace client) conformément aux normes de sécurité telles que ISO 2700x, SOC 2 type 2 et HDS |  | RA |
+| Gérer la sécurité des systèmes d'exploitation (mises à jour et montées de version majeures) et des logiciels installés après la livraison du service | I | RA |
+| Gérer la sécurité physique des équipements et des infrastructures hébergés chez OVHcloud | I | RA |
+
+##### **3.1.7. Continuité d'activité**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer les systèmes de gestion automatique de l'infrastructure fournie | I | RA |
+| Maintenir un plan de continuité et de reprise d'activité pour les services hébergés | RA | I |
+| Réaliser des tests de restauration périodiques | RA |  |
+
+#### 3.2. Gestion des événements
+
+##### **3.2.1. Incidents**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Traiter les incidents matériels et réseau (tickets et contacts) | AI | RA |
+
+##### **3.2.2. Changements**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Respecter la politique de cycle de vie du service (EoL) | I | RA |
+| Déployer les correctifs et mettre à jour les logiciels sur l'infrastructure de management du service |  | RA |
+| Réaliser les interventions préventives sur les éléments managés du service |  | AR |
+
+### 4. Réversibilité
+
+#### 4.1. Modèle de réversibilité
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Planifier les opérations de réversibilité | RA |  |
+| Choisir les infrastructures de repli | RA |  |
+
+#### 4.2. Récupération des données
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer les opérations de réversibilité : extraction manuelle, API, import/export des données dans un format pris en charge par l'hyperviseur ou par une distribution compatible NFS  | RA | I |
+| Migrer/transférer les données | RA |
+
+### 5. Fin de service
+
+#### 5.1. Destruction des configurations
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Supprimer les services de stockage (via l'API ou l'interface utilisateur ) | RA | I |
+| Décommissionner le service du client suite à la résiliation du contrat  | I | RA |
+
+#### 5.2. Destruction des données
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Réaliser un effacement sécurisé des données sur les supports de stockage |  | RA |
+
+## Aller plus loin
+
+Rendez-vous sur notre canal Discord dédié : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos retours et échangez directement avec l'équipe qui construit nos services.
+
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/micron-7500-fw-upgrade.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/micron-7500-fw-upgrade.mdx
@@ -1,73 +1,73 @@
 ---
-title: Serveurs Dédiés - Mise à jour du firmware de votre Micron 7500 PRO (EN)
-description: Learn how to upgrade your Micron 7500 PRO firmware for Linux, ESXi and Windows Dedicated Servers
+title: Serveurs dédiés - Mise à jour du firmware de votre Micron 7500 PRO
+description: Découvrez comment mettre à jour le firmware de votre Micron 7500 PRO pour les serveurs dédiés Linux, ESXi et Windows
 lastUpdated: 2025-09-25
 ---
 
-## Objective
+## Objectif
 
-Routine firmware updates play a pivotal role in upholding your drives, performance, stability, and security. Such updates often encompass critical bug fixes, enhanced compatibility, and advanced security features that are indispensable for preserving your data integrity and maintaining optimal operational efficiency.
+Les mises à jour régulières du firmware jouent un rôle déterminant dans le maintien de vos disques, de leurs performances, de leur stabilité et de leur sécurité. Ces mises à jour intègrent souvent des corrections de bugs critiques, une compatibilité améliorée et des fonctionnalités de sécurité avancées, indispensables pour préserver l'intégrité de vos données et maintenir une efficacité opérationnelle optimale.
 
-**An important patch has been introduced in this new firmware (version E3MQ005). We strongly recommend updating your firmware to avoid premature failure.**
+**Un correctif important a été introduit dans ce nouveau firmware (version E3MQ005). Nous vous recommandons fortement de mettre à jour votre firmware afin d'éviter une défaillance prématurée.**
 
-> **Firmware Release Notes:**
+> **Notes de version du firmware :**
 > 
-> - Increased compatibility with customer platforms  
-> - Disable LTR (Latency Tolerance Reporting) support  
-> - Improved overall product robustness for handling invalid commands and non‑compliant host behavior  
-> - Improved firmware handling during shutdown and power‑on  
-> - Improved MCP command handling  
-> - Improved NVMe‑Mi command processing and handling  
-> - Improved alignment with OCP 2.0 specification  
+> - Compatibilité accrue avec les plateformes clientes  
+> - Désactivation de la prise en charge du LTR (Latency Tolerance Reporting)  
+> - Robustesse globale du produit améliorée pour le traitement des commandes non valides et des comportements hôtes non conformes  
+> - Gestion du firmware améliorée lors de l'extinction et de la mise sous tension  
+> - Traitement des commandes MCP amélioré  
+> - Traitement et gestion des commandes NVMe‑Mi améliorés  
+> - Meilleur alignement sur la spécification OCP 2.0  
 
-## Drive Part Number
+## Référence du disque
 
-- **MTFDKCC960TGP-1BK1DABYY** (960 GB capacity)  
-- **MTFDKCC1T9TGP-1BK1DABYY** (1.92 TB capacity)  
-- **MTFDKCC3T8TGP-1BK1DABYY** (3.84 TB capacity)  
-- **MTFDKCC7T6TGP-1BK1DABYY** (7.86 TB capacity)  
-- **MTFDKCC15T3TGP-1BK1DABYY** (15.36 TB capacity)  
+- **MTFDKCC960TGP-1BK1DABYY** (capacité de 960 Go)  
+- **MTFDKCC1T9TGP-1BK1DABYY** (capacité de 1,92 To)  
+- **MTFDKCC3T8TGP-1BK1DABYY** (capacité de 3,84 To)  
+- **MTFDKCC7T6TGP-1BK1DABYY** (capacité de 7,86 To)  
+- **MTFDKCC15T3TGP-1BK1DABYY** (capacité de 15,36 To)  
 
-**The purpose of this guide is to help you upgrade your Micron 7500 PRO PCIe 4.0 NVMe firmware.**
+**Ce guide a pour objectif de vous aider à mettre à jour le firmware de votre Micron 7500 PRO PCIe 4.0 NVMe.**
 
-## Requirements
+## Prérequis
 
-A bare metal server with a Micron 7500 PRO PCIe 4.0 NVMe device, from the following ranges:
+Un serveur bare metal équipé d'un périphérique Micron 7500 PRO PCIe 4.0 NVMe, parmi les gammes suivantes :
 
 - High Grade  
 - Scale  
 - Advance  
-- Rise (Processor AMD Ryzen R5‑5600X, AMD Ryzen R7‑5800X, AMD Ryzen R7‑3700pro, AMD Epyc 7302, Intel Xeon E5‑2689v4)  
+- Rise (processeur AMD Ryzen R5‑5600X, AMD Ryzen R7‑5800X, AMD Ryzen R7‑3700pro, AMD Epyc 7302, Intel Xeon E5‑2689v4)  
 
-## Instructions
+## En pratique
 
 :::danger
-- Before attempting any firmware update, a backup of the data on the drive **must** be made. Use our guide on [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) to learn how to back up your data.  
-- The firmware update does **not** format the drive or delete data, but a firmware update failure may happen. **Do not power off the drive or the bare metal server during the firmware update process.**
+- Avant toute tentative de mise à jour du firmware, une sauvegarde des données présentes sur le disque **doit** être réalisée. Consultez notre guide sur le [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) pour savoir comment sauvegarder vos données.  
+- La mise à jour du firmware ne formate **pas** le disque et ne supprime pas les données, mais un échec de la mise à jour du firmware peut se produire. **N'éteignez ni le disque ni le serveur bare metal pendant le processus de mise à jour du firmware.**
 
 :::
 
 
 
 :::info
-All commands must be run as **root** for Linux and VMware ESXi, and with an **administrator** account for Windows.  
+Toutes les commandes doivent être exécutées en tant que **root** pour Linux et VMware ESXi, et avec un compte **administrateur** pour Windows.  
 :::
 
 
 ### Linux
 
-#### Software configuration tested by OVHcloud
+#### Configuration logicielle testée par OVHcloud
 
-| Platform      | nvme flash tool version | Firmware | Result |
+| Plateforme    | Version de l'outil de flash nvme | Firmware | Résultat |
 |---------------|-------------------------|----------|--------|
-| Debian 13 OS  | 2.13‑2                 | E3MQ005 | OK |
-| Debian 12 OS  | 2.4+really2.3‑3       | E3MQ005 | OK |
-| Ubuntu 22.04 OS | 1.16‑3ubuntu0.3      | E3MQ005 | OK |
-| Ubuntu 24.04 OS | 2.8‑1ubuntu0.1       | E3MQ005 | OK |
-| Rocky 9 OS    | 2.11‑6.el9_6           | E3MQ005 | OK |
-| Rocky 10 OS   | 2.11‑6.el10_0          | E3MQ005 | OK |
+| Debian 13 OS  | 2.13‑2                 | E3MQ005 | OK |
+| Debian 12 OS  | 2.4+really2.3‑3       | E3MQ005 | OK |
+| Ubuntu 22.04 OS | 1.16‑3ubuntu0.3      | E3MQ005 | OK |
+| Ubuntu 24.04 OS | 2.8‑1ubuntu0.1       | E3MQ005 | OK |
+| Rocky 9 OS    | 2.11‑6.el9_6           | E3MQ005 | OK |
+| Rocky 10 OS   | 2.11‑6.el10_0          | E3MQ005 | OK |
 
-#### Step 1 – Install `nvme‑cli`
+#### Étape 1 – Installer `nvme-cli`
 
 ```bash
 dnf install nvme-cli          # RHEL, CentOS, RockyLinux, AlmaLinux, Fedora, etc.
@@ -77,49 +77,49 @@ dnf install nvme-cli          # RHEL, CentOS, RockyLinux, AlmaLinux, Fedora, etc
 apt install nvme-cli          # Debian, Ubuntu, Mint, Proxmox, etc.
 ```
 
-#### Step 2 – Check if a firmware update is needed
+#### Étape 2 – Vérifier si une mise à jour du firmware est nécessaire
 
-The command `nvme list` lists all NVMe devices on your server:
+La commande `nvme list` affiche la liste de tous les périphériques NVMe présents sur votre serveur :
 
 ```bash
 nvme list | grep -E 'Node|MTFDKCC960TGP-1BK1DABYY|MTFDKCC1T9TGP-1BK1DABYY|MTFDKCC3T8TGP-1BK1DABYY|MTFDKCC7T6TGP-1BK1DABYY|MTFDKCC15T3TGP-1BK1DABYY'
 ```
 
 :::info
-We added a filter on this command to only display Micron 7500 PRO NVMe devices, because the firmware update only concerns these NVMe models and your server may have other disks connected to it.
+Nous avons ajouté un filtre à cette commande afin de n'afficher que les périphériques NVMe Micron 7500 PRO, car la mise à jour du firmware ne concerne que ces modèles NVMe et votre serveur peut être équipé d'autres disques.
 :::
 
 
 :::info
-If the column **FW Rev** for all your Micron 7500 PRO devices is already **E3MQ005**, your firmware is up‑to‑date and you do not need to continue. Otherwise, proceed with step 3.
+Si la colonne **FW Rev** affiche déjà **E3MQ005** pour tous vos périphériques Micron 7500 PRO, votre firmware est à jour et vous n'avez pas besoin de poursuivre. Dans le cas contraire, passez à l'étape 3.
 :::
 
 
-##### Example result (2 drives to update)
+##### Exemple de résultat (2 disques à mettre à jour)
 
 ```text
 Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
-/dev/nvme0n1          /dev/ng0n1            032510B842C5         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ001
-/dev/nvme1n1          /dev/ng1n1            132510B824CD         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ001
+/dev/nvme0n1          /dev/ng0n1            032510B842C5         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ001
+/dev/nvme1n1          /dev/ng1n1            132510B824CD         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ001
 ```
 
-#### Step 3 – Firmware update
+#### Étape 3 – Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/7500_PRO/Micron_7500_E3MQ005_release.ubi
 ```
 
-Execute the following command for each NVMe identified in step 2:  
-(Replace `X` with the device node.)
+Exécutez la commande suivante pour chaque NVMe identifié à l'étape 2 :  
+(remplacez `X` par le nœud du périphérique).
 
 ```bash
 nvme fw-download --fw Micron_7500_E3MQ005_release.ubi /dev/nvmeX
 nvme fw-commit /dev/nvmeX -s 2 -a 3
 ```
 
-**NVMe firmware update example**
+**Exemple de mise à jour du firmware NVMe**
 
 ```text
 root@labo:/home/debian# nvme fw-download --fw Micron_7500_E3MQ005_release.ubi /dev/nvme0
@@ -135,40 +135,40 @@ Multiple Update Detected (MUD) Value: 0
 ```
 
 :::info
-Once the command line is launched, a confirmation is requested before starting the flash. Confirm with `Y`.
+Une fois la ligne de commande lancée, une confirmation est demandée avant le démarrage du flash. Confirmez avec `Y`.
 :::
 
 
-#### Step 4 – Verify firmware version after server reboot
+#### Étape 4 – Vérifier la version du firmware après le redémarrage du serveur
 
-You can use the same command as in step 2:
+Vous pouvez utiliser la même commande qu'à l'étape 2 :
 
 ```bash
 nvme list | grep -E 'Node|MTFDKCC960TGP-1BK1DABYY|MTFDKCC1T9TGP-1BK1DABYY|MTFDKCC3T8TGP-1BK1DABYY|MTFDKCC7T6TGP-1BK1DABYY|MTFDKCC15T3TGP-1BK1DABYY'
 ```
 
-Expected output:
+Résultat attendu :
 
 ```text
 Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
-/dev/nvme0n1          /dev/ng0n1            032510B842C5         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ005
-/dev/nvme1n1          /dev/ng1n1            132510B824CD         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ005
+/dev/nvme0n1          /dev/ng0n1            032510B842C5         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ005
+/dev/nvme1n1          /dev/ng1n1            132510B824CD         MTFDKCC1T9TGP-1BK1DABYY                  0x1          8.19 kB /   1.92 TB    512 B + 0 B   E3MQ005
 ```
 
-Now your NVMe drives should have have the firmware version **E3MQ005**.
+Vos disques NVMe doivent désormais disposer de la version de firmware **E3MQ005**.
 
 ### ESXi
 
-#### Software configuration tested by OVHcloud
+#### Configuration logicielle testée par OVHcloud
 
-| Platform          | Flash tool | Firmware | Result |
+| Plateforme        | Outil de flash | Firmware | Résultat |
 |-------------------|------------|----------|--------|
-| ESXi 8.0.3 OS     | esxcli 8.0.3 | E3MQ005 | OK |
-| ESXi 9.0.0 OS     | esxcli 9.0.0 | E3MQ005 | OK |
+| ESXi 8.0.3 OS     | esxcli 8.0.3 | E3MQ005 | OK |
+| ESXi 9.0.0 OS     | esxcli 9.0.0 | E3MQ005 | OK |
 
-#### Step 1 – List NVMe drives and check if a firmware update is needed
+#### Étape 1 – Lister les disques NVMe et vérifier si une mise à jour du firmware est nécessaire
 
-The command  `esxcli nvme controller list` lists all NVMe devices on your server:
+La commande  `esxcli nvme controller list` affiche la liste de tous les périphériques NVMe présents sur votre serveur :
 
 ```bash
 esxcli nvme adapter list | grep -oE '^vmhba\S' \
@@ -179,17 +179,17 @@ esxcli nvme adapter list | grep -oE '^vmhba\S' \
 ```
 
 :::info
- We added a filter on this command to only display Micron 7500 PRO NVMe devices, because the firmware update only concerns these NVMe models and your server may have other disks connected to it.
+ Nous avons ajouté un filtre à cette commande afin de n'afficher que les périphériques NVMe Micron 7500 PRO, car la mise à jour du firmware ne concerne que ces modèles NVMe et votre serveur peut être équipé d'autres disques.
 :::
 
 
 :::info
-If the column "Firmware Revision" for all your NVMe Micron 7500 PRO devices is already version E3MQ005, your firmware is up-to-date and you do not need to continue this process.
-On the other hand, if at least one firmware is different from version E3MQ005, you must proceed with step 2.
+Si la colonne « Firmware Revision » correspond déjà à la version E3MQ005 pour tous vos périphériques NVMe Micron 7500 PRO, votre firmware est à jour et vous n'avez pas besoin de poursuivre cette procédure.
+En revanche, si au moins un firmware est différent de la version E3MQ005, vous devez passer à l'étape 2.
 :::
 
 
-##### Example result (2 drives to update)
+##### Exemple de résultat (2 disques à mettre à jour)
 
 ```bash
 [root@labo:~] esxcli nvme adapter list | grep -oE '^vmhba\S' | xargs -I% sh -c "esxcli nvme device get -A % | grep -qE 'MTFDKCC960TGP-1BK1DABYY|MTFDKCC1T9TGP-1BK1DABYY|MTFDKCC3T8TGP-1BK1DABYY|MTFDKCC7T6TG
@@ -204,30 +204,30 @@ vmhba5:
    Firmware Revision: E3MQ001
 ```
 
-#### Step 2 – Firmware update
+#### Étape 2 – Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/7500_PRO/Micron_7500_E3MQ005_release.ubi --no-check-certificate
 ```
 
 :::info
-By default, ESXi’s firewall blocks outbound HTTPS traffic. If the download fails, add a firewall rule to allow outbound HTTPS connections.
+Par défaut, le pare-feu d'ESXi bloque le trafic HTTPS sortant. Si le téléchargement échoue, ajoutez une règle de pare-feu autorisant les connexions HTTPS sortantes.
 :::
 
 
-Execute the following command for each NVMe identified in step 1:  
-(Replace `X` with the adapter index.)
+Exécutez la commande suivante pour chaque NVMe identifié à l'étape 1 :  
+(remplacez `X` par l'index de l'adaptateur).
 
 ```bash
 esxcli nvme device firmware download -A vmhbaX -f /[path-to-firmware]/Micron_7500_E3MQ005_release.ubi
 esxcli nvme device firmware activate -a 3 -A vmhbaX -s 2
 ```
 
-##### NVMe firmware update example
+##### Exemple de mise à jour du firmware NVMe
 
-In our previous example, both NVMe drives need a firmware update to the latest version ****. Here are example commands for how to update the 2 NVMe drives and their output:
+Dans notre exemple précédent, les deux disques NVMe nécessitent une mise à jour du firmware vers la dernière version ****. Voici des exemples de commandes pour mettre à jour les 2 disques NVMe, ainsi que leur résultat :
 
 ```bash
 [root@labo:~] esxcli nvme device firmware download -A vmhba6 -f /Micron_7500_E3MQ005_release.ubi
@@ -240,11 +240,11 @@ Download firmware successfully.
 Commit firmware successfully.
 ```
 
-At this point the firmware update is complete. Reboot the server to finish the process.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez le serveur pour finaliser le processus.
 
-#### Step 3 – Verify firmware version after reboot
+#### Étape 3 – Vérifier la version du firmware après le redémarrage
 
-You can use the same nvme list command as in step 1:
+Vous pouvez utiliser la même commande nvme list qu'à l'étape 1 :
 
 ```bash
 esxcli nvme adapter list | grep -oE '^vmhba\S' \
@@ -254,7 +254,7 @@ esxcli nvme adapter list | grep -oE '^vmhba\S' \
       | grep -E 'Model Number:|Firmware Revision:'"
 ```
 
-Expected output:
+Résultat attendu :
 
 ```text
 vmhba4:
@@ -265,52 +265,52 @@ vmhba5:
    Firmware Revision: E3MQ005
 ```
 
-Now your NVMe drives should have have the firmware version **E3MQ005**.
+Vos disques NVMe doivent désormais disposer de la version de firmware **E3MQ005**.
 
 
 ### Windows
 
-#### Software configuration tested by OVHcloud
+#### Configuration logicielle testée par OVHcloud
 
-| Platform        | Flash tool      | Firmware | Result |
+| Plateforme      | Outil de flash  | Firmware | Résultat |
 |-----------------|-----------------|----------|--------|
 | Windows 2019 OS | msecli 08.11.25 | E3MQ005  | OK     |
 | Windows 2022 OS | msecli 08.11.25 | E3MQ005  | OK     |
 | Windows 2025 OS | msecli 08.11.25 | E3MQ005  | OK     |
 
-#### Step 1 – Download `msecli`
+#### Étape 1 – Télécharger `msecli`
 
-Download the `msecli` executable:  
+Téléchargez l'exécutable `msecli` :  
 [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/7500_PRO/msecli-windows.exe](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/7500_PRO/msecli-windows.exe)
 
-Install the software with the default options.
+Installez le logiciel avec les options par défaut.
 
-#### Step 2 – List NVMe drive
+#### Étape 2 – Lister le disque NVMe
 
-Open Windows PowerShell as Administrator, then run the following command to list NVMe devices:
+Ouvrez Windows PowerShell en tant qu'administrateur, puis exécutez la commande suivante pour lister les périphériques NVMe :
 
 ```bash
 msecli -L | sls "MTFDKCC960TGP-1BK1DABYY","MTFDKCC1T9TGP-1BK1DABYY","MTFDKCC3T8TGP-1BK1DABYY","MTFDKCC7T6TGP-1BK1DABYY","MTFDKCC15T3TGP-1BK1DABYY" -Context 0,11
 ```
 
 :::info
-We added a filter on this command to only display the Micron 7500 PRO NVMe, because the firmware update only concerns these NVMe references and your server may have other disks connected to it.
+Nous avons ajouté un filtre à cette commande afin de n'afficher que les NVMe Micron 7500 PRO, car la mise à jour du firmware ne concerne que ces références NVMe et votre serveur peut être équipé d'autres disques.
 :::
 
 
 :::info
-If the line **FW‑Rev** for all your NVMe Micron 7500 PRO devices already displays version **E3MQ005**, your firmware is up‑to‑date and you do not need to continue this process.  
-On the other hand, if at least one firmware is different from version **E3MQ005**, you must proceed with step 3.
+Si la ligne **FW‑Rev** affiche déjà la version **E3MQ005** pour tous vos périphériques NVMe Micron 7500 PRO, votre firmware est à jour et vous n'avez pas besoin de poursuivre cette procédure.  
+En revanche, si au moins un firmware est différent de la version **E3MQ005**, vous devez passer à l'étape 3.
 :::
 
 
-##### Example result on a server with 2 NVMe drives to update
+##### Exemple de résultat sur un serveur comportant 2 disques NVMe à mettre à jour
 
 ```bash
 PS C:\Windows\system32> msecli -L | sls "MTFDKCC960TGP-1BK1DABYY","MTFDKCC1T9TGP-1BK1DABYY","MTFDKCC3T8TGP-1BK1DABYY","MTFDKCC7T6TGP-1BK1DABYY","MTFDKCC15T3TGP-1BK1DABYY" -Context 0,11
 ```
 
-Expected output:
+Résultat attendu :
 
 ```text
 > Model No             : MTFDKCC1T9TGP-1BK1DABYY
@@ -339,29 +339,29 @@ Expected output:
   OS Device            : Drive1
 ```
 
-#### Step 3 – Firmware update
+#### Étape 3 – Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 Invoke-WebRequest "https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/7500_PRO/Micron_7500_E3MQ005_release.ubi" -OutFile "Micron_7500_E3MQ005_release.ubi"
 ```
 
-Execute the following command for each identified NVMe in step 2. 
-(Replace `X` with the "OS Device" index listed in step 2.)
+Exécutez la commande suivante pour chaque NVMe identifié à l'étape 2. 
+(Remplacez `X` par l'index « OS Device » listé à l'étape 2.)
 
 ```bash
 msecli -F -U Micron_7500_E3MQ005_release.ubi -n DriveX -S 2
 ```
 
 :::info
-Once the command is launched, a confirmation is requested before starting the flash. Confirm with `Y`.
+Une fois la commande lancée, une confirmation est demandée avant le démarrage du flash. Confirmez avec `Y`.
 :::
 
 
-##### NVMe firmware update example
+##### Exemple de mise à jour du firmware NVMe
 
-In our previous example, both NVMe drives need a firmware update to the latest version **E3MQ005**. Here are example commands for how to update the 2 NVMe drives and their output:
+Dans notre exemple précédent, les deux disques NVMe nécessitent une mise à jour du firmware vers la dernière version **E3MQ005**. Voici des exemples de commandes pour mettre à jour les 2 disques NVMe, ainsi que leur résultat :
 
 ```bash
 PS C:\Windows\system32> msecli -F -U Micron_7500_E3MQ005_release.ubi -n Drive0 -S 2
@@ -400,17 +400,17 @@ TIME_STAMP   : Tue Sep 23 02:29:10 2025
 Copyright (C) 2025 Micron Technology, Inc.
 ```
 
-At this point the firmware update is complete. Reboot the server to finish the process.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez le serveur pour finaliser le processus.
 
-#### Step 4 – Verify firmware version after server reboot
+#### Étape 4 – Vérifier la version du firmware après le redémarrage du serveur
 
-You can use the same command as in step 2:
+Vous pouvez utiliser la même commande qu'à l'étape 2 :
 
 ```bash
 msecli -L | sls "MTFDKCC960TGP-1BK1DABYY","MTFDKCC1T9TGP-1BK1DABYY","MTFDKCC3T8TGP-1BK1DABYY","MTFDKCC7T6TGP-1BK1DABYY","MTFDKCC15T3TGP-1BK1DABYY" -0,11
 ```
 
-##### Example output after the update
+##### Exemple de résultat après la mise à jour
 
 ```bash
 PS C:\Windows\system32> msecli -L | sls "MTFDKCC960TGP-1BK1DABYY","MTFDKCC1T9TGP-1BK1DABYY","MTFDKCC3T8TGP-1BK1DABYY","MTFDKCC7T6TGP-1BK1DABYY","MTFDKCC15T3TGP-1BK1DABYY" -Context 0,11
@@ -443,10 +443,14 @@ PS C:\Windows\system32> msecli -L | sls "MTFDKCC960TGP-1BK1DABYY","MTFDKCC1T9TGP
   OS Device            : Drive3
 ```
 
-Now your NVMe drives should have have the firmware version **E3MQ005**.
+Vos disques NVMe doivent désormais disposer de la version de firmware **E3MQ005**.
 
-## Go further
+## Aller plus loin
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+[Mise à jour du firmware Samsung NVMe PM9A1 sur les serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
 
-Join our [community of users](/links/community).
+[Serveur dédié - Mise à jour du firmware du SSD Solidigm D7-P5520](/guides/bare-metal-cloud/dedicated-servers/solidigm-d7-p5520-fw-update)
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade.mdx
@@ -1,20 +1,20 @@
 ---
-title: Advance Dedicated Servers - Upgrading your Samsung NVMe PM9A1 firmware (EN)
-description: Learn how to upgrade your Samsung NVMe PM9A1 firmware for Linux, ESXi and Windows Dedicated Servers
+title: Serveurs dédiés Advance - Mise à jour du firmware de votre Samsung NVMe PM9A1
+description: Découvrez comment mettre à jour le firmware de votre Samsung NVMe PM9A1 pour les serveurs dédiés Linux, ESXi et Windows
 lastUpdated: 2023-10-18
 ---
 
-## Objective
+## Objectif
 
-Routine firmware updates play a pivotal role in upholding your NVMe drives' performance, stability, and security. Such updates often encompass critical bug fixes, enhanced compatibility, and advanced security features that are indispensable for preserving your data integrity and maintaining optimal operational efficiency.
+Les mises à jour régulières du firmware jouent un rôle déterminant dans le maintien des performances, de la stabilité et de la sécurité de vos disques NVMe. Ces mises à jour intègrent souvent des corrections de bugs critiques, une compatibilité améliorée et des fonctionnalités de sécurité avancées, indispensables pour préserver l'intégrité de vos données et maintenir une efficacité opérationnelle optimale.
 
-Firmware changelog : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/PM9A1_FW_Change_Notification_for_General_customer_v2.1_PDF.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/PM9A1_FW_Change_Notification_for_General_customer_v2.1_PDF.pdf)
+Journal des modifications du firmware : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/PM9A1_FW_Change_Notification_for_General_customer_v2.1_PDF.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/PM9A1_FW_Change_Notification_for_General_customer_v2.1_PDF.pdf)
 
-**The purpose of this guide is to help you upgrade your NVMe Samsung PM9A1 firmware.**
+**Ce guide a pour objectif de vous aider à mettre à jour le firmware de votre NVMe Samsung PM9A1.**
 
-## Requirements
+## Prérequis
 
-- An [Advance Dedicated Server](https://www.ovhcloud.com/fr/bare-metal/advance/) with NVMe Samsung PM9A1, from the following:
+- Un [serveur dédié Advance](https://www.ovhcloud.com/fr/bare-metal/advance/) équipé d'un NVMe Samsung PM9A1, parmi les modèles suivants :
     - Advance-1
     - Advance-2
     - Advance-3
@@ -22,49 +22,49 @@ Firmware changelog : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/har
     - Advance-5
     - Advance-6
 
-## Instructions
+## En pratique
 
 :::danger
-- Before attempting any firmware update, a backup of the data on the drive must be made. Use our guide on [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) to learn how to back up your data.
-- The firmware update does not format the data, but a firmware update failure may happen. Please do not power off the drive or the bare metal server during the firmware update process.
+- Avant toute tentative de mise à jour du firmware, une sauvegarde des données présentes sur le disque doit impérativement être réalisée. Consultez notre guide sur le [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) pour savoir comment sauvegarder vos données.
+- La mise à jour du firmware ne formate pas les données, mais un échec de la mise à jour du firmware peut se produire. N'éteignez ni le disque ni le serveur bare metal pendant le processus de mise à jour du firmware.
 
 :::
 
 
 ### Linux
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-**The tests have been performed without SED configuration.**
+**Les tests ont été réalisés sans configuration SED.**
 
-| Platform                                         | Flash tool    | Firmware | Result |
-|--------------------------------------------------|---------------|----------|--------|
-| Debian 11 OS + data in clear from disk           | cli 1.12      | GXA7802Q | OK     |
-| Ubuntu 22.04 OS + data in clear from disk        | nvme-cli 1.16 | GXA7802Q | OK     |
-| Rocky 8 OS + data in clear from disk             | nvme-cli 1.16 | GXA7802Q | OK     |
-| Debian 11 OS + data in clear from disk + RAID    | nvme-cli 1.12 | GXA7802Q | OK     |
-| Ubuntu 22.04 OS + data in clear from disk + RAID | nvme-cli 1.16 | GXA7802Q | OK     |
-| Rocky 8 OS + data in clear from disk + RAID      | nvme-cli 1.16 | GXA7802Q | OK     |
+| Plateforme                                                 | Outil de flash | Firmware | Résultat |
+|------------------------------------------------------------|----------------|----------|----------|
+| Debian 11 OS + données en clair depuis le disque           | cli 1.12       | GXA7802Q | OK       |
+| Ubuntu 22.04 OS + données en clair depuis le disque        | nvme-cli 1.16  | GXA7802Q | OK       |
+| Rocky 8 OS + données en clair depuis le disque             | nvme-cli 1.16  | GXA7802Q | OK       |
+| Debian 11 OS + données en clair depuis le disque + RAID    | nvme-cli 1.12  | GXA7802Q | OK       |
+| Ubuntu 22.04 OS + données en clair depuis le disque + RAID | nvme-cli 1.16  | GXA7802Q | OK       |
+| Rocky 8 OS + données en clair depuis le disque + RAID      | nvme-cli 1.16  | GXA7802Q | OK       |
 
-#### Step 1 - Install nvme-cli
+#### Étape 1 - Installer nvme-cli
 
-You can install nvme-cli from your distribution's package manager.
+Vous pouvez installer nvme-cli à partir du gestionnaire de paquets de votre distribution.
 
-- For RHEL, CentOS, RockyLinux, AlmaLinux, Fedora and similar:
+- Pour RHEL, CentOS, RockyLinux, AlmaLinux, Fedora et similaires :
 
 ```bash
 sudo dnf install nvme-cli
 ```
 
-- For Debian, Ubuntu, Mint, Proxmox and similar:
+- Pour Debian, Ubuntu, Mint, Proxmox et similaires :
 
 ```bash
 sudo apt install nvme-cli
 ```
 
-#### Step 2 - List NVMe drives <a name="linux-step2"></a>
+#### Étape 2 - Lister les disques NVMe <a name="linux-step2"></a>
 
-The nvme list command lists all NVMe devices on your server:
+La commande nvme list affiche la liste de tous les périphériques NVMe présents sur votre serveur :
 
 ```bash
 sudo nvme list | grep 'Node\|MZVL2512HCJQ-00B07'
@@ -74,30 +74,30 @@ Node             SN                   Model                                    N
 ```
 
 :::info
-We added a filter on this command to only display the `SAMSUNG MZVL2512HCJQ-00B07 NVME`, because the firmware update only concerns this NVMe reference and your server may have other disks connected to it.
+Nous avons ajouté un filtre à cette commande afin de n'afficher que le `SAMSUNG MZVL2512HCJQ-00B07 NVME`, car la mise à jour du firmware ne concerne que cette référence NVMe et votre serveur peut être équipé d'autres disques.
 :::
 
 
-#### Step 3 - Check if a firmware updated is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-The firmware of each drive is displayed in the `FW Rev` column.
+Le firmware de chaque disque est affiché dans la colonne `FW Rev`.
 
-If the firmware version for all your drive is already version **GXA7802Q**, your firmware is up to date and you do not need to continue this process.
+Si la version du firmware de tous vos disques est déjà la version **GXA7802Q**, votre firmware est à jour et vous n'avez pas besoin de poursuivre cette procédure.
 
-On the other hand, if at least one firmware is different from version **GXA7802Q**, you must proceed to the update detailed in step 4.
+En revanche, si au moins un firmware est différent de la version **GXA7802Q**, vous devez procéder à la mise à jour détaillée à l'étape 4.
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server :
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin
 ```
 
-Execute the following command for each identified drive with a firmware different from version **GXA7802Q**:
+Exécutez la commande suivante pour chaque disque identifié dont le firmware est différent de la version **GXA7802Q** :
 
 :::info
-In your command, replace `X` with the NVME node listed in [step 2](#linux-step2).
+Dans votre commande, remplacez `X` par le nœud NVME listé à l'[étape 2](#linux-step2).
 :::
 
 
@@ -106,9 +106,9 @@ sudo nvme fw-download --fw GXA7802Q_Noformat.bin /dev/nvmeX
 sudo nvme fw-activate --slot 0x1 --action 0x1 /dev/nvmeX
 ```
 
-- **Example**:
+- **Exemple** :
 
-In our previous example both NVMe drives need a firmware update to the latest version GXA7802Q. Here's how we update the 2 NVMe drives and the command line returns:
+Dans notre exemple précédent, les deux disques NVMe nécessitent une mise à jour du firmware vers la dernière version GXA7802Q. Voici comment nous mettons à jour les 2 disques NVMe, ainsi que les retours de la ligne de commande :
 
 ```bash
 root@labo:/home/ubuntu# sudo nvme fw-download --fw GXA7802Q_Noformat.bin /dev/nvme0
@@ -123,11 +123,11 @@ Success committing firmware action:1 slot:1
 Multiple Update Detected (MUD) Value: 0
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-You can use the same nvme list command which lists all NVMe drives on your server:
+Vous pouvez utiliser la même commande nvme list, qui affiche la liste de tous les disques NVMe présents sur votre serveur :
 
 ```bash
 sudo nvme list | grep 'Node\|MZVL2512HCJQ-00B07'
@@ -136,22 +136,22 @@ Node             SN                   Model                                    N
 /dev/nvme1n1     S63CNX0RA09597       SAMSUNG MZVL2512HCJQ-00B07               1          11.06  GB / 512.11  GB    512   B +  0 B   GXA7802Q
 ```
 
-Your NVMe drive now should have the firmware version **GXA7802Q**.
+Votre disque NVMe doit désormais disposer de la version de firmware **GXA7802Q**.
 
 ### ESXi
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-**The tests have been performed without SED configuration.**
+**Les tests ont été réalisés sans configuration SED.**
 
-| Platform                                         | Flash tool                   | Firmware | Result |
+| Plateforme                                       | Outil de flash               | Firmware | Résultat |
 |--------------------------------------------------|------------------------------|----------|--------|
-| ESXi 7.0 U3j OS + data in clear from disk        | esxcli 7.0.0                 | GXA7802Q | OK     |
-| ESXi 7.0 U3j OS + data in clear from disk + RAID | esxcli 7.0.0                 | GXA7802Q | OK     |
+| ESXi 7.0 U3j OS + données en clair depuis le disque        | esxcli 7.0.0                 | GXA7802Q | OK     |
+| ESXi 7.0 U3j OS + données en clair depuis le disque + RAID | esxcli 7.0.0                 | GXA7802Q | OK     |
 
-#### Step 1 - List NVMe drives <a name="esxi-step1"></a>
+#### Étape 1 - Lister les disques NVMe <a name="esxi-step1"></a>
 
-The `nvme controller list` command lists all NVMe devices on your server:
+La commande `nvme controller list` affiche la liste de tous les périphériques NVMe présents sur votre serveur :
 
 ```bash
 esxcli nvme controller list | grep -i 'PM9A1\|Adapter'
@@ -161,16 +161,16 @@ nqn.1994-11.com.samsung:nvme:PM9A1:M.2:S63CNX0TC10816                257  vmhba1
 ```
 
 :::info
-We added a filter on this command to only display the **PM9A1 NVMe**, because the firmware update only concerns this NVMe reference and your server may have other disks connected to it.
+Nous avons ajouté un filtre à cette commande afin de n'afficher que le **PM9A1 NVMe**, car la mise à jour du firmware ne concerne que cette référence NVMe et votre serveur peut être équipé d'autres disques.
 :::
 
 
-#### Step 2 - Check if a firmware update is needed <a name="esxi-step2"></a>
+#### Étape 2 - Vérifier si une mise à jour du firmware est nécessaire <a name="esxi-step2"></a>
 
-For each NVMe in the previous list, we have to check the firmware version :
+Pour chaque NVMe de la liste précédente, nous devons vérifier la version du firmware :
 
 :::info
-In your command, replace `X` with the NVME node listed in [step 2](#esxi-step1).
+Dans votre commande, remplacez `X` par le nœud NVME listé à l'[étape 2](#esxi-step1).
 :::
 
 
@@ -178,7 +178,7 @@ In your command, replace `X` with the NVME node listed in [step 2](#esxi-step1).
 esxcli nvme device get -A vmhbaX | egrep "Model Number|Firmware Revision"
 ```
 
-- **Example**:
+- **Exemple** :
 
 ```bash
 [root@labo:~] esxcli nvme device get -A vmhba2 | egrep "Model Number|Firmware Revision"
@@ -189,23 +189,23 @@ Model Number: SAMSUNG MZVL2512HCJQ-00B07
 Firmware Revision: GXA7602Q
 ```
 
-If the `Firmware Revision` for all your NVMe is already version **GXA7802Q**, your firmware is up to date and you do not need to continue this process.
+Si la valeur `Firmware Revision` de tous vos NVMe correspond déjà à la version **GXA7802Q**, votre firmware est à jour et vous n'avez pas besoin de poursuivre cette procédure.
 
-On the other hand, if at least one firmware is different from version **GXA7802Q**, you must proceed to the update detailed in step 3.
+En revanche, si au moins un firmware est différent de la version **GXA7802Q**, vous devez procéder à la mise à jour détaillée à l'étape 3.
 
-#### Step 3 - Firmware update
+#### Étape 3 - Mise à jour du firmware
 
-Download the firmware binary on your server :
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin
 ```
 
-Execute the following command for each identified drive with a firmware different from version **GXA7802Q**:
+Exécutez la commande suivante pour chaque disque identifié dont le firmware est différent de la version **GXA7802Q** :
 
 :::info
-- Replace `X` with the NVME node listed in [step 2](#esxi-step1).
-- Replace `[path-to-firmware]` with the actual firmware image path.
+- Remplacez `X` par le nœud NVME listé à l'[étape 2](#esxi-step1).
+- Remplacez `[path-to-firmware]` par le chemin réel de l'image du firmware.
 
 :::
 
@@ -215,10 +215,10 @@ esxcli nvme device firmware download -A vmhbaX -f /[path-to-firmware]/GXA7802Q_N
 esxcli nvme device firmware activate -a 1 -A vmhbaX -s 1
 ```
 
-- **Example**:
+- **Exemple** :
 
-In our previous example both NVMe drives needed a firmware update to the latest version **GXA7802Q**.<br/>
-Here's how we updated the 2 NVMe drives and the command line returns:
+Dans notre exemple précédent, les deux disques NVMe nécessitaient une mise à jour du firmware vers la dernière version **GXA7802Q**.<br/>
+Voici comment nous avons mis à jour les 2 disques NVMe, ainsi que les retours de la ligne de commande :
 
 ```bash
 [root@labo:~] esxcli nvme device firmware download -A vmhba2 -f /GXA7802Q_Noformat.bin
@@ -231,11 +231,11 @@ Download firmware successfully.
 Commit firmware successfully, but activation requires reboot.
 ```
 
-At this point the firmware update is complete, you need to reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Vous devez redémarrer votre serveur.
 
-#### Step 4 - Check the firmware version after the server reboot
+#### Étape 4 - Vérifier la version du firmware après le redémarrage du serveur
 
-You can use the same command as in [step 2](#esxi-step2) to check the firmware versions on your server:
+Vous pouvez utiliser la même commande qu'à l'[étape 2](#esxi-step2) pour vérifier les versions de firmware sur votre serveur :
 
 ```bash
 [root@labo:~] esxcli nvme device get -A vmhba2 | egrep "Model Number|Firmware Revision"
@@ -246,40 +246,40 @@ You can use the same command as in [step 2](#esxi-step2) to check the firmware v
    Firmware Revision: GXA7802Q
 ```
 
-Your NVMe drive now should have the firmware version **GXA7802Q**.
+Votre disque NVMe doit désormais disposer de la version de firmware **GXA7802Q**.
 
 ### Windows
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-**The tests have been performed without SED configuration.**
+**Les tests ont été réalisés sans configuration SED.**
 
-| Platform                                      | Flash tool                   | Firmware | Result |
+| Plateforme                                    | Outil de flash               | Firmware | Résultat |
 |-----------------------------------------------|------------------------------|----------|--------|
-| Windows 2016 + data in clear from disk        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
-| Windows 2019 + data in clear from disk        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
-| Windows 2022 + data in clear from disk        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
-| Windows 2016 + data in clear from disk + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
-| Windows 2019 + data in clear from disk + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
-| Windows 2022 + data in clear from disk + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2016 + données en clair depuis le disque        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2019 + données en clair depuis le disque        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2022 + données en clair depuis le disque        | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2016 + données en clair depuis le disque + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2019 + données en clair depuis le disque + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
+| Windows 2022 + données en clair depuis le disque + RAID | Samsung DC Toolkit 2.1.W.Q.0 | GXA7802Q | OK     |
 
-#### Step 1 - Download Samsung DC Toolkit for Windows
+#### Étape 1 - Télécharger le Samsung DC Toolkit pour Windows
 
-Download the Samgung DC Toolkit via [this link](https://semiconductor.samsung.com/resources/software-resources/Samsung_SSD_DC_Toolkit_for_Windows_1.exe).
+Téléchargez le Samsung DC Toolkit via [ce lien](https://semiconductor.samsung.com/resources/software-resources/Samsung_SSD_DC_Toolkit_for_Windows_1.exe).
 
-Tool version: Samsung DC Toolkit Version 2.1.W.Q.0
+Version de l'outil : Samsung DC Toolkit Version 2.1.W.Q.0
 
-#### Step 2 -  List drives and firmware versions <a name="windows-step2"></a>
+#### Étape 2 -  Lister les disques et les versions de firmware <a name="windows-step2"></a>
 
-Open Windows Command Prompt as Administrator, then use the following command in the directory where the DC Toolkit was downloaded:
+Ouvrez l'invite de commandes Windows en tant qu'administrateur, puis utilisez la commande suivante dans le répertoire où le DC Toolkit a été téléchargé :
 
 ```bash
 Samsung_SSD_DC_Toolkit_for_Windows_1.exe -L
 ```
 
-#### Step 3 -  Check if a firmware update is needed <a name="windows-step3"></a>
+#### Étape 3 -  Vérifier si une mise à jour du firmware est nécessaire <a name="windows-step3"></a>
 
-The following command lists all the devices on your server:
+La commande suivante affiche la liste de tous les périphériques présents sur votre serveur :
 
 ```bash
 C:\Users\admin\Downloads>Samsung_SSD_DC_Toolkit_for_Windows_1.exe -L
@@ -298,25 +298,25 @@ Copyright (C) 2017 SAMSUNG Electronics Co. Ltd. All rights reserved.
 ```
 
 :::warning
-This command displays all the disks present in the server. Only the lines `SAMSUNG MZVL2512HCJQ-00B07` have to be checked.
+Cette commande affiche tous les disques présents dans le serveur. Seules les lignes `SAMSUNG MZVL2512HCJQ-00B07` doivent être vérifiées.
 :::
 
 
-The firmware of each drive is displayed in the `Firmware` column.
+Le firmware de chaque disque est affiché dans la colonne `Firmware`.
 
-If the firmware version for all your drives is already version **GXA7802Q**, your firmware is up to date and you do not need to continue this process.
+Si la version du firmware de tous vos disques est déjà la version **GXA7802Q**, votre firmware est à jour et vous n'avez pas besoin de poursuivre cette procédure.
 
-On the other hand, if at least one firmware is different from version **GXA7802Q**, you must proceed to the update detailed in step 4.
+En revanche, si au moins un firmware est différent de la version **GXA7802Q**, vous devez procéder à la mise à jour détaillée à l'étape 4.
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin)
+Téléchargez le binaire du firmware sur votre serveur : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/PM9A1/GXA7802Q_Noformat.bin)
 
-Execute the following command for each identified drive with a firmware different from version **GXA7802Q**:
+Exécutez la commande suivante pour chaque disque identifié dont le firmware est différent de la version **GXA7802Q** :
 
 :::info
-- Replace `<X>` with the Disk Number listed in [step 3](#windows-step3).
-- Replace `<firmware directory>` with the directory where the firmware is located.
+- Remplacez `<X>` par le Disk Number listé à l'[étape 3](#windows-step3).
+- Remplacez `<firmware directory>` par le répertoire dans lequel se trouve le firmware.
 
 :::
 
@@ -325,10 +325,10 @@ Execute the following command for each identified drive with a firmware differen
 Samsung_SSD_DC_Toolkit_for_Windows_1.exe --disk `<X>` ---firmware-download --path `<firmware directory>GXA7802Q_Noformat.bin` --action 1 --slot 1
 ```
 
-- **Example**:
+- **Exemple** :
 
-In our previous example both NVMe drives needed a firmware update to the latest version GXA7802Q.`<bt>`
-Here's how we updated the 2 NVMe drives and the command line returns:
+Dans notre exemple précédent, les deux disques NVMe nécessitaient une mise à jour du firmware vers la dernière version GXA7802Q.`<bt>`
+Voici comment nous avons mis à jour les 2 disques NVMe, ainsi que les retours de la ligne de commande :
 
 ```bash
 C:\Users\admin\Downloads>Samsung_SSD_DC_Toolkit_for_Windows_1.exe --disk 0:c --nvme-firmware-download --path C:\Users\admin\Downloads\GXA7802Q_Noformat.bin --action 1 --slot 1
@@ -368,11 +368,11 @@ Continue Firmware image download ? [ yes ]: yes
 ------------------------------------------------------------------------------------------------
 ```
 
-At this point the firmware update is complete, you need to reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Vous devez redémarrer votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-You can use the same command as in [step 2](#windows-step2) to list all NVMe drives on your server:
+Vous pouvez utiliser la même commande qu'à l'[étape 2](#windows-step2) pour lister tous les disques NVMe présents sur votre serveur :
 
 ```bash
 C:\Users\admin\Downloads>Samsung_SSD_DC_Toolkit_for_Windows_1.exe -L
@@ -390,10 +390,14 @@ Copyright (C) 2017 SAMSUNG Electronics Co. Ltd. All rights reserved.
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-Your NVMe drive now should have the firmware version **GXA7802Q**.
+Votre disque NVMe doit désormais disposer de la version de firmware **GXA7802Q**.
 
-## Go further <a name="gofurther"></a>
+## Aller plus loin <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+[Serveurs dédiés - Mise à jour du firmware de votre Micron 7500 PRO](/guides/bare-metal-cloud/dedicated-servers/micron-7500-fw-upgrade)
 
-Join our [community of users](/links/community).
+[Serveur dédié - Mise à jour du firmware du SSD Solidigm D7-P5520](/guides/bare-metal-cloud/dedicated-servers/solidigm-d7-p5520-fw-update)
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/wd-sas-fw-upgrade.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/wd-sas-fw-upgrade.mdx
@@ -1,51 +1,51 @@
 ---
-title: High Grade Dedicated Servers - Upgrading your SSD SAS Western Digital SS300 firmware (EN)
-description: Learn how to upgrade your SSD SAS Western Digital SS300 firmware for Linux, ESXi and Windows Dedicated Servers
+title: Serveurs dédiés High Grade - Mise à jour du firmware de votre SSD SAS Western Digital SS300
+description: Découvrez comment mettre à jour le firmware de votre SSD SAS Western Digital SS300 pour les serveurs dédiés Linux, ESXi et Windows
 lastUpdated: 2024-03-26
 ---
 
-## Objective
+## Objectif
 
-Routine firmware updates play a pivotal role in upholding your drive's performance, stability, and security. Such updates often encompass critical bug fixes, enhanced compatibility, and advanced security features that are indispensable for preserving your data integrity and maintaining optimal operational efficiency.
+Les mises à jour régulières du firmware jouent un rôle essentiel dans le maintien des performances, de la stabilité et de la sécurité de votre disque. Ces mises à jour intègrent souvent des corrections de bugs critiques, une compatibilité améliorée et des fonctionnalités de sécurité avancées, indispensables à la préservation de l'intégrité de vos données et au maintien d'une efficacité opérationnelle optimale.
 
-An important patch has been introduced in this new firmware (version BCGNB17D). We strongly recommend updating your firmware to avoid any premature end-of-life.
+Un correctif important a été introduit dans ce nouveau firmware (version BCGNB17D). Nous vous recommandons fortement de mettre à jour votre firmware afin d'éviter toute fin de vie prématurée.
 
-Firmware Release Notes: [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/PCN-005015-A00.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/PCN-005015-A00.pdf)
+Notes de version du firmware : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/PCN-005015-A00.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/PCN-005015-A00.pdf)
 
-**The purpose of this guide is to help you upgrade your SSD SAS Western Digital SS300 firmware.**
+**L'objectif de ce guide est de vous aider à mettre à jour le firmware de votre SSD SAS Western Digital SS300.**
 
-Disk part numbers:
+Références des disques :
 
-- HUSMR3280ASS201 (800GB capacity)
-- HUSMR3240ASS201 (400GB capacity)
+- HUSMR3280ASS201 (capacité de 800 Go)
+- HUSMR3240ASS201 (capacité de 400 Go)
 
-## Requirements
+## Prérequis
 
-- A bare metal server with SSD SAS Western Digital SS300, from the following:
+- Un serveur bare metal équipé d'un SSD SAS Western Digital SS300, parmi les gammes suivantes :
     - mHG/HG/BHG 2017
     - mHG/HG/BHG 2018
     - mHG/HG/BHG 2019
 
 
-## Instructions
+## En pratique
 
 :::danger
-- Before attempting any firmware update, a backup of the data on the drive must be made. Use our guide on [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) to learn how to back up your data.
-- The firmware update does not format the drive or delete data, but a firmware update failure may happen. Please do not power off the drive or the bare metal server during the firmware update process.
+- Avant toute tentative de mise à jour du firmware, une sauvegarde des données présentes sur le disque doit être effectuée. Consultez notre guide sur le [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) pour savoir comment sauvegarder vos données.
+- La mise à jour du firmware ne formate pas le disque et n'efface pas les données, mais un échec de la mise à jour du firmware peut survenir. N'éteignez pas le disque ni le serveur bare metal pendant le processus de mise à jour du firmware.
 
 :::
 
 
 :::info
-All commands must be run as root for Linux and VMWare and with an administrator account for Windows.
+Toutes les commandes doivent être exécutées en tant que root sous Linux et VMWare, et avec un compte administrateur sous Windows.
 :::
 
 
 ### Linux
 
-#### Hardware/software configuration tested on the OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool    | Firmware | Result |
+| Plateforme                                       | Outil de flash | Firmware | Résultat |
 |--------------------------------------------------|---------------|----------|--------|
 | Debian 11/12 OS                                  | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 | Ubuntu 22.04 OS                                  | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
@@ -54,49 +54,49 @@ All commands must be run as root for Linux and VMWare and with an administrator 
 | Ubuntu 22.04 OS + HARD RAID                      | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 | Rocky 7/8 OS + HARD RAID                         | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-- For Debian, Ubuntu, Mint, Proxmox and similar:
+- Pour Debian, Ubuntu, Mint, Proxmox et similaires :
 
 ```bash
 dpkg -i Unified_storcli_all_os/Ubuntu/storcli_007.2705.0000.0000_all.deb
 ```
 
-- For RHEL, CentOS, RockyLinux, AlmaLinux, Fedora and similar:
+- Pour RHEL, CentOS, RockyLinux, AlmaLinux, Fedora et similaires :
 
 ```bash
 rpm -ivh Unified_storcli_all_os/Linux/storcli-007.2705.0000.0000-1.noarch.rpm
 ```
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the *Ctl* field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ *Ctl* :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 show
 ```
 
-Example:
+Exemple :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 show
@@ -130,20 +130,20 @@ Hlth=Health|Safe=Safe-mode boot|CertProv-Certificate Provision mode
 Chrg=Charging | MsngCbl=Cable Failure
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS300 because the firmware update only concerns this particular disk and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS300, car la mise à jour du firmware ne concerne que ce disque en particulier et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk enclosure ID and 0/1 the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (252:0 et 252:1). 252 est l'identifiant de l'enclosure du disque et 0/1 le numéro d'emplacement du disque :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
@@ -151,26 +151,26 @@ root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep -i 'HUS
 252:1     4 JBOD  -  745.211 GB SAS  SSD Y   N  512B HUSMR3280ASS201  U  -
 ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/BCGNB17D.bin
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /ey /sz download src=BCGNB17D.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version BCGNB17D. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version BCGNB17D. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /e252 /s0 download src=BCGNB17D.bin
@@ -191,22 +191,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /ey /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@rescue:~# /opt/MegaRAID/storcli/storcli64 /c0 /e252 /s0 show all | grep -i 'Firmware Revision'
@@ -216,70 +216,70 @@ Firmware Revision = B17D
 ```
 
 :::info
-The firmware version displayed for each disk must be B17D, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B17D, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
-Your NVMe drive now should have the firmware version **BCGNB17D**.
+Votre disque NVMe doit désormais disposer de la version de firmware **BCGNB17D**.
 
 ### ESXi 7.x
 
-#### Hardware/software configuration tested on the OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool                   | Firmware | Result |
+| Plateforme                                       | Outil de flash               | Firmware | Résultat |
 |--------------------------------------------------|------------------------------|----------|--------|
-| ESXi 7.0 U3o OS + data in clear from disk        | StorCLI 007.2705.0000.0000   | BCGNB17D | OK     |
+| ESXi 7.0 U3o OS + données en clair depuis le disque | StorCLI 007.2705.0000.0000   | BCGNB17D | OK     |
 | ESXi 7.0 U3o OS + HARD RAID                      | StorCLI 007.2705.0000.0000   | BCGNB17D | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip --no-check-certificate
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-Unpack the ESXi 7.x archive:
+Décompressez l'archive ESXi 7.x :
 
 ```bash
 unzip Unified_storcli_all_os/VMware/ESXi7/BCM-vmware-storcli64_007.2705.0000.0000-01_22442561-package.zip
 unzip BCM-vmware-storcli64_007.2705.0000.0000-01_22442561.zip
 ```
 
-Then install StorCLI:
+Installez ensuite StorCLI :
 
 ```bash
 esxcli software vib install -v=<absolute path>/vib20/vmware-storcli64/BCM_bootbank_vmware-storcli64_007.2705.0000.0000-01.vib
 ```
 
 :::info
-`<absolute path>` must be replaced with the .vib package absolute path from the root directory (/).
+`<absolute path>` doit être remplacé par le chemin absolu du paquet .vib depuis le répertoire racine (/).
 :::
 
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the *Ctl* field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ *Ctl* :
 
 ```bash
 /opt/lsi/storcli64/storcli64 show
 ```
 
-Example:
+Exemple :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 show
@@ -313,21 +313,21 @@ Hlth=Health|Safe=Safe-mode boot|CertProv-Certificate Provision mode
 Chrg=Charging | MsngCbl=Cable Failure
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS300 because the firmware update only concerns this particular disk and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS300, car la mise à jour du firmware ne concerne que ce disque en particulier et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk enclosure ID and 0/1 the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (252:0 et 252:1). 252 est l'identifiant de l'enclosure du disque et 0/1 le numéro d'emplacement du disque :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 /c0 /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
@@ -335,27 +335,27 @@ In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk en
 252:1     4 Onln   0 744.687 GB SAS  SSD Y   N  512B HUSMR3280ASS201  U  -
 ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/BCGNB17D.bin --no-check-certificate
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /ey /sz download src=BCGNB17D.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BCGNB17D**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BCGNB17D**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 /c0 /e252 /s0 download src=BCGNB17D.bin
@@ -376,22 +376,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /ey /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@rescue:~# /opt/lsi/storcli64/storcli64 /c0 /e252 /s0 show all | grep -i 'Firmware Revision'
@@ -401,71 +401,71 @@ Firmware Revision = B17D
 ```
 
 :::info
-The firmware version displayed for each disk must be B17D, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B17D, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 
 ### ESXi 8.x
 
-#### Hardware/software configuration tested on the OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool                   | Firmware | Result |
+| Plateforme                                       | Outil de flash               | Firmware | Résultat |
 |--------------------------------------------------|------------------------------|----------|--------|
 | ESXi 8.0b OS                                     | StorCLI 007.2705.0000.0000   | BCGNB17D | OK     |
 | ESXi 8.0b OS + HARD RAID                         | StorCLI 007.2705.0000.0000   | BCGNB17D | OK     |
   
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip --no-check-certificate
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-Unpack the ESXi 8.x archive:
+Décompressez l'archive ESXi 8.x :
 
 ```bash
 unzip Unified_storcli_all_os/VMware/ESXi8/BCM-storcli_007.2705.0000.0000-01_22439253-package.zip
 unzip BCM-storcli_007.2705.0000.0000-01_22439253.zip
 ```
 
-Then install StorCLI:
+Installez ensuite StorCLI :
 
 ```bash
 esxcli software vib install -v=<absolute path>/vib20/storcli/BCM_bootbank_storcli_007.2705.0000.0000-01.vib
 ```
 
 :::info
-`<absolute path>` must be replaced with the .vib package absolute path from the root directory (/).
+`<absolute path>` doit être remplacé par le chemin absolu du paquet .vib depuis le répertoire racine (/).
 :::
 
 
-Run a server reboot, which is necessary in order to update the binary. 
+Effectuez un redémarrage du serveur, nécessaire à la mise à jour du binaire. 
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the *Ctl* field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ *Ctl* :
 
 ```bash
 /opt/storcli/bin/storcli64 show
 ```
 
-Example:
+Exemple :
 
 ```bash
 [root@labo:~] /opt/storcli/bin/storcli64 show
@@ -499,21 +499,21 @@ Hlth=Health|Safe=Safe-mode boot|CertProv-Certificate Provision mode
 Chrg=Charging | MsngCbl=Cable Failure
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS300 because the firmware update only concerns this particular disk and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS300, car la mise à jour du firmware ne concerne que ce disque en particulier et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk enclosure ID and 0/1 the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (252:0 et 252:1). 252 est l'identifiant de l'enclosure du disque et 0/1 le numéro d'emplacement du disque :
 
 ```bash
 [root@labo:~] /opt/storcli/bin/storcli64 /c0 /eall /sall show | grep -i 'HUSMR3240ASS201\|HUSMR3280ASS201'
@@ -521,26 +521,26 @@ In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk en
 252:1     4 Onln   0 744.687 GB SAS  SSD Y   N  512B HUSMR3280ASS201  U  -
 ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/BCGNB17D.bin --no-check-certificate
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /ey /sz download src=BCGNB17D.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BCGNB17D**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BCGNB17D**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 [root@labo:~] /opt/storcli/bin/storcli64 /c0 /e252 /s0 download src=BCGNB17D.bin
@@ -561,22 +561,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /ey /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@rescue:~# /opt/storcli/bin/storcli64 /c0 /e252 /s0 show all | grep -i 'Firmware Revision'
@@ -586,16 +586,16 @@ Firmware Revision = B17D
 ```
 
 :::info
-The firmware version displayed for each disk must be B17D, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B17D, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 
 ### Windows
 
-#### Hardware/software configuration tested on the OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                      | Flash tool                   | Firmware | Result |
+| Plateforme                                    | Outil de flash               | Firmware | Résultat |
 |-----------------------------------------------|------------------------------|----------|--------|
 | Windows 2016                                  | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 | Windows 2019                                  | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
@@ -604,15 +604,15 @@ The firmware version displayed for each disk must be B17D, corresponding to the 
 | Windows 2019 + HARD RAID                      | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 | Windows 2022 + HARD RAID	                     | StorCLI 007.2705.0000.0000 | BCGNB17D | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI via this link: [https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip](https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip)
+Téléchargez StorCLI via ce lien : [https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip](https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip)
 
-Unzip the archive. The tool you need to use, **storcli.exe**, is located in the folder: storcli_rel\Unified_storcli_all_os.zip\Unified_storcli_all_os\Windows
+Décompressez l'archive. L'outil que vous devez utiliser, **storcli.exe**, se trouve dans le dossier : storcli_rel\Unified_storcli_all_os.zip\Unified_storcli_all_os\Windows
 
-#### Step 2 - Check if a firmware update is needed
+#### Étape 2 - Vérifier si une mise à jour du firmware est nécessaire
 
-Open Windows PowerShell as Administrator, then run the following command in the directory where storcli.exe was unzipped to retrieve your controller ID in the *Ctl* field:
+Ouvrez Windows PowerShell en tant qu'administrateur, puis exécutez la commande suivante dans le répertoire où storcli.exe a été décompressé afin de récupérer l'identifiant de votre contrôleur dans le champ *Ctl* :
 
 ```bash
 .\storcli64.exe show
@@ -650,20 +650,20 @@ Hlth=Health|Safe=Safe-mode boot|CertProv-Certificate Provision mode
 Chrg=Charging | MsngCbl=Cable Failure
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 .\storcli64.exe /cx /eall /sall show | oss | sls "HUSMR3240ASS201","HUSMR3280ASS201"
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS300 because the firmware update only concerns this particular disk and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS300, car la mise à jour du firmware ne concerne que ce disque en particulier et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (252:0 and 252:1). 252 is the disk enclosure ID and 0/1 the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (252:0 et 252:1). 252 est l'identifiant de l'enclosure du disque et 0/1 le numéro d'emplacement du disque :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /eall /sall show | oss | sls "HUSMR3240ASS201","HUSMR3280ASS201"
@@ -672,26 +672,26 @@ PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_sto
 252:1     4 Onln   0 744.687 GB SAS  SSD Y   N  512B HUSMR3280ASS201  U  -
 ```
 
-#### Step 3 - Firmware update
+#### Étape 3 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget "https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS300/BCGNB17D.bin" -outfile "BCGNB17D.bin"
 ```
 
-Execute the following command for each identified disk displayed in step 2:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 2 :
 
 ```bash
 .\storcli64.exe /cx /ey /sz download src=BCGNB17D.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version BCGNB17D. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version BCGNB17D. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /e252 /s0 download src=BCGNB17D.bin
@@ -713,20 +713,20 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-#### Step 4 - Check the firmware version after the server reboot
+#### Étape 4 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 2:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 2 :
 
 ```bash
 .\storcli64.exe /cx /ey /sz show all | oss | sls "Firmware Revision"
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /e252 /s0 show all | oss | sls "Firmware Revision"
@@ -739,13 +739,17 @@ Firmware Revision = B17D
 ```
 
 :::info
-The firmware version displayed for each disk must be B17D, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B17D, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 
-## Go further <a name="gofurther"></a>
+## Aller plus loin <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+[Mise à jour du firmware des SSD WD SS530 sur un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade)
 
-Join our [community of users](/links/community).
+[Mise à jour du firmware des SSD Samsung NVMe PM9A1 sur les serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade.mdx
@@ -1,51 +1,51 @@
 ---
-title: High Grade Dedicated Servers - Upgrading your SSD SAS Western Digital SS530 firmware (EN)
-description: Learn how to upgrade your SSD SAS Western Digital SS530 firmware for Linux, ESXi and Windows Dedicated Servers
+title: Serveurs dédiés High Grade - Mise à jour du firmware de votre SSD SAS Western Digital SS530
+description: Découvrez comment mettre à jour le firmware de votre SSD SAS Western Digital SS530 pour les serveurs dédiés Linux, ESXi et Windows
 lastUpdated: 2024-08-06
 ---
 
-## Objective
+## Objectif
 
-Routine firmware updates play a pivotal role in upholding your drives performance, stability, and security. Such updates often encompass critical bug fixes, enhanced compatibility, and advanced security features that are indispensable for preserving your data integrity and maintaining optimal operational efficiency.
+Les mises à jour régulières du firmware jouent un rôle essentiel dans le maintien des performances, de la stabilité et de la sécurité de vos disques. Ces mises à jour intègrent souvent des corrections de bugs critiques, une compatibilité améliorée et des fonctionnalités de sécurité avancées, indispensables à la préservation de l'intégrité de vos données et au maintien d'une efficacité opérationnelle optimale.
 
-An important patch has been introduced in this new firmware (version BPGNB969). We strongly recommend that you update your firmware to avoid premature end-of-life.
+Un correctif important a été introduit dans ce nouveau firmware (version BPGNB969). Nous vous recommandons fortement de mettre à jour votre firmware afin d'éviter une fin de vie prématurée.
 
-Firmware Release Notes: [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/PCN-005196-A01.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/PCN-005196-A01.pdf)
+Notes de version du firmware : [https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/PCN-005196-A01.pdf](https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/PCN-005196-A01.pdf)
 
-**The purpose of this guide is to help you upgrade your SSD SAS Western Digital SS530 firmware.**
+**L'objectif de ce guide est de vous aider à mettre à jour le firmware de votre SSD SAS Western Digital SS530.**
 
-Disk Part Number:
+Référence du disque :
 
-- WUSTR6440ASS201 (400GB capacity)
-- WUSTR6416ASS201 (1.6TB capacity)
-- WUSTR1538ASS201 (3.84TB capacity)
-- WUSTR1515ASS201 (15.36TB capacity)
+- WUSTR6440ASS201 (capacité de 400 Go)
+- WUSTR6416ASS201 (capacité de 1,6 To)
+- WUSTR1538ASS201 (capacité de 3,84 To)
+- WUSTR1515ASS201 (capacité de 15,36 To)
 
-## Requirements
+## Prérequis
 
-- A bare metal server with SSD SAS Western Digital SS530, from the following:
+- Un serveur bare metal équipé d'un SSD SAS Western Digital SS530, parmi les gammes suivantes :
     - High Grade HCI
     - mHG/HG/BHG 2019
 
-## Instructions
+## En pratique
 
 :::danger
-- Before attempting any firmware update, a backup of the data on the drive must be made. Use our guide on [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) to learn how to back up your data.
-- The firmware update does not format the drive or delete data, but a firmware update failure may happen. Please do not power off the drive or the bare metal server during the firmware update process.
+- Avant toute tentative de mise à jour du firmware, une sauvegarde des données présentes sur le disque doit être effectuée. Consultez notre guide sur le [Backup Storage](/guides/bare-metal-cloud/dedicated-servers/services-backup-storage) pour savoir comment sauvegarder vos données.
+- La mise à jour du firmware ne formate pas le disque et n'efface pas les données, mais un échec de la mise à jour du firmware peut survenir. N'éteignez pas le disque ni le serveur bare metal pendant le processus de mise à jour du firmware.
 
 :::
 
 
 :::info
-All commands must be run as root for Linux and VMWare and with an administrator account for Windows.
+Toutes les commandes doivent être exécutées en tant que root sous Linux et VMWare, et avec un compte administrateur sous Windows.
 :::
 
 
 ### Linux
 
-#### Hardware/software configuration tested on the OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool    | Firmware | Result |
+| Plateforme                                       | Outil de flash | Firmware | Résultat |
 |--------------------------------------------------|---------------|----------|--------|
 | Debian 11/12 OS                                  | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 | Ubuntu 22.04 OS                                  | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
@@ -54,49 +54,49 @@ All commands must be run as root for Linux and VMWare and with an administrator 
 | Ubuntu 22.04 OS + HARD RAID                      | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 | Rocky 7/8 OS + HARD RAID                         | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-- For Debian, Ubuntu, Mint, Proxmox and similar:
+- Pour Debian, Ubuntu, Mint, Proxmox et similaires :
 
 ```bash
 dpkg -i Unified_storcli_all_os/Ubuntu/storcli_007.2705.0000.0000_all.deb
 ```
 
-- For RHEL, CentOS, RockyLinux, AlmaLinux, Fedora and similar:
+- Pour RHEL, CentOS, RockyLinux, AlmaLinux, Fedora et similaires :
 
 ```bash
 rpm -ivh Unified_storcli_all_os/Linux/storcli-007.2705.0000.0000-1.noarch.rpm
 ```
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the *Ctl* field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ *Ctl* :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 show
 ```
 
-Example:
+Exemple :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 show
@@ -122,20 +122,20 @@ Ctl Model       AdapterType   VendId DevId SubVendId SubDevId PCI Address
 --------------------------------------------------------------------------
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS530 because the firmware update only concerns these disk reference and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS530, car la mise à jour du firmware ne concerne que ces références de disque et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (:0 et :1). 0/1 est le numéro d'emplacement du disque :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
@@ -143,26 +143,26 @@ root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /sall show | grep -i 'WUSTR6440
  :1       3 UGood -  3.492 TB SAS  SSD -   -  512B WUSTR1538ASS201  -
 ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/BPGNB969.bin
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /sz download src=BPGNB969.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BPGNB969**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BPGNB969**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /s0 download src=BPGNB969.bin
@@ -181,22 +181,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/MegaRAID/storcli/storcli64 /cx /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@labo:~# /opt/MegaRAID/storcli/storcli64 /c0 /s0 show all | grep -i 'Firmware Revision'
@@ -206,68 +206,68 @@ Firmware Revision = B969
 ```
 
 :::info
-The firmware version displayed for each disk must be B969, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B969, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 ### ESXi 7.x
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool                   | Firmware | Result |
+| Plateforme                                       | Outil de flash               | Firmware | Résultat |
 |--------------------------------------------------|------------------------------|----------|--------|
-| ESXi 7.0 U3o OS + data in clear from disk        | StorCLI 007.2705.0000.0000   | BPGNB969 | OK     |
+| ESXi 7.0 U3o OS + données en clair depuis le disque | StorCLI 007.2705.0000.0000   | BPGNB969 | OK     |
 | ESXi 7.0 U3o OS + HARD RAID                      | StorCLI 007.2705.0000.0000   | BPGNB969 | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip --no-check-certificate
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-Unpack the ESXi 7.x archive:
+Décompressez l'archive ESXi 7.x :
 
 ```bash
 unzip Unified_storcli_all_os/VMware/ESXi7/BCM-vmware-storcli64_007.2705.0000.0000-01_22442561-package.zip
 unzip BCM-vmware-storcli64_007.2705.0000.0000-01_22442561.zip
 ```
 
-Then install StorCLI:
+Installez ensuite StorCLI :
 
 ```bash
 esxcli software vib install -v=<absolute path>/vib20/vmware-storcli64/BCM_bootbank_vmware-storcli64_007.2705.0000.0000-01.vib
 ```
 
 :::info
-`<absolute path>` must be replaced with the .vib package absolute path from the root directory (/).
+`<absolute path>` doit être remplacé par le chemin absolu du paquet .vib depuis le répertoire racine (/).
 :::
 
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the Ctl field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ Ctl :
 
 ```bash
 /opt/lsi/storcli64/storcli64 show
 ```
 
-Example:
+Exemple :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 show
@@ -293,20 +293,20 @@ Ctl Model       AdapterType   VendId DevId SubVendId SubDevId PCI Address
 --------------------------------------------------------------------------
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS530 because the firmware update only concerns this disk reference and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS530, car la mise à jour du firmware ne concerne que cette référence de disque et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (:0 et :1). 0/1 est le numéro d'emplacement du disque :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 /c0 /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
@@ -314,26 +314,26 @@ In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot num
  :1       3 UGood -  3.492 TB SAS  SSD -   -  512B WUSTR1538ASS201  -
 ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/BPGNB969.bin --no-check-certificate
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /sz download src=BPGNB969.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BPGNB969**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BPGNB969**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 [root@labo:~] /opt/lsi/storcli64/storcli64 /c0 /s0 download src=BPGNB969.bin
@@ -354,22 +354,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/lsi/storcli64/storcli64 /cx /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@rescue:~# /opt/lsi/storcli64/storcli64 /c0 /s0 show all | grep -i 'Firmware Revision'
@@ -379,65 +379,65 @@ Firmware Revision = B969
 ```
 
 :::info
-The firmware version displayed for each disk must be B969, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B969, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 ### ESXi 8.x
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                         | Flash tool                   | Firmware | Result |
+| Plateforme                                       | Outil de flash               | Firmware | Résultat |
 |--------------------------------------------------|------------------------------|----------|--------|
 | ESXi 8.0b OS                                     | StorCLI 007.2705.0000.0000   | BPGNB969 | OK     |
 | ESXi 8.0b OS + HARD RAID                         | StorCLI 007.2705.0000.0000   | BPGNB969 | OK     |
 
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI package on your server:
+Téléchargez le paquet StorCLI sur votre serveur :
 
 ```bash
 wget https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip --no-check-certificate
 ```
 
-Unpack the global archive:
+Décompressez l'archive globale :
 
 ```bash
 unzip 007.2705.0000.0000_storcli_rel.zip
 ```
 
-Then unpack the archive containing the binaries for the various OS:
+Décompressez ensuite l'archive contenant les binaires pour les différents systèmes d'exploitation :
 
 ```bash
 unzip storcli_rel/Unified_storcli_all_os.zip
 ```
 
-#### Step 2 - Install StorCLI
+#### Étape 2 - Installer StorCLI
 
-Unpack the ESXi 8.x archive:
+Décompressez l'archive ESXi 8.x :
 
 ```bash
 unzip Unified_storcli_all_os/VMware/ESXi8/BCM-storcli_007.2705.0000.0000-01_22439253-package.zip
 unzip BCM-storcli_007.2705.0000.0000-01_22439253.zip
 ```
 
-Then install StorCLI:
+Installez ensuite StorCLI :
 
 ```bash
 esxcli software vib install -v=<absolute path>/vib20/storcli/BCM_bootbank_storcli_007.2705.0000.0000-01.vib
 ```
 
 :::info
-`<absolute path>` must be replaced with the .vib package absolute path from the root directory (/).
+`<absolute path>` doit être remplacé par le chemin absolu du paquet .vib depuis le répertoire racine (/).
 :::
 
 
-Run a server reboot, which is necessary in order to update the binary.
+Effectuez un redémarrage du serveur, nécessaire à la mise à jour du binaire.
 
-#### Step 3 - Check if a firmware update is needed
+#### Étape 3 - Vérifier si une mise à jour du firmware est nécessaire
 
-Run the following command to retrieve your controller ID in the Ctl field:
+Exécutez la commande suivante pour récupérer l'identifiant de votre contrôleur dans le champ Ctl :
 
 ```bash
 /opt/storcli/bin/storcli64 show
@@ -467,20 +467,20 @@ Ctl Model       AdapterType   VendId DevId SubVendId SubDevId PCI Address
 --------------------------------------------------------------------------
 ```
 
-Then retrieve enclosure and disks slots numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement des disques en exécutant la commande suivante :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS530 because the firmware update only concerns these disk reference and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS530, car la mise à jour du firmware ne concerne que ces références de disque et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (:0 et :1). 0/1 est le numéro d'emplacement du disque :
 
 ```bash
 [root@labo:~] /opt/storcli/bin/storcli64 /c0 /sall show | grep -i 'WUSTR6440ASS201\|WUSTR6416ASS201\|WUSTR1538ASS201\|WUSTR1515ASS201'
@@ -488,26 +488,26 @@ In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot num
  :1       3 UGood -  3.492 TB SAS  SSD -   -  512B WUSTR1538ASS201  -
  ```
 
-#### Step 4 - Firmware update
+#### Étape 4 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/BPGNB969.bin --no-check-certificate
 ```
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /sz download src=BPGNB969.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BPGNB969**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BPGNB969**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 [root@labo:~] /opt/storcli/bin/storcli64 /c0 /s0 download src=BPGNB969.bin
@@ -526,22 +526,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 5 - Check the firmware version after the server reboot
+#### Étape 5 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 3:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 3 :
 
 ```bash
 /opt/storcli/bin/storcli64 /cx /sz show all | grep -i 'Firmware Revision'
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 root@rescue:~# /opt/storcli/bin/storcli64 /c0 /s0 show all | grep -i 'Firmware Revision'
@@ -551,15 +551,15 @@ Firmware Revision = B969
 ```
 
 :::info
-The firmware version displayed for each disk must be B969, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B969, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
 ### Windows
 
-#### Hardware/software configuration tested on OVHcloud side
+#### Configuration matérielle/logicielle testée par OVHcloud
 
-| Platform                                      | Flash tool                   | Firmware | Result |
+| Plateforme                                    | Outil de flash               | Firmware | Résultat |
 |-----------------------------------------------|------------------------------|----------|--------|
 | Windows 2016                                  | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 | Windows 2019                                  | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
@@ -568,17 +568,17 @@ The firmware version displayed for each disk must be B969, corresponding to the 
 | Windows 2019 + HARD RAID                      | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 | Windows 2022 + HARD RAID	                    | StorCLI 007.2705.0000.0000 | BPGNB969 | OK     |
 
-#### Step 1 - Download StorCLI
+#### Étape 1 - Télécharger StorCLI
 
-Download the StorCLI via this link: [https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip](https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip)
+Téléchargez StorCLI via ce lien : [https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip](https://docs.broadcom.com/docs-and-downloads/007.2705.0000.0000_storcli_rel.zip)
 
-Tool version: StorCLI 007.2705.0000.0000
+Version de l'outil : StorCLI 007.2705.0000.0000
 
-Unzip the archive. The tool **storcli.exe** to use is located in the folder: `storcli_rel\Unified_storcli_all_os.zip\Unified_storcli_all_os\Windows`
+Décompressez l'archive. L'outil **storcli.exe** à utiliser se trouve dans le dossier : `storcli_rel\Unified_storcli_all_os.zip\Unified_storcli_all_os\Windows`
 
-##### Step 2 - Check if a firmware update is needed
+##### Étape 2 - Vérifier si une mise à jour du firmware est nécessaire
 
-Open Windows PowerShell as Administrator, then run the following command in the directory where storcli.exe was unzipped to retrieve your controller ID in the Ctl field:
+Ouvrez Windows PowerShell en tant qu'administrateur, puis exécutez la commande suivante dans le répertoire où storcli.exe a été décompressé afin de récupérer l'identifiant de votre contrôleur dans le champ Ctl :
 
 ```bash
 .\storcli64.exe show
@@ -608,20 +608,20 @@ Ctl Model       AdapterType   VendId DevId SubVendId SubDevId PCI Address
 --------------------------------------------------------------------------
 ```
 
-Then retrieve enclosure and disk slot numbers by running the command:
+Récupérez ensuite les numéros d'enclosure et d'emplacement du disque en exécutant la commande suivante :
 
 ```bash
 .\storcli64.exe /cx /sall show | oss | sls "WUSTR6440ASS201","WUSTR6416ASS201","WUSTR1538ASS201","WUSTR1515ASS201"
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour (voir ci-dessus).
 :::
 
 
-**We added a filter on this command to only display the SSD SAS Western Digital SS530 because the firmware update only concerns these disk reference and your server may have other disks connected to it.**
+**Nous avons ajouté un filtre à cette commande pour n'afficher que les SSD SAS Western Digital SS530, car la mise à jour du firmware ne concerne que ces références de disque et votre serveur peut être équipé d'autres disques.**
 
-In our example, 2 disks need to be updated (:0 and :1). 0/1 is the disk slot number:
+Dans notre exemple, 2 disques doivent être mis à jour (:0 et :1). 0/1 est le numéro d'emplacement du disque :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /sall show | oss | sls "WUSTR6440ASS201","WUSTR6416ASS201","WUSTR1538ASS201","WUSTR1515ASS201"
@@ -630,26 +630,26 @@ PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_sto
  :1       3 UGood -  3.492 TB SAS  SSD -   -  512B WUSTR1538ASS201  -
 ```
 
-#### Step 3 - Firmware update
+#### Étape 3 - Mise à jour du firmware
 
-Download the firmware binary on your server:
+Téléchargez le binaire du firmware sur votre serveur :
 
 ```bash
 wget "https://last-public-ovh-baremetal.snap.mirrors.ovh.net/hardware/SS530/BPGNB969.bin" -outfile "BPGNB969.bin"
 ```
 
-Execute the following command for each identified disk displayed in step 2:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 2 :
 
 ```bash
 .\storcli64.exe /cx /sz download src=BPGNB969.bin
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-In our previous example, 2 disks need a firmware update to the latest firmware version **BPGNB969**. Here's how we update the 2 disks and the command line returns:
+Dans notre exemple précédent, 2 disques nécessitent une mise à jour du firmware vers la dernière version **BPGNB969**. Voici comment nous mettons à jour les 2 disques et les retours de la ligne de commande :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /s0 download src=BPGNB969.bin
@@ -669,22 +669,22 @@ Status = Success
 Description = Firmware Download Succeeded.
 ```
 
-At this point the firmware update is complete, please reboot your server.
+À ce stade, la mise à jour du firmware est terminée. Redémarrez votre serveur.
 
-#### Step 4 - Check the firmware version after the server reboot
+#### Étape 4 - Vérifier la version du firmware après le redémarrage du serveur
 
-Execute the following command for each identified disk displayed in step 2:
+Exécutez la commande suivante pour chaque disque identifié à l'étape 2 :
 
 ```bash
 .\storcli64.exe /cx /sz show all | oss | sls "Firmware Revision"
 ```
 
 :::info
-x is the ID of the controller managing the disks to be updated; y is the disk enclosure ID; z is the disk slot number (see above).
+x est l'identifiant du contrôleur gérant les disques à mettre à jour ; y est l'identifiant de l'enclosure du disque ; z est le numéro d'emplacement du disque (voir ci-dessus).
 :::
 
 
-Result for our example in this guide:
+Résultat pour l'exemple de ce guide :
 
 ```bash
 PS C:\Users\admin\Desktop\007.2705.0000.0000_storcli_rel\storcli_rel\Unified_storcli_all_os\Unified_storcli_all_os\Windows> .\storcli64.exe /c0 /s0 show all | oss | sls "Firmware Revision"
@@ -697,12 +697,16 @@ Firmware Revision = B969
 ```
 
 :::info
-The firmware version displayed for each disk must be B969, corresponding to the firmware we have just flashed.
+La version du firmware affichée pour chaque disque doit être B969, ce qui correspond au firmware que nous venons de flasher.
 :::
 
 
-## Go further <a name="gofurther"></a>
+## Aller plus loin <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+[Mise à jour du firmware des SSD WD SS300 sur un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/wd-sas-fw-upgrade)
 
-Join our [community of users](/links/community).
+[Mise à jour du firmware des SSD Samsung NVMe PM9A1 sur les serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/manage-and-operate/api/api-right-delegation.mdx
+++ b/docs/fr/guides/manage-and-operate/api/api-right-delegation.mdx
@@ -1,1 +1,115 @@
-../../../../en/guides/manage-and-operate/api/api-right-delegation.mdx
+---
+title: Gérer le compte d'un client via l'API OVHcloud
+description: Découvrez comment créer une application et gérer les services de vos clients
+lastUpdated: 2026-07-17
+---
+
+## Objectif
+
+Dans ce guide, vous allez apprendre à utiliser l'OVHcloud API pour gérer les services et les ressources du compte d'une autre personne.
+
+À titre d'exemple, supposons que vous souhaitiez créer une marketplace dans laquelle vous pourriez, en tant que fournisseur de services, installer et configurer les ressources d'autres clients OVHcloud.
+
+## Prérequis
+
+- un compte OVHcloud
+
+## En pratique
+
+### Enregistrement de l'application
+
+La première étape, en tant que développeur de l'application, consiste à enregistrer votre application auprès d'OVHcloud.
+
+Pour cela, rendez-vous sur la <ManagerLink urls={{ eu: 'https://auth.eu.ovhcloud.com/api/createApp', ca: 'https://auth.ca.ovhcloud.com/api/createApp' }}>page de création d'application de l'OVHcloud API</ManagerLink>.
+
+Vous devrez vous connecter, puis définir un nom et une description pour votre application.
+
+<img className="thumbnail" alt="Création d'une application" src="/images/manage-and-operate/api/api-right-delegation/createapp.png" loading="lazy" />
+
+Une fois connecté, vous obtiendrez votre `Application Key` et votre `Application Secret`, désignés par la suite par `AK` et `AS`.
+
+<img className="thumbnail" alt="Application Key et Application Secret" src="/images/manage-and-operate/api/api-right-delegation/ak-as.png" loading="lazy" />
+
+L'`AK` identifie votre application. Elle peut être partagée publiquement.
+
+L'`AS` est une clé utilisée pour signer les requêtes API qui seront effectuées ultérieurement par votre application. Elle **doit** rester secrète.
+
+#### Synthèse
+
+<img className="thumbnail" alt="diagramme de séquence" src="/images/manage-and-operate/api/api-right-delegation/sequence01.png" loading="lazy" />
+
+### Déployer votre application
+
+Pour illustrer cette partie, supposons que vous avez déployé le code de votre application sur un serveur.
+
+Votre application peut accéder à la valeur de l'`AK` et de l'`AS`, et affiche une liste de stacks logicielles ou de services que les clients peuvent installer.
+
+### Délégation de droits
+
+Supposons qu'un client parcourant votre marketplace sélectionne un service à déployer sur son compte OVHcloud. À ce stade, vous n'avez aucun droit sur son API. Vous devez lui demander l'autorisation de gérer ses ressources.
+
+### Créer une demande d'autorisation
+
+La première étape consiste, pour votre application, à demander des autorisations sur l'API du client.
+
+Pour cela, votre application va demander des identifiants en appelant <ApiLink section="/auth" method="POST" route={"/auth/credential"}>`POST /auth/credential`</ApiLink> et en passant en argument la liste des endpoints auxquels elle doit accéder.
+
+{/*
+Application Name: maketplace
+Application Description: my little marketplace
+Application Key: F7gzxgxN5eqwuAsK
+Application Secret: UsNmaE8iqvAV6qT0VieCNVrSys9a5hkr
+ */}
+
+{/* https://webhook.site/586c652e-061e-453f-bd71-51912e33419d */}
+
+Exemple avec curl, avec une demande d'accès à `GET /me`.
+
+```bash
+export AK=F7gzxgxN5eqwuAsK
+export REDIRECT_URL=https://webhook.site/586c652e-061e-453f-bd71-51912e33419d # usefull for debug
+
+curl -H "Content-type: application/json" -H "X-Ovh-Application: $AK" -d '{"redirection": "$REDIRECT_URL", "accessRules": [{"method": "GET", "path": "/me"}]}' https://eu.api.ovh.com/1.0/auth/credential
+```
+
+Le résultat de cet appel est un dictionnaire JSON.
+
+```json
+{
+  "state":"pendingValidation",
+  "consumerKey":"5DU984kYxyoAe4lRaevZCGnmt9FVnKT2",
+  "validationUrl":"https://eu.api.ovh.com/auth/?credentialToken=RAXoRq9FvUQFI1S6hE0HmkySyVp8aDWwIqBA3fYrOr0vVSMdpjqxFqp3IjyjGAfu"
+}
+```
+
+En tant que développeur, vous devez stocker la `consumerKey`, désignée par la suite par `CK`. Cette clé servira à signer les requêtes vers l'OVHcloud API effectuées pour le compte de votre client.
+
+La demande a été effectuée : vous devez maintenant obtenir l'accord de votre client en le redirigeant vers la `validationUrl`.
+
+### Formulaire de connexion du client
+
+Après avoir été redirigé vers la `validationUrl`, le client est invité à confirmer la délégation de droits.
+
+<img className="thumbnail" alt="confirmation des droits" src="/images/manage-and-operate/api/api-right-delegation/validate-ck.png" loading="lazy" />
+
+En cas de succès, le client est redirigé vers l'URL précédemment définie par `REDIRECT_URL` dans la commande curl.
+
+### Accéder à l'API du client
+
+À ce stade, vous devez disposer de trois jetons :
+
+- l'application key `AK`
+- l'application secret `AS`
+- la consumer key `CK`
+
+À partir de là, et selon les autorisations demandées, vous pouvez commencer à gérer les ressources de vos clients.
+
+#### Synthèse
+
+<img className="thumbnail" alt="diagramme de séquence" src="/images/manage-and-operate/api/api-right-delegation/sequence02.png" loading="lazy" />
+
+Bon développement !
+
+## Aller plus loin
+
+- <ApiLink>API Console</ApiLink>

--- a/docs/fr/guides/manage-and-operate/terraform/at-ovhcloud.mdx
+++ b/docs/fr/guides/manage-and-operate/terraform/at-ovhcloud.mdx
@@ -1,1 +1,190 @@
-../../../../en/guides/manage-and-operate/terraform/at-ovhcloud.mdx
+---
+title: Utiliser Terraform avec OVHcloud
+description: Découvrez les ressources utiles pour utiliser Terraform avec OVHcloud
+lastUpdated: 2025-06-13
+---
+
+## Introduction
+
+[Terraform](https://www.terraform.io/) est un outil open source d'infrastructure as code (IaC) créé par [Hashicorp](https://www.hashicorp.com/) en 2014 et écrit en Go. Il a pour objectif de construire, modifier et versionner votre infrastructure. Vous pouvez définir et provisionner votre infrastructure en écrivant la définition de vos ressources en Hashicorp Configuration Language (HCL).
+
+Il est largement utilisé et vous pouvez également l'employer avec OVHcloud.
+
+Le concept de [provider](https://developer.hashicorp.com/terraform/language/providers) est au cœur du produit Terraform : il s'agit d'un plugin qui permet d'interagir avec une API.
+
+## Providers
+
+En fonction de vos besoins d'automatisation chez OVHcloud, vous devez choisir un ou plusieurs des providers Terraform suivants :
+
+- [Provider OVH](https://registry.terraform.io/providers/ovh/ovh/latest), qui interagit avec l'<ApiLink>API OVHcloud</ApiLink>. Vous pouvez consulter [ce guide](/guides/manage-and-operate/api/first-steps) pour en savoir plus sur l'utilisation de l'API. Par ailleurs, le provider OVH évolue au même rythme que l'offre OVHcloud : pensez à suivre les [releases](https://github.com/ovh/terraform-provider-ovh/releases).
+- [Provider OpenStack](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/lastest) : la plateforme de cloud computing open standard utilisée par OVHcloud pour propulser son service Public Cloud. Pour plus d'informations, consultez [cette page](/links/public-cloud/openstack).
+- [Provider AWS de Hashicorp](https://registry.terraform.io/providers/hashicorp/aws/latest/), pour automatiser les opérations sur l'Object Storage.
+- [Provider Kubernetes de Hashicorp](https://registry.terraform.io/providers/hashicorp/kubernetes/latest) : une fois votre cluster Kubernetes provisionné avec le provider OVH, vous pouvez gérer votre configuration Kubernetes avec ce provider.
+- [Provider vSphere de Hashicorp](https://registry.terraform.io/providers/hashicorp/vsphere/latest), pour automatiser les opérations sur les [solutions VMware on OVHcloud](/links/hosted-private-cloud/enterprise).
+- [Provider Nutanix](https://registry.terraform.io/providers/nutanix/nutanix/latest), pour automatiser les opérations sur [Nutanix on OVHcloud](/links/hosted-private-cloud/nutanix).
+
+## Correspondance entre l'interface OVHcloud et les providers et ressources Terraform
+
+L'interface graphique de la console OVHcloud (également appelée « espace client » ou « Manager ») masque à l'utilisateur une partie de la complexité de l'API sous-jacente. À partir d'un concept de l'interface graphique, il peut être difficile de trouver le provider correspondant et la
+[ressource](https://developer.hashicorp.com/terraform/language/resources) associée. Les tableaux ci-dessous sont là pour vous aider.
+
+:::info
+- Les catégories suivantes sont basées sur la version « New version (Beta) » de l'espace client de décembre 2022.
+- Si aucune ressource n'est disponible mais qu'une [data source](https://developer.hashicorp.com/terraform/language/data-sources) Terraform l'est, cela est indiqué dans le tableau par « [source de données] ».
+- Lorsque plusieurs ressources sont disponibles pour un même concept de l'interface graphique, seule la ressource principale est indiquée dans cette liste.
+
+:::
+
+ 
+### Bare Metal Cloud
+
+| Concept de l'espace client | Provider Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Serveur dédié | ovh | [source de données] [ovh_dedicated_server](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/dedicated_server) |
+| Serveur privé virtuel | ovh | [ovh_vps](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/vps) |
+| HA-NAS | ovh |-[source de données] [ovh_dedicated_nasha](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/dedicated_nasha)<br/>- [ovh_dedicated_nasha_partition](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dedicated_nasha_partition)|
+| Enterprise File Storage | ovh | non disponible |
+| Cloud Disk array | ovh | [source de données] [ovh_dedicated_ceph](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/dedicated_ceph)|
+| Veeam Cloud Connect | non disponible ||
+| Logs Data Platform | ovh | partiellement disponible :<br/>- [ovh_dbaas_logs_graylog_output_stream](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dbaas_logs_graylog_output_stream) <br/> - [ovh_dbaas_logs_input](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dbaas_logs_input) <br/>- [source de données] [ovh_dbaas_logs_input_engine](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/dbaas_logs_input_engine)
+
+### Hosted Private Cloud
+
+| Concept de l'espace client | Provider Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| VMware   |- non disponible pour la commande<br/>- [vsphere](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs) pour la gestion| voir le provider|
+| Nutanix |- non disponible pour la commande<br/>- [nutanix](https://registry.terraform.io/providers/nutanix/nutanix/lastest) pour la gestion| voir le provider|
+
+### Public Cloud
+
+#### Compute
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Instances (VM et Metal)  | openstack | [openstack_compute_instance_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2) |
+
+#### Stockage et sauvegarde
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Block Storage  | openstack | [blockstorage_volume_v3](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/blockstorage_volume_v3)|
+| Object Storage (Swift) | openstack | [objectstorage_object_v1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/objectstorage_object_v1) |
+| Object Storage | ovh | [cloud_project_storage](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_storage)|
+| Utilisateurs Object Storage | ovh | [ovh_cloud_project_user](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_user) avec le rôle *objectstore_operator*|
+| Cloud Archive | openstack | [objectstorage_object_v1](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/objectstorage_object_v1) avec [storage_policy](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/objectstorage_container_v1#storage_policy) défini sur « PCA » afin de créer un conteneur swift « archive » |
+| Cold Archive | Hashicorp aws | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)|
+| Bases de données | ovh | [cloud_project_database](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_database) et [cloud_project_database_database](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_database_database)|
+| Snapshot de volume | openstack | [openstack_blockstorage_snapshot_v3](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/data-sources/blockstorage_snapshot_v3)|
+| Sauvegarde de volume | openstack | [source de données] [openstack_blockstorage_volume_v3](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/data-sources/blockstorage_volume_v3)|
+| Sauvegarde d'instance | openstack |[openstack_images_image_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/images_image_v2)|
+
+#### Réseau
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Réseau privé (vRack) | ovh et openstack | - [ovh_vrack_cloudproject](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/vrack_cloudproject) <br/>- [openstack_networking_network_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/data-sources/networking_network_v2) <br/>- [openstack_networking_subnet_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_subnet_v2) <br/>- [ovh_cloud_project_network_private](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_network_private) <br/>- [ovh_cloud_project_network_private_subnet](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_network_private_subnet)|
+|Load Balancer| openstack |[openstack_lb_loadbalancer_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/lb_loadbalancer_v2)|
+|IP publiques - IP flottantes| openstack | [openstack_networking_floatingip_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_floatingip_v2)|
+|IP publiques - IP additionnelles| ovh | [ovh_ip_service](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ip_service)
+|Gateway| openstack | [openstack_networking_router_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_router_v2)|
+
+#### Conteneurs et orchestration
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+|Managed Kubernetes Service - Opérations sur le cluster|ovh|[ovh_cloud_project_kube](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_kube)
+|Managed Kubernetes Service - Opérations de déploiement d'applications|Hashicorp Kubernetes|[kubernetes_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) [kubernetes_deployment](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment)|
+|Load Balancer Kubernetes|Hashicorp kubernetes|[kubernetes_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) comme décrit dans ce [tutoriel](/guides/public-cloud/containers-orchestration/managed-kubernetes/using-lb)|
+|Managed Private Registry|ovh|[ovh_cloud_project_containerregistry](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_containerregistry)<br/>[ovh_cloud_project_containerregistry_user](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_containerregistry_user)|
+|Gestion des workflows|ovh|[cloud_project_workflow_backup](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_workflow_backup)|
+
+#### AI & Machine Learning
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| AI Notebooks | non disponible, mais la [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-overview) peut vous aider à automatiser||
+| AI Training | non disponible, mais la [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-overview) peut vous aider à automatiser||
+| AI Deploy | non disponible, mais la [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-overview) peut vous aider à automatiser||
+
+#### Data & Analytics
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Logs Data Platform | ovh | partiellement disponible :<br/>- [ovh_dbaas_logs_graylog_output_stream](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dbaas_logs_graylog_output_stream) <br/> - [ovh_dbaas_logs_input](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dbaas_logs_input) <br/>- [ovh_dbaas_logs_cluster](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/dbaas_logs_cluster) <br/>- [source de données] [ovh_dbaas_logs_input_engine](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/dbaas_logs_input_engine)|
+
+#### Paramètres
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Utilisateurs et rôles | ovh | [ovh_cloud_project_user](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project_user#role_names)|
+| Quotas et régions | non disponible||
+| Clés SSH | ovh et openstack | [ovh_me_ssh_key](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/me_ssh_key). Si vous utilisez le provider openstack pour le compute, vous devrez utiliser [openstack_compute_keypair_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_keypair_v2) pour gérer les clés ssh|
+| Paramètres du projet | ovh | [ovh_cloud_project](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/cloud_project)|
+
+### Web Cloud
+
+#### Noms de domaine
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Nom de domaine | ovh | [ovh_domain_zone](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ovh_domain_zone)
+| Enregistrement de zone DNS | ovh | [ovh_domain_zone_record](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ovh_domain_zone_record)|
+| Serveur DNS | non disponible ||
+| Redirection | ovh | [ovh_domain_zone_redirection](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ovh_domain_zone_redirection)|
+| DynHost | non disponible ||
+| Enregistrement GLUE | non disponible ||
+
+#### Web
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Offre d'hébergement |  non disponible ||
+| Base de données | ovh | [ovh_hosting_privatedatabase](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/hosting_privatedatabase)|
+| E-mails | non disponible ||
+| Microsoft | non disponible ||
+
+### Network
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Réseau privé vRack | ovh | [ovh_vrack](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/vrack)|
+| Adresses IP publiques - IP additionnelles | ovh | [ovh_ip_service](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ip_service) |
+| OVHcloud Connect | ovh | [ovh_ovhcloud_connect](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/ovhcloud_connect)|
+| Load Balancer |ovh| [ovh_iploadbalancing](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/iploadbalancing)|
+| Infrastructure CDN| non disponible ||
+
+### Telecom
+
+Cet univers n'est actuellement pas pris en charge par les providers Terraform
+
+### Mon compte
+
+#### Mon profil
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Profil | ovh | [source de données] [ovh_me](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/me)|
+| Moyen de paiement | ovh |- [source de données] [ovh_me_paymentmean_bankaccount](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/me_paymentmean_bankaccount) <br/>- [source de données] [ovh_me_paymentmean_creditcard](https://registry.terraform.io/providers/ovh/ovh/latest/docs/data-sources/me_paymentmean_creditcard)|
+
+#### Identity and Access Management (IAM)
+
+| Concept de l'espace client | Provider(s) Terraform | Ressource ou source de données |
+| --- | --- | --- |
+| Politiques | ovh |[ovh_iam_policy](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/iam_policy)|
+|Identités| ovh |- [ovh_me_identity_user](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/me_identity_user) <br/>- [ovh_me_identity_group](https://registry.terraform.io/providers/ovh/ovh/latest/docs/resources/me_identity_group)| 
+|Groupes de ressources | non disponible | |
+
+## Ressources
+
+### Exemples d'utilisation de Terraform avec OVHcloud
+
+- [Dépôt d'exemples Public Cloud sur GitHub](https://github.com/ovh/public-cloud-examples)
+- [Créer un cluster Kubernetes avec Terraform](/guides/public-cloud/containers-orchestration/managed-kubernetes/create-cluster)
+- [Créer un registre privé (Harbor) avec Terraform](/guides/public-cloud/containers-orchestration/managed-private-registry/creation)
+- [Utiliser l'Object Storage OVHcloud High Performance (S3) comme backend Terraform pour stocker votre état Terraform](/guides/public-cloud/compute/use-object-storage-terraform-backend-state)
+
+### Provider OVH
+
+- [Entrée du registre](https://registry.terraform.io/providers/ovh/ovh/latest)
+- [Documentation](https://registry.terraform.io/providers/ovh/ovh/latest/docs)
+- Code source sur [GitHub](https://github.com/ovh/terraform-provider-ovh) (les contributions sont bienvenues) 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions.mdx
@@ -1,50 +1,50 @@
 ---
-title: Adding IP restrictions on an OVHcloud Managed Private Registry
-description: Find out how to add IP restrictions and manage access to the HMI/API & registry of an OVHcloud Managed Private Registry
+title: Ajouter des restrictions IP sur un OVHcloud Managed Private Registry
+description: Découvrez comment ajouter des restrictions IP et gérer les accès à l'interface/API et au registre d'un OVHcloud Managed Private Registry
 lastUpdated: 2024-02-01
 ---
 
 import Api from '@components/Api';
 
 
-## Objective
+## Objectif
 
-The OVHcloud Managed Private Registry service, a cloud-native registry built on Harbor, allows you to store, manage and access your container images (OCI artifacts) and Helm charts.
+Le service OVHcloud Managed Private Registry, un registre cloud-native basé sur Harbor, vous permet de stocker, gérer et consulter vos images de conteneurs (artefacts OCI) et vos charts Helm.
 
-This guide will cover the feature that allows you to manage access to the HMI of your OVHcloud Managed Private Registry and to the registry itself. Thanks to that you can add IP restrictions in a cluster.
+Ce guide présente la fonctionnalité qui vous permet de gérer les accès à l'interface Harbor de votre OVHcloud Managed Private Registry ainsi qu'au registre lui-même. Vous pouvez ainsi ajouter des restrictions IP dans un cluster.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Private Registry (see the [creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) guide for more information)
+- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un OVHcloud Managed Private Registry (consultez le guide « [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) » pour plus d'informations)
 
-## Instructions
+## En pratique
 
-The IP restrictions feature allows you to add whitelisted IP for two parts of the OVHcloud Managed Private Registry:
+La fonctionnalité de restrictions IP vous permet d'ajouter des IP autorisées pour deux parties de l'OVHcloud Managed Private Registry :
 
-- `/management` -> HMI/Harbor user interface
-- `/registry` -> Client/CLI side: docker login/pull/push, helm...
+- `/management` -> interface utilisateur Harbor
+- `/registry` -> côté client/CLI : docker login/pull/push, helm...
 
-This means that you can configure different IP blocks (CIDR) for the HMI and the registry part, depending on your teams, environments, needs...
+Vous pouvez donc configurer des blocs d'IP (CIDR) différents pour la partie interface et pour la partie registre, en fonction de vos équipes, de vos environnements, de vos besoins...
 
-### Adding IP restrictions through the API
+### Ajouter des restrictions IP via l'API
 
-#### The API Explorer
+#### L'API Explorer
 
-To simplify things, we are using the [API Explorer](/guides/manage-and-operate/api/first-steps) which allows to explore, learn and interact with the API in an interactive way.
+Pour simplifier les choses, nous utilisons l'[API Explorer](/guides/manage-and-operate/api/first-steps), qui permet d'explorer l'API, de la découvrir et d'interagir avec elle de manière interactive.
 
-If you go to the Container Registry section of the API Explorer, you will see the available endpoints, such as:
+En vous rendant dans la section Container Registry de l'API Explorer, vous accédez aux endpoints disponibles, tels que :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/{serviceName}/containerRegistry"} />
 
-#### API endpoints
+#### Endpoints d'API
 
-- Get an existing IP restriction on management endpoint:
+- Récupérer une restriction IP existante sur l'endpoint management :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/ipRestrictions/management"} />
 
 
-**Result:**
+**Résultat :**
 
 ```json
 [
@@ -57,7 +57,7 @@ If you go to the Container Registry section of the API Explorer, you will see th
 ]
 ```
 
-- Add or update an IP restriction on management endpoint:
+- Ajouter ou mettre à jour une restriction IP sur l'endpoint management :
 
 <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/ipRestrictions/management"} />
 
@@ -71,7 +71,7 @@ If you go to the Container Registry section of the API Explorer, you will see th
 ]
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 [
@@ -85,36 +85,36 @@ If you go to the Container Registry section of the API Explorer, you will see th
 ```
 
 :::info
-The list of specified IPs override the existing IP restrictions if there are any, always specify the complete list of IPs.
+La liste des IP spécifiées remplace les restrictions IP existantes, le cas échéant : indiquez toujours la liste complète des IP.
 :::
 
 
 :::info
-If you specify an IP address instead of an IP block/CIDR, we will add `/32` at the end of the IP.
+Si vous indiquez une adresse IP au lieu d'un bloc d'IP/CIDR, nous ajoutons `/32` à la fin de l'adresse IP.
 :::
 
 
-After adding IP restrictions for the `management` endpoint, an unauthorized IP will have an "UNAUTHENTICATED" error message on the Harbor user interface:
+Après l'ajout de restrictions IP pour l'endpoint `management`, une IP non autorisée obtient un message d'erreur « UNAUTHENTICATED » sur l'interface utilisateur Harbor :
 
-![Alt text](/images/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions/unauthenticated-hmi.png)
+![Interface Harbor avec le message d'erreur UNAUTHENTICATED](/images/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions/unauthenticated-hmi.png)
 
 :::info
-Wait about 30 seconds for the IP restriction to propagate.
+Comptez environ 30 secondes pour que la restriction IP soit propagée.
 :::
 
 
-- Get an existing IP restriction on registry endpoint:
+- Récupérer une restriction IP existante sur l'endpoint registry :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/ipRestrictions/registry"} />
 
 
-**Result:**
+**Résultat :**
 
 ```json
 []
 ```
 
-- Add or update an IP restriction on registry endpoint:
+- Ajouter ou mettre à jour une restriction IP sur l'endpoint registry :
 
 <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/ipRestrictions/registry"} />
 
@@ -128,7 +128,7 @@ Wait about 30 seconds for the IP restriction to propagate.
 ]
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 [
@@ -142,25 +142,25 @@ Wait about 30 seconds for the IP restriction to propagate.
 ```
 
 :::info
-The list of specified IPs override the existing IP restrictions if there are any, always specify the complete list of IPs.
+La liste des IP spécifiées remplace les restrictions IP existantes, le cas échéant : indiquez toujours la liste complète des IP.
 :::
 
 
 :::info
-If you specify an IP address instead of an IP block/CIDR, we will add `/32` at the end of the IP.
+Si vous indiquez une adresse IP au lieu d'un bloc d'IP/CIDR, nous ajoutons `/32` à la fin de l'adresse IP.
 :::
 
 
-After adding IP restrictions for the `registry` endpoint, an unauthorized IP will have an error message:
+Après l'ajout de restrictions IP pour l'endpoint `registry`, une IP non autorisée obtient un message d'erreur :
 
-- For Docker CLI:
+- Pour la CLI Docker :
 
 ```bash
 $ docker pull xxxxx.c1.gra9.container.registry.ovh.net/library/ubuntu:10.04
 Error response from daemon: error parsing HTTP 403 response body: Invalid character '<' looking for begining of value...
 ```
 
-- For Helm CLI:
+- Pour la CLI Helm :
 
 ```bash
 $ helm registry login xxxxx.c1.gra9.container.registry.ovh.net
@@ -170,14 +170,14 @@ Error: login attempt to https://xxxxx.c1.gra9.container.registry.ovh.net/v2/ fai
 ```
 
 :::info
-Wait about 30 seconds for the IP restriction to propagate.
+Comptez environ 30 secondes pour que la restriction IP soit propagée.
 :::
 
 
-## Go further
+## Aller plus loin
 
-To have an overview of OVHcloud Managed Private Registry service, read the OVHcloud Managed Private Registry documentation.
+Pour obtenir une vue d'ensemble du service OVHcloud Managed Private Registry, consultez la documentation OVHcloud Managed Private Registry.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configure the authentication via an OIDC provider on an OVHcloud Managed Private Registry
-description: Find out how to configure the authentication via an OIDC provider on an OVHcloud Managed Private Registry
+title: Configurer l'authentification via un fournisseur OIDC sur un OVHcloud Managed Private Registry
+description: Découvrez comment configurer l'authentification via un fournisseur OIDC sur un OVHcloud Managed Private Registry
 lastUpdated: 2026-02-25
 ---
 
@@ -9,63 +9,62 @@ import Api from '@components/Api';
 
 
 
-## Objective
+## Objectif
 
-The OVHcloud Managed Private Registry service, a cloud-native registry built on Harbor, allows you to store, manage and access your container images (OCI artifacts) and Helm charts.
+Le service OVHcloud Managed Private Registry, un registre cloud native basé sur Harbor, vous permet de stocker, gérer et consulter vos images de conteneurs (artefacts OCI) et vos charts Helm.
 
-By default, to log in to your OVHcloud Managed private registries you have to generate credentials (from the OVHcloud Control Panel, the APIv6 or Terraform), then log in with this user and administrate other users in the Harbor HMI.
+Par défaut, pour vous connecter à vos registres privés OVHcloud Managed Private Registry, vous devez générer des identifiants (depuis l'espace client OVHcloud, l'APIv6 ou Terraform), puis vous connecter avec cet utilisateur et administrer les autres utilisateurs dans l'interface Harbor.
 
-However, you can also configure an Open ID Connect (OIDC) provider, for the OVHcloud Managed Private registry authentication, such as Keycloack.
+Vous pouvez cependant configurer un fournisseur Open ID Connect (OIDC), tel que Keycloak, pour l'authentification de votre OVHcloud Managed Private Registry.
 
-- First of all, what is OIDC?
+- Tout d'abord, qu'est-ce qu'OIDC ?
 
 <img className="thumbnail" alt="OIDC" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/oidc.png" loading="lazy" />
 
-OIDC stands for [OpenID Connect](https://en.wikipedia.org/wiki/OpenID). It is an open standard and decentralized authentication protocol.
-This protocol allows verifying the user identity when a user is trying to access a protected HTTPs endpoint.
+OIDC signifie [OpenID Connect](https://en.wikipedia.org/wiki/OpenID). Il s'agit d'un standard ouvert et d'un protocole d'authentification décentralisé.
+Ce protocole permet de vérifier l'identité de l'utilisateur lorsque celui-ci tente d'accéder à un endpoint HTTPS protégé.
 
-Several OpenID Connect providers exists like Dex, Keycloak, Okta or a SaaS provider. Harbor supports all of them. In this tutorial we will use Keycloack.
+Il existe plusieurs fournisseurs OpenID Connect, comme Dex, Keycloak, Okta ou un fournisseur SaaS. Harbor les prend tous en charge. Dans ce tutoriel, nous utiliserons Keycloak.
 
-- What is Keycloak?
+- Qu'est-ce que Keycloak ?
 
 <img className="thumbnail" alt="Keycloak" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloak.png" loading="lazy" />
 
-[Keycloak](https://www.keycloak.org/) is an open source Identity and Access Management solution aimed at modern applications and services.
-It makes it easy to secure applications and services with little to no code.
-More information can be found here: [Official Keycloak documentation](https://www.keycloak.org/documentation.html).
+[Keycloak](https://www.keycloak.org/) est une solution open source d'Identity and Access Management destinée aux applications et services modernes.
+Elle facilite la sécurisation des applications et des services avec peu ou pas de code.
+Vous trouverez davantage d'informations ici : [documentation officielle de Keycloak](https://www.keycloak.org/documentation.html).
 
-**This guide will explain how to configure the authentication of your OVHcloud Managed Private Registry service to use an OIDC provider.**
+**Ce guide explique comment configurer l'authentification de votre service OVHcloud Managed Private Registry afin d'utiliser un fournisseur OIDC.**
 
-## Requirements
+## Prérequis
 
-- An OVHcloud [Managed Private Registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation).
-- The URL and login/password of your private registry.
-- an OIDC provider, like a KeyCloack instance and credentials to access it.
+- Un OVHcloud [Managed Private Registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation).
+- L'URL et le login/mot de passe de votre registre privé.
+- Un fournisseur OIDC, comme une instance Keycloak, ainsi que les identifiants permettant d'y accéder.
 
-Follow the official guide if you want to [install Keycloack on an OVHcloud Managed Kubernetes cluster](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-keycloak).
+Suivez le guide officiel si vous souhaitez [installer Keycloak sur un cluster OVHcloud Managed Kubernetes](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-keycloak).
 
-## Instructions
+## En pratique
+### Configurer le fournisseur OIDC via l'API
 
-### Configure ythe OIDC provider through the API
+#### L'API Explorer
 
-#### The API Explorer
+Pour simplifier les choses, nous utilisons l'[API Explorer](/guides/manage-and-operate/api/first-steps), qui permet d'explorer, de découvrir et d'interagir avec l'API de manière interactive.
 
-To simplify things, we are using the [API Explorer](/guides/manage-and-operate/api/first-steps) which allows to explore, learn and interact with the API in an interactive way.
-
-If you go to the Container Registry section of the API Explorer, you will see the available endpoints, such as:
+Si vous accédez à la section Container Registry de l'API Explorer, vous verrez les endpoints disponibles, tels que :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/{serviceName}/containerRegistry"} />
 
-#### API endpoints
+#### Endpoints d'API
 
-- Configure an OIDC provider for your OVHcloud Managed Private Registry:
+- Configurer un fournisseur OIDC pour votre OVHcloud Managed Private Registry :
 
-Do a POST HTTP request and fill the input fields with the keycloack/OIDC provider information.
+Effectuez une requête HTTP POST et renseignez les champs avec les informations du fournisseur Keycloak/OIDC.
 
 <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/openIdConnect"} />
 
 
-**Input:**
+**Entrée :**
 
 ```
 serviceName: <your service name>
@@ -83,47 +82,47 @@ OIDCPost:
     verifyCert: true //optional, if you want to check the keycloack SSL/TLS certificate
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 null
 ```
 
-Go to the [Harbor documentation](https://goharbor.io/docs/2.14.0/administration/configure-authentication/oidc-auth/) to see the details of the needed information.
+Consultez la [documentation Harbor](https://goharbor.io/docs/2.14.0/administration/configure-authentication/oidc-auth/) pour connaître le détail des informations nécessaires.
 
 :::info
-If you forget to enable the `deleteUsers` option, you will have an error: `{ "class": "Client::BadRequest", "message": "4 users exist, set parameter deleteUsers to delete them" }`. Indeed, when a new Private Registry is created, several users are created. So you need to enable the `deleteUsers` option in order to remove existing local users and enable OIDC authentication.
+Si vous oubliez d'activer l'option `deleteUsers`, vous obtiendrez l'erreur suivante : `{ "class": "Client::BadRequest", "message": "4 users exist, set parameter deleteUsers to delete them" }`. En effet, lorsqu'un nouveau registre privé est créé, plusieurs utilisateurs sont créés. Vous devez donc activer l'option `deleteUsers` afin de supprimer les utilisateurs locaux existants et d'activer l'authentification OIDC.
 :::
 
 
-Now, access the Harbor HMI. New buttons should appear, especially the <code className="action">Login via OIDC provider</code>:
+Accédez maintenant à l'interface Harbor. De nouveaux boutons doivent apparaître, notamment <code className="action">Login via OIDC provider</code> :
 
-<img className="thumbnail" alt="Harbor login via oidc provider" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/login.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion Harbor via un fournisseur OIDC" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/login.png" loading="lazy" />
 
-When you click the <code className="action">Login via OIDC provider</code> button, you are redirected to the Keycloack interface. 
+Lorsque vous cliquez sur le bouton <code className="action">Login via OIDC provider</code>, vous êtes redirigé vers l'interface Keycloak.
 
-<img className="thumbnail" alt="keycloack login" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack-login.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion Keycloak" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack-login.png" loading="lazy" />
 
-If you don't enable the `autoOnboard` input field, a popup in the Harbor interface should appear asking you to fill the username.
-When this option is checked, the attribute `UserClaim` must be set, Harbor will read the value of this claim from the ID token and use it as the username for onboarding the user.
+Si vous n'activez pas le champ `autoOnboard`, une fenêtre doit apparaître dans l'interface Harbor pour vous demander de renseigner le nom d'utilisateur.
+Lorsque cette option est cochée, l'attribut `UserClaim` doit être défini : Harbor lira la valeur de ce claim dans le jeton d'identité et l'utilisera comme nom d'utilisateur lors de l'enrôlement de l'utilisateur.
 
-<img className="thumbnail" alt="Harbor login via OIDC provider" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/autoonboard_off.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion Harbor via un fournisseur OIDC" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/autoonboard_off.png" loading="lazy" />
 
-Click on the <code className="action">Save</code> button to finally log in to Harbor with the OIDC provider.
+Cliquez sur le bouton <code className="action">Save</code> pour vous connecter enfin à Harbor avec le fournisseur OIDC.
 
-- Get an existing registry's OIDC configuration:
+- Récupérer la configuration OIDC d'un registre existant :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/openIdConnect"} />
 
 
-**Input:**
+**Entrée :**
 
 ```
 serviceName: <your service name>
 registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 {
@@ -143,21 +142,21 @@ registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 }
 ```
 
-- Update an existing registry's OIDC provider:
+- Mettre à jour le fournisseur OIDC d'un registre existant :
 
-With this API endpoint, we can, for example, add adminGroup and groupsClaim fields.
+Avec cet endpoint d'API, nous pouvons par exemple ajouter les champs adminGroup et groupsClaim.
 
-When an `adminGroup` is configured, all users belonging to this group will have the admin rights on Harbor.
+Lorsqu'un `adminGroup` est configuré, tous les utilisateurs appartenant à ce groupe disposent des droits d'administration sur Harbor.
 
-First, retrieve information about groups in keycloack:
+Récupérez d'abord les informations relatives aux groupes dans Keycloak :
 
-<img className="thumbnail" alt="keycloack group" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack_groups.png" loading="lazy" />
+<img className="thumbnail" alt="Groupe Keycloak" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack_groups.png" loading="lazy" />
 
-Check you have at least one member in the group:
+Vérifiez que le groupe contient au moins un membre :
 
-<img className="thumbnail" alt="keycloack group member" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack_group_member.png" loading="lazy" />
+<img className="thumbnail" alt="Membre du groupe Keycloak" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/keycloack_group_member.png" loading="lazy" />
 
-Then, update the configuration with a PUT request.
+Mettez ensuite la configuration à jour avec une requête PUT.
 
 <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/openIdConnect"} />
 
@@ -169,27 +168,27 @@ OIDCPost:
     groupsClaim: groups
 ```
 
-Result:
+Résultat :
 
 ```json
 null
 ```
 
-- Listing users
+- Lister les utilisateurs
 
-When you log in to the Harbor HMI with an OIDC provider user, the user will be saved. Use this API endpoint to list users:
+Lorsque vous vous connectez à l'interface Harbor avec un utilisateur issu d'un fournisseur OIDC, cet utilisateur est enregistré. Utilisez cet endpoint d'API pour lister les utilisateurs :
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/users"} />
 
 
-**Input:**
+**Entrée :**
 
 ```
 serviceName: <your service name>
 registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 [
@@ -202,14 +201,14 @@ registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ]
 ```
 
-- Setting a user as admin
+- Définir un utilisateur comme administrateur
 
-By default a user created in an OIDC provider doesn't have the admin rights. To grant a user the admin rights, use the following PUT call:
+Par défaut, un utilisateur créé dans un fournisseur OIDC ne dispose pas des droits d'administration. Pour accorder ces droits à un utilisateur, utilisez l'appel PUT suivant :
 
 <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/users/\{userID\}/setAsAdmin"} />
 
 
-**Input:**
+**Entrée :**
 
 ```
 serviceName: <your service name>
@@ -217,55 +216,55 @@ registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 userID: 8 //the user ID
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 ```
 
 :::info
-The response will be empty but you should get a 2xx HTTP status code telling you that everything worked successfully.
+La réponse sera vide, mais vous devriez obtenir un code de statut HTTP 2xx indiquant que tout s'est déroulé correctement.
 :::
 
 
-When you log again with this user, you are now an Administrator.
+Lorsque vous vous reconnectez avec cet utilisateur, vous êtes désormais administrateur.
 
-<img className="thumbnail" alt="admin user" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/admin.png" loading="lazy" />
+<img className="thumbnail" alt="Utilisateur administrateur" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication/admin.png" loading="lazy" />
 
-- Deleting an existing registry's OIDC configuration:
+- Supprimer la configuration OIDC d'un registre existant :
 
-If you want to delete the authentication with OIDC configuration, execute a DELETE action in the API:
+Si vous souhaitez supprimer l'authentification avec la configuration OIDC, exécutez une action DELETE dans l'API :
 
 <Api version="v1" section="/cloud" method="DELETE" route={"/cloud/project/\{serviceName\}/containerRegistry/\{registryID\}/openIdConnect"} />
 
 
-**Input:**
+**Entrée :**
 
 ```
 serviceName: <your service name>
 registryId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-**Result:**
+**Résultat :**
 
 ```json
 ```
 
 :::info
-The response will be empty but you should get a 2xx HTTP status code telling you that everything worked successfully.
+La réponse sera vide, mais vous devriez obtenir un code de statut HTTP 2xx indiquant que tout s'est déroulé correctement.
 :::
 
 
-This request will delete all the users.
+Cette requête supprimera tous les utilisateurs.
 
 :::info
-You can generate again the users credentials via the OVHcloud Control Panel, the APIv6 or Terraform and log in with these new local credentials.
+Vous pouvez générer de nouveau les identifiants des utilisateurs depuis l'espace client OVHcloud, l'APIv6 ou Terraform, puis vous connecter avec ces nouveaux identifiants locaux.
 :::
 
 
-## Go further
+## Aller plus loin
 
-To have an overview of OVHcloud Managed Private Registry service, read the OVHcloud Managed Private Registry documentation.
+Pour obtenir une vue d'ensemble du service OVHcloud Managed Private Registry, consultez la documentation OVHcloud Managed Private Registry.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/configure-proxy-cache.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/configure-proxy-cache.mdx
@@ -1,1 +1,89 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/configure-proxy-cache.mdx
+---
+title: Configurer le Proxy Cache sur un OVHcloud Managed Private Registry
+description: Découvrez comment configurer le Proxy Cache sur un OVHcloud Managed Private Registry
+lastUpdated: 2026-02-25
+---
+
+## Objectif
+
+Harbor propose une fonctionnalité **proxy cache** qui permet de mettre en miroir et en cache les images provenant de registres externes tels que **Docker Hub**, **Github Container Registry**, **Quay**, **JFrog Artifactory Registry**, etc. Cela améliore les performances et réduit l'effet des limites de débit imposées par les registres externes.
+
+Nous **recommandons fortement** d'utiliser un **compte Docker** (même gratuit) afin d'**éviter les limites de débit** lors du pull des images. Sans authentification, Docker Hub applique des limites de pull strictes, susceptibles de provoquer des échecs lors du pull d'images fréquemment utilisées.
+
+## Prérequis
+
+- Un **[Managed Private Registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation)** en service.
+- Un accès à l'**interface web Harbor** (avec des droits d'administration).
+- Un **compte Docker Hub** (recommandé pour éviter les limites de débit).
+
+## En pratique
+### 1. Activer le proxy cache
+
+1. Connectez-vous à l'[interface web Harbor](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) en tant qu'**administrateur**.
+2. Rendez-vous dans `Administration`, puis <code className="action">Registries</code>.
+3. Cliquez sur <code className="action">+ New Endpoint</code>, puis sélectionnez <code className="action">Docker Hub</code> comme fournisseur.
+4. Renseignez les informations suivantes :
+    - **Registry Type** : Docker Hub
+    - **Registry Name** : (par exemple `docker-hub-proxy`)
+    - **Registry Endpoint** : `https://hub.docker.com`
+    - **Access ID** : *(votre nom d'utilisateur Docker Hub)*
+    - **Access Secret** : *(votre mot de passe Docker Hub ou un token d'accès personnel)*
+5. Cliquez sur <code className="action">OK</code>.
+
+:::info
+Si vous ne fournissez pas d'identifiants Docker Hub, vos requêtes peuvent atteindre les **limites de débit** (10 pulls par heure et par IPv4 pour les utilisateurs anonymes).
+:::
+
+
+<img className="thumbnail" alt="Proxy cache" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-proxy-cache/registry-proxy-cache-001.png" loading="lazy" style={{ maxWidth: '500px' }} />
+
+### 2. Créer un projet proxy cache
+
+1. Dans l'**interface web Harbor**, rendez-vous dans <code className="action">Projects</code>.
+2. Cliquez sur <code className="action">+ New Project</code>.
+3. Saisissez un **Project Name** (par exemple `docker-hub-mirror`).
+4. Sélectionnez <code className="action">Proxy Cache</code>.
+5. Sous **Upstream Registry**, choisissez le **registre proxy Docker Hub** créé précédemment.
+6. Cliquez sur <code className="action">Save</code>.
+
+:::info
+Par défaut, Harbor crée une **politique de rétention de 7 jours** pour chaque nouveau projet proxy cache. Pour en savoir plus, consultez la page [Tag Retention Policies](https://goharbor.io/docs/2.14.0/working-with-projects/working-with-images/create-tag-retention-rules/).
+:::
+
+
+<img className="thumbnail" alt="Proxy cache" src="/images/public-cloud/containers-orchestration/managed-private-registry/configure-proxy-cache/registry-proxy-cache-002.png" loading="lazy" style={{ maxWidth: '500px' }} />
+
+### 3. Configurer Docker pour utiliser le proxy cache Harbor
+
+#### 3.1 Se connecter au Managed Private Registry
+
+```sh
+docker login <your-managed-registry-domain> -u `<username>` -p <password>
+```
+
+#### 3.2 Faire un pull des images via le proxy cache
+
+Au lieu de faire un pull directement depuis Docker Hub, utilisez votre **Managed Private Registry** comme intermédiaire :
+
+```bash
+docker pull <your-managed-registry-domain>/dockerhub-mirror/library/nginx:latest
+```
+
+Harbor met l'image en cache localement : les pulls suivants seront beaucoup plus rapides et ne seront pas décomptés des limites de débit Docker Hub.
+
+## Avantages du proxy cache
+
+- ✅ Éviter les limites de débit Docker Hub (avec authentification).
+- ✅ Pull des images plus rapide pour les images fréquemment utilisées.
+- ✅ Dépendance réduite aux registres externes.
+- ✅ Fiabilité améliorée grâce à la mise en cache locale des images.
+
+## Résolution des incidents
+
+### Erreurs « Too Many Requests »
+
+- Vérifiez que vous avez bien configuré l'authentification Docker Hub dans Harbor.
+
+## Conclusion
+
+Le proxy cache de Harbor permet d'optimiser le pull des images Docker, d'éviter les limites de débit et d'améliorer les performances. Veillez à vous authentifier auprès de Docker Hub dans Harbor pour éviter les problèmes de limites de débit.

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui.mdx
@@ -1,1 +1,44 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui.mdx
+---
+title: Se connecter à l'interface
+description: Découvrez comment vous connecter à l'interface Harbor pour administrer votre service Managed Private Registry OVHcloud
+lastUpdated: 2021-09-24
+---
+
+
+
+## Objectif
+
+Le service Managed Private Registry d'OVHcloud met à votre disposition un registre Docker managé et authentifié dans lequel vous pouvez stocker vos images Docker de manière privée. Ce registre privé est une instance de [Harbor](https://goharbor.io/), un projet open source de registre cloud-native de confiance qui permet de stocker, signer et analyser des images Docker. Ce guide explique comment se connecter à l'interface Harbor pour administrer votre service Managed Private Registry OVHcloud.
+
+## Prérequis
+
+- Un Managed Private Registry OVHcloud (consultez le guide « [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) » pour plus d'informations)
+
+{/* CP-NAV-START:publiccloud-projects */}
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
+- **Chemin de navigation :** <code className="action">Public Cloud</code> > Sélectionnez votre projet
+
+---
+{/* CP-NAV-END:publiccloud-projects */}
+
+## En pratique
+
+1. Dans la section <code className="action">Managed Private Registry</code>, cliquez sur le bouton *plus d'options* (<code className="action">...</code>) à l'extrémité droite, puis cliquez sur <code className="action">Interface utilisateur Harbor</code> :
+
+    <img className="thumbnail" alt="Se connecter à l'interface" src="/images/public-cloud/containers-orchestration/managed-private-registry/connecting-to-the-ui/connecting-to-the-ui-002.png" loading="lazy" />
+
+2. Sur la page de connexion de l'interface [Harbor](https://goharbor.io/), le moteur open source qui fait fonctionner votre Managed Private Registry OVHcloud, saisissez les identifiants (utilisateur et mot de passe) de votre Managed Private Registry OVHcloud :
+
+    <img className="thumbnail" alt="Se connecter à l'interface" src="/images/public-cloud/containers-orchestration/managed-private-registry/connecting-to-the-ui/connecting-to-the-ui-003.png" loading="lazy" />
+
+Vous pouvez désormais utiliser l'interface Harbor pour gérer votre registre privé.
+
+<img className="thumbnail" alt="Se connecter à l'interface" src="/images/public-cloud/containers-orchestration/managed-private-registry/connecting-to-the-ui/connecting-to-the-ui-004.png" loading="lazy" />
+
+## Aller plus loin
+
+Pour aller plus loin, consultez notre guide « [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) ».

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image.mdx
@@ -1,1 +1,233 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image.mdx
+---
+title: Créer et utiliser une image Docker stockée dans un OVHcloud Managed Private Registry
+description: Découvrez comment créer et utiliser une image stockée dans un OVHcloud Managed Private Registry
+lastUpdated: 2026-07-17
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+## Objectif
+
+Le service OVHcloud Managed Private Registry vous fournit un registre Docker managé et authentifié, dans lequel vous pouvez stocker vos images Docker de manière privée. Ce guide explique comment créer une image Docker, la stocker dans le service OVHcloud Managed Private Registry et l'utiliser depuis un client Docker.
+
+## Prérequis
+
+- Un OVHcloud Managed Private Registry (consultez le guide « [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) » pour plus d'informations)
+- Un accès à l'interface Harbor pour administrer le registre privé (consultez le guide « [Se connecter à l'interface](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) » pour plus d'informations)
+- Un projet privé et un utilisateur disposant des droits de lecture et d'écriture sur ce projet (consultez le guide « [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) » pour plus d'informations)
+
+## En pratique
+### Récupérer l'URL de votre OVHcloud Managed Private Registry
+
+<Tabs>
+  <Tab label="Espace client OVHcloud">
+
+Rendez-vous dans la section de votre registre privé dans l'espace client OVHcloud Public Cloud, puis, dans le bouton *plus d'options* (*...*) situé à droite, cliquez sur Harbor API.
+
+<img className="thumbnail" alt="API Harbor" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-and-using-a-private-image/creating-a-using-a-private-image-001b.png" loading="lazy" />
+
+Copiez l'URL de l'API Harbor : il s'agit de l'URL de votre registre privé et nous allons l'utiliser à plusieurs reprises dans ce guide.
+
+<img className="thumbnail" alt="API Harbor" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-and-using-a-private-image/creating-a-using-a-private-image-002.png" loading="lazy" />
+
+:::info
+L'URL copiée commence par `https://`. Supprimez le préfixe `https://` avant de l'utiliser dans des commandes Docker.
+:::
+
+  </Tab>
+  <Tab label="OVHcloud CLI">
+
+Récupérez l'URL de votre registre avec la [CLI OVHcloud](/guides/manage-and-operate/cli/getting-started) :
+
+```bash
+ovhcloud cloud managed-registry list --cloud-project <project_id>
+```
+
+Notez l'`id` de votre registre, puis récupérez son URL :
+
+```bash
+ovhcloud cloud managed-registry get <registry_id> --cloud-project <project_id> --output url
+```
+
+La commande renvoie l'URL complète (par exemple `https://8093ff7x.gra5.container-registry.ovh.net`). Supprimez le préfixe `https://` avant de l'utiliser dans des commandes Docker.
+
+  </Tab>
+</Tabs>
+
+### Créer une image Docker
+
+Vous allez créer une image Docker à l'aide d'un Dockerfile très simple et de quelques fichiers de ressources.
+
+Créez un dossier `hello-ovh/` et, à l'intérieur, créez :
+
+- Un fichier `Dockerfile` :
+
+```dockerfile
+FROM nginx:1.15-alpine
+
+COPY index.html /usr/share/nginx/html/index.html
+COPY ovh.svg /usr/share/nginx/html/ovh.svg
+```
+
+- Un fichier `index.html` :
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>OVHcloud K8S</title>
+  </head>
+  <body>
+    <div class="title">
+      <p>Hello from Private Registry!</p>
+      <img src="./ovh.svg"/>
+    </div>
+  </body>
+</html>
+```
+
+- Un fichier `ovh.svg` (faites un clic droit et enregistrez-le) :
+
+    (`ovh.svg`)
+
+Vous devez avoir ces fichiers dans votre répertoire `hello-ovh` :
+
+```bash
+├── Dockerfile
+├── index.html
+└── ovh.svg
+```
+
+- Rendez-vous dans le dossier `hello-ovh`, qui contient les trois fichiers, et lancez un `docker build`. Vous devez taguer votre build en utilisant l'URL de votre registre privé, le projet au sein du registre (*private* si vous avez suivi le guide « [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) ») et le nom de l'image (*hello-ovh*) :
+
+```bash
+docker build --tag [YOUR_PRIVATE_REGISTRY_URL]/[YOUR_PROJECT]/hello-ovh:1.0.0 .
+```
+
+  Voici le résultat de l'exécution de la commande pour mon registre privé dans le projet `private` :
+
+```console
+$ docker build --tag 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0 .
+Sending build context to Docker daemon  14.34kB
+Step 1/3 : FROM nginx:1.15-alpine
+1.15-alpine: Pulling from library/nginx
+e7c96db7181b: Pull complete 
+264026bbe255: Pull complete 
+a71634c55d29: Pull complete 
+5595887beb81: Pull complete 
+Digest: sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
+Status: Downloaded newer image for nginx:1.15-alpine
+---> dd025cdfe837
+Step 2/3 : COPY index.html /usr/share/nginx/html/index.html
+---> f1f2487532bc
+Step 3/3 : COPY ovh.svg /usr/share/nginx/html/ovh.svg
+---> 3f803b45da18
+Successfully built 3f803b45da18
+Successfully tagged 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0
+```
+
+- Connectez-vous à votre registre privé, avec un utilisateur disposant des droits d'écriture sur le projet (*private-user* si vous avez suivi le guide « [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) »)
+
+```bash
+docker login [YOUR_PRIVATE_REGISTRY_URL]
+```
+
+  Dans mon registre privé :
+
+```console
+$ docker login 8093ff7x.gra5.container-registry.ovh.net
+Username: private-user
+Password: 
+Login Succeeded
+```
+
+- Envoyez l'image dans le registre privé
+
+```bash
+docker push [YOUR_PRIVATE_REGISTRY_URL]/[YOUR_PROJECT]/hello-ovh:1.0.0
+```
+
+  Dans mon exemple de registre privé :
+
+```console
+$ docker push 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0
+The push refers to repository [8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh]
+369ed87ef8b1: Pushed 
+d2220a0eb85b: Pushed 
+a521e1bbddf5: Pushed 
+bf381a670956: Pushed 
+a61993362baf: Pushed 
+f1b5933fe4b5: Pushed 
+1.0.0: digest: sha256:f5a6a8f0d7c95cf3926b504a7949c8575e478106b59d8913ab947729aa5bd075 size: 1568
+```
+
+En vous rendant dans votre interface Harbor, vous constatez qu'un dépôt `hello-ovh` est présent dans le projet *private* :
+
+<img className="thumbnail" alt="Dépôt hello-ovh" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-and-using-a-private-image/creating-a-using-a-private-image-003.png" loading="lazy" />
+
+Ce dépôt stockera toutes les versions de l'image `hello-ovh` (pour l'instant, uniquement la *1.0.0*) :
+
+<img className="thumbnail" alt="Dépôt hello-ovh" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-and-using-a-private-image/creating-a-using-a-private-image-004.png" loading="lazy" />
+
+### Déployer l'image privée
+
+Vous pouvez maintenant utiliser `docker pull` (précédé d'un `docker login` sur votre registre privé si vous le faites depuis un autre ordinateur) pour déployer l'image depuis l'OVHcloud Managed Private Registry.
+
+```bash
+docker pull [YOUR_PRIVATE_REGISTRY_URL]/[YOUR_PROJECT]/hello-ovh:1.0.0 
+```
+
+Dans mon exemple de registre privé :
+
+```console
+$ docker pull 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0
+1.0.0: Pulling from private/hello-ovh
+e7c96db7181b: Already exists 
+264026bbe255: Already exists 
+a71634c55d29: Already exists 
+5595887beb81: Already exists 
+4c1b9819c67d: Pull complete 
+5df2876c6416: Pull complete 
+Digest: sha256:f5a6a8f0d7c95cf3926b504a7949c8575e478106b59d8913ab947729aa5bd075
+Status: Downloaded newer image for 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0
+```
+
+Vous pouvez ensuite l'exécuter :
+
+```bash
+docker run -d -p 80:80 [YOUR_PRIVATE_REGISTRY_URL]/[YOUR_PROJECT]/hello-ovh:1.0.0 
+```
+
+Dans mon exemple de registre privé :
+
+```console
+$ docker run -d -p 8080:80 8093ff7x.gra5.container-registry.ovh.net/private/hello-ovh:1.0.0
+c18f071c3c8c10ca636ed9be84878c12f3a270b6def131eb756f69435b978da1
+```
+
+Vous pouvez maintenant le tester avec la commande `curl` :
+
+```bash
+$ curl localhost:8080
+<!doctype html>
+
+<html>
+<head>
+<title>OVH K8S</title>
+</head>
+<body>
+<div class="title">
+<p>Hello from Private Registry!</p>
+<img src="./ovh.svg"/>
+</div>
+</body>
+</html>
+```
+
+Ou dans votre navigateur :
+
+<img className="thumbnail" alt="hello-ovh" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-and-using-a-private-image/creating-a-using-a-private-image-005.jpg" loading="lazy" />
+
+### Aller plus loin
+
+Pour aller plus loin, consultez notre guide « [Utiliser votre registre privé avec Kubernetes](/guides/public-cloud/containers-orchestration/managed-private-registry/kubernetes) ».

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/creation.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/creation.mdx
@@ -1,1 +1,408 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/creation.mdx
+---
+title: Créer un registre privé
+description: Créez un OVHcloud Managed Private Registry depuis l'espace client, avec l'OVHcloud CLI, Terraform ou Pulumi
+lastUpdated: 2026-07-17
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+Un registre Docker est un système qui vous permet de stocker et de distribuer des images Docker. OVHcloud Managed Private Registry met à votre disposition une instance [Harbor](https://goharbor.io/) managée et authentifiée, dans laquelle vous pouvez stocker vos images Docker de manière privée — l'idéal pour une utilisation avec [OVHcloud Managed Kubernetes Service](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
+
+## Objectif
+
+Ce guide explique comment créer un OVHcloud Managed Private Registry depuis l'espace client OVHcloud, avec l'OVHcloud CLI, Terraform ou Pulumi.
+
+## Prérequis
+
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+
+{/* CP-NAV-START:publiccloud-projects */}
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
+- **Chemin de navigation :** <code className="action">Public Cloud</code> > Sélectionnez votre projet
+
+---
+{/* CP-NAV-END:publiccloud-projects */}
+
+## En pratique
+
+<Tabs>
+  <Tab label="Espace client OVHcloud">
+
+1. Dans le menu de gauche, dans la section <code className="action">Containers & Orchestration</code>, sélectionnez <code className="action">Managed Private Registry</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-001.png" loading="lazy" />
+
+2. Cliquez sur <code className="action">Créer un registre privé</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-002.png" loading="lazy" />
+
+3. Choisissez une région, puis cliquez sur <code className="action">Suivant</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-003.png" loading="lazy" />
+
+4. Saisissez un nom pour votre registre, puis cliquez sur <code className="action">Suivant</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-004.png" loading="lazy" />
+
+5. Choisissez un plan et cliquez sur <code className="action">Suivant</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-005.png" loading="lazy" />
+
+:::info
+Les plans `M` et `L` incluent un scanner de vulnérabilités managé : [Trivy](https://trivy.dev/).
+:::
+
+6. Votre registre privé est en cours de création.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-006.png" loading="lazy" />
+
+7. Lorsque le statut passe à `OK`, cliquez sur le bouton <code className="action">...</code> et sélectionnez <code className="action">Générer les informations d'identification</code>.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-007.png" loading="lazy" />
+
+8. Cliquez sur <code className="action">Confirmer</code> pour générer les identifiants.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-008.png" loading="lazy" />
+
+9. Notez les identifiants affichés — ils vous seront nécessaires pour accéder à votre registre.
+
+    <img className="thumbnail" alt="Créer un registre privé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry/create-a-private-registry-009.png" loading="lazy" />
+
+  </Tab>
+  <Tab label="OVHcloud CLI">
+
+**Prérequis**
+
+- L'[OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) installé et configuré
+
+**1. Listez les plans disponibles pour récupérer un identifiant de plan :**
+
+```bash
+ovhcloud cloud reference managed-registry list-plans --cloud-project <project_id>
+```
+
+**2. Créez le registre :**
+
+```bash
+ovhcloud cloud managed-registry create \
+  --cloud-project <project_id> \
+  --name my-registry \
+  --region GRA \
+  --plan-id <plan_id>
+```
+
+Notez le champ `id` dans le résultat : il s'agit de l'identifiant de votre registre.
+
+**3. Créez un utilisateur :**
+
+```bash
+ovhcloud cloud managed-registry users create <registry_id> \
+  --cloud-project <project_id> \
+  --login myuser \
+  --email myuser@example.com
+```
+
+Conservez les identifiants affichés dans le résultat : le mot de passe ne sera plus affiché par la suite.
+
+**4. Récupérez l'URL du registre :**
+
+```bash
+ovhcloud cloud managed-registry get <registry_id> --cloud-project <project_id>
+```
+
+Le champ `url` correspond à l'adresse de votre interface Harbor.
+
+  </Tab>
+  <Tab label="Terraform">
+
+[Terraform](https://developer.hashicorp.com/terraform) est un outil open source d'Infrastructure as Code (IaC). OVHcloud met à disposition un [provider Terraform](https://registry.terraform.io/providers/ovh/ovh/latest) officiel pour gérer vos ressources par programmation.
+
+**Prérequis**
+
+- L'[interface en ligne de commande Terraform](https://developer.hashicorp.com/terraform/install) en version 0.12.x ou supérieure
+
+**Récupérer vos identifiants d'API**
+
+Le provider Terraform OVHcloud nécessite des identifiants d'API. Suivez le guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) » pour générer vos `application_key`, `application_secret` et `consumer_key`.
+
+Récupérez l'identifiant de votre projet Public Cloud (`service_name`) à l'aide du bouton <code className="action">Copier dans le presse-papier</code>, dans la vue d'ensemble de votre projet.
+
+<img className="thumbnail" alt="Copier le nom du service" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry-through-terraform/get-service-name.png" loading="lazy" />
+
+**Définition des ressources**
+
+Créez un fichier `provider.tf` :
+
+```hcl
+terraform {
+  required_providers {
+    ovh = {
+      source = "ovh/ovh"
+    }
+  }
+}
+
+provider "ovh" {
+  endpoint           = "ovh-eu"
+  application_key    = "<your_access_key>"
+  application_secret = "<your_application_secret>"
+  consumer_key       = "<your_consumer_key>"
+}
+```
+
+:::tip
+Utilisez des variables d'environnement (`OVH_ENDPOINT`, `OVH_APPLICATION_KEY`, `OVH_APPLICATION_SECRET`, `OVH_CONSUMER_KEY`) afin d'éviter de stocker des identifiants dans vos fichiers sources.
+:::
+
+Créez un fichier `variables.tf` :
+
+```hcl
+variable service_name {
+  type    = string
+  default = "<your_service_name>"
+}
+```
+
+Créez un fichier `ovh_private_registry.tf` :
+
+```hcl
+data "ovh_cloud_project_capabilities_containerregistry_filter" "capabilities" {
+  service_name = var.service_name
+  plan_name    = "SMALL"
+  region       = "GRA"
+}
+
+resource "ovh_cloud_project_containerregistry" "myregistry" {
+  service_name = data.ovh_cloud_project_capabilities_containerregistry_filter.capabilities.service_name
+  plan_id      = data.ovh_cloud_project_capabilities_containerregistry_filter.capabilities.id
+  region       = data.ovh_cloud_project_capabilities_containerregistry_filter.capabilities.region
+  name         = "my-docker-private-registry"
+}
+
+resource "ovh_cloud_project_containerregistry_user" "myuser" {
+  service_name = ovh_cloud_project_containerregistry.myregistry.service_name
+  registry_id  = ovh_cloud_project_containerregistry.myregistry.id
+  email        = "my.user@mycompany.com"
+  login        = "myuser"
+}
+```
+
+Créez un fichier `output.tf` :
+
+```hcl
+output "registry-url" {
+  value = ovh_cloud_project_containerregistry.myregistry.url
+}
+
+output "user" {
+  value = ovh_cloud_project_containerregistry_user.myuser.user
+}
+
+output "password" {
+  value     = ovh_cloud_project_containerregistry_user.myuser.password
+  sensitive = true
+}
+```
+
+**Déploiement**
+
+Initialisez Terraform et appliquez le plan :
+
+```bash
+terraform init
+terraform apply
+```
+
+Vérifiez le plan d'exécution et saisissez `yes` pour confirmer. La création du registre prend quelques minutes.
+
+Une fois l'opération terminée, récupérez vos identifiants :
+
+```bash
+terraform output registry-url
+terraform output user
+terraform output password
+```
+
+Accédez à la section <code className="action">Managed Private Registry</code> pour vérifier que le registre a bien été créé.
+
+<img className="thumbnail" alt="Registre privé créé" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry-through-terraform/registry-created.png" loading="lazy" />
+
+**Suppression**
+
+Pour supprimer toutes les ressources créées :
+
+```bash
+terraform destroy
+```
+
+  </Tab>
+  <Tab label="Pulumi">
+
+[Pulumi](https://www.pulumi.com/) est un outil d'Infrastructure as Code (IaC) qui vous permet de définir votre infrastructure à l'aide de langages de programmation généralistes. OVHcloud met à disposition un [provider Pulumi](https://github.com/ovh/pulumi-ovh) officiel qui s'appuie sur le provider Terraform OVHcloud.
+
+**Prérequis**
+
+- La [CLI Pulumi](https://www.pulumi.com/docs/install/) installée
+- Un [compte Pulumi](https://www.pulumi.com/) et un [jeton d'accès](https://app.pulumi.com/account/tokens)
+
+**Récupérer vos identifiants d'API**
+
+Le provider Pulumi OVHcloud nécessite des identifiants d'API. Suivez le guide « [Premiers pas avec les API OVHcloud](/guides/manage-and-operate/api/first-steps) » pour générer vos jetons, puis exportez-les comme variables d'environnement :
+
+```bash
+export OVH_ENDPOINT="ovh-eu"
+export OVH_APPLICATION_KEY="xxx"
+export OVH_APPLICATION_SECRET="xxx"
+export OVH_CONSUMER_KEY="xxx"
+```
+
+Récupérez l'identifiant de votre projet Public Cloud (`serviceName`) à l'aide du bouton <code className="action">Copier dans le presse-papier</code>, dans la vue d'ensemble de votre projet.
+
+<img className="thumbnail" alt="Copier le nom du service" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry-with-pulumi/get-service-name.png" loading="lazy" />
+
+**Créer le projet**
+
+Créez et initialisez un projet Pulumi en Go :
+
+```bash
+mkdir ovh-registry-go && cd ovh-registry-go
+pulumi new go -y
+```
+
+Installez les providers OVHcloud et Harbor :
+
+```bash
+go get github.com/ovh/pulumi-ovh/sdk/go/...
+go get github.com/pulumiverse/pulumi-harbor/sdk/v3/go/...
+```
+
+Définissez votre `serviceName` :
+
+```bash
+pulumi config set serviceName <your-service-name>
+```
+
+**Définir l'infrastructure**
+
+Remplacez le contenu du fichier `main.go` par :
+
+```go
+package main
+
+import (
+	"github.com/ovh/pulumi-ovh/sdk/go/ovh/cloudproject"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+	"github.com/pulumiverse/pulumi-harbor/sdk/v3/go/harbor"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		serviceName := config.Require(ctx, "serviceName")
+
+		regcap, err := cloudproject.GetCapabilitiesContainerFilter(ctx, &cloudproject.GetCapabilitiesContainerFilterArgs{
+			ServiceName: serviceName,
+			PlanName:    "SMALL",
+			Region:      "GRA",
+		}, nil)
+		if err != nil {
+			return err
+		}
+
+		myRegistry, err := cloudproject.NewContainerRegistry(ctx, "my-registry", &cloudproject.ContainerRegistryArgs{
+			ServiceName: pulumi.String(regcap.ServiceName),
+			PlanId:      pulumi.String(regcap.Id),
+			Region:      pulumi.String(regcap.Region),
+		})
+		if err != nil {
+			return err
+		}
+
+		myRegistryUser, err := cloudproject.NewContainerRegistryUser(ctx, "user", &cloudproject.ContainerRegistryUserArgs{
+			ServiceName: pulumi.String(regcap.ServiceName),
+			RegistryId:  myRegistry.ID(),
+			Email:       pulumi.String("myuser@ovh.com"),
+			Login:       pulumi.String("myuser"),
+		})
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("registryID", myRegistry.ID())
+		ctx.Export("registryURL", myRegistry.Url)
+		ctx.Export("registryUser", myRegistryUser.User)
+		ctx.Export("registryPassword", myRegistryUser.Password)
+
+		harborProvider, err := harbor.NewProvider(ctx, "harbor", &harbor.ProviderArgs{
+			Username: myRegistryUser.User,
+			Password: myRegistryUser.Password,
+			Url:      myRegistry.Url,
+		}, pulumi.DependsOn([]pulumi.Resource{myRegistry, myRegistryUser}))
+		if err != nil {
+			return err
+		}
+
+		project, err := harbor.NewProject(ctx, "project", &harbor.ProjectArgs{
+			Name:   pulumi.String("my-new-project"),
+			Public: pulumi.String("true"),
+		}, pulumi.Provider(harborProvider))
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("project", project.Name)
+
+		return nil
+	})
+}
+```
+
+Exécutez `go mod tidy` pour installer les dépendances :
+
+```bash
+go mod tidy
+```
+
+**Déploiement**
+
+```bash
+pulumi up
+```
+
+Vérifiez l'aperçu et confirmez avec `yes`. La création du registre prend quelques minutes.
+
+Une fois l'opération terminée, récupérez vos identifiants :
+
+```bash
+pulumi stack output registryURL -s dev
+pulumi stack output registryUser -s dev
+pulumi stack output registryPassword --show-secrets -s dev
+```
+
+Accédez à la section <code className="action">Managed Private Registry</code> pour vérifier que le registre a bien été créé.
+
+<img className="thumbnail" alt="Managed Private Registry" src="/images/public-cloud/containers-orchestration/managed-private-registry/creating-a-private-registry-with-pulumi/private-registry.png" loading="lazy" />
+
+:::info
+Si vous rencontrez l'erreur `Provider is missing a required configuration key`, assurez-vous que toutes les variables d'environnement `OVH_*` sont exportées avant d'exécuter `pulumi up`.
+:::
+
+**Suppression**
+
+Pour supprimer toutes les ressources créées :
+
+```bash
+pulumi destroy
+```
+
+  </Tab>
+</Tabs>
+
+## Aller plus loin
+
+- [Se connecter à l'interface du registre](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui)
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/deploy-chart-from-kubernetes-registry.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/deploy-chart-from-kubernetes-registry.mdx
@@ -1,1 +1,120 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/deploy-chart-from-kubernetes-registry.mdx
+---
+title: Déployer un chart Helm depuis votre registre privé dans Kubernetes
+description: Découvrez comment déployer un chart Helm depuis votre registre privé dans un cluster Kubernetes
+lastUpdated: 2023-11-27
+---
+
+Le service Managed Private Registry d'OVHcloud est un registre cloud-native composite qui prend en charge à la fois la gestion des images de conteneurs et la gestion des [charts](https://helm.sh/docs/topics/charts/) [Helm](https://helm.sh/).
+
+Ce guide explique comment déployer un chart Helm depuis votre Managed Private Registry OVHcloud dans un cluster Kubernetes.
+
+## Avant de commencer
+
+Ce tutoriel suppose que vous disposez déjà d'un cluster OVHcloud Managed Kubernetes opérationnel, ainsi que de connaissances de base sur son utilisation. Pour en savoir plus sur ces sujets, consultez la documentation [Déployer une application Hello World](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world). Helm doit être installé sur votre cluster (consultez le guide « [Installer Helm](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) » pour plus d'informations).
+
+Vous devez également disposer d'un Managed Private Registry OVHcloud opérationnel et avoir suivi le guide « [Gérer les charts Helm dans le Managed Private Registry OVHcloud](/guides/public-cloud/containers-orchestration/managed-private-registry/helm-charts) ».
+
+Après avoir suivi le guide précédent, vous devriez avoir au moins un chart Helm WordPress dans votre Managed Private Registry :
+
+![Charts Helm dans le Managed Private Registry OVHcloud](/images/public-cloud/containers-orchestration/managed-private-registry/deploy-chart-from-registry-in-kubernetes/helm-chart-in-ovh-private-registry.png)
+
+## Prérequis
+
+### Installer Helm v3.8+
+
+Vérifiez que Helm est installé dans la version requise :
+
+```bash
+$ helm version
+version.BuildInfo{Version:"v3.12.0", GitCommit:"c9f554d75773799f72ceef38c51210f1842a1dea", GitTreeState:"clean", GoVersion:"go1.20.3"}
+```
+
+Si la version est antérieure à la v3.8.0, suivez les [instructions officielles](https://helm.sh/docs/intro/install/) pour installer Helm dans sa dernière version.
+
+## En pratique
+### Déployer un chart depuis votre registre dans Kubernetes
+
+#### Se connecter au Managed Private Registry OVHcloud
+
+Avant de pouvoir faire un pull ou un push de charts Helm, connectez-vous à Harbor :
+
+```bash
+helm registry login <registry url>
+```
+
+Par exemple :
+
+```console
+$ helm registry login https://8xghzr01.c1.bhs5.container-registry.ovh.net
+Username: MbwQLGCglA
+Password: 
+Login Succeeded
+```
+
+#### Installer des charts
+
+Déployez le chart Helm WordPress dans le cluster Kubernetes :
+
+```bash
+helm install myrelease oci://<registry url>/<project>/<chart name> --version <version>
+```
+
+Dans notre cas :
+
+```console
+$ helm install my-wordpress-release oci://8xghzr01.c1.bhs5.container-registry.ovh.net/private/wordpress --version 18.1.14
+
+Pulled: 8xghzr01.c1.bhs5.container-registry.ovh.net/private/wordpress:18.1.14
+Digest: sha256:89afb47c221899db67c7b125f49394eecd078245181715337b5691a0ee199cb7
+NAME: my-wordpress-release
+LAST DEPLOYED: Mon Nov 20 17:46:16 2023
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+CHART NAME: wordpress
+CHART VERSION: 18.1.14
+APP VERSION: 6.4.1
+
+** Please be patient while the chart is being deployed **
+
+Your WordPress site can be accessed through the following DNS name from within your cluster:
+
+    my-wordpress-release.default.svc.cluster.local (port 80)
+
+To access your WordPress site from outside the cluster follow the steps below:
+
+1. Get the WordPress URL by running these commands:
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace default -w my-wordpress-release'
+
+   export SERVICE_IP=$(kubectl get svc --namespace default my-wordpress-release --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
+
+  echo Username: user
+  echo Password: $(kubectl get secret --namespace default my-wordpress-release -o jsonpath="{.data.wordpress-password}" | base64 -d)
+
+```
+
+Vérifiez que WordPress fonctionne correctement :
+
+```console
+$ kubectl get pod -l app.kubernetes.io/instance=my-wordpress-release
+NAME                                    READY   STATUS    RESTARTS   AGE
+my-wordpress-release-796cc4d6b8-ckb6c   1/1     Running   0          3m25s
+my-wordpress-release-mariadb-0          1/1     Running   0          3m25s
+
+```
+
+## Aller plus loin
+
+Pour obtenir une vue d'ensemble du service Managed Private Registry d'OVHcloud, consultez le site Managed Private Registry d'OVHcloud.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/helm-charts.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/helm-charts.mdx
@@ -1,1 +1,209 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/helm-charts.mdx
+---
+title: Gérer les charts Helm dans OVHcloud Managed Private Registry
+description: Découvrez comment gérer les charts Helm dans OVHcloud Managed Private Registry
+lastUpdated: 2023-11-27
+---
+
+Le service OVHcloud Managed Private Registry est un registre cloud-native composite qui prend en charge à la fois la gestion des images de conteneurs et celle des [charts](https://helm.sh/docs/topics/charts/) [Helm](https://helm.sh/).
+
+Ce guide explique comment gérer les charts Helm dans le service OVHcloud Managed Private Registry : comment envoyer des charts et comment les utiliser.
+
+## Avant de commencer
+
+Ce tutoriel suppose que vous disposez déjà d'un cluster OVHcloud Managed Kubernetes fonctionnel et que vous savez l'utiliser. Pour en savoir plus sur ces sujets, consultez la documentation [Déployer une application Hello World](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world). Helm doit être installé sur votre cluster (consultez le guide « [Installer Helm](/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm) » pour plus d'informations).
+
+Vous devez également disposer d'un OVHcloud Managed Private Registry fonctionnel et avoir suivi les guides [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation), [Se connecter à l'interface](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui), [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects), [Créer et utiliser des images privées](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image) et [Utiliser Managed Private Registry avec OVHcloud Managed Kubernetes](/guides/public-cloud/containers-orchestration/managed-private-registry/kubernetes).
+
+## Prérequis
+
+### Installer Helm v3.8+
+
+Vérifiez que Helm est installé dans la version requise :
+
+```bash
+$ helm version
+version.BuildInfo{Version:"v3.12.0", GitCommit:"c9f554d75773799f72ceef38c51210f1842a1dea", GitTreeState:"clean", GoVersion:"go1.20.3"}
+```
+
+Si la version est antérieure à v3.8.0, suivez les [instructions officielles](https://helm.sh/docs/intro/install/) pour installer Helm dans sa dernière version.
+
+## En pratique
+### Préparer un chart Helm
+
+Pour réaliser ce tutoriel, vous avez besoin d'un chart Helm à envoyer dans votre OVHcloud Managed Private Registry.
+
+Si vous disposez déjà d'un chart Helm sur votre système de fichiers, vous pouvez l'utiliser pour l'exemple. Dans cette section, nous partons du principe que vous n'en avez aucun. Nous utilisons un chart Helm bien connu, souvent pris comme exemple : le chart [WordPress](https://github.com/helm/charts/tree/master/stable/wordpress).
+
+#### Télécharger le chart
+
+La première étape consiste à télécharger le chart WordPress à l'aide de `helm` :
+
+```bash
+helm fetch bitnami/wordpress
+```
+
+Le chart Helm WordPress est téléchargé sous la forme d'un fichier `tgz`.
+
+```console
+$ helm fetch bitnami/wordpress
+
+$ ls
+wordpress-18.1.14.tgz
+```
+
+#### Inspecter le chart (facultatif)
+
+Le fichier que vous avez téléchargé est un chart Helm empaqueté, pratique pour le télécharger et pour l'envoyer dans votre OVHcloud Managed Private Registry. Décompressons-le afin d'y jeter un œil et de mieux comprendre sa structure.
+
+Un chart décompressé est organisé comme un ensemble de fichiers dans un répertoire. Le nom du répertoire est le nom du chart (sans information de version). Le chart décrivant WordPress doit donc être stocké dans un dossier « wordpress/ ».
+
+À l'intérieur de ce répertoire, Helm attend une structure correspondant à celle-ci :
+
+```bash
+wordpress/
+  Chart.yaml          # A YAML file containing information about the chart
+  LICENSE             # OPTIONAL: A plain text file containing the license for the chart
+  README.md           # OPTIONAL: A human-readable README file
+  values.yaml         # The default configuration values for this chart
+  values.schema.json  # OPTIONAL: A JSON Schema for imposing a structure on the values.yaml file
+  charts/             # A directory containing any charts upon which this chart depends.
+  crds/               # Custom Resource Definitions
+  templates/          # A directory of templates that, when combined with values,
+                      # will generate valid Kubernetes manifest files.
+  templates/NOTES.txt # OPTIONAL: A plain text file containing short usage notes
+```
+
+Décompressons le chart Helm :
+
+```bash
+tar zxf wordpress-18.1.14.tgz
+```
+
+Comme prévu, le fichier est décompressé dans un dossier `wordpress`, contenant les fichiers et dossiers requis :
+
+```console
+$ tar zxf wordpress-18.1.14.tgz
+
+$ ls -l
+total 132
+drwxr-xr-x 4 avache staff   4096 Nov 14 19:07 wordpress
+-rw-r--r-- 1 avache staff 130981 Nov 14 19:07 wordpress-18.1.14.tgz
+
+$ ls -l wordpress
+total 148
+-rw-r--r-- 1 avache staff   405 Nov 14 01:02 Chart.lock
+drwxr-xr-x 5 avache staff  4096 Nov 14 19:07 charts
+-rw-r--r-- 1 avache staff  1287 Nov 14 01:02 Chart.yaml
+-rw-r--r-- 1 avache staff 73911 Nov 14 01:02 README.md
+drwxr-xr-x 2 avache staff  4096 Nov 14 19:07 templates
+-rw-r--r-- 1 avache staff  5706 Nov 14 01:02 values.schema.json
+-rw-r--r-- 1 avache staff 48675 Nov 14 01:02 values.yaml
+```
+
+Vous pouvez maintenant supprimer le fichier `tgz`, puisque nous allons le recréer.
+
+Pour empaqueter un chart depuis un répertoire de chart, utilisez `helm package` :
+
+```bash
+helm package wordpress
+```
+
+Le chart empaqueté est créé, avec la version ajoutée au nom du fichier :
+
+```console
+$ helm package wordpress
+Successfully packaged chart and saved it to: /Users/avache/tmp/test-doc-k8s/helm/wordpress-18.1.14.tgz
+```
+
+### Gérer les charts Helm via la CLI Helm
+
+#### Connexion
+
+Avant de pouvoir faire un pull ou un push de charts Helm, connectez-vous à Harbor :
+
+```bash
+helm registry login <registry url>
+```
+
+Par exemple :
+
+```bash
+helm registry login https://8xghzr01.c1.bhs5.container-registry.ovh.net
+```
+
+#### Push d'un chart Helm
+
+Envoyez un chart dans un registre :
+
+```bash
+helm push <chart name>-<version>.tgz oci://<registry url>/<project>
+```
+
+Par exemple, pour pousser le chart Helm WordPress en version « 18.1.14 » dans le projet Harbor nommé « private » :
+
+```bash
+helm push wordpress-18.1.14.tgz oci://8xghzr01.c1.bhs5.container-registry.ovh.net/private
+```
+
+#### Pull d'un chart Helm
+
+Téléchargez un chart depuis un registre :
+
+```bash
+helm pull oci://<registry url>/<project>/<chart name> --version <version>
+```
+
+Par exemple, pour récupérer le chart Helm WordPress en version « 18.1.14 » depuis le projet Harbor nommé « private » :
+
+```bash
+helm pull oci://8xghzr01.c1.bhs5.container-registry.ovh.net/private/wordpress --version 18.1.14
+```
+
+Un nouveau fichier doit apparaître :
+```bash
+$ ls -l
+
+-rw-r--r-- 1 avache staff 130981 Nov 14 19:11 wordpress-18.1.14.tgz
+```
+
+#### Installation d'un chart Helm
+
+Installez un chart sur un cluster Kubernetes :
+
+```bash
+helm install myrelease oci://<registry url>/<project>/<chart name> --version <version>
+```
+
+Par exemple, pour installer le chart Helm WordPress en version « 18.1.14 » depuis le projet Harbor nommé « private » :
+
+```bash
+helm install myrelease oci://8xghzr01.c1.bhs5.container-registry.ovh.net/private/wordpress --version 18.1.14
+```
+
+### Gérer les charts Helm via l'interface Harbor
+
+Les charts poussés dans le registre compatible OCI de Harbor sont traités comme n'importe quel autre type d'artefact.
+
+Nous pouvons les lister, les copier, les supprimer, modifier leurs labels, obtenir leurs détails, ajouter ou retirer des tags, exactement comme pour les images de conteneurs.
+
+Dans l'exemple suivant, nous avons poussé le chart Helm WordPress en version 18.1.14 et l'image Docker WordPress en version 6.4.1 :
+
+<img className="thumbnail" alt="Liste des projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/using-helm-charts/harbor-ui-001.png" loading="lazy" />
+
+Cliquez sur le nom du projet `private` pour lister ses dépôts :
+
+<img className="thumbnail" alt="Liste des dépôts du projet" src="/images/public-cloud/containers-orchestration/managed-private-registry/using-helm-charts/harbor-ui-002.png" loading="lazy" />
+
+Cliquez ensuite sur le nom du dépôt `private/wordpress` pour afficher ses 2 artefacts : l'image Docker et le chart Helm. Le logo à gauche du hash de l'artefact permet de les différencier :
+
+<img className="thumbnail" alt="Liste des artefacts du dépôt du projet" src="/images/public-cloud/containers-orchestration/managed-private-registry/using-helm-charts/harbor-ui-003.png" loading="lazy" />
+
+Enfin, cliquez sur le hash du second artefact pour afficher les détails du chart Helm :
+
+<img className="thumbnail" alt="Détails de la version du chart - Values" src="/images/public-cloud/containers-orchestration/managed-private-registry/using-helm-charts/harbor-ui-004.png" loading="lazy" />
+
+## Aller plus loin
+
+Pour obtenir une vue d'ensemble du service OVHcloud Managed Private Registry, consultez le site OVHcloud Managed Private Registry.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/kubernetes.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/kubernetes.mdx
@@ -1,35 +1,35 @@
 ---
-title: Using Private Registry with OVHcloud Managed Kubernetes
-description: Find out how to use images from OVHcloud Managed Private Registry service on OVHcloud Managed Kubernetes clusters
+title: Utiliser Private Registry avec OVHcloud Managed Kubernetes
+description: Découvrez comment utiliser les images du service OVHcloud Managed Private Registry sur des clusters OVHcloud Managed Kubernetes
 lastUpdated: 2022-02-28
 ---
 
-In this tutorial we are going to guide you in using images from OVHcloud Managed Private Registry service on OVHcloud Managed Kubernetes clusters.
+Ce tutoriel vous guide dans l'utilisation des images du service OVHcloud Managed Private Registry sur des clusters OVHcloud Managed Kubernetes.
 
-## Before you begin
+## Avant de commencer
 
-This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [deploying a Hello World application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world) documentation.
+Ce tutoriel suppose que vous disposez déjà d'un cluster OVHcloud Managed Kubernetes opérationnel et que vous savez l'administrer. Pour en savoir plus sur ces sujets, consultez la documentation [Deploying a Hello World application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-You also need to have a working OVHcloud Managed Private Registry and have followed the guides on [creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation), [connecting to the UI](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui), [managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) and [creating and using private images](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
+Vous devez également disposer d'un OVHcloud Managed Private Registry opérationnel et avoir suivi les guides [Creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation), [Connecting to the UI](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui), [Managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) et [Creating and using private images](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
 
-We will specifically suppose you have followed the last one and you have a `hello-ovh` image on your private registry.
+Nous supposons plus précisément que vous avez suivi le dernier guide et que vous disposez d'une image `hello-ovh` dans votre registre privé.
 
-## Create Kubernetes Secret
+## Créer un secret Kubernetes
 
-Kubernetes needs to have access to the private registry to pull images from it, so you need to store the private registry credentials in a Kubernetes Secret.
-There are 2 ways to create the registry credentials secret. Chose the solution you prefer.
+Kubernetes doit pouvoir accéder au registre privé pour y faire un pull des images : vous devez donc stocker les identifiants du registre privé dans un secret Kubernetes.
+Il existe 2 façons de créer le secret contenant les identifiants du registre. Choisissez celle que vous préférez.
 
-### 1. Create a Secret based on existing Docker credentials
+### 1. Créer un secret à partir d'identifiants Docker existants
 
-#### Log in to your OVHcloud Managed Private Registry
+#### Se connecter à votre OVHcloud Managed Private Registry
 
-In order to pull a private image from your private registry, you must authenticate with it using `docker login`.
+Pour faire un pull d'une image privée depuis votre registre privé, vous devez vous y authentifier avec `docker login`.
 
 ```bash
 docker login [YOUR_PRIVATE_REGISTRY_URL]
 ```
 
-For my private registry:
+Pour notre registre privé :
 
 ```console
   $ docker login 8093ff7x.gra5.container-registry.ovh.net
@@ -38,21 +38,21 @@ For my private registry:
   Login Succeeded
 ```
 
-The login process creates or updates a `config.json` file that holds an authorization token.
+La connexion crée ou met à jour un fichier `config.json` qui contient un jeton d'autorisation.
 
-View the `config.json` file:
+Affichez le fichier `config.json` :
 
 ```bash
 cat ~/.docker/config.json
 ```
 
-#### Creating the Secret
+#### Créer le secret
 
-Let's create a Secret of `docker-registry` type.
+Créez un secret de type `docker-registry`.
 
-You will use this Secret to authenticate with your private registry to pull a private image.
+Vous utiliserez ce secret pour vous authentifier auprès de votre registre privé et faire un pull d'une image privée.
 
-If you already ran `docker login`, you can copy that credential into Kubernetes:
+Si vous avez déjà exécuté `docker login`, vous pouvez copier ces identifiants dans Kubernetes :
 
 ```bash
 kubectl create secret generic regcred \
@@ -60,7 +60,7 @@ kubectl create secret generic regcred \
     --type=kubernetes.io/dockerconfigjson
 ```
 
-For my private registry:
+Pour notre registre privé :
 
 ```console
 $ kubectl create secret generic regcred \
@@ -70,7 +70,7 @@ $ kubectl create secret generic regcred \
   secret/regcred created
 ```
 
-You can check the secret has been correctly deployed in your Kubernetes cluster:
+Vous pouvez vérifier que le secret a bien été déployé dans votre cluster Kubernetes :
 
 ```console
 $ kubectl get secret regcred -o jsonpath="{.data.\.dockerconfigjson}"
@@ -79,15 +79,15 @@ ewogICAgICAgICJhdXRocyI6IHsKCQkiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEvIjogewogICAg
 ```
 
 :::info
-Secrets are encoded in base64 and automatically decoded when they are attached to a Pod.
+Les secrets sont encodés en base64 et automatiquement décodés lorsqu'ils sont attachés à un pod.
 :::
 
 
-### 2. Create a Secret by providing credentials on the command line
+### 2. Créer un secret en fournissant les identifiants en ligne de commande
 
-Let's create a Secret of `docker-registry` type.
+Créez un secret de type `docker-registry`.
 
-You will use this Secret to authenticate with your private registry to pull a private image:
+Vous utiliserez ce secret pour vous authentifier auprès de votre registre privé et faire un pull d'une image privée :
 
 ```bash
 kubectl create secret docker-registry regcred \
@@ -96,7 +96,7 @@ kubectl create secret docker-registry regcred \
     --docker-password=`<your-password>`
 ```
 
-For my private registry:
+Pour notre registre privé :
 
 ```console
 $ kubectl create secret docker-registry regcred \
@@ -107,7 +107,7 @@ $ kubectl create secret docker-registry regcred \
   secret/regcred created
 ```
 
-You can check the secret has been correctly deployed in your Kubernetes cluster:
+Vous pouvez vérifier que le secret a bien été déployé dans votre cluster Kubernetes :
 
 ```console
 $ kubectl get secret regcred -o jsonpath="{.data.\.dockerconfigjson}"
@@ -116,13 +116,13 @@ eyJhdXRocyI6eyJjeDZkczMwZC5ncmE3LmNvbnRhaW5lci1yZWdpc3RyeS5vdmgubmV0Ijp7InVzZXJu
 ```
 
 :::info
-Secrets are encoded in base64 and automatically decoded when they are attached to a Pod.
+Les secrets sont encodés en base64 et automatiquement décodés lorsqu'ils sont attachés à un pod.
 :::
 
 
-## Deploying an image
+## Déployer une image
 
-The first step to deploy a Docker image in a Kubernetes cluster is to write a YAML manifest. Let's call it `hello-ovh.yaml`:
+La première étape pour déployer une image Docker dans un cluster Kubernetes consiste à écrire un manifeste YAML. Nommez-le `hello-ovh.yaml` :
 
 ```yaml
 apiVersion: v1
@@ -167,17 +167,17 @@ spec:
 ```
 
 :::info
-Replace `[YOUR_PRIVATE_REGISTRY_URL]` and `[YOUR_PROJECT]` with your private registry URL and your project name, for example for my private registry it will be: `cx6ds30d.gra7.container-registry.ovh.net/private/hello-ovh:1.0.0`
+Remplacez `[YOUR_PRIVATE_REGISTRY_URL]` et `[YOUR_PROJECT]` par l'URL de votre registre privé et le nom de votre projet. Par exemple, pour notre registre privé : `cx6ds30d.gra7.container-registry.ovh.net/private/hello-ovh:1.0.0`
 :::
 
 
-And then we can apply the file:
+Vous pouvez ensuite appliquer le fichier :
 
 ```bash
 kubectl apply -f hello-ovh.yaml
 ```
 
-After applying the YAML file, a new `hello-world` service and the corresponding `hello-world-deployment` deployment are created:
+Après application du fichier YAML, un nouveau service `hello-world` et le déploiement `hello-world-deployment` correspondant sont créés :
 
 ```console
 $ kubectl apply -f hello-ovh.yaml
@@ -190,10 +190,10 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 hello-ovh-deployment-6df76cb7b8-vbk2b   1/1     Running   0          66s
 ```
 
-Our Pod is correctly running, so Kubernetes has pulled the image from your private registry with success.
+Le pod fonctionne correctement : Kubernetes a donc bien effectué le pull de l'image depuis votre registre privé.
 
-## Go further
+## Aller plus loin
 
-To have an overview of OVHcloud Managed Private Registry service, you can go to the OVHcloud Managed Private Registry site.
+Pour une vue d'ensemble du service OVHcloud Managed Private Registry, consultez le site OVHcloud Managed Private Registry.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managed-private-registry-faq.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managed-private-registry-faq.mdx
@@ -1,1 +1,82 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/managed-private-registry-faq.mdx
+---
+title: FAQ Managed Private Registry (MPR)
+description: Retrouvez les réponses aux questions les plus fréquemment posées sur le service Managed Private Registry (MPR) d'OVHcloud
+lastUpdated: 2026-07-01
+---
+
+## Objectif
+
+Voici les questions les plus fréquemment posées au sujet de Managed Private Registry (MPR).
+
+### Dans quelles régions la solution Managed Private Registry est-elle disponible ?
+
+Managed Private Registry est actuellement disponible dans les régions suivantes :
+
+| Région       |    Ville    |   Pays    | Continent | Zones de disponibilité |
+|--------------|:-----------:|:---------:|:---------:|:----------------------:|
+| AP-SOUTH-MUM |   Mumbai    |   Inde    |   Asie    |          1-AZ          |
+| BHS          | Beauharnois |  Canada   | Amérique  |          1-AZ          |
+| DE           |  Francfort  | Allemagne |  Europe   |          1-AZ          |
+| EU-SOUTH-MIL |    Milan    |  Italie   |  Europe   |          3-AZ          |
+| EU-WEST-PAR  |    Paris    |  France   |  Europe   |          3-AZ          |
+| GRA          | Gravelines  |  France   |  Europe   |          1-AZ          |
+
+### Quelles sont les différences entre une région 1-AZ et une région 3-AZ
+
+#### Déploiement en région 1 AZ
+
+Tous les composants du service sont hébergés au sein d'une seule zone de disponibilité.
+
+Le stockage repose sur **S3 Standard**.
+
+#### Déploiement en région 3 AZ
+
+Le service est répliqué et réparti sur plusieurs zones de disponibilité distinctes (jusqu'à 3), selon le plan choisi.
+
+- Les **plans Medium et Large** fonctionnent en mode actif-actif sur au moins 2 AZ : le trafic est réparti et les données sont disponibles simultanément dans plusieurs zones, ce qui garantit une résilience accrue.
+- Le **plan Small** fonctionne en mode actif-passif sur 2 AZ : une zone primaire est utilisée en continu, tandis qu'une zone secondaire peut prendre le relais en cas d'incident.
+
+Le stockage repose sur **S3 Standard 3AZ**, qui assure la durabilité et la haute disponibilité des artefacts.
+
+### Quelles sont les dépendances du service Managed Private Registry ?
+
+Le service MPR (Managed Private Registry) est géré par nos équipes et s'appuie sur des ressources de calcul et de réseau Public Cloud ainsi que sur l'Object Storage (classe Standard). Ces dépendances ne sont ni visibles, ni facturées.
+
+Vous trouverez ci-dessous la localisation exacte de ces dépendances :
+
+| Région       | Région Public Cloud Compute | Object Storage (classe Standard) |
+|--------------|:---------------------------:|:--------------------------------:|
+| AP-SOUTH-MUM |       AP-SOUTH-MUM-1        |           AP-SOUTH-MUM           |
+| BHS          |            BHS5             |               BHS                |
+| DE           |             DE1             |                DE                |
+| EU-SOUTH-MIL |        EU-SOUTH-MIL         |           EU-SOUTH-MIL           |
+| EU-WEST-PAR  |         EU-WEST-PAR         |           EU-WEST-PAR            |
+| GRA          |          GRA7/GRA9          |               GRA                |
+
+### Quelle version de Harbor est proposée ?
+
+Tous les nouveaux services Managed Private Registry exposent Harbor **2.15.1**. Nous rétroportons régulièrement les correctifs de sécurité et de performance des dernières versions et nous proposerons régulièrement de nouvelles montées de version fonctionnelles.
+
+#### Astuces
+
+Tout le trafic entrant et sortant du registre est entièrement **gratuit**.
+
+### Quels niveaux de service sont inclus dans le service Managed Private Registry ?
+
+Managed Private Registry est couvert par un niveau de service (SLA) qui garantit une très haute disponibilité, afin de vous assurer une grande efficacité de vos développements et de vos déploiements. Les plans **M** et **L** disposent d'un SLA qui couvre également des composants tels que l'interface utilisateur et l'analyse de vulnérabilités. Vous trouverez tous les détails dans les [Conditions particulières du service OVHcloud Public Cloud](/links/terms-conditions-contracts).
+
+### Suis-je obligé d'utiliser OVHcloud Managed Kubernetes Service avec Managed Private Registry ?
+
+Non, car en souscrivant au service Managed Private Registry, vous disposez de votre propre registre Docker et de votre propre [Harbor](https://goharbor.io/) (API et interface graphique). Une fois vos identifiants reçus, vous pouvez utiliser le service Managed Private Registry avec n'importe quel outil de conteneurisation ou d'orchestration, la solution Kubernetes d'OVHcloud ou une autre.
+
+### En tant qu'utilisateur de Managed Private Registry, ai-je la possibilité de changer de plan ?
+
+Vous pouvez migrer vers un plan de capacité supérieure à tout moment. Dès que vous nous informez de votre souhait d'évolution, les nouvelles limites sont prises en compte en quelques dizaines de secondes, **sans aucune perte de données** ni modification de configuration.
+
+#### Astuces
+
+Si vous créez, modifiez ou supprimez votre service en cours de mois, vous n'êtes facturé que pour les heures réellement utilisées. Selon le plan choisi, vous pouvez disposer d'une capacité de stockage allant jusqu'à 5 To. Pour chacun des plans, le trafic illimité est inclus, quelle que soit sa destination.
+
+## Aller plus loin
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managed-private-registry-iam-authentication.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managed-private-registry-iam-authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Configure access control using OVHcloud IAM on an OVHcloud Managed Private Registry"
-description: "Learn how to enable and manage OVHcloud IAM authentication to control access to your Managed Private Registry (MPR) using centralized identities and roles."
+title: "Configurer le contrôle d'accès avec OVHcloud IAM sur un OVHcloud Managed Private Registry"
+description: "Découvrez comment activer et gérer l'authentification OVHcloud IAM pour contrôler l'accès à votre Managed Private Registry (MPR) à l'aide d'identités et de rôles centralisés"
 lastUpdated: 2025-09-10
 ---
 
@@ -10,63 +10,62 @@ import Api from '@components/Api';
 
 
 
-## Objective
+## Objectif
 
-OVHcloud Managed Private Registry (MPR) supports authentication through OVHcloud IAM, allowing you to manage access using centralized user identities and roles.
+OVHcloud Managed Private Registry (MPR) prend en charge l'authentification via OVHcloud IAM, ce qui vous permet de gérer les accès à l'aide d'identités et de rôles utilisateurs centralisés.
 
-This guide explains how to enable IAM authentication and control user access to your registry using OVHcloud IAM users and roles.
+Ce guide explique comment activer l'authentification IAM et contrôler l'accès des utilisateurs à votre registre à l'aide des utilisateurs et des rôles OVHcloud IAM.
 
-## Requirements
+## Prérequis
 
-- An OVHcloud Managed Private Registry (see the [creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) guide for more information).
-- An access to the Harbor UI to operate the private registry (see the [connecting to the UI](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) guide for more information).
+- Un OVHcloud Managed Private Registry (consultez le guide « [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) » pour plus d'informations).
+- Un accès à l'interface Harbor pour administrer le registre privé (consultez le guide « [Se connecter à l'interface](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) » pour plus d'informations).
 
-## Instructions
+## En pratique
+### Introduction à OVHcloud IAM
 
-### Introduction to OVHcloud IAM
+OVHcloud IAM (Identity and Access Management) est un système centralisé qui vous permet de gérer qui peut accéder à vos services OVHcloud et ce que ces personnes sont autorisées à faire. Il offre un contrôle d'accès fin grâce aux utilisateurs, aux groupes et aux rôles.
 
-OVHcloud IAM (Identity and Access Management) is a centralized system that lets you manage who can access your OVHcloud services and what they are allowed to do. It provides fine-grained access control through users, groups and roles.
+Utilisé avec Managed Private Registry (MPR), OVHcloud IAM remplace la base d'utilisateurs locale de Harbor. Cela vous permet de :
 
-When used with Managed Private Registry (MPR), OVHcloud IAM replaces Harbor's local user database. This enables you to:
+- utiliser le SSO (Single Sign-On) avec vos identifiants OVHcloud pour accéder à Harbor ;
+- attribuer des rôles IAM prédéfinis (admin, standard) pour contrôler les niveaux d'accès ;
+- gérer les permissions à grande échelle grâce aux groupes et aux projets IAM.
 
-- use SSO (Single Sign-On) with your OVHcloud credentials to access Harbor.
-- assign predefined IAM roles (admin, standard) to control access levels.
-- manage permissions at scale using IAM groups and projects.
+En intégrant l'IAM à votre registre, vous garantissez un contrôle d'accès cohérent sur l'ensemble de vos services OVHcloud, ce qui réduit la gestion manuelle et améliore la sécurité.
 
-By integrating IAM with your registry, you ensure consistent access control across your OVHcloud services — reducing manual management and improving security.
-
-### Activate/disable authentication via OVHcloud IAM
+### Activer/désactiver l'authentification via OVHcloud IAM
 
 :::warning
-When you enable OVHcloud IAM authentication on your Managed Private Registry:
+Lorsque vous activez l'authentification OVHcloud IAM sur votre Managed Private Registry :
 
-- all existing Harbor users will be removed.
-- existing robot accounts remain functional.
-- new robot accounts can still be created and managed.
+- tous les utilisateurs Harbor existants sont supprimés ;
+- les comptes robots existants restent fonctionnels ;
+- de nouveaux comptes robots peuvent toujours être créés et gérés.
 
-From this point on, all users access are managed through OVHcloud IAM roles and policies.
+À partir de ce moment, tous les accès utilisateurs sont gérés via les rôles et les politiques OVHcloud IAM.
 :::
 
 <Tabs>
-<Tab label="Via the OVHcloud Control Panel">
+<Tab label="Depuis l'espace client OVHcloud">
 
-Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the `Public Cloud` section, and select the relevant project. Then, in the left-hand menu under **Containers & Orchestration**, click on `Managed Private Registry`.
+Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, accédez à la section `Public Cloud` et sélectionnez le projet concerné. Puis, dans le menu de gauche, sous **Containers & Orchestration**, cliquez sur `Managed Private Registry`.
 
-In the list of registries, click the `...` button for the relevant registry, then select:
+Dans la liste des registres, cliquez sur le bouton `...` du registre concerné, puis sélectionnez :
 
-- `Activate authentication via OVHcloud IAM` to enable it.
+- `Activer l'authentification via OVHcloud IAM` pour l'activer.
 
-![activate IAM](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/activate_iam.png)
+![activer l'IAM](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/activate_iam.png)
 
-- `Disable authentication via OVHcloud IAM` to disable it.
+- `Désactiver l'authentification via OVHcloud IAM` pour la désactiver.
 
-![disable IAM](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/disable_iam.png)
+![désactiver l'IAM](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/disable_iam.png)
 
 </Tab>
-<Tab label="Via the OVHcloud API">
+<Tab label="Via l'API OVHcloud">
 
 <details>
-<summary>Enable IAM authentication</summary>
+<summary>Activer l'authentification IAM</summary>
 
 
 <Api version="v1" section="/cloud" method="POST" route={"/cloud/project/\\{serviceName\\}/containerRegistry/\\{registryID\\}/iam"} />
@@ -75,7 +74,7 @@ In the list of registries, click the `...` button for the relevant registry, the
 </details>
 
 <details>
-<summary>Disable IAM authentication</summary>
+<summary>Désactiver l'authentification IAM</summary>
 
 
 <Api version="v1" section="/cloud" method="DELETE" route={"/cloud/project/\\{serviceName\\}/containerRegistry/\\{registryID\\}/iam"} />
@@ -83,84 +82,84 @@ In the list of registries, click the `...` button for the relevant registry, the
 
 </details>
 
-Replace:
+Remplacez :
 
-- `serviceName` with the ID of your Public Cloud project.
-- `registryID` with the ID of the Managed Private Registry.
+- `serviceName` par l'identifiant de votre projet Public Cloud.
+- `registryID` par l'identifiant du Managed Private Registry.
 
-You can retrieve the `registryID` in two ways:
+Vous pouvez récupérer le `registryID` de deux manières :
 
-- **Via API:**
+- **Via l'API :**
 
 <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/containerRegistry"} />
 
-- **Via the OVHcloud Control Panel:**
+- **Depuis l'espace client OVHcloud :**
 
-Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the `Public Cloud` section, and select the relevant project. Then, in the left-hand menu under **Containers & Orchestration**, click on `Managed Private Registry`.
+Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, accédez à la section `Public Cloud` et sélectionnez le projet concerné. Puis, dans le menu de gauche, sous **Containers & Orchestration**, cliquez sur `Managed Private Registry`.
 
 </Tab>
 </Tabs>
 
 
-### Authentication using SSO with OVHcloud IAM users
+### Authentification par SSO avec les utilisateurs OVHcloud IAM
 
-Once IAM authentication is enabled, access to the Harbor UI is handled via OVHcloud Single Sign-On (SSO). Users no longer log in with Harbor-local credentials but authenticate directly using their OVHcloud IAM identity.
+Une fois l'authentification IAM activée, l'accès à l'interface Harbor se fait via le SSO (Single Sign-On) OVHcloud. Les utilisateurs ne se connectent plus avec des identifiants locaux Harbor, mais s'authentifient directement avec leur identité OVHcloud IAM.
 
-To log in via SSO:
+Pour vous connecter via le SSO :
 
-- Open the `Harbor user interface` from the Control Panel.
+- Ouvrez l'`Interface utilisateur Harbor` depuis l'espace client.
 
-![harbor user interface](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/harbor_interface.png)
+![interface utilisateur Harbor](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/harbor_interface.png)
 
-- You will be redirected to the OVHcloud authentication page, log in using your OVHcloud IAM credentials.
+- Vous êtes redirigé vers la page d'authentification OVHcloud : connectez-vous avec vos identifiants OVHcloud IAM.
 
-![login with SSO](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/iam_authentication.png)
+![connexion avec le SSO](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/iam_authentication.png)
 
-- Access to Harbor is granted based on the IAM role associated with your user account.
+- L'accès à Harbor est accordé en fonction du rôle IAM associé à votre compte utilisateur.
 
 :::info
-Only users with the appropriate IAM role (admin or standard) can access the registry after IAM authentication is enabled.
+Seuls les utilisateurs disposant du rôle IAM approprié (admin ou standard) peuvent accéder au registre une fois l'authentification IAM activée.
 :::
 
-### Managing access rights with OVHcloud IAM
+### Gérer les droits d'accès avec OVHcloud IAM
 
-OVHcloud IAM provides two predefined roles for managing access to your Managed Private Registry (MPR):
+OVHcloud IAM propose deux rôles prédéfinis pour gérer l'accès à votre Managed Private Registry (MPR) :
 
 - Standard
 - Admin
 
 :::info
-**Admin** role: Regardless of the user group defined in the Identities section, assigning the Admin role will grant full administrative privileges on the selected registry.
+Rôle **Admin** : quel que soit le groupe d'utilisateurs défini dans la section Identités, l'attribution du rôle Admin accorde tous les privilèges d'administration sur le registre sélectionné.
 
-**Standard** role: Be aware that users belonging to the Default group in the Identities section automatically inherit admin privileges on the registry. Assigning them the Standard role will not override these inherited rights. To ensure proper separation of roles, we recommend:
+Rôle **Standard** : notez que les utilisateurs appartenant au groupe Default dans la section Identités héritent automatiquement des privilèges d'administration sur le registre. Leur attribuer le rôle Standard ne remplace pas ces droits hérités. Pour assurer une séparation correcte des rôles, nous recommandons de :
 
-- Organizing users into clearly defined groups.
-- After changing a user's group and assigning the Standard role, fine-tune their permissions directly in Harbor for better control and consistency. See the different roles in Harbor [here](https://goharbor.io/docs/1.10/administration/managing-users/user-permissions-by-role/).
+- organiser les utilisateurs en groupes clairement définis ;
+- après avoir changé le groupe d'un utilisateur et lui avoir attribué le rôle Standard, ajuster précisément ses permissions directement dans Harbor, pour un meilleur contrôle et une plus grande cohérence. Consultez les différents rôles disponibles dans Harbor [ici](https://goharbor.io/docs/1.10/administration/managing-users/user-permissions-by-role/).
 
 :::
 
-These roles are assigned through IAM policies. To create and configure a policy, log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> and navigate to the `Identity, Security & Operations` section. Then, in the left-hand menu under **Identity and Access management**, click on `Policies` and click the `Create a policy` button.
+Ces rôles sont attribués via des politiques IAM. Pour créer et configurer une politique, connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et accédez à la section `Identity, Security & Operations`. Puis, dans le menu de gauche, sous **Identity and Access management**, cliquez sur `Politiques`, puis sur le bouton `Créer une politique`.
 
-![Create policy](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/managing_iam.png)
+![Créer une politique](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/managing_iam.png)
 
-Define users and groups, name your policy, add the users you want to include and optionally, add user groups if they have already been created.
+Définissez les utilisateurs et les groupes, nommez votre politique, ajoutez les utilisateurs que vous souhaitez inclure et, si vous le souhaitez, ajoutez des groupes d'utilisateurs s'ils ont déjà été créés.
 
-![Create policy users](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy.png)
+![Créer une politique - utilisateurs](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy.png)
 
-Set permissions for MPR: 
+Définissez les permissions pour MPR :
 
-- In the `Product types` section, select `Public Cloud Project/Managed Registry`.
-- In the `Resources` section, choose the specific MPR instance to which the policy will apply.
+- Dans la section `Types de produits`, sélectionnez `Public Cloud Project/Managed Registry`.
+- Dans la section `Ressources`, choisissez l'instance MPR spécifique à laquelle la politique s'appliquera.
 
-![Create policy product types](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy_product_types.png)
+![Créer une politique - types de produits](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy_product_types.png)
 
-Expand `Public Cloud Project/Managed Registry` and select the desired role for the users defined in the policy.
+Développez `Public Cloud Project/Managed Registry` et sélectionnez le rôle souhaité pour les utilisateurs définis dans la politique.
 
-![Create policy roles](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy_action.png)
+![Créer une politique - rôles](/images/guides/public-cloud/containers-orchestration/managed-private-registry/managing-iam-authentication/create_policy_action.png)
 
-### Go further
+### Aller plus loin
 
-To go further you can look at our guides on:
+Pour aller plus loin, vous pouvez consulter nos guides sur :
 
-- [Managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects).
-- [Creating and using a private image](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
+- [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects).
+- [Créer et utiliser une image privée](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects.mdx
@@ -1,1 +1,80 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects.mdx
+---
+title: Gérer les utilisateurs et les projets
+description: Découvrez comment gérer les utilisateurs et les projets de votre Managed Private Registry (MPR) OVHcloud
+lastUpdated: 2022-04-13
+---
+
+
+
+## Objectif
+
+Le service Managed Private Registry d'OVHcloud met à votre disposition un Harbor managé, un registre Docker authentifié dans lequel vous pouvez stocker vos images Docker de manière privée. Ce guide explique comment gérer les utilisateurs et les projets de votre service Managed Private Registry OVHcloud.
+
+## Prérequis
+
+- Un Managed Private Registry OVHcloud (consultez le guide « [Créer un registre privé](/guides/public-cloud/containers-orchestration/managed-private-registry/creation) » pour plus d'informations)
+- Un accès à l'interface Harbor pour administrer le registre privé (consultez le guide « [Se connecter à l'interface](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) » pour plus d'informations)
+
+## En pratique
+
+Vous pouvez gérer les projets, les utilisateurs et les droits de votre registre privé depuis l'interface Harbor.
+
+### Créer un nouveau projet
+
+Un projet dans Harbor contient tous les dépôts d'une application. Aucune image ne peut être poussée vers Harbor avant la création du projet.
+
+Il existe deux types de projet dans Harbor :
+
+- Public : tous les utilisateurs peuvent lire le contenu d'un projet Harbor public.
+- Privé : seuls les utilisateurs disposant des droits appropriés peuvent lire le contenu de ce projet.
+
+Créons un projet privé :
+
+1. Créez un nouveau projet dans l'interface Harbor.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-005.png" loading="lazy" />
+
+1. Nommez-le *private* et laissez la case « public » décochée.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-006.png" loading="lazy" />
+
+:::info
+Conservez la valeur `-1` pour le quota de stockage si vous ne souhaitez pas de limitation.
+:::
+
+
+Une fois le projet créé, vous pouvez parcourir les dépôts, les charts Helm, les membres, les libellés, le scanner, la politique, les comptes robots, les webhooks, les logs et la configuration depuis l'onglet de navigation.
+
+<img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-007.png" loading="lazy" />
+
+### Créer un nouvel utilisateur et lui attribuer des droits sur le projet *private*
+
+Vous allez maintenant créer un nouvel utilisateur et lui attribuer des droits de développeur sur le projet *private*.
+
+1. Rendez-vous dans la section <code className="action">Users</code> de l'interface Harbor et cliquez sur <code className="action">New user</code>.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-008.png" loading="lazy" />
+
+1. Ajoutez un nouvel utilisateur *private-user*. Pour le domaine de l'adresse e-mail, utilisez le domaine présent dans l'URL de votre interface Harbor.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-009.png" loading="lazy" />
+
+1. Le nouvel utilisateur est désormais visible dans votre interface Harbor.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-010.png" loading="lazy" />
+
+1. Revenez dans la section <code className="action">Projects</code>, choisissez le projet <code className="action">private</code> puis, dans l'onglet <code className="action">Members</code>, cliquez sur <code className="action">+User</code>.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-011.png" loading="lazy" />
+
+1. Ajoutez *private-user* comme membre du projet et attribuez-lui le rôle *Developer*.
+
+    <img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-012.png" loading="lazy" />
+
+*private-user* est désormais membre du projet *private*.
+
+<img className="thumbnail" alt="Gérer les utilisateurs et les projets" src="/images/public-cloud/containers-orchestration/managed-private-registry/managing-users-and-projects/managing-users-and-projects-013.png" loading="lazy" />
+
+### Aller plus loin
+
+Pour aller plus loin, consultez notre guide « [Créer et utiliser une image privée](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image) ».

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts.mdx
@@ -1,1 +1,120 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts.mdx
+---
+title: Migrer des charts Helm de Chartmuseum vers OCI
+description: Découvrez comment migrer des charts Helm de Chartmuseum (Harbor < 2.8) vers OCI
+lastUpdated: 2026-02-25
+---
+
+## Objectif
+
+Le service Managed Private Registry d'OVHcloud met à votre disposition un registre Docker managé et authentifié dans lequel vous pouvez stocker vos images Docker et vos charts Helm de manière privée.
+
+Managed Private Registry repose sur la solution open source [Harbor](https://github.com/goharbor/harbor), afin de garantir son interopérabilité.
+
+[Harbor](https://github.com/goharbor/harbor) prend en charge deux méthodes de stockage des données des charts Helm :
+
+1. le stockage du registre Harbor, directement via l'API OCI ;
+2. le backend Chartmuseum hébergé par Harbor, via l'API de Chartmuseum.
+
+À partir de la version 2.6 de Harbor, [Chartmuseum](https://github.com/helm/chartmuseum) est déprécié et il est supprimé à partir de la version 2.8 de Harbor.
+
+## Comment savoir si des charts Helm sont stockés dans Chartmuseum ?
+
+Suivez le guide « [Se connecter à l'interface](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui) » pour vous connecter à votre registre.
+
+Depuis la page principale (liste des projets), une fois connecté, vérifiez si des charts Helm Chartmuseum sont présents dans la colonne « Chart Count ».
+![Projets Harbor](/images/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts-from-chartmuseum-to-oci/harbor-projects.png)
+
+Les charts Helm stockés dans Chartmuseum sont visibles dans l'onglet « Helm Charts » du projet.
+![Charts Helm Chartmuseum dans Harbor](/images/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts-from-chartmuseum-to-oci/harbor-helm-charts-chartmuseum.png)
+
+Les charts Helm stockés au format OCI sont, quant à eux, visibles dans l'onglet « Repository » du projet, comme les images Docker.
+![Charts Helm OCI dans Harbor](/images/public-cloud/containers-orchestration/managed-private-registry/migrate-helm-charts-from-chartmuseum-to-oci/harbor-helm-charts-oci.png)
+
+## En pratique
+
+Nous avons développé un outil nommé [chartmuseum2oci](https://github.com/goharbor/chartmuseum-migration-tools) dont l'objectif est de migrer les charts Helm du Chartmuseum de Harbor vers un registre Helm OCI.
+
+### Prérequis
+
+Pour migrer l'ensemble des charts Helm, vous devez utiliser un utilisateur administrateur ou un utilisateur disposant au minimum du rôle « developer » sur tous les projets.
+
+:::warning
+Si l'utilisateur ne dispose pas de droits suffisants, seuls les charts Helm contenus dans les projets auxquels il a accès seront copiés. Aucune erreur ne sera affichée.
+:::
+
+
+Exportez ensuite les variables suivantes :
+
+```bash
+export HARBOR_URL=https://
+export HARBOR_USER=
+export HARBOR_PASSWORD=
+```
+
+### Lancer la migration
+
+Exécutez les commandes suivantes :
+
+```bash
+git clone https://github.com/goharbor/chartmuseum-migration-tools.git
+cd chartmuseum-migration-tools/chartmuseum2oci
+docker build -t goharbor/chartmuseum2oci .
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
+```
+
+Pendant la migration, l'outil indique le nombre de charts à migrer ainsi que l'avancement de la migration :
+
+```console
+$ docker run -ti --rm ovhcloud/harbor-chartmuseum-migrator --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
+$ docker run -ti --rm ovhcloud/harbor-chartmuseum-migrator --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
+2023/06/28 16:17:32 416 Helm charts to migrate from Chartmuseum to OCI
+   4% |█████                                                                                                                                        | (19/416, 20 it/min) [56s:19m36s]
+```
+
+Puis, une fois la migration terminée :
+```console
+$ docker run -ti --rm ovhcloud/harbor-chartmuseum-migrator --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
+$ docker run -ti --rm ovhcloud/harbor-chartmuseum-migrator --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
+2023/06/28 16:17:32 416 Helm charts to migrate from Chartmuseum to OCI
+   100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (416/416, 20 it/min)
+2023/06/28 16:38:14 416 Helm charts successfully migrated from Chartmuseum to OCI
+```
+
+:::info
+Important : l'outil copie les charts Helm mais ne les supprime pas de Chartmuseum.
+:::
+
+
+### Utiliser des charts Helm OCI
+
+Pour interagir avec des charts Helm au format OCI, utilisez Helm en version 3.8 ou supérieure (https://helm.sh/docs/intro/install/).
+Pour finaliser le processus de migration, vous devez modifier toutes les occurrences de charts Helm afin d'utiliser l'URL OCI à la place de celle de Chartmuseum.
+Voici quelques exemples OCI.
+
+#### Connexion
+
+```bash
+helm registry login $HARBOR_URL
+```
+
+#### Push
+```bash
+helm push dummy-chart-0.1.0.tgz $HARBOR_URL/$HARBOR_PROJECT
+```
+
+#### Installation
+
+```bash
+helm install dummy-chart oci://$HARBOR_URL/$HARBOR_PROJECT/dummy-chart --version 0.1.0
+```
+
+#### Liens utiles
+
+- [Documentation Helm de Harbor](https://goharbor.io/docs/2.14.0/working-with-projects/working-with-oci/working-with-helm-oci-charts/)
+- [Documentation Helm OCI](https://helm.sh/docs/topics/registries/#using-an-oci-based-registry)
+
+## Aller plus loin
+
+Pour obtenir une vue d'ensemble du service Managed Private Registry d'OVHcloud, consultez le site Managed Private Registry d'OVHcloud.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/responsibility-model.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/responsibility-model.mdx
@@ -1,175 +1,175 @@
 ---
-title: Managed Private Registry - Responsibility model
-description: Shared responsibilities between OVHcloud and the customer
+title: Managed Private Registry - Modèle de responsabilité
+description: Répartition des responsabilités entre OVHcloud et le client
 lastUpdated: 2023-07-04
 ---
 
-Managed Private Registries allow you to focus on using Harbor to host, share and manage your cloud native artifacts while OVHcloud takes care of the required software and hardware maintenance in operational conditions.
+Les registres privés managés vous permettent de vous concentrer sur l'utilisation de Harbor pour héberger, partager et gérer vos artefacts cloud native, tandis qu'OVHcloud prend en charge la maintenance logicielle et matérielle nécessaire au maintien en conditions opérationnelles.
 
-The RACI below details shared responsibilities between OVHcloud and the customer for Public Cloud Managed Private Registry services.
-This shared model can help relieve the customer’s operational burden.
+Le RACI ci-dessous détaille la répartition des responsabilités entre OVHcloud et le client pour les services Public Cloud Managed Private Registry.
+Ce modèle partagé permet d'alléger la charge opérationnelle du client.
 
-## RACI definition
+## Définition du RACI
 
-| Roles |
+| Rôles |
 | --- |
-| R: Is in charge of carrying out the process |
-| A: Accountable for the successful completion of the process|
-| C: Is consulted during the process |
-| I: Is informed of the results of the process |
+| R : est chargé de réaliser le processus |
+| A : est responsable de la bonne réalisation du processus |
+| C : est consulté pendant le processus |
+| I : est informé des résultats du processus |
 
-For your information, a **Service** is considered as a Public Cloud Databases service such as a MySQL, PostgreSQL, MongoDB, Valkey or Kafka cluster.
+Pour information, un **Service** désigne un service Public Cloud Databases tel qu'un cluster MySQL, PostgreSQL, MongoDB, Valkey ou Kafka.
 
-### 1. Before subscription
+### 1. Avant la souscription
 
-#### 1.1. Specify service as needed
+#### 1.1. Définir le service en fonction des besoins
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Learn about the capabilities and limitations of the Services detailed in the OVHcloud documentation | RA | CI |
-| Use a container or orchestrator tool | RA | I |
-| Create a  Public Cloud project | RA | I |
-| Choose the service location | RA | I |
-| Choose the range plan following business needs (Model : S , M or L) | RA | I |
+| Prendre connaissance des capacités et des limites des Services détaillées dans la documentation OVHcloud | RA | CI |
+| Utiliser un outil de conteneurisation ou d'orchestration | RA | I |
+| Créer un projet Public Cloud | RA | I |
+| Choisir la localisation du service | RA | I |
+| Choisir le plan de la gamme en fonction des besoins métier (modèle : S, M ou L) | RA | I |
 
-### 2. Service availability
+### 2. Mise à disposition du service
 
-#### 2.1. Install service
+#### 2.1. Installer le service
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Produce, route, deliver and maintain underlying software, physical machines, hosting buildings |  | RA |
-| Buy and hold licences and usage rights for softwares provided by OVHcloud (Harbor, Trivy, etc.) |  | RA |
+| Produire, acheminer, livrer et maintenir les logiciels sous-jacents, les machines physiques et les bâtiments d'hébergement |  | RA |
+| Acquérir et détenir les licences et droits d'usage des logiciels fournis par OVHcloud (Harbor, Trivy, etc.) |  | RA |
 
-#### 2.2. Reversibility model
+#### 2.2. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Import images using any Docker images or chart helm within OCI format | RA |  |
+| Importer des images en utilisant n'importe quelle image Docker ou chart Helm au format OCI | RA |  |
 
-#### 2.3. Customer Information System setup
+#### 2.3. Mise en place du système d'information du client
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Deploy workloads using his images| RA |  |
-| Modify templates, helm charts, dockerfile, urls for images' names, image dockers, etc . | RA |  |
+| Déployer des charges de travail à partir de ses images | RA |  |
+| Modifier les templates, les charts Helm, les dockerfiles, les URL des noms d'images, les images Docker, etc. | RA |  |
 
-### 3. Service usage
+### 3. Utilisation du service
 
-#### 3.1. Operations
+#### 3.1. Opérations
 
-##### 3.1.1. Daily operations
+##### 3.1.1. Opérations quotidiennes
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Leverage adequate compute and storage to deliver the service withing the plan limits|  | RA |
-| Decide to upgrade plan of the existing service following business needs | RA | I |
-| Define and implement an image policy (use of official and trusted public images Registry, updates, vulnerability scoring, etc.) | RA | I |
-| Implement a backup policy for Registry images | RA | I |
+| Mobiliser les ressources de calcul et de stockage nécessaires à la fourniture du service dans les limites du plan |  | RA |
+| Décider de faire évoluer le plan du service existant en fonction des besoins métier | RA | I |
+| Définir et appliquer une politique d'images (utilisation de registres d'images publiques officiels et de confiance, mises à jour, notation des vulnérabilités, etc.) | RA | I |
+| Mettre en place une politique de sauvegarde des images du registre | RA | I |
 
-##### 3.1.2. Access management
+##### 3.1.2. Gestion des accès
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage access to the OVHcloud Control Panel | RA | I |
-| Manage access to management interfaces specific to the Service (Harbor UI, API, Docker command line, etc.)| RA | I |
-| Manage OVHcloud teams’ physical access to infrastructures |  | RA |
-| Manage OVHcloud teams’ logical access to infrastructures |  | RA |
+| Gérer les accès à l'espace client OVHcloud | RA | I |
+| Gérer les accès aux interfaces d'administration propres au Service (interface Harbor, API, ligne de commande Docker, etc.) | RA | I |
+| Gérer les accès physiques des équipes OVHcloud aux infrastructures |  | RA |
+| Gérer les accès logiques des équipes OVHcloud aux infrastructures |  | RA |
 
-##### 3.1.3. Monitoring
+##### 3.1.3. Supervision
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Monitor the proper functioning of physical devices (utilities) in support of the registry service |   | RA |
-| Monitor the proper functioning of virtual devices (utilities) in support of the registry service | I | RA |
-| Process and pay for alarms from managed devices in the Private Registry infrastructure | I | RA |
-| Maintain and monitor logs generated by the Private Registry service on the management infrastructure |  | RA |
-| Keep logs of the Private Registry service provided in Harbor UI or by using API | RA |  |
+| Superviser le bon fonctionnement des équipements physiques (utilitaires) qui soutiennent le service de registre |   | RA |
+| Superviser le bon fonctionnement des équipements virtuels (utilitaires) qui soutiennent le service de registre | I | RA |
+| Traiter et prendre en charge les alarmes des équipements managés de l'infrastructure du registre privé | I | RA |
+| Maintenir et superviser les logs générés par le service de registre privé sur l'infrastructure d'administration |  | RA |
+| Conserver les logs du service de registre privé mis à disposition dans l'interface Harbor ou via l'API | RA |  |
 
-##### 3.1.4. Storage
+##### 3.1.4. Stockage
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage content hosted on the Private Registry service  | RA | I |
-| Manage data continuity and sustainability | RA | |
-| Perform storage and device maintenance |  | RA |
+| Gérer le contenu hébergé sur le service de registre privé | RA | I |
+| Assurer la continuité et la pérennité des données | RA | |
+| Assurer la maintenance du stockage et des équipements |  | RA |
 
-##### 3.1.5. Connectivity
+##### 3.1.5. Connectivité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Operate automatic network management systems (architecture, implementation, software and hardware maintenance for deployed public and private networks) | I | RA |
-| Provide and maintain a domain name on the service | I |  RA |
+| Exploiter les systèmes automatiques de gestion du réseau (architecture, mise en place, maintenance logicielle et matérielle des réseaux publics et privés déployés) | I | RA |
+| Fournir et maintenir un nom de domaine sur le service | I |  RA |
 
-##### 3.1.6. Management
+##### 3.1.6. Gestion
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Provide inventory of the service used | I | RA |
-| Manage risks on managed components of the Private Regitry service |  | RA |
-| Maintain the service in operational and security conditions |  | RA |
-| Plan vulnerability scans on used impages (in case of subscription to M or L plan or with the client's proper tool)  | RA | I |
-| Manage alerts raised by vulnerability scans on images | RA |  |
+| Fournir l'inventaire du service utilisé | I | RA |
+| Gérer les risques sur les composants managés du service de registre privé |  | RA |
+| Maintenir le service en conditions opérationnelles et de sécurité |  | RA |
+| Planifier les analyses de vulnérabilités sur les images utilisées (en cas de souscription à un plan M ou L, ou avec l'outil propre au client) | RA | I |
+| Gérer les alertes remontées par les analyses de vulnérabilités sur les images | RA |  |
 
-##### 3.1.7. Business continuity
+##### 3.1.7. Continuité d'activité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage automatic management systems and availability for the managed Platform service | I | RA |
-| Maintain a business continuity and disaster recovery plan on the Registry images | RA | I |
+| Gérer les systèmes de gestion automatique et la disponibilité du service de plateforme managée | I | RA |
+| Maintenir un plan de continuité et de reprise d'activité sur les images du registre | RA | I |
 
-#### 3.2. Event management
+#### 3.2. Gestion des événements
 
 ##### 3.2.1. Incidents
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Notify incidents wihin the service Registry | RA | I |
-| Intervene with Public Cloud Private Registry managed elements | I | RA |
+| Signaler les incidents survenus sur le service de registre | RA | I |
+| Intervenir sur les éléments managés du registre privé Public Cloud | I | RA |
 
-##### 3.2.2. Changes
+##### 3.2.2. Changements
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Comply with the service Lifecycle Policy | RA | |
-| Deploy patches, update software and information systems hosted in Public Cloud Private Registry  | I | RA |
-| Deploy patches, update and configure the information system using Public Cloud Private Registry | RA |  |
-| Perform preventive interventions on managed elements of the Public Cloud Private Registry  | I | AR |
+| Respecter la politique de cycle de vie du service | RA | |
+| Déployer les correctifs, mettre à jour les logiciels et les systèmes d'information hébergés dans le registre privé Public Cloud | I | RA |
+| Déployer les correctifs, mettre à jour et configurer le système d'information utilisant le registre privé Public Cloud | RA |  |
+| Réaliser les interventions préventives sur les éléments managés du registre privé Public Cloud | I | AR |
 
-### 4. Reverting
+### 4. Réversibilité
 
-#### 4.1. Reversibility model
+#### 4.1. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Schedule reversibility operations | RA | I |
-| Choose fallback infrastructures | RA |  |
-| Use Docker to transfer image by image or to replicate images by using Harbor registry | RA |  |
+| Planifier les opérations de réversibilité | RA | I |
+| Choisir les infrastructures de repli | RA |  |
+| Utiliser Docker pour transférer les images une à une ou les répliquer via le registre Harbor | RA |  |
 
-#### 4.2. Data recovery
+#### 4.2. Récupération des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage reversibility operations | RA | I |
-| Migrate/transfer data | RA |  |
+| Gérer les opérations de réversibilité | RA | I |
+| Migrer/transférer les données | RA |  |
 
-### 5. End of service
+### 5. Fin de service
 
-#### 5.1. Destroying configurations
+#### 5.1. Suppression des configurations
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Delete the Private Registry service configurations (using API or user interface )  | RA | I |
+| Supprimer les configurations du service de registre privé (via l'API ou l'interface utilisateur) | RA | I |
 
-#### 5.2. Data destruction
+#### 5.2. Destruction des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Destroy DB image registry service |   | RA |
-| Destroy project information |   | RA |
+| Détruire la base de données du service de registre d'images |   | RA |
+| Détruire les informations du projet |   | RA |
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our private registry services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/responsibility-model.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/responsibility-model.mdx
@@ -18,7 +18,7 @@ Ce modèle partagé permet d'alléger la charge opérationnelle du client.
 | C : est consulté pendant le processus |
 | I : est informé des résultats du processus |
 
-Pour information, un **Service** désigne un service Public Cloud Databases tel qu'un cluster MySQL, PostgreSQL, MongoDB, Valkey ou Kafka.
+Pour information, un **Service** désigne un service Public Cloud Managed Private Registry, c'est-à-dire une instance de registre Harbor hébergeant vos images de conteneurs et vos charts Helm.
 
 ### 1. Avant la souscription
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities.mdx
@@ -1,1 +1,90 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities.mdx
+---
+title: Analyser les vulnérabilités des images Docker avec OVHcloud Managed Private Registry
+description: Découvrez comment analyser les vulnérabilités des images Docker avec OVHcloud Managed Private Registry
+lastUpdated: 2022-04-15
+---
+
+
+
+Le service OVHcloud Managed Private Registry est un registre cloud-native composite qui prend en charge à la fois la gestion des images de conteneurs et celle des [charts](https://helm.sh/docs/topics/charts/) [Helm](https://helm.sh/).
+
+**Ce guide explique comment activer le scanner de vulnérabilités et analyser manuellement une image dans un service OVHcloud Managed Private Registry.**
+
+## Avant de commencer
+
+Ce tutoriel suppose que vous disposez déjà d'un OVHcloud Managed Private Registry opérationnel et que vous avez suivi les guides [Creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation), [Connecting to the UI](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui), [Managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) et [Creating and using private images](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
+
+Vous devez disposer d'au moins une image dans votre Private Registry :
+
+![Image Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-01.png)
+
+## En pratique
+
+Vous pouvez analyser les images de votre registre privé depuis l'interface Harbor.
+
+### Vérifier qu'un scanner de vulnérabilités est activé
+
+Par défaut, lorsque vous créez un Private Registry, vous devez choisir un plan `M` ou `L` pour pouvoir activer un scanner de vulnérabilités.
+
+:::info
+Avec les plans `M` et `L`, OVHcloud installe et maintient un scanner de vulnérabilités pour vous : [Trivy](https://aquasecurity.github.io/trivy/) pour Harbor version 2.x ou [Clair](https://github.com/quay/clair) pour Harbor version 1.x.
+:::
+
+
+Pour vérifier la présence d'un scanner de vulnérabilités dans votre registre privé, rendez-vous dans <code className="action">Interrogation Services</code> depuis la barre de navigation.
+
+![Scanner de vulnérabilités dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-02.png)
+
+Comme vous pouvez le constater, Trivy est installé et prêt à l'emploi.
+
+Si vous souhaitez ajouter manuellement un scanner de vulnérabilités, vous pouvez également le faire via <code className="action">New Scanner</code>. Il ne sera toutefois ni mis à jour ni maintenu par OVHcloud.
+
+### Analyser une image Docker manuellement
+
+Vous pouvez analyser une image Docker manuellement.
+Pour cela, accédez à votre projet, sélectionnez une image et cliquez sur <code className="action">Scan</code>.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-03.png)
+
+Le scanner démarre l'analyse de l'image.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-04.png)
+
+Le nombre de vulnérabilités s'affiche.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-05.png)
+
+Lorsque vous survolez la colonne des vulnérabilités, un graphique présentant leur criticité s'affiche.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-06.png)
+
+Cliquez sur l'identifiant de l'image pour afficher toutes les vulnérabilités, classées par criticité.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-07.png)
+
+#### Analyser toutes les images
+
+Vous pouvez également analyser manuellement toutes les images de votre registre privé.
+
+Pour cela, rendez-vous dans l'onglet <code className="action">Vulnerability</code> et ouvrez <code className="action">Interrogation Services</code>. Cliquez ensuite sur <code className="action">Scan Now</code>.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-08.png)
+
+### Analyser toutes les images régulièrement
+
+Vous pouvez planifier une analyse :
+
+- toutes les heures
+- tous les jours
+- toutes les semaines
+- quand vous le souhaitez (à saisir au format cron)
+
+Pour cela, sélectionnez la planification et cliquez sur le bouton <code className="action">Save</code>.
+
+![Analyse des images Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/scan-docker-images-vulnerabilities/scan-docker-images-vulnerabilities-09.png)
+
+## Aller plus loin
+
+Pour une vue d'ensemble du service OVHcloud Managed Private Registry, consultez le site OVHcloud Managed Private Registry.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign.mdx
@@ -1,1 +1,143 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign.mdx
+---
+title: Signer des artefacts OCI avec Cosign sur OVHcloud Managed Private Registry
+description: Découvrez comment signer des artefacts OCI avec Cosign sur OVHcloud Managed Private Registry
+lastUpdated: 2026-02-25
+---
+
+## Objectif
+
+Le service OVHcloud Managed Private Registry, un registre cloud-native basé sur Harbor, vous permet de stocker, gérer et consulter vos images de conteneurs (artefacts OCI) et vos charts Helm.
+
+La sécurité est un sujet important : grâce à la signature des artefacts et à la vérification des signatures, vous pouvez renforcer la sécurité de vos OVHcloud Managed Private Registry en vérifiant l'intégrité d'un artefact.
+
+Depuis la version 2.5, Harbor prend en charge [Cosign](https://github.com/sigstore/cosign), une solution de signature et de vérification d'artefacts OCI (Open Container Initiative) qui fait partie du [projet Sigstore](https://github.com/sigstore).
+
+:::info
+Harbor a entamé la dépréciation de Notary dans Harbor 2.6. Notary sera supprimé dans Harbor v2.8 : vous devez donc utiliser Cosign pour signer vos images de conteneurs et vos charts Helm.
+:::
+
+
+Comparé à Notary, Cosign est très simple à utiliser et présente l'avantage de permettre l'usage des capacités de réplication de Harbor pour répliquer les signatures avec l'artefact signé associé.
+
+**Ce guide explique comment signer des artefacts avec Cosign dans un service OVHcloud Managed Private Registry.**
+
+## Prérequis
+
+- Un OVHcloud Managed Private Registry
+- L'URL et l'identifiant/mot de passe de votre registre privé
+- Une image stockée dans votre registre
+
+Ce tutoriel suppose que vous disposez déjà d'un OVHcloud Managed Private Registry opérationnel et que vous avez suivi les guides [Creating a private registry](/guides/public-cloud/containers-orchestration/managed-private-registry/creation), [Connecting to the UI](/guides/public-cloud/containers-orchestration/managed-private-registry/connect-to-ui), [Managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects) et [Creating and using private images](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
+
+Vous devez également disposer d'un Private Registry en version 2.5 minimum, avec une image stockée et un accès à votre registre privé.
+
+![Image Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign/image-stored.png)
+
+## En pratique
+### Installer la CLI Cosign
+
+Vous pouvez installer la CLI [Cosign](https://docs.sigstore.dev/cosign/installation/) sur votre ordinateur depuis les binaires, un paquet rpm, HomeBrew, ou même l'utiliser directement dans une Github Action.
+
+Pour ce tutoriel, vous allez l'installer via HomeBrew :
+
+```bash
+brew install cosign
+```
+
+Vérifiez que Cosign est bien installé sur votre machine :
+
+```bash
+cosign version
+```
+
+Le résultat doit ressembler à ceci :
+
+```console
+$ cosign version
+  ______   ______        _______. __    _______ .__   __.
+ /      | /  __  \      /       ||  |  /  _____||  \ |  |
+|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
+|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
+|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
+ \______| \______/  |_______/    |__|  \______| |__| \__|
+cosign: A tool for Container Signing, Verification and Storage in an OCI registry.
+
+GitVersion:    2.1.1
+GitCommit:     baf97ccb4926ed09c8f204b537dc0ee77b60d043
+GitTreeState:  "clean"
+BuildDate:     2023-06-27T06:57:11Z
+GoVersion:     go1.20.5
+Compiler:      gc
+Platform:      darwin/arm64
+```
+
+### Générer une clé privée
+
+Cosign permet de générer une clé privée que vous pourrez utiliser ensuite pour signer vos images. Un mot de passe vous sera demandé de manière interactive.
+
+Générez une clé privée :
+
+```bash
+cosign generate-key-pair
+```
+
+Le résultat doit ressembler à ceci :
+
+```console
+$ cosign generate-key-pair
+Enter password for private key: 
+Enter password for private key again: 
+Private key written to cosign.key
+Public key written to cosign.pub
+```
+
+:::info
+Dans ce guide, la clé privée est générée en local. En environnement de production, vous pouvez évidemment générer la clé privée et la stocker dans un gestionnaire de clés, par exemple un Vault ou un KMS.
+:::
+
+
+### Signer votre artefact OCI (image de conteneur)
+
+Signez votre image et poussez la signature vers votre instance OVHcloud Managed Private Registry.
+
+```bash
+cosign sign --key cosign.key `<harbor-instance>`/<project>/<image/path>:`<image-tag>`
+```
+
+Le résultat doit ressembler à ceci :
+
+```console
+$ cosign sign --key cosign.key xxxxxx.c1.gra9.container-registry.ovh.net/library/hello-ovh:1.0.0
+Enter password for private key: 
+WARNING: Image reference xxxxxx.c1.gra9.container-registry.ovh.net/library/hello-ovh:1.0.0 uses a tag, not a digest, to identify the image to sign.
+    This can lead you to sign a different image than the intended one. Please use a
+    digest (example.com/ubuntu@sha256:abc123...) rather than tag
+    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
+    images by tag will be removed in a future release.
+
+        The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+        Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+        This may include the email address associated with the account with which you authenticate your contractual Agreement.
+        This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
+
+By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
+Are you sure you would like to continue? [y/N] y
+tlog entry created with index: 30480064
+Pushing signature to: xxxxxx.c1.gra9.container-registry.ovh.net/library/hello-ovh
+```
+
+### Vérifier que l'image est signée avec Cosign
+
+Pour vérifier que votre image est bien signée, connectez-vous à votre registre privé (dans l'interface Harbor), cliquez sur <code className="action">Projects</code>, puis sur votre projet et sur votre image : une nouvelle coche verte apparaît.
+
+![Image Docker signée dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign/image-signed.png)
+
+Un clic sur l'icône <code className="action">></code> affiche les informations de signature cosign associées :
+
+![Signature cosign d'une image Docker dans OVHcloud Managed Private Registry](/images/public-cloud/containers-orchestration/managed-private-registry/sign-artifacts-with-cosign/image-cosign-signature.png)
+
+## Aller plus loin
+
+Pour une vue d'ensemble du service OVHcloud Managed Private Registry, consultez la documentation OVHcloud Managed Private Registry.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3.mdx
@@ -1,175 +1,175 @@
 ---
-title: Backing up and restoring a Kubernetes cluster in Managed Rancher Service
-description: Find out how to backup and restore a Kubernetes cluster and configure recurring etcd backups to an OVHcloud Object Storage S3 on a Managed Rancher Service
+title: Sauvegarder et restaurer un cluster Kubernetes dans Managed Rancher Service
+description: Découvrez comment sauvegarder et restaurer un cluster Kubernetes et configurer des sauvegardes etcd récurrentes vers un Object Storage OVHcloud sur Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. 
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes.
 
-In this guide, you will use Rancher to backup and restore a Kubernetes cluster, take a snapshot and save the etcd recurring snapshots on an OVHcloud Object Storage bucket.
+Dans ce guide, vous allez utiliser Rancher pour sauvegarder et restaurer un cluster Kubernetes, prendre un instantané (snapshot) et enregistrer les snapshots etcd récurrents dans un bucket Object Storage OVHcloud.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- A Kubernetes cluster created or imported in Rancher
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'utiliser (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un cluster Kubernetes créé ou importé dans Rancher
 
 ## Instructions
 
-In the Rancher UI, Kubernetes cluster's `etcd` backup and recovery can be easily performed.
+Dans l'interface Rancher, la sauvegarde et la restauration de l'`etcd` d'un cluster Kubernetes se réalisent facilement.
 
-It is recommended to configure recurrent `etcd` snapshots for all production clusters. Additionally, one-time snapshots can be taken as well.
+Nous vous recommandons de configurer des snapshots `etcd` récurrents pour tous les clusters de production. Vous pouvez également prendre des snapshots ponctuels.
 
-Snapshots of the etcd database are taken and saved either [locally onto the etcd nodes](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters#local-backup-target) or to a S3 **\*** compatible target like our OVHcloud Object Storage. 
+Les snapshots de la base de données etcd sont pris et enregistrés soit [localement sur les nœuds etcd](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters#local-backup-target), soit sur une cible compatible S3 **\*** comme notre Object Storage OVHcloud.
 
-The advantages of configuring Object Storage is that if all `etcd` nodes are lost, your snapshot is saved remotely and can be used to restore the cluster.
+L'avantage de configurer un Object Storage est que si tous les nœuds `etcd` sont perdus, votre snapshot est enregistré à distance et peut servir à restaurer le cluster.
 
-### Create an OVHcloud Object Storage backup
+### Créer une sauvegarde sur un Object Storage OVHcloud
 
-First, you need to have an Object Storage container. If you don't already have one, you can follow the [Getting started with Object Storage Swift](/guides/storage-and-backup/object-storage/pcs-create-container) guide.
+Vous devez d'abord disposer d'un conteneur Object Storage. Si vous n'en avez pas encore, suivez le guide [Premiers pas avec Object Storage Swift](/guides/storage-and-backup/object-storage/pcs-create-container).
 
-Note that you need to create a `Object Storage API` object:
+Notez que vous devez créer un objet `Object Storage API` :
 
-<img className="thumbnail" alt="Create Object Storage Object Storage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-object.png" loading="lazy" />
+<img className="thumbnail" alt="Créer un Object Storage Object Storage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-object.png" loading="lazy" />
 
-In this guide, our Object Storage container is named `etcd-rancher` and its region is `GRA`.
+Dans ce guide, notre conteneur Object Storage est nommé `etcd-rancher` et sa région est `GRA`.
 
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3.png" loading="lazy" />
-
-:::info
-Save the Object Storage credentials, you will use the `Object Storage access key` and the `Object Storage secret key` in the configuration of the upcoming etcd backup.
-:::
-
-
-Click the name of your object storage bucket to see its information:
-
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher bucket information" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-details.png" loading="lazy" />
+<img className="thumbnail" alt="Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3.png" loading="lazy" />
 
 :::info
-Copy the ID/name of your bucket and the endpoint, this information will be needed in the next step on the Rancher user interface.
+Conservez les identifiants de l'Object Storage : vous utiliserez l'`Object Storage access key` et l'`Object Storage secret key` lors de la configuration de la sauvegarde etcd présentée ci-après.
 :::
 
 
-### Enable etcd recurring backup snapshots to Object Storage on an existing Kubernetes cluster
+Cliquez sur le nom de votre bucket Object Storage pour afficher ses informations :
 
-Log into your Managed Rancher Service UI.
+<img className="thumbnail" alt="Informations du bucket Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-details.png" loading="lazy" />
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-ui.png" loading="lazy" />
+:::info
+Copiez l'ID/le nom de votre bucket ainsi que l'endpoint : ces informations seront nécessaires à l'étape suivante, dans l'interface utilisateur Rancher.
+:::
 
-Click on <code className="action">Cluster Management</code> in the menu.
 
-For the chosen cluster, click on the three-dot button and then on the <code className="action">Edit Config</code> button.
+### Activer les snapshots de sauvegarde etcd récurrents vers un Object Storage sur un cluster Kubernetes existant
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-edit-config.png" loading="lazy" />
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-In the **Cluster Configuration** section, click on the **etcd** tab.<br/>
-In **Automatic Snapshots**, change the radio button from `Disable` to `Enable` and change the `Cron Schedule` according to your needs.
+<img className="thumbnail" alt="Interface du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-ui.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher automatic snapshots" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/automatic-snapshots.png" loading="lazy" />
+Cliquez sur <code className="action">Cluster Management</code> dans le menu.
 
-In this configuration of automatic etcd snapshots, you will have a snapshot every hour at hh:35 minutes and you will keep the last 5 snapshots per nodes.
+Pour le cluster choisi, cliquez sur le bouton à trois points, puis sur le bouton <code className="action">Edit Config</code>.
 
-In **Backup Snapshots to Object Storage**, change the radio button from `Disable` to `Enable`.
+<img className="thumbnail" alt="Interface du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-edit-config.png" loading="lazy" />
 
-In the Authentication list, select the `Create a S3-Compatible Auth Secret`.
-Fill in the Object Storage Access Key, the Object Storage Secret Key and the bucket name.
-Also fill in the `Region` (in lowercase).
+Dans la section **Cluster Configuration**, cliquez sur l'onglet **etcd**.<br/>
+Dans **Automatic Snapshots**, faites passer le bouton radio de `Disable` à `Enable` et modifiez le `Cron Schedule` selon vos besoins.
+
+<img className="thumbnail" alt="Snapshots automatiques Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/automatic-snapshots.png" loading="lazy" />
+
+Avec cette configuration des snapshots etcd automatiques, vous obtiendrez un snapshot toutes les heures à hh:35 et vous conserverez les 5 derniers snapshots par nœud.
+
+Dans **Backup Snapshots to Object Storage**, faites passer le bouton radio de `Disable` à `Enable`.
+
+Dans la liste Authentication, sélectionnez `Create a S3-Compatible Auth Secret`.
+Renseignez l'Object Storage Access Key, l'Object Storage Secret Key et le nom du bucket.
+Renseignez également la `Region` (en minuscules).
 
 :::warning
-The region must be typed in lowercase. If your bucket is in the `GRA` region, you must enter `gra`.
+La région doit être saisie en minuscules. Si votre bucket se trouve dans la région `GRA`, vous devez saisir `gra`.
 :::
 
 
-Fill in the endpoint `s3.gra.io.cloud.ovh.net`: 
+Renseignez l'endpoint `s3.gra.io.cloud.ovh.net` :
 
 :::warning
-It is a copy of the endpoint of your Object Storage bucket without `https://`.
+Il s'agit d'une copie de l'endpoint de votre bucket Object Storage, sans `https://`.
 :::
 
 
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-etcd-config.png" loading="lazy" />
+<img className="thumbnail" alt="Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-etcd-config.png" loading="lazy" />
 
-Finally, click to activate the checkbox `Accept any certificate (insecure)` and click the <code className="action">Save</code> button. 
+Enfin, cochez la case `Accept any certificate (insecure)` et cliquez sur le bouton <code className="action">Enregistrer</code>.
 
-### Check the etcd snapshots
+### Vérifier les snapshots etcd
 
-In **Cluster Management**, click on your cluster.
+Dans **Cluster Management**, cliquez sur votre cluster.
 
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-cluster.png" loading="lazy" />
+<img className="thumbnail" alt="Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-cluster.png" loading="lazy" />
 
-To check and retrieve the backup snapshots, click on the **Snapshots** tab.
+Pour consulter et récupérer les snapshots de sauvegarde, cliquez sur l'onglet **Snapshots**.
 
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher snapshots local" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-backup-local.png" loading="lazy" />
+<img className="thumbnail" alt="Snapshots locaux Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-backup-local.png" loading="lazy" />
 
-<img className="thumbnail" alt="OVHcloud Object Storage Rancher snapshots " src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-backup-s3.png" loading="lazy" />
+<img className="thumbnail" alt="Snapshots Object Storage OVHcloud Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/rancher-backup-s3.png" loading="lazy" />
 
-The name of the snapshot is automatically generated, it is based on the type (whether the snapshot is manual: `on-demand` or recurring: `etcd-snapshot`). The naming convention is as follows:
+Le nom du snapshot est généré automatiquement : il repose sur le type (selon que le snapshot est manuel, `on-demand`, ou récurrent, `etcd-snapshot`). La convention de nommage est la suivante :
 
 `<name>-<node>-<timestamp>`
 
-You can also verify in your bucket in the OVHcloud Control Panel that the snapshots have been successfully saved.
+Vous pouvez également vérifier dans votre bucket, depuis l'espace client OVHcloud, que les snapshots ont bien été enregistrés.
 
-<img className="thumbnail" alt="OVHcloud object storage bucket etcd snapshots" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-etcd.png" loading="lazy" />
+<img className="thumbnail" alt="Snapshots etcd dans le bucket Object Storage OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/s3-etcd.png" loading="lazy" />
 
-### Create a one-time snapshot
+### Créer un snapshot ponctuel
 
-In addition to recurring snapshots, you may want to take a "one-time" snapshot.
+En complément des snapshots récurrents, vous pouvez souhaiter prendre un snapshot « ponctuel ».
 
-It can be useful, for example, before upgrading the Kubernetes version of a cluster and ugrading the Service Mesh version of a cluster. In general, it is recommended to backup the state of the cluster to protect against upgrade failure.
+Cela peut être utile, par exemple, avant de mettre à jour la version de Kubernetes d'un cluster ou la version du Service Mesh d'un cluster. De manière générale, il est recommandé de sauvegarder l'état du cluster afin de se prémunir contre un échec de mise à jour.
 
-On the **Cluster Management** view on Rancher UI, click on the checkbox near your Kubernetes cluster and click the <code className="action">Take Snapshot</code> button.
+Dans la vue **Cluster Management** de l'interface Rancher, cochez la case située à côté de votre cluster Kubernetes et cliquez sur le bouton <code className="action">Take Snapshot</code>.
 
-<img className="thumbnail" alt="Rancher Take Snapshot" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/take-snapshot.png" loading="lazy" />
+<img className="thumbnail" alt="Take Snapshot dans Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/take-snapshot.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher Snapshot in progress" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/snapshot-in-progress.png" loading="lazy" />
+<img className="thumbnail" alt="Snapshot Rancher en cours" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/snapshot-in-progress.png" loading="lazy" />
 
-### Restore from a snapshot
+### Restaurer depuis un snapshot
 
-On the **Snapshots** tab of your Kubernetes cluster in the Rancher UI, click the <code className="action">Restore</code> button.
+Dans l'onglet **Snapshots** de votre cluster Kubernetes, dans l'interface Rancher, cliquez sur le bouton <code className="action">Restaurer</code>.
 
-<img className="thumbnail" alt="Rancher etcd snapshots" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/snapshots.png" loading="lazy" />
+<img className="thumbnail" alt="Snapshots etcd Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/snapshots.png" loading="lazy" />
 
-On Rancher, you can choose different restore types:
+Dans Rancher, vous pouvez choisir différents types de restauration :
 
-- Only etcd
-- Kubernetes version and etcd
-- Cluster config, Kubernetes version and etcd
+- etcd uniquement
+- Version de Kubernetes et etcd
+- Configuration du cluster, version de Kubernetes et etcd
 
-In the **Restore Snapshot** popup, click on the restore type you want to do and click the <code className="action">Restore</code> button.
+Dans la fenêtre **Restore Snapshot**, cliquez sur le type de restauration souhaité, puis sur le bouton <code className="action">Restaurer</code>.
 
-<img className="thumbnail" alt="Rancher Restore Snapshot" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-snapshot.png" loading="lazy" />
+<img className="thumbnail" alt="Restore Snapshot dans Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-snapshot.png" loading="lazy" />
 
-After clicking the button, the restore from the snapshot is in progress.
+Après un clic sur le bouton, la restauration depuis le snapshot est en cours.
 
-<img className="thumbnail" alt="Rancher restore progressing" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-in-progress.png" loading="lazy" />
+<img className="thumbnail" alt="Restauration Rancher en cours" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-in-progress.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher restore in progress" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-in-progress-2.png" loading="lazy" />
+<img className="thumbnail" alt="Restauration Rancher en cours" src="/images/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3/restore-in-progress-2.png" loading="lazy" />
 
-The restoration of a cluster can take a few minutes.
+La restauration d'un cluster peut prendre quelques minutes.
 
-### Known issues
+### Problèmes connus
 
 #### Failed to test for existence of bucket xxx: Access Denied
 
-If you have this following error message: `failed to test for existence of bucket etcd-rancher: Access Denied.`, you may have an error in the Object Storage endpoint.
+Si vous obtenez le message d'erreur suivant : `failed to test for existence of bucket etcd-rancher: Access Denied.`, il se peut que l'endpoint de l'Object Storage soit erroné.
 
-Remove the `https://` scheme in the endpoint URL and check the endpoint URL of your OVHcloud Object Storage bucket.
+Supprimez le schéma `https://` de l'URL de l'endpoint et vérifiez l'URL de l'endpoint de votre bucket Object Storage OVHcloud.
 
-A correct Object Storage endpoint should be `s3.gra.io.cloud.ovh.net`.
+Un endpoint Object Storage correct doit être de la forme `s3.gra.io.cloud.ovh.net`.
 
-## Go further
+## Aller plus loin
 
-- Follow the Rancher official documentation to know more about [backup and restore](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters).
+- Consultez la documentation officielle Rancher pour en savoir plus sur la [sauvegarde et la restauration](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher-launched-kubernetes-clusters).
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour obtenir une vue d'ensemble de Managed Rancher Service OVHcloud, consultez la [page Managed Rancher Service OVHcloud](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).
 
-**\***: S3 is a trademark of Amazon Technologies, Inc. OVHcloud’s service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.
+**\*** : S3 est une marque déposée d'Amazon Technologies, Inc. Le service d'OVHcloud n'est pas sponsorisé, approuvé ni affilié à Amazon Technologies, Inc.

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-compute-instances.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-compute-instances.mdx
@@ -1,184 +1,184 @@
 ---
-title: Creating a Kubernetes cluster based on OVHcloud Public Cloud Compute Instances in MRS
-description: Find out how to create a Kubernetes cluster based on OVHcloud Public Cloud Compute Instances (PCI) on a Managed Rancher Service
+title: Créer un cluster Kubernetes reposant sur des instances Public Cloud OVHcloud dans MRS
+description: Découvrez comment créer un cluster Kubernetes reposant sur des instances Public Cloud OVHcloud (PCI) sur un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
 :::warning
-Usage of [Managed Rancher Service](https://labs.ovhcloud.com/en/managed-rancher-service/) is currently in Beta phase.
-This guide may be incomplete and will be extended during the beta phase. Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+L'utilisation de [Managed Rancher Service](https://labs.ovhcloud.com/en/managed-rancher-service/) est actuellement en phase bêta.
+Ce guide est susceptible d'être incomplet et sera enrichi au cours de la phase bêta. Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 :::
 
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. You can use Rancher to launch a Kubernetes cluster on any platform and location including:
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Vous pouvez utiliser Rancher pour déployer un cluster Kubernetes sur n'importe quelle plateforme et n'importe quelle localisation, notamment :
 
-- Hosted Kubernetes provider (e.g. OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc).
-- Infrastructure Provider - Public Cloud or Private Cloud (vSphere, Nutanix, etc).
-- Bare-metal servers, cloud hosted or on premise.
-- Virtual machines, cloud hosted or on premise
+- un fournisseur de Kubernetes managé (par exemple OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc.) ;
+- un fournisseur d'infrastructure – Public Cloud ou Private Cloud (vSphere, Nutanix, etc.) ;
+- des serveurs bare metal, hébergés dans le cloud ou sur site ;
+- des machines virtuelles, hébergées dans le cloud ou sur site.
 
-In this guide we will explore how to **use OVHcloud as an Infrastructure Provider** and create a Kubernetes cluster based on [OVHcloud Compute Instances](https://www.ovhcloud.com/fr/public-cloud/compute/).
+Ce guide explique comment **utiliser OVHcloud comme fournisseur d'infrastructure** et créer un cluster Kubernetes reposant sur des [instances Public Cloud OVHcloud](https://www.ovhcloud.com/fr/public-cloud/compute/).
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An [OpenStack user](/guides/public-cloud/cross-functional/create-and-delete-a-user)
-- A [private network with a Gateway](/guides/public-cloud/network-services/create-private-network-gateway)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'administrer (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un [utilisateur OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user)
+- Un [réseau privé avec une passerelle](/guides/public-cloud/network-services/create-private-network-gateway)
 
 ## Instructions
 
-### Creating OVHcloud Public Cloud credentials
+### Créer des cloud credentials OVHcloud Public Cloud
 
-To create OVHcloud Public Cloud credential, you need to have an existing **OpenStack user** with the `Compute Operator` role as a minimum. Read this guide on how to [create an OpenStack user](/guides/public-cloud/cross-functional/create-and-delete-a-user) if you don't have one yet.
+Pour créer des cloud credentials OVHcloud Public Cloud, vous devez disposer d'un **utilisateur OpenStack** ayant au minimum le rôle `Compute Operator`. Si vous n'en avez pas encore, consultez le guide [Créer un utilisateur OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user).
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-ui.png" loading="lazy" />
 
-Click on <code className="action">Cluster Management</code> in the menu.
+Cliquez sur <code className="action">Cluster Management</code> dans le menu.
 
-Then click on <code className="action">Cloud Credentials</code>.
+Cliquez ensuite sur <code className="action">Cloud Credentials</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Credentials UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-creds.png" loading="lazy" />
+<img className="thumbnail" alt="Interface des credentials Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-creds.png" loading="lazy" />
 
-If you don't have any **OVHcloud Public Cloud** credentials yet, click the <code className="action">Create</code> button.
+Si vous n'avez pas encore de credentials **OVHcloud Public Cloud**, cliquez sur le bouton <code className="action">Créer</code>.
 
-Click the <code className="action">OVHcloud Public Cloud</code> button.
+Cliquez sur le bouton <code className="action">OVHcloud Public Cloud</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service PCI credentials UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/pci-creds.png" loading="lazy" />
+<img className="thumbnail" alt="Interface des credentials PCI Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/pci-creds.png" loading="lazy" />
 
-Define a name for the credentials, e.g. `pci`. Then fill in the OpenStack user's username and password.
+Définissez un nom pour ces credentials, par exemple `pci`. Renseignez ensuite le nom d'utilisateur et le mot de passe de l'utilisateur OpenStack.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create Credentials" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-create-pci-creds.png" loading="lazy" />
+<img className="thumbnail" alt="Création des credentials Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-create-pci-creds.png" loading="lazy" />
 
-Click on <code className="action">Get projects list</code>:
+Cliquez sur <code className="action">Get projects list</code> :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create Credentials" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-pci-creds-project.png" loading="lazy" />
+<img className="thumbnail" alt="Création des credentials Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-pci-creds-project.png" loading="lazy" />
 
-Select your Public Cloud Project in this list then click the <code className="action">Create</code> button.
+Sélectionnez votre projet Public Cloud dans cette liste, puis cliquez sur le bouton <code className="action">Créer</code>.
 
 :::warning
-You don't have to click the <code className="action">Edit Auth Config</code> button.
+Vous n'avez pas besoin de cliquer sur le bouton <code className="action">Edit Auth Config</code>.
 :::
 
 
-The OVHcloud Public Cloud credentials have been created. Now you can use them to create a Kubernetes cluster based on Public Cloud Instances (PCI). These credentials will be used to provision nodes in your clusters.
-You can use these credentials to create several Kubernetes clusters.
+Les cloud credentials OVHcloud Public Cloud sont créés. Vous pouvez maintenant les utiliser pour créer un cluster Kubernetes reposant sur des instances Public Cloud (PCI). Ces credentials serviront à provisionner les nœuds de vos clusters.
+Vous pouvez les utiliser pour créer plusieurs clusters Kubernetes.
 
-### Creating a Kubernetes cluster on Compute Instances
+### Créer un cluster Kubernetes sur des instances Compute
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-ui.png" loading="lazy" />
 
-Click the <code className="action">Create</code> button.
+Cliquez sur le bouton <code className="action">Créer</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create Kubernetes PCI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-create.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'un Kubernetes PCI dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-create.png" loading="lazy" />
 
-In Rancher you can create a Kubernetes cluster with different methods. To create a Kubernetes cluster running in Compute Instances, use the **Provision new nodes and create a cluster using RKE2/K3s** way and click the <code className="action">OVHcloud Public Cloud</code> driver.
+Rancher propose plusieurs méthodes pour créer un cluster Kubernetes. Pour créer un cluster Kubernetes fonctionnant sur des instances Compute, utilisez la méthode **Provision new nodes and create a cluster using RKE2/K3s** et cliquez sur le driver <code className="action">OVHcloud Public Cloud</code>.
 
-Select an OVHcloud Public Cloud credential:
+Sélectionnez des cloud credentials OVHcloud Public Cloud :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create Kubernetes PCI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-select-creds.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'un Kubernetes PCI dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-select-creds.png" loading="lazy" />
 
-Then, define the cluster name.
+Définissez ensuite le nom du cluster.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster Name" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-name.png" loading="lazy" />
+<img className="thumbnail" alt="Nom du cluster dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-name.png" loading="lazy" />
 
-In the **Machine Pools** section you will configure your cluster.
+C'est dans la section **Machine Pools** que vous configurez votre cluster.
 
 :::info
-When you configure a machine pool in Rancher, there are three roles that can be assigned to nodes: `etcd`, `Control Plane` and `Worker`.
+Lorsque vous configurez un machine pool dans Rancher, trois rôles peuvent être attribués aux nœuds : `etcd`, `Control Plane` et `Worker`.
 :::
 
 
-Here are some good practices:
+Voici quelques bonnes pratiques :
 
-- At least 3 machines/nodes with the role `etcd` are needed to survive a loss of 1 node and have a minimum high availability configuration for etcd. 3 `etcd` nodes are generally sufficient for smaller and medium clusters, and 5 `etcd` nodes for large clusters.
-- At least 2 machines/nodes with the role `Control Plane` for master component high availability.
-- You can set both the `etcd` and `Control Plane` roles for one instance.
-- The `Worker` role should not be used or added to nodes with the `etcd` or `Control Plane` role.
-- At least 2 machines/nodes with the `Worker` role for workload rescheduling upon node failure.
+- Au moins 3 machines/nœuds portant le rôle `etcd` sont nécessaires pour survivre à la perte d'un nœud et disposer d'une configuration minimale de haute disponibilité pour etcd. 3 nœuds `etcd` suffisent généralement pour les clusters de petite et moyenne taille, et 5 nœuds `etcd` pour les grands clusters.
+- Au moins 2 machines/nœuds portant le rôle `Control Plane` pour assurer la haute disponibilité des composants master.
+- Vous pouvez attribuer à la fois les rôles `etcd` et `Control Plane` à une même instance.
+- Le rôle `Worker` ne doit pas être utilisé ni ajouté sur des nœuds portant le rôle `etcd` ou `Control Plane`.
+- Au moins 2 machines/nœuds portant le rôle `Worker` pour permettre le reschedule des workloads en cas de défaillance d'un nœud.
 
-In this guide we will:
+Dans ce guide, nous allons :
 
-- Create a machine pool with 3 compute instances for `etcd` and `Control Plane`.
-- Create a machine pool with 2 compute instances for `Worker`.
+- créer un machine pool avec 3 instances Compute pour `etcd` et `Control Plane` ;
+- créer un machine pool avec 2 instances Compute pour `Worker`.
 
-For each of the machine pools, you have to:
+Pour chacun des machine pools, vous devez :
 
-- Define the pool name (`node-pool-1` for example for the first machine pool).
-- Define machine count (3 for example for the first machine pool).
-- Select roles (check `etcd` and `Control Plane` for the first machine pool)/
-- Choose the region (`GRA9` for example for the first machine pool). If you want to check the availability of specific products that you plan to use alongside Kubernetes, you can refer to the [Availability of Public Cloud Product](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) page.
-- Choose the flavor (`b2-7` for example). You can refer to the [OVHcloud Flavor list](https://www.ovhcloud.com/fr/public-cloud/prices/).
-- Choose the image for the Operating System (OS) used for your machines/nodes. Please refer to [Rancher Operating Systems and Container Runtime Requirements](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters).
-- Choose a Key Pair (optional). It's the SSH Key Pair that will be used to access your nodes. Please refer to this guide on [how to create a SSH KeyPair and add it to your Public Cloud project](/guides/public-cloud/compute/getting-started). If you leave this field empty, a new keypair will be generated automatically.
-- Choose the Security Group that will be applied to created instances. You can leave the field empty.
-- Choose the Availability Zone (only `nova` is supported at the moment).
-- Choose the Floating IP Pools (only `Ext-Net` is supported at the moment).
-- Choose the Networks. You need to choose a private network (with a gateway). The compute instances will be created in this private network.
+- définir le nom du pool (`node-pool-1` par exemple pour le premier machine pool) ;
+- définir le nombre de machines (3 par exemple pour le premier machine pool) ;
+- sélectionner les rôles (cochez `etcd` et `Control Plane` pour le premier machine pool) ;
+- choisir la région (`GRA9` par exemple pour le premier machine pool). Si vous souhaitez vérifier la disponibilité de produits spécifiques que vous prévoyez d'utiliser avec Kubernetes, consultez la page [Disponibilité des produits Public Cloud](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) ;
+- choisir le flavor (`b2-7` par exemple). Vous pouvez consulter la [liste des flavors OVHcloud](https://www.ovhcloud.com/fr/public-cloud/prices/) ;
+- choisir l'image du système d'exploitation utilisée pour vos machines/nœuds. Consultez la documentation [Rancher Operating Systems and Container Runtime Requirements](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters) ;
+- choisir une paire de clés (facultatif). Il s'agit de la paire de clés SSH qui servira à accéder à vos nœuds. Consultez le guide [Créer une paire de clés SSH et l'ajouter à votre projet Public Cloud](/guides/public-cloud/compute/getting-started). Si vous laissez ce champ vide, une nouvelle paire de clés sera générée automatiquement ;
+- choisir le groupe de sécurité qui sera appliqué aux instances créées. Vous pouvez laisser ce champ vide ;
+- choisir l'Availability Zone (seule la zone `nova` est prise en charge pour le moment) ;
+- choisir les Floating IP Pools (seul `Ext-Net` est pris en charge pour le moment) ;
+- choisir les Networks. Vous devez sélectionner un réseau privé (disposant d'une passerelle). Les instances Compute seront créées dans ce réseau privé.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Machine Pool 1" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-machine-pool-1.png" loading="lazy" />
+<img className="thumbnail" alt="Machine pool 1 dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-machine-pool-1.png" loading="lazy" />
 
-At the bottom of the **Machine Pools** section, click on the <code className="action">+</code> button to add the second machine pool with 2 `workers` machines/nodes and the same configuration.
+En bas de la section **Machine Pools**, cliquez sur le bouton <code className="action">+</code> pour ajouter le second machine pool, avec 2 machines/nœuds `workers` et la même configuration.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Machine Pool 2" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-machine-pool-2.png" loading="lazy" />
+<img className="thumbnail" alt="Machine pool 2 dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-machine-pool-2.png" loading="lazy" />
 
-In the **Cluster Configuration** section, choose the Kubernetes version. You need to choose between RKE2 and K3s Kubernetes Operating System (OS). For a production environment, we recommend choosing RKE2.
+Dans la section **Cluster Configuration**, choisissez la version de Kubernetes. Vous devez choisir entre les distributions Kubernetes `RKE2` et `K3s`. Pour un environnement de production, nous recommandons `RKE2`.
 
-Select the `Container Network`, choose if you want to activate a Project Network isolation and the System Services tooling you want to install in your cluster.
+Sélectionnez le `Container Network`, choisissez si vous souhaitez activer l'isolation réseau des projets, ainsi que les System Services que vous souhaitez installer dans votre cluster.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-config.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du cluster dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-config.png" loading="lazy" />
 
 :::info
-Follow the [RKE2 cluster configuration reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration) for the Cluster Configuration.
+Pour la section Cluster Configuration, suivez la [référence de configuration des clusters RKE2](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration).
 :::
 
 
-In the **Member Roles** tab, you can add members for users that need to access the cluster.
-After creating the cluster, you can also add members.
+Dans l'onglet **Member Roles**, vous pouvez ajouter des membres pour les utilisateurs devant accéder au cluster.
+Vous pourrez également ajouter des membres après la création du cluster.
 
-Finally, click the <code className="action">Create</code> button to create your Kubernetes cluster with OVHcloud PCI driver.
+Enfin, cliquez sur le bouton <code className="action">Créer</code> pour créer votre cluster Kubernetes avec le driver PCI d'OVHcloud.
 
-The cluster creation can take several minutes (depending on the OS and on the number of nodes you want).
+La création du cluster peut prendre plusieurs minutes (selon le système d'exploitation et le nombre de nœuds souhaité).
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster Created" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-created.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster créé dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-created.png" loading="lazy" />
 
-### Testing the Kubernetes cluster 
+### Tester le cluster Kubernetes
 
-To test your cluster, on the Rancher UI, in the **Cluster** menu, after selecting your cluster, you can simply click on the <code className="action">Kubectl Shell</code> icon to open a terminal.
+Pour tester votre cluster, dans l'interface Rancher, menu **Cluster**, sélectionnez votre cluster puis cliquez sur l'icône <code className="action">Kubectl Shell</code> pour ouvrir un terminal.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster Created" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-created.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster créé dans Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/rancher-cluster-created.png" loading="lazy" />
 
-List the nodes:
+Listez les nœuds :
 
 ```bash
 kubectl get nodes
 ```
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Test Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/kubectl-get-nodes.png" loading="lazy" />
+<img className="thumbnail" alt="Test du cluster Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/kubectl-get-nodes.png" loading="lazy" />
 
-List the namespaces:
+Listez les namespaces :
 
 ```bash
 kubectl get ns
 ```
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Test Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/kubectl-get-ns.png" loading="lazy" />
+<img className="thumbnail" alt="Test du cluster Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-pci-compute-instances/kubectl-get-ns.png" loading="lazy" />
 
-You can now install applications in your Kubernetes cluster though the `kubectl` CLI or the Rancher UI.
+Vous pouvez désormais installer des applications dans votre cluster Kubernetes, via l'interface en ligne de commande `kubectl` ou via l'interface Rancher.
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour un aperçu de la solution OVHcloud Managed Rancher Service, consultez la page [OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-custom-nodes.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-custom-nodes.mdx
@@ -1,81 +1,80 @@
 ---
-title: Creating a Kubernetes cluster with existing nodes (Generic) in MRS
-description: Find out how to create a RKE2/K3s Kubernetes cluster with existing nodes on a Managed Rancher Service
+title: Créer un cluster Kubernetes avec des nœuds existants (Generic) dans MRS
+description: Découvrez comment créer un cluster Kubernetes RKE2/K3s avec des nœuds existants sur un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. You can use Rancher to deploy a Kubernetes cluster on any platform and location including:
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Vous pouvez utiliser Rancher pour déployer un cluster Kubernetes sur n'importe quelle plateforme et à n'importe quel emplacement, notamment :
 
-- Hosted Kubernetes provider (e.g. OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc).
-- Infrastructure Provider - Public Cloud or Private Cloud (vSphere, Nutanix, etc).
-- Bare-metal servers, cloud hosted or on premise.
-- Virtual machines, cloud hosted or on premise
+- un fournisseur Kubernetes hébergé (par exemple OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc.) ;
+- un fournisseur d'infrastructure - Public Cloud ou cloud privé (vSphere, Nutanix, etc.) ;
+- des serveurs bare metal, hébergés dans le cloud ou sur site ;
+- des machines virtuelles, hébergées dans le cloud ou sur site.
 
-<img className="thumbnail" alt="Rancher Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-creation.jpg" loading="lazy" />
+<img className="thumbnail" alt="Création d'un cluster Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-creation.jpg" loading="lazy" />
 
-In this guide we will explore how to create a RKE2 or K3s Kubernetes cluster using existing nodes through the **Custom** driver.
+Ce guide explique comment créer un cluster Kubernetes `RKE2` ou `K3s` à partir de nœuds existants, à l'aide du driver **Custom**.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- Existing machines accessible through SSH
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un OVHcloud Managed Rancher Service (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'administrer (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Des machines existantes accessibles en SSH
 
 ## Instructions
 
-You should have existing machines (virtual or physical) accessible through SSH.
+Vous devez disposer de machines existantes (virtuelles ou physiques) accessibles en SSH.
 
-Follow this guide if you want to [create OVHcloud Compute Instances](/guides/public-cloud/compute/getting-started).
+Suivez ce guide si vous souhaitez [créer des instances Compute OVHcloud](/guides/public-cloud/compute/getting-started).
 
-### Creating a Kubernetes cluster with existing nodes 
+### Créer un cluster Kubernetes avec des nœuds existants
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-ui.png" loading="lazy" />
 
-Click the <code className="action">Create</code> button.
+Cliquez sur le bouton <code className="action">Create</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create Kubernetes PCI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-create-custom.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service - création d'un Kubernetes PCI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-create-custom.png" loading="lazy" />
 
-Click on the **Custom** driver.
+Cliquez sur le driver **Custom**.
 
-Fill in a cluster name (`custom-kube-cluster` for example).
+Renseignez un nom de cluster (`custom-kube-cluster` par exemple).
 
-In the Kubernetes version list, choose the latest version of the wanted OS. You can choose between K3s and RKE2. For production needs we recommend RKE2.
+Dans la liste des versions de Kubernetes, choisissez la dernière version de l'OS souhaité. Vous pouvez choisir entre `K3s` et `RKE2`. Pour un usage en production, nous recommandons `RKE2`.
 
-Choose the container network (`calico` by default).
+Choisissez le réseau de conteneurs (`calico` par défaut).
 
-<img className="thumbnail" alt="Rancher Custom Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-creation.png" loading="lazy" />
+<img className="thumbnail" alt="Création d'un cluster Rancher personnalisé" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-creation.png" loading="lazy" />
 
-Click on the different tabs to configure your cluster depending on your needs.
+Parcourez les différents onglets afin de configurer votre cluster selon vos besoins.
 
-Click the <code className="action">Create</code> button.
+Cliquez sur le bouton <code className="action">Create</code>.
 
-### Configuring a Kubernetes cluster with existing nodes 
+### Configurer un cluster Kubernetes avec des nœuds existants
 
 :::info
-When you configure a node in Rancher, there are three roles that can be assigned to nodes: `etcd`, `Control Plane` and `Worker`.
+Lorsque vous configurez un nœud dans Rancher, trois rôles peuvent lui être attribués : `etcd`, `Control Plane` et `Worker`.
 :::
 
+Voici quelques bonnes pratiques :
 
-There are some good practices:
+- Au moins 3 nœuds avec le rôle `etcd` sont nécessaires pour supporter la perte d'un nœud et disposer d'une configuration `etcd` à haute disponibilité minimale. 3 nœuds `etcd` suffisent généralement pour les clusters de petite et moyenne taille, et 5 nœuds `etcd` pour les grands clusters.
+- Au moins 2 nœuds avec le rôle `Control Plane` pour la haute disponibilité des composants master.
+- Vous pouvez attribuer à la fois les rôles `etcd` et `Control Plane` à une même instance.
+- Le rôle `Worker` ne doit pas être utilisé ni ajouté sur des nœuds portant le rôle `etcd` ou `controlplane`.
+- Au moins 2 nœuds avec le rôle `Worker` pour permettre la replanification des workloads en cas de défaillance d'un nœud.
 
-- At least 3 nodes with the role `etcd` are needed to survive a loss of 1 node and have a minimum high availability configuration for `etcd`. 3 `etcd` nodes are generally sufficient for smaller and medium clusters, and 5 `etcd` nodes for large clusters.
-- At least 2 nodes with the role `Control Plane` for master component high availability.
-- You can set both the `etcd` and `Control Plane` roles for one instance.
-- The `Worker` role should not be used or added to nodes with the `etcd` or `controlplane` role.
-- At least 2 nodes with the role `Worker` for workload rescheduling upon node failure.
+Pour la configuration de nos nœuds `etcd` + `Control Plane`, cochez uniquement les rôles de nœuds `etcd` et `Control Plane` :
 
-For the configuration of our `etcd` + `Control Plane` nodes, check only the `etcd` and `Control Plane` Nodes Roles:
+<img className="thumbnail" alt="Rôles du cluster Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher cluster roles" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles.png" loading="lazy" />
+<img className="thumbnail" alt="Commande Rancher pour les rôles etcd et control plane" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles-command.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher command roles for etcd and control plane" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles-command.png" loading="lazy" />
-
-SSH to your machines/nodes you created for `etcd` and `Control Plane` and copy/paste the registration command.
+Connectez-vous en SSH aux machines/nœuds que vous avez créés pour `etcd` et `Control Plane`, puis copiez-collez la commande d'enregistrement.
 
 ```bash
 ssh xxxxx@xxx.xxx.xxx.xxx
@@ -83,13 +82,13 @@ ssh xxxxx@xxx.xxx.xxx.xxx
 curl -fL https://xxxxxx.xxxx.rancher.ovh.net/system-agent-install.sh | sudo  sh -s - --server https://xxxxxx.xxxx.rancher.ovh.net --label 'cattle.io/os=linux' --token z2r458coqudhfilgdsifgdsqilgfqsdigfidsufgoisdnvzj --etcd --controlplane
 ```
 
-For the configuration of our `Worker` nodes, uncheck the checkboxes and check only the Worker checkbox:
+Pour la configuration de nos nœuds `Worker`, décochez les cases et cochez uniquement la case Worker :
 
-<img className="thumbnail" alt="Rancher cluster roles" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles-worker.png" loading="lazy" />
+<img className="thumbnail" alt="Rôles du cluster Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-cluster-roles-worker.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher command for workers" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-command-worker.png" loading="lazy" />
+<img className="thumbnail" alt="Commande Rancher pour les nœuds de travail" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-kubernetes-custom-nodes/rancher-command-worker.png" loading="lazy" />
 
-SSH to your machines/nodes you created for `etcd` and `controlpane` and copy/paste the registration command.
+Connectez-vous en SSH aux machines/nœuds que vous avez créés pour vos nœuds de travail, puis copiez-collez la commande d'enregistrement.
 
 ```bash
 ssh xxxxx@xxx.xxx.xxx.xxx
@@ -97,14 +96,14 @@ ssh xxxxx@xxx.xxx.xxx.xxx
 curl -fL https://xxxxxx.xxxx.rancher.ovh.net/system-agent-install.sh | sudo  sh -s - --server https://xxxxxx.xxxx.rancher.ovh.net --label 'cattle.io/os=linux' --token z2r458coqudhfilgdsifgdsqilgfqsdigfidsufgoisdnvzj --worker
 ```
 
-After executing these commands to the machines/nodes, wait until the cluster is in `Active` state in the Rancher UI.
+Après avoir exécuté ces commandes sur les machines/nœuds, attendez que le cluster passe à l'état `Active` dans l'interface Rancher.
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour obtenir une vue d'ensemble d'OVHcloud Managed Rancher Service, consultez la [page OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/creating-mks.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/creating-mks.mdx
@@ -1,101 +1,100 @@
 ---
-title: Creating a Managed Kubernetes Service (MKS) cluster in MRS
-description: Find out how to create a Managed Kubernetes Service (MKS) cluster on a Managed Rancher Service
+title: Créer un cluster Managed Kubernetes Service (MKS) dans MRS
+description: Découvrez comment créer un cluster Managed Kubernetes Service (MKS) sur un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. In this guide we will explore how to create a Managed Kubernetes Service (MKS) cluster.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce guide explique comment créer un cluster Managed Kubernetes Service (MKS).
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'utiliser (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
 
 ## Instructions
 
-### Creating a Managed Kubernetes Service (MKS) cluster
+### Créer un cluster Managed Kubernetes Service (MKS)
 
-You can create your [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/) clusters via the OVHcloud Control Panel, the OVHcloud API and the OVHcloud Terraform provider, but managing several Kubernetes clusters can be complicated, so let's discover how to create an MKS cluster via Managed Rancher Service (MRS).
+Vous pouvez créer vos clusters [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/) via l'espace client OVHcloud, l'API OVHcloud et le provider Terraform OVHcloud. La gestion de plusieurs clusters Kubernetes peut toutefois s'avérer complexe : voyons donc comment créer un cluster MKS via Managed Rancher Service (MRS).
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-ui.png" loading="lazy" />
 
-Next, click on the <code className="action">Create</code> button.
+Cliquez ensuite sur le bouton <code className="action">Create</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create MKS UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-create.png" loading="lazy" />
+<img className="thumbnail" alt="Interface de création MKS OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-create.png" loading="lazy" />
 
-In Rancher, you can create a Kubernetes cluster in a different way. To create an MKS cluster, use the **hosted Kubernetes provider** way and click on the <code className="action">OVHcloud MKS</code> driver.
+Dans Rancher, plusieurs méthodes permettent de créer un cluster Kubernetes. Pour créer un cluster MKS, utilisez la méthode **hosted Kubernetes provider** et cliquez sur le driver <code className="action">OVHcloud MKS</code>.
 
-First, enter an MKS cluster name, for example `my-mks-cluster`:
+Saisissez d'abord un nom de cluster MKS, par exemple `my-mks-cluster` :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Create MKS UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-mks-name.png" loading="lazy" />
+<img className="thumbnail" alt="Interface de création MKS OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/rancher-mks-name.png" loading="lazy" />
 
-(Optional) You can configure **Member Roles** to control who has access to the cluster and what permissions they have to change it. If you want to change the default parameters, click the <code className="action">Add Member</code> button to add users that can access the cluster and use the **Role** drop-down menu to set permissions for each user.
+(Facultatif) Vous pouvez configurer les **Member Roles** afin de contrôler qui a accès au cluster et quelles autorisations de modification lui sont accordées. Si vous souhaitez modifier les paramètres par défaut, cliquez sur le bouton <code className="action">Add Member</code> pour ajouter les utilisateurs pouvant accéder au cluster, puis utilisez le menu déroulant **Role** pour définir les autorisations de chaque utilisateur.
 
-(Optional) You can add **Labels & Annotations** on your cluster. Click on the <code className="action">Add Label</code> button if you want to add some labels and on the <code className="action">Add Annotation</code> button if you want to add some annotations.
+(Facultatif) Vous pouvez ajouter des **Labels & Annotations** sur votre cluster. Cliquez sur le bouton <code className="action">Add Label</code> pour ajouter des labels et sur le bouton <code className="action">Add Annotation</code> pour ajouter des annotations.
 
-For the **Account Configuration**, you need to provide your OVHcloud API credentials (`Application Key`, `Application Secret` and `Consumer Key`).
-If you don't have OVHcloud API credentials, you can follow our guide on how to [Generate your OVHcloud API keys](/guides/manage-and-operate/api/first-steps#advanced-usage-pair-ovhcloud-apis-with-an-application).
+Pour la partie **Account Configuration**, vous devez fournir vos identifiants d'API OVHcloud (`Application Key`, `Application Secret` et `Consumer Key`).
+Si vous ne disposez pas d'identifiants d'API OVHcloud, vous pouvez suivre notre guide [Générer vos clés d'API OVHcloud](/guides/manage-and-operate/api/first-steps#advanced-usage-pair-ovhcloud-apis-with-an-application).
 
-Also provide your `Public Cloud project ID`. The project ID is where your Managed Kubernetes Service (MKS) cluster will be deployed. You can follow the guide on [How to create your first Project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) or if already existing, you can copy/paste it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or <ApiLink section="/cloud" method="GET" route={"/cloud/project"}>API</ApiLink>.
+Renseignez également votre `Public Cloud project ID`. Il s'agit de l'identifiant du projet dans lequel votre cluster Managed Kubernetes Service (MKS) sera déployé. Vous pouvez suivre le guide [Créer votre premier projet](/guides/public-cloud/cross-functional/create-a-public-cloud-project) ou, si le projet existe déjà, copier/coller son identifiant depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> ou l'<ApiLink section="/cloud" method="GET" route={"/cloud/project"}>API</ApiLink>.
 
-<img className="thumbnail" alt="OVHcloud Project ID" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/project-id.png" loading="lazy" />
+<img className="thumbnail" alt="Identifiant de projet OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/project-id.png" loading="lazy" />
 
-Finally, for this step, choose an `OVH API Endpoint`, depending on your location (EU, US or CA).
+Pour terminer cette étape, choisissez un `OVH API Endpoint` en fonction de votre localisation (EU, US ou CA).
 
-For the **Cluster Configuration**, you need to select the `Region` where your cluster will be deployed. Then, select the `Kubernetes Version`. Note that only versions supported by the current version of Rancher are listed (you can refer to the [Official Support Matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)). Then, select `Update Policy` information. If you want further information, refer to the [Managed Kubernetes Update Policies](/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update) guide.
+Pour la partie **Cluster Configuration**, vous devez sélectionner la `Region` dans laquelle votre cluster sera déployé. Sélectionnez ensuite la `Kubernetes Version`. Notez que seules les versions prises en charge par la version actuelle de Rancher sont listées (vous pouvez consulter la [matrice de support officielle](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)). Renseignez enfin les informations d'`Update Policy`. Pour plus d'informations, consultez le guide [Politiques de mise à jour de Managed Kubernetes](/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update).
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/cluster-config.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du cluster OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/cluster-config.png" loading="lazy" />
 
-For the **Network Configuration**, in the `Private Network ID` field, select an existing OVHcloud Public Cloud private network or choose `None` if you want to create a cluster with nodes using only public interfaces.
+Pour la partie **Network Configuration**, dans le champ `Private Network ID`, sélectionnez un réseau privé Public Cloud OVHcloud existant ou choisissez `None` si vous souhaitez créer un cluster dont les nœuds utilisent uniquement des interfaces publiques.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Network Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/network-config.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration réseau OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/network-config.png" loading="lazy" />
 
-For the **NodePools Configuration**, for every NodePool you want to:
+Pour la partie **NodePools Configuration**, pour chaque NodePool souhaité :
 
-- Enter the **Name** of the NodePool. The name must be unique inside a same MKS cluster.
-- Choose an OVHcloud instance **Flavor** used by this NodePool.
-- Enable or disable the Autoscaling.
-- Enter the number of nodes you want, it's the **Size** of your NodePool. If the autoscaling is enabled, then choose the minimum and maximum number of nodes.
-- Enable the **Monthly Billing** (Hourly billing by default).
-- Click on the <code className="action">Add Node Pool</code> button to add the node pool in the list below.
+- Saisissez le **Name** du NodePool. Ce nom doit être unique au sein d'un même cluster MKS.
+- Choisissez un **Flavor** d'instance OVHcloud utilisé par ce NodePool.
+- Activez ou désactivez l'autoscaling.
+- Saisissez le nombre de nœuds souhaité, il s'agit de la **Size** de votre NodePool. Si l'autoscaling est activé, choisissez alors le nombre minimum et maximum de nœuds.
+- Activez la **Monthly Billing** (facturation à l'heure par défaut).
+- Cliquez sur le bouton <code className="action">Add Node Pool</code> pour ajouter le pool de nœuds à la liste ci-dessous.
 
-You can add multiple Node Pools and then manage your list of Node Pools. Note that the "Delete" button (represented by a garbage icon) next to your first NodePool is grayed out until a second one is created.
+Vous pouvez ajouter plusieurs pools de nœuds, puis gérer votre liste de pools de nœuds. Notez que le bouton « Delete » (représenté par une icône de corbeille) situé à côté de votre premier NodePool est grisé jusqu'à la création d'un second.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Node Pool" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/nodepool.png" loading="lazy" />
+<img className="thumbnail" alt="Pool de nœuds OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/nodepool.png" loading="lazy" />
 
-Click on the <code className="action">Finish & Create Cluster</code> button.
+Cliquez sur le bouton <code className="action">Finish & Create Cluster</code>.
 
-Your MKS cluster is provisioning, the creation will take several minutes. 
+Votre cluster MKS est en cours de provisionnement, la création prendra plusieurs minutes.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service MKS creating" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mks-creating.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster MKS OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mks-creating.png" loading="lazy" />
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service MKS Active" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mks-active.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster MKS OVHcloud Managed Rancher Service actif" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mks-active.png" loading="lazy" />
 
-When the MKS cluster becomes `Active`, click on the name of your cluster in order to jump into the **Cluster** view and have more information.
+Lorsque le cluster MKS passe à l'état `Active`, cliquez sur son nom pour accéder à la vue **Cluster** et obtenir davantage d'informations.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Node Pool" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mycluster.png" loading="lazy" />
+<img className="thumbnail" alt="Pool de nœuds OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/creating-mks-kubernetes-cluster/mycluster.png" loading="lazy" />
 
-You can click on the <code className="action">Explore</code> button to manage your MKS Cluster.
+Vous pouvez cliquer sur le bouton <code className="action">Explore</code> pour gérer votre cluster MKS.
 
 :::warning
-Deploying to OVHcloud will incur charges. For more information, refer to the [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) and [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/) pricing pages.
+Tout déploiement chez OVHcloud entraîne une facturation. Pour plus d'informations, consultez les pages de tarifs [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) et [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/).
 
-Once your Managed Kubernetes clusters are created, we do recommend performing all actions (upgrade, nodepool management, cluster modification) from the Rancher console and not performing any action directly via the OVHcloud API, OVHcloud Terraform provider or the OVHcloud Control Panel as this can lead to desynchronization.
+Une fois vos clusters Managed Kubernetes créés, nous vous recommandons d'effectuer toutes les actions (mise à jour, gestion des pools de nœuds, modification du cluster) depuis la console Rancher et de n'effectuer aucune action directement via l'API OVHcloud, le provider Terraform OVHcloud ou l'espace client OVHcloud, car cela peut entraîner une désynchronisation.
 
 :::
 
+## Aller plus loin
 
-## Go further
+- Pour obtenir une vue d'ensemble d'OVHcloud Managed Rancher Service, consultez la [page OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- To have an overview of the OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
-
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/creation.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/creation.mdx
@@ -1,78 +1,78 @@
 ---
-title: Creating, updating and accessing a Managed Rancher Service
-description: Find out how to create, update and use a Managed Rancher Service on OVHcloud
+title: Créer, mettre à jour et accéder à un Managed Rancher Service
+description: Découvrez comment créer, mettre à jour et utiliser un Managed Rancher Service chez OVHcloud
 lastUpdated: 2026-06-29
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
-## Objective
+## Objectif
 
-Container orchestration has become a cornerstone of modern application deployment, offering scalability, flexibility, and resource efficiency. Rancher is an open-source container management platform that simplifies the deployment and management of Kubernetes clusters.
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. This guide will cover the creation of a Managed Rancher Service.
+L'orchestration de conteneurs est devenue un élément central du déploiement d'applications modernes, en apportant évolutivité, flexibilité et optimisation des ressources. Rancher est une plateforme open source de gestion de conteneurs qui simplifie le déploiement et l'administration de clusters Kubernetes.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce guide décrit la création d'un Managed Rancher Service.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
 
-### OVHcloud Control Panel Access
+### Accès à l'espace client OVHcloud
 
-- **Direct link:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Navigation path:** <code className="action">Public Cloud</code> > Select your project
+- **Lien direct :** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
+- **Chemin de navigation :** <code className="action">Public Cloud</code> > Sélectionnez votre projet
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}
 
 ## Instructions
 
-### Creating a Managed Rancher Service
+### Créer un Managed Rancher Service
 
 <Tabs>
-  <Tab label="OVHcloud Control Panel">
+  <Tab label="Espace client OVHcloud">
 
-In the left-hand menu under **Containers & Orchestration**, click on <code className="action">Managed Rancher Service</code>. You can trigger the creation of a Rancher which will be operated and managed by OVHcloud.
+Dans le menu de gauche, sous **Containers & Orchestration**, cliquez sur <code className="action">Managed Rancher Service</code>. Vous pouvez alors lancer la création d'un Rancher qui sera exploité et administré par OVHcloud.
 
-<img className="thumbnail" alt="Create an OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/create-rancher.png" loading="lazy" />
+<img className="thumbnail" alt="Créer un OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/create-rancher.png" loading="lazy" />
 
-Click on the <code className="action">Create a Managed Rancher Service</code> button.
+Cliquez sur le bouton <code className="action">Créer un Managed Rancher Service</code>.
 
-Fill in the name:
+Renseignez le nom :
 
-<img className="thumbnail" alt="Create an OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-name.png" loading="lazy" />
+<img className="thumbnail" alt="Créer un OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-name.png" loading="lazy" />
 
-Choose your plan between **OVHcloud Edition** and **Standard**.
+Choisissez votre plan entre **OVHcloud Edition** et **Standard**.
 
-<img className="thumbnail" alt="Create an OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-plan.png" loading="lazy" />
+<img className="thumbnail" alt="Créer un OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-plan.png" loading="lazy" />
 
-Choose the Rancher version and then click on <code className="action">Create a Managed Rancher Service</code> button.
+Choisissez la version de Rancher, puis cliquez sur le bouton <code className="action">Créer un Managed Rancher Service</code>.
 
-<img className="thumbnail" alt="Create an OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-version.png" loading="lazy" />
+<img className="thumbnail" alt="Créer un OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-version.png" loading="lazy" />
 
-The Rancher creation is now in progress. It should be available within a few minutes in your OVHcloud Control Panel.
+La création du Rancher est en cours. Il devrait être disponible dans votre espace client OVHcloud d'ici quelques minutes.
 
   </Tab>
   <Tab label="OVHcloud CLI">
 
-**Requirements**
+**Prérequis**
 
-- [OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) installed and configured
+- L'[OVHcloud CLI](/guides/manage-and-operate/cli/getting-started) installé et configuré
 
-**1. List available plans:**
+**1. Lister les plans disponibles :**
 
 ```bash
 ovhcloud cloud managed-rancher plan list --cloud-project <project_id>
 ```
 
-**2. List available versions:**
+**2. Lister les versions disponibles :**
 
 ```bash
 ovhcloud cloud managed-rancher version list --cloud-project <project_id>
 ```
 
-**3. Create the service:**
+**3. Créer le service :**
 
 ```bash
 ovhcloud cloud managed-rancher create \
@@ -82,48 +82,48 @@ ovhcloud cloud managed-rancher create \
   --version <version>
 ```
 
-Note the `id` field in the output — it is your Rancher service ID, used in subsequent commands.
+Notez le champ `id` présent dans le résultat : il correspond à l'identifiant de votre service Rancher, utilisé dans les commandes suivantes.
 
   </Tab>
 </Tabs>
 
-### Updating a Managed Rancher Service
+### Mettre à jour un Managed Rancher Service
 
 <Tabs>
-  <Tab label="OVHcloud Control Panel">
+  <Tab label="Espace client OVHcloud">
 
-Access the administration UI for your OVHcloud Managed Rancher instances by clicking on <code className="action">Managed Rancher Service</code> in the left-hand menu.
+Accédez à l'interface d'administration de vos instances OVHcloud Managed Rancher en cliquant sur <code className="action">Managed Rancher Service</code> dans le menu de gauche.
 
-<img className="thumbnail" alt="List of OVHcloud Managed Rancher Services" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-list.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des OVHcloud Managed Rancher Services" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-list.png" loading="lazy" />
 
-Click on the <code className="action">...</code> button to the right of your Rancher instance and choose <code className="action">Manage</code> or click on the name of your Rancher instance.
+Cliquez sur le bouton <code className="action">...</code> à droite de votre instance Rancher et choisissez <code className="action">Gérer</code>, ou cliquez sur le nom de votre instance Rancher.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Services to update" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-to-update.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Managed Rancher Services à mettre à jour" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-to-update.png" loading="lazy" />
 
-If the Rancher instance needs to be updated, the information message `A new Managed Rancher Service update is now available.` is displayed.
+Si l'instance Rancher doit être mise à jour, le message d'information `Une nouvelle mise à jour de Managed Rancher Service est disponible.` s'affiche.
 
-Click on the <code className="action">Update</code> button.
+Cliquez sur le bouton <code className="action">Mettre à jour</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Services update" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update.png" loading="lazy" />
+<img className="thumbnail" alt="Mise à jour des OVHcloud Managed Rancher Services" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update.png" loading="lazy" />
 
-Choose the version and click the <code className="action">Update</code> button.
+Choisissez la version et cliquez sur le bouton <code className="action">Mettre à jour</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Services update" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update-popup.png" loading="lazy" />
+<img className="thumbnail" alt="Mise à jour des OVHcloud Managed Rancher Services" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update-popup.png" loading="lazy" />
 
 :::warning
-You can read the changelog before updating a cluster by clicking on the <code className="action">View the changelog</code> button.
+Vous pouvez consulter le changelog avant de mettre à jour un cluster en cliquant sur le bouton <code className="action">Consulter le changelog</code>.
 :::
 
-A popup will appear, click on the <code className="action">Confirm</code> button to update your Rancher.
+Une fenêtre s'affiche : cliquez sur le bouton <code className="action">Confirmer</code> pour mettre à jour votre Rancher.
 
-The Rancher instance is now updating. It should be updated within a few minutes.
+L'instance Rancher est en cours de mise à jour. Celle-ci devrait aboutir d'ici quelques minutes.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Services update" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update-in-progress.png" loading="lazy" />
+<img className="thumbnail" alt="Mise à jour des OVHcloud Managed Rancher Services" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-update-in-progress.png" loading="lazy" />
 
   </Tab>
   <Tab label="OVHcloud CLI">
 
-**1. List available versions for your Rancher instance:**
+**1. Lister les versions disponibles pour votre instance Rancher :**
 
 ```bash
 ovhcloud cloud managed-rancher version list \
@@ -131,7 +131,7 @@ ovhcloud cloud managed-rancher version list \
   --rancher-id <rancher_id>
 ```
 
-**2. Apply the update:**
+**2. Appliquer la mise à jour :**
 
 ```bash
 ovhcloud cloud managed-rancher edit <rancher_id> \
@@ -140,58 +140,58 @@ ovhcloud cloud managed-rancher edit <rancher_id> \
 ```
 
 :::warning
-Read the changelog for the target version before updating.
+Consultez le changelog de la version cible avant de procéder à la mise à jour.
 :::
 
   </Tab>
 </Tabs>
 
-### Accessing a Managed Rancher Service
+### Accéder à un Managed Rancher Service
 
 <Tabs>
-  <Tab label="OVHcloud Control Panel">
+  <Tab label="Espace client OVHcloud">
 
-Access the administration UI for your OVHcloud Managed Rancher instances by clicking on <code className="action">Managed Rancher Service</code> in the left-hand menu.
+Accédez à l'interface d'administration de vos instances OVHcloud Managed Rancher en cliquant sur <code className="action">Managed Rancher Service</code> dans le menu de gauche.
 
-Click on the <code className="action">...</code> button to the right of your Rancher instance and choose <code className="action">Manage</code> or click on the name of your Rancher instance.
+Cliquez sur le bouton <code className="action">...</code> à droite de votre instance Rancher et choisissez <code className="action">Gérer</code>, ou cliquez sur le nom de votre instance Rancher.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service access" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-access.png" loading="lazy" />
+<img className="thumbnail" alt="Accès à OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-access.png" loading="lazy" />
 
-In the "Access and security" section, Click on <code className="action">Generate access codes</code> button.
+Dans la section « Accès et sécurité », cliquez sur le bouton <code className="action">Generate access codes</code>.
 
-A popup will appear, then click on <code className="action">Confirm</code> button.
+Une fenêtre s'affiche : cliquez ensuite sur le bouton <code className="action">Confirmer</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service popup" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/popup.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/popup.png" loading="lazy" />
 
-Copy/paste the generated username and password and click on <code className="action">Go to Rancher</code> button to access the Rancher login page.
+Copiez/collez le nom d'utilisateur et le mot de passe générés, puis cliquez sur le bouton <code className="action">Accéder à Rancher</code> pour ouvrir la page de connexion de Rancher.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service login" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-login-page.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion à OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-login-page.png" loading="lazy" />
 
-Finally, fill the Username and the Password fields and then click on <code className="action">Log in with Local User</code> button.
+Renseignez enfin les champs Username et Password, puis cliquez sur le bouton <code className="action">Log in with Local User</code>.
 
 :::warning
-At your first login, you will be asked to change your password with a randomly generated one or you can define it yourself.
-In case of lost password, you have the possibility to generate a new one by using the Generate access details action button.
+Lors de votre première connexion, il vous sera demandé de modifier votre mot de passe, soit avec un mot de passe généré aléatoirement, soit avec celui que vous définissez vous-même.
+En cas de perte du mot de passe, vous avez la possibilité d'en générer un nouveau en utilisant le bouton d'action Generate access details.
 :::
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-home.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/create-update-rancher/rancher-home.png" loading="lazy" />
 
-You now have access to the Rancher dashboard. It is designed to offer an intuitive and comprehensive view of your containerized environment.
-This web-based interface serves as your command center for orchestrating containers & clusters, visualizing cluster health, and managing various aspects of your Kubernetes infrastructure. Explore the navigation menu, which includes sections for clusters, projects, applications, and Rancher settings.
+Vous avez désormais accès au tableau de bord Rancher. Celui-ci est conçu pour offrir une vue intuitive et complète de votre environnement conteneurisé.
+Cette interface web constitue votre interface de gestion pour orchestrer vos conteneurs et vos clusters, visualiser l'état de santé des clusters et administrer les différents aspects de votre infrastructure Kubernetes. Parcourez le menu de navigation, qui comprend des sections dédiées aux clusters, aux projets, aux applications et aux paramètres de Rancher.
 
   </Tab>
   <Tab label="OVHcloud CLI">
 
-**1. Reset admin credentials:**
+**1. Réinitialiser les identifiants administrateur :**
 
 ```bash
 ovhcloud cloud managed-rancher reset-admin-credentials <rancher_id> \
   --cloud-project <project_id>
 ```
 
-Save the returned username and password — they will not be shown again.
+Conservez le nom d'utilisateur et le mot de passe renvoyés : ils ne seront plus affichés par la suite.
 
-**2. Retrieve the service URL:**
+**2. Récupérer l'URL du service :**
 
 ```bash
 ovhcloud cloud managed-rancher get <rancher_id> \
@@ -199,21 +199,21 @@ ovhcloud cloud managed-rancher get <rancher_id> \
   --output currentState.url
 ```
 
-Open the URL in your browser and log in with the credentials from step 1.
+Ouvrez l'URL dans votre navigateur et connectez-vous avec les identifiants obtenus à l'étape 1.
 
 :::warning
-At your first login, you will be asked to change your password with a randomly generated one or you can define it yourself.
+Lors de votre première connexion, il vous sera demandé de modifier votre mot de passe, soit avec un mot de passe généré aléatoirement, soit avec celui que vous définissez vous-même.
 :::
 
   </Tab>
 </Tabs>
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Rancher service, you can go to the [OVHcloud Managed Rancher page](/links/public-cloud/rancher).
+- Pour obtenir une vue d'ensemble du service OVHcloud Managed Rancher, consultez la [page OVHcloud Managed Rancher](/links/public-cloud/rancher).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to get a quote and ask our Professional Services experts for assistance with your specific use case.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback, and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics.mdx
@@ -1,149 +1,149 @@
 ---
-title: Deploying a monitoring stack (Prometheus & Grafana) in a Kubernetes cluster in MRS
-description: Find out how to deploy monitoring applications (Prometheus & Grafana) in a Kubernetes cluster and display metrics and dashboards on a Managed Rancher Service
+title: Déployer une stack de monitoring (Prometheus & Grafana) dans un cluster Kubernetes dans MRS
+description: Découvrez comment déployer des applications de monitoring (Prometheus & Grafana) dans un cluster Kubernetes et afficher des métriques et des tableaux de bord sur Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. 
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes.
 
-This guide will show you how to deploy, in Rancher, a monitoring stack (Prometheus & Grafana) to monitor your Kubernetes cluster.
+Ce guide vous explique comment déployer, dans Rancher, une stack de monitoring (Prometheus & Grafana) afin de superviser votre cluster Kubernetes.
 
-The `rancher-monitoring` operator is powered by [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/grafana/), [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), and the [Prometheus adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter).
+L'opérateur `rancher-monitoring` repose sur [Prometheus](https://prometheus.io/), [Grafana](https://grafana.com/grafana/), [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), le [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) et le [Prometheus adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter).
 
-The monitoring application allows you to:
+L'application de monitoring vous permet de :
 
-- Monitor the state and processes of your cluster nodes, Kubernetes components, and software deployments
-- Define alerts based on metrics collected via Prometheus
-- Create custom Grafana dashboards
-- Configure alert-based notifications via Email, Slack, PagerDuty, etc. using Prometheus Alertmanager
-- Define precomputed, frequently needed or computationally expensive expressions as new time series based on metrics collected via Prometheus
-- Expose collected metrics from Prometheus to the Kubernetes Custom Metrics API via Prometheus Adapter for use in HPA
+- Superviser l'état et les processus des nœuds de votre cluster, des composants Kubernetes et des déploiements logiciels
+- Définir des alertes basées sur les métriques collectées via Prometheus
+- Créer des tableaux de bord Grafana personnalisés
+- Configurer des notifications basées sur des alertes par e-mail, Slack, PagerDuty, etc. avec Prometheus Alertmanager
+- Définir en tant que nouvelles séries temporelles des expressions précalculées, fréquemment utilisées ou coûteuses en ressources, à partir des métriques collectées via Prometheus
+- Exposer les métriques collectées par Prometheus à l'API Custom Metrics de Kubernetes via Prometheus Adapter, en vue d'une utilisation avec le HPA
 
-<img className="thumbnail" alt="Monitoring stack" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/monitoring-stack.png" loading="lazy" />
+<img className="thumbnail" alt="Stack de monitoring" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/monitoring-stack.png" loading="lazy" />
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- A Kubernetes cluster created or imported in Rancher
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'utiliser (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un cluster Kubernetes créé ou importé dans Rancher
 
 ## Instructions
 
-In this guide you will deploy the monitoring Helm chart that is based on the upstream [kube-prometheus-stack chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). The chart deploys [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) and its CRDs along with [Grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana), [Prometheus Adapter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-adapter) and additional charts / Kubernetes manifests to gather metrics. It allows users to monitor their Kubernetes clusters, view metrics in Grafana dashboards, and set up alerts and notifications.
+Dans ce guide, vous allez déployer la chart Helm de monitoring, basée sur la [chart kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) upstream. Cette chart déploie le [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) et ses CRD, ainsi que [Grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana), [Prometheus Adapter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-adapter) et des charts et manifestes Kubernetes supplémentaires destinés à collecter les métriques. Elle permet aux utilisateurs de superviser leurs clusters Kubernetes, de consulter les métriques dans des tableaux de bord Grafana et de mettre en place des alertes et des notifications.
 
-### Install the monitoring stack (Prometheus & Grafana)
+### Installer la stack de monitoring (Prometheus & Grafana)
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-ui.png" loading="lazy" />
 
-Click on the name of your cluster.
+Cliquez sur le nom de votre cluster.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-cluster.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-cluster.png" loading="lazy" />
 
-Click on <code className="action">Install Monitoring</code>.
+Cliquez sur <code className="action">Install Monitoring</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-cluster-tools.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-cluster-tools.png" loading="lazy" />
 
-Click on <code className="action">Install</code> in the **Monitoring** app to install Prometheus.
+Cliquez sur <code className="action">Installer</code> dans l'application **Monitoring** pour installer Prometheus.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-install-prom.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-install-prom.png" loading="lazy" />
 
-You can customize Helm chart options if you want by ticking the `Customize Helm options before install` checkbox.
+Vous pouvez personnaliser les options de la chart Helm en cochant la case `Customize Helm options before install`.
 
-Click the <code className="action">Next</code> button to jump into the second step.
+Cliquez sur le bouton <code className="action">Suivant</code> pour passer à la deuxième étape.
 
-Choose the `Cluster Type`.
+Choisissez le `Cluster Type`.
 
 :::warning
-Select `K3s` or `RKE2` if you installed the Kubernetes cluster nodes with Rancher or `Other` for a MKS cluster.
+Sélectionnez `K3s` ou `RKE2` si vous avez installé les nœuds du cluster Kubernetes avec Rancher, ou `Other` pour un cluster MKS.
 :::
 
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service RKE2 Cluster Type" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-rke2.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster Type RKE2 du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-rke2.png" loading="lazy" />
 
-In the `Prometheus` tab you can configure scrapping intervals, retention and resource memory and limits.
+Dans l'onglet `Prometheus`, vous pouvez configurer les intervalles de scraping, la rétention ainsi que les ressources et limites mémoire.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service RKE2 Cluster Type" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-prometheus.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster Type RKE2 du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-prometheus.png" loading="lazy" />
 
-In the `Alerting` tab you can configure and deploy Alertmanager.
+Dans l'onglet `Alerting`, vous pouvez configurer et déployer Alertmanager.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Alertmanager" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-alertmanager.png" loading="lazy" />
+<img className="thumbnail" alt="Alertmanager du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-alertmanager.png" loading="lazy" />
 
-In the `Grafana` tab you can view the chart info and configure Grafana storage.
+Dans l'onglet `Grafana`, vous pouvez consulter les informations de la chart et configurer le stockage de Grafana.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Grafana" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-grafana.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-grafana.png" loading="lazy" />
 
-Click the <code className="action">Install</code> button to install the monitoring stack.
+Cliquez sur le bouton <code className="action">Installer</code> pour installer la stack de monitoring.
 
-The Logs will be displayed and showing you that the Helm chart has been installed.
+Les logs s'affichent et indiquent que la chart Helm a bien été installée.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Grafana" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-logs.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-logs.png" loading="lazy" />
 
-Click the `Kubectl Shell` icon to open a terminal inside Rancher and then execute the following command to list the monitoring pods installed:
+Cliquez sur l'icône `Kubectl Shell` pour ouvrir un terminal dans Rancher, puis exécutez la commande suivante pour lister les pods de monitoring installés :
 
 ```bash
 kubectl get po -n cattle-monitoring-system
 ```
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Monitoring Pods" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monito-pods.png" loading="lazy" />
+<img className="thumbnail" alt="Pods de monitoring du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monito-pods.png" loading="lazy" />
 
-### View metrics and Grafana dashboards
+### Consulter les métriques et les tableaux de bord Grafana
 
-By default, the monitoring application deploys:
+Par défaut, l'application de monitoring déploie :
 
-- Grafana dashboards (curated by the kube-prometheus project) onto a cluster.
-- An Alertmanager UI and a Prometheus UI.
-- Exporters (such as node-exporter and kube-state-metrics).
-- Some alerts by default.
+- Des tableaux de bord Grafana (conçus par le projet kube-prometheus) sur un cluster.
+- Une interface Alertmanager et une interface Prometheus.
+- Des exporters (tels que node-exporter et kube-state-metrics).
+- Quelques alertes par défaut.
 
-On the Rancher UI, click the <code className="action">Cluster Management</code> menu, then click the <code className="action">Explore</code> button for the cluster which metrics you want to visualize.
+Dans l'interface Rancher, cliquez sur le menu <code className="action">Cluster Management</code>, puis sur le bouton <code className="action">Explore</code> du cluster dont vous souhaitez visualiser les métriques.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Explore Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-explore.png" loading="lazy" />
+<img className="thumbnail" alt="Explorer un cluster du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-explore.png" loading="lazy" />
 
-In the left navigation bar, click on <code className="action">Monitoring</code>.
+Dans la barre de navigation de gauche, cliquez sur <code className="action">Monitoring</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Monitoring Menu" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monitoring-menu.png" loading="lazy" />
+<img className="thumbnail" alt="Menu Monitoring du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monitoring-menu.png" loading="lazy" />
 
-In this page you can see the links to the Alertmanager, Grafana dashboard and also active Prometheus alerts.
+Sur cette page, vous pouvez voir les liens vers Alertmanager, le tableau de bord Grafana, ainsi que les alertes Prometheus actives.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Monitoring" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monitoring.png" loading="lazy" />
+<img className="thumbnail" alt="Monitoring du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/rancher-monitoring.png" loading="lazy" />
 
-By clicking on the Grafana link you can see the Grafana dashboards:
+En cliquant sur le lien Grafana, vous accédez aux tableaux de bord Grafana :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Grafana" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/grafana.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana du Managed Rancher OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/grafana.png" loading="lazy" />
 
-You can also execute PromQL queries.
+Vous pouvez également exécuter des requêtes PromQL.
 
-Without doing anything on your side, several built-in metrics are already available. You can test them by typing `sum(kube_pod_owner{job="kube-state-metrics"}) by (namespace)` in the search bar.
+Sans aucune action de votre part, plusieurs métriques intégrées sont déjà disponibles. Pour les tester, saisissez `sum(kube_pod_owner{job="kube-state-metrics"}) by (namespace)` dans la barre de recherche.
 
-Click the <code className="action">Execute</code> button to determine if the Kubernetes metrics are visible:
+Cliquez sur le bouton <code className="action">Execute</code> pour vérifier que les métriques Kubernetes sont bien visibles :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Grafana" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/promql.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana du Managed Rancher OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/promql.png" loading="lazy" />
 
-Thanks to this PromQL query you can list the number of pods per namespace in your Kubernetes cluster.
+Grâce à cette requête PromQL, vous pouvez lister le nombre de pods par namespace dans votre cluster Kubernetes.
 
-### Known issues
+### Problèmes connus
 
-In the installation view, you can have a warning message: "This chart requires 4.5 CPU cores, but the cluster only has xx.x available":
+Dans la vue d'installation, un message d'avertissement peut apparaître : « This chart requires 4.5 CPU cores, but the cluster only has xx.x available » :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service Error CPU Core Insufficient" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/error-cpu-core-insufficient.png" loading="lazy" />
+<img className="thumbnail" alt="Erreur de cœurs CPU insuffisants du Managed Rancher Service OVHcloud" src="/images/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics/error-cpu-core-insufficient.png" loading="lazy" />
 
-If it's the case, you can add more nodes in your Kubernetes cluster and try the installation of the monitoring stack.
+Dans ce cas, ajoutez des nœuds à votre cluster Kubernetes, puis relancez l'installation de la stack de monitoring.
 
-## Go further
+## Aller plus loin
 
-- Follow the Rancher official documentation to know more about [monitoring and alerting](https://ranchermanager.docs.rancher.com/v2.5/explanations/integrations-in-rancher/monitoring-and-alerting).
+- Consultez la documentation officielle Rancher pour en savoir plus sur le [monitoring et les alertes](https://ranchermanager.docs.rancher.com/v2.5/explanations/integrations-in-rancher/monitoring-and-alerting).
 
-- When the monitoring application is installed, you will be able to [edit components in the Rancher UI](https://ranchermanager.docs.rancher.com/v2.5/explanations/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works#components-exposed-in-the-rancher-ui).
+- Une fois l'application de monitoring installée, vous pourrez [modifier les composants dans l'interface Rancher](https://ranchermanager.docs.rancher.com/v2.5/explanations/integrations-in-rancher/monitoring-and-alerting/how-monitoring-works#components-exposed-in-the-rancher-ui).
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour obtenir une vue d'ensemble de Managed Rancher Service OVHcloud, consultez la [page Managed Rancher Service OVHcloud](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/edit-kubernetes-cluster.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/edit-kubernetes-cluster.mdx
@@ -1,67 +1,67 @@
 ---
-title: Editing the configuration of a Kubernetes cluster in Managed Rancher Service
-description: Find out how to edit the configuration of a Kubernetes cluster on a Managed Rancher Service
+title: Modifier la configuration d'un cluster Kubernetes dans Managed Rancher Service
+description: Découvrez comment modifier la configuration d'un cluster Kubernetes sur un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. In this guide we will explore how to edit the configuration of a Kubernetes cluster including the name, labels and annotations, the OVHcloud API credentials and even the update policy.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce guide explique comment modifier la configuration d'un cluster Kubernetes : son nom, ses labels et annotations, les identifiants de l'API OVHcloud, ainsi que la politique de mise à jour.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An existing Kubernetes cluster you created or imported in Managed Rancher Service (MRS)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un OVHcloud Managed Rancher Service (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'administrer (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un cluster Kubernetes existant, que vous avez créé ou importé dans Managed Rancher Service (MRS)
 
 ## Instructions
 
-Through the Rancher UI you can edit several information about a Kubernetes cluster you created or imported.
+L'interface Rancher vous permet de modifier plusieurs informations relatives à un cluster Kubernetes que vous avez créé ou importé.
 
-Log in your Managed Rancher Service UI.
-In the menu, click on the <code className="action">Cluster Management</code> button: 
+Connectez-vous à l'interface de votre Managed Rancher Service.
+Dans le menu, cliquez sur le bouton <code className="action">Cluster Management</code> :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-cluster-management.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-cluster-management.png" loading="lazy" />
 
-For the chosen Kubernetes cluster, click on the <code className="action">...</code> button and then on <code className="action">Edit Config</code>.
+Pour le cluster Kubernetes choisi, cliquez sur le bouton <code className="action">...</code>, puis sur <code className="action">Edit Config</code>.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-edit-config.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-edit-config.png" loading="lazy" />
 
-You can now edit the name of the cluster. In this example we changed `my-mks-cluster` to `my-mks-rancher-cluster`:
+Vous pouvez désormais modifier le nom du cluster. Dans cet exemple, nous avons remplacé `my-mks-cluster` par `my-mks-rancher-cluster` :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-cluster-name.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-cluster-name.png" loading="lazy" />
 
-You can also change **Member Roles**, to control who has access to your cluster and with what permissions, by adding or removing members.
+Vous pouvez également modifier les **Member Roles**, afin de contrôler qui accède à votre cluster et avec quelles permissions, en ajoutant ou en retirant des membres.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-members.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-members.png" loading="lazy" />
 
-You can view the **Labels and Annotations** automatically added by Rancher, and add new ones if you wish.
+Vous pouvez consulter les **Labels and Annotations** ajoutés automatiquement par Rancher, et en ajouter de nouveaux si vous le souhaitez.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-labels-annotations.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-labels-annotations.png" loading="lazy" />
 
-**OVH API credentials** can also be modified in this page. Edit them if you defined credentials that have expired.
+Les **identifiants de l'API OVHcloud** peuvent aussi être modifiés sur cette page. Modifiez-les si les identifiants que vous avez définis ont expiré.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-api-creds.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-api-creds.png" loading="lazy" />
 
-You can change the Kubernetes version and the Update Policy:
+Vous pouvez modifier la version de Kubernetes ainsi que la politique de mise à jour :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-update-policy.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-update-policy.png" loading="lazy" />
 
-You can also add new Node Pool or edit existing ones:
+Vous pouvez également ajouter un nouveau pool de nœuds ou modifier ceux qui existent déjà :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-np.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/edit-config-kubernetes-cluster/rancher-np.png" loading="lazy" />
 
-Finally, click on the <code className="action">Save</code> button to save the changes to your cluster.
+Enfin, cliquez sur le bouton <code className="action">Save</code> pour enregistrer les modifications apportées à votre cluster.
 
-The cluster will be in `Updating` state during the changing period and `Active` again after the changes.
+Le cluster passe à l'état `Updating` pendant la durée des modifications, puis revient à l'état `Active` une fois celles-ci terminées.
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour obtenir une vue d'ensemble d'OVHcloud Managed Rancher Service, consultez la [page OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started.mdx
@@ -1,257 +1,257 @@
 ---
-title: Getting Started with Managed Rancher Service
-description: Find out how to start using Managed Rancher Service on OVHcloud
+title: Premiers pas avec Managed Rancher Service
+description: Découvrez comment commencer à utiliser Managed Rancher Service chez OVHcloud
 lastUpdated: 2025-06-24
 ---
 
-## Objective
+## Objectif
 
-Container orchestration has become a cornerstone of modern application deployment, offering scalability, flexibility, and resource efficiency. Rancher is an open-source container management platform that simplifies the deployment and management of Kubernetes clusters.
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. In this Getting Started guide we will explore the intricacies of setting up and managing container clusters.
+L'orchestration de conteneurs est devenue un élément central du déploiement des applications modernes, car elle apporte évolutivité, souplesse et optimisation des ressources. Rancher est une plateforme open source de gestion de conteneurs qui simplifie le déploiement et l'administration des clusters Kubernetes.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Dans ce guide de démarrage, nous allons découvrir en détail la mise en place et la gestion de clusters de conteneurs.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) in your OVHcloud account
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
 
-### OVHcloud Control Panel Access
+### Accès à l'espace client OVHcloud
 
-- **Direct link:** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
-- **Navigation path:** <code className="action">Public Cloud</code> > Select your project
+- **Lien direct :** <ManagerLink to="/#/pci/projects">Public Cloud Projects</ManagerLink>
+- **Chemin de navigation :** <code className="action">Public Cloud</code> > Sélectionnez votre projet
 
 ---
 {/* CP-NAV-END:publiccloud-projects */}
 
 :::tip
-Take advantage of reduced prices by committing to a period of 1 to 36 months on your Public Cloud resources. More information on our [Savings Plans](https://www.ovhcloud.com/fr/public-cloud/savings-plan/) page.
+Bénéficiez de tarifs réduits en vous engageant sur une période de 1 à 36 mois sur vos ressources Public Cloud. Plus d'informations sur notre page [Savings Plans](https://www.ovhcloud.com/fr/public-cloud/savings-plan/).
 
 :::
 
 
 ## Instructions
 
-### Rancher Creation and Access
+### Créer un Rancher et y accéder
 
-In the left-hand menu under **Containers & Orchestration**, click on <code className="action">Managed Rancher Service</code>. You can trigger the creation of a Rancher which will be operated and managed by OVHcloud.
+Dans le menu de gauche, sous **Containers & Orchestration**, cliquez sur <code className="action">Managed Rancher Service</code>. Vous pouvez alors lancer la création d'un Rancher qui sera exploité et administré par OVHcloud.
 
-Simply click on the <code className="action">Create</code> button at the top right of the Control Panel and follow the steps below:
+Cliquez sur le bouton <code className="action">Créer</code> en haut à droite de l'espace client, puis suivez les étapes ci-dessous :
 
-1. Define your Rancher's name.
-2. Select your Plan between **OVHcloud Edition** (coming soon) and **Standard**.
-3. Select the Rancher version.
-4. Click on <code className="action">Create</code>.
-5. Wait for your Rancher to be created.
-6. Access the details of your newly created Rancher by clicking on its name.
-7. In the "Security and Access" section, click on <code className="action">Generate access details</code>, confirm, then click <code className="action">Access Rancher UI</code>.
-8. Copy/Paste the provided credentials on the Rancher login page. Note: you will need to change your password at first login. In case of lost password, you have the possibility to generate a new one by using the <code className="action">Generate access details</code> action button.
+1. Définissez le nom de votre Rancher.
+2. Choisissez votre plan entre **OVHcloud Edition** (bientôt disponible) et **Standard**.
+3. Sélectionnez la version de Rancher.
+4. Cliquez sur <code className="action">Créer</code>.
+5. Attendez la fin de la création de votre Rancher.
+6. Accédez aux détails de votre Rancher nouvellement créé en cliquant sur son nom.
+7. Dans la section « Sécurité et accès », cliquez sur <code className="action">Generate access details</code>, confirmez, puis cliquez sur <code className="action">Access Rancher UI</code>.
+8. Copiez-collez les identifiants fournis sur la page de connexion de Rancher. Remarque : vous devrez modifier votre mot de passe lors de la première connexion. En cas de perte du mot de passe, vous pouvez en générer un nouveau à l'aide du bouton <code className="action">Generate access details</code>.
 
-You now have access to the Rancher dashboard. It is designed to offer an intuitive and comprehensive view of your containerized environment.
-This web-based interface serves as your command center for orchestrating containers & clusters, visualizing cluster health and managing various aspects of your Kubernetes infrastructure. Explore the navigation menu, which includes sections for clusters, projects, applications and Rancher settings.
+Vous avez désormais accès au tableau de bord de Rancher. Il est conçu pour offrir une vue intuitive et complète de votre environnement conteneurisé.
+Cette interface web constitue votre interface de gestion pour orchestrer conteneurs et clusters, visualiser l'état de santé des clusters et administrer les différents aspects de votre infrastructure Kubernetes. Parcourez le menu de navigation, qui comporte des sections dédiées aux clusters, aux projets, aux applications et aux paramètres de Rancher.
 
-As it is a brand new Rancher instance you do not have any downstream Kubernetes cluster. The next step will describe how to add one. To do so, you have two options: Importing an existing Kubernetes cluster or creating a new cluster using Rancher.
+Puisqu'il s'agit d'une instance Rancher toute neuve, vous ne disposez d'aucun « downstream cluster » Kubernetes. L'étape suivante décrit comment en ajouter un. Pour cela, vous avez deux possibilités : importer un cluster Kubernetes existant ou créer un nouveau cluster avec Rancher.
 
-### Creating or importing a Kubernetes cluster
+### Créer ou importer un cluster Kubernetes
 
-#### Creating a Kubernetes cluster with Rancher
+#### Créer un cluster Kubernetes avec Rancher
 
-Using this option you will be able to create a Kubernetes cluster from scratch. Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives.
-You can use Rancher to launch a Kubernetes cluster on any platform and location including:
+Cette option vous permet de créer un cluster Kubernetes à partir de zéro. Rancher simplifie la création des clusters en vous permettant de les créer depuis son interface, plutôt que par des méthodes plus complexes.
+Vous pouvez utiliser Rancher pour déployer un cluster Kubernetes sur n'importe quelle plateforme et n'importe quelle localisation, notamment :
 
-- Hosted Kubernetes provider (e.g. OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc).
-- Infrastructure Provider - Public Cloud or Private Cloud (vSphere, Nutanix, etc).
-- Bare-metal servers, cloud hosted or on premise.
-- Virtual machines, cloud hosted or on premise.
+- un fournisseur de Kubernetes managé (par exemple OVHcloud Managed Kubernetes Service, AWS EKS, GCP GKE, etc.) ;
+- un fournisseur d'infrastructure – Public Cloud ou Private Cloud (vSphere, Nutanix, etc.) ;
+- des serveurs bare metal, hébergés dans le cloud ou sur site ;
+- des machines virtuelles, hébergées dans le cloud ou sur site.
 
-For the last three options, when Rancher deploys Kubernetes onto these nodes, you can choose between the Rancher Kubernetes Engine (`RKE2`) or `K3s` distributions.
+Pour les trois dernières options, lorsque Rancher déploie Kubernetes sur ces nœuds, vous pouvez choisir entre les distributions Rancher Kubernetes Engine (`RKE2`) et `K3s`.
 
-Follow the official Rancher documentation on [How to launch Kubernetes with Rancher](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher). This documentation explains how to define cluster settings, the number of nodes (master, worker, etcd), authentication and other additional configuration.
+Suivez la documentation officielle de Rancher [How to launch Kubernetes with Rancher](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher). Elle explique comment définir les paramètres du cluster, le nombre de nœuds (master, worker, etcd), l'authentification et les autres options de configuration.
 
-We will detail below how to use OVHcloud as a Hosted Kubernetes provider and Infrastructure Provider using our official OVHcloud Drivers.
+Nous détaillons ci-dessous l'utilisation d'OVHcloud comme fournisseur de Kubernetes managé et comme fournisseur d'infrastructure, à l'aide de nos drivers officiels OVHcloud.
 
-##### Use OVHcloud as a **Hosted Kubernetes Provider**
+##### Utiliser OVHcloud comme **fournisseur de Kubernetes managé**
 
 :::warning
-Deploying to OVHcloud will incur charges. For more information, refer to the [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) and [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/) pricing pages.
-Once your Managed Kubernetes clusters are created, we do recommend performing all actions (upgrade, nodepool management, cluster modification) from the Rancher console and not performing any action directly via the OVHcloud API or the OVHcloud Control Panel as this can lead to desynchronizations.
+Le déploiement chez OVHcloud est facturé. Pour plus d'informations, consultez les pages tarifaires [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) et [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/).
+Une fois vos clusters Managed Kubernetes créés, nous vous recommandons d'effectuer toutes les actions (mise à jour, gestion des pools de nœuds, modification du cluster) depuis la console Rancher et de n'effectuer aucune action directement via l'API OVHcloud ou l'espace client OVHcloud, sous peine de désynchronisations.
 
 :::
 
 
-On this part we will detail how to use Rancher to create and manage [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/) clusters.
+Cette partie détaille l'utilisation de Rancher pour créer et administrer des clusters [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
 
-1. From the Rancher Homepage, click on <code className="action">Create</code>.
+1. Depuis la page d'accueil de Rancher, cliquez sur <code className="action">Créer</code>.
 
-<img className="thumbnail" alt="Rancher Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage_create.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil de Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage_create.png" loading="lazy" />
 
-2\. Use the OVHcloud **Hosted Kubernetes provider** by clicking on <code className="action">OVHcloud MKS</code>.
+2\. Utilisez le **fournisseur de Kubernetes managé** OVHcloud en cliquant sur <code className="action">OVHcloud MKS</code>.
 
-<img className="thumbnail" alt="Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-creation.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-creation.png" loading="lazy" />
 
-3\. Set the parameters of your MKS cluster:
+3\. Définissez les paramètres de votre cluster MKS :
 
-<img className="thumbnail" alt="Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mks-cluster-creation-form.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mks-cluster-creation-form.png" loading="lazy" />
 
-You need to provide the following parameters:
+Vous devez renseigner les paramètres suivants :
 
-| Field | Mandatory | Description |
+| Champ | Obligatoire | Description |
 |---|---|---|
-| Name | Yes | Name of the Managed Kubernetes Service Cluster that will be created. |
-| Member Roles | Yes, default value is ok | Configure user authorization for the cluster. Click <code className="action">Add Member</code> to add users that can access the cluster. Use the Role drop-down menu to set permissions for each user. |
-| Label & Annotations | No | Add Kubernetes labels or annotations to the cluster. |
-| Account Configuration | Yes | Provide your OVH API credentials, you can follow our guide on how to [Generate your OVHcloud API keys](/guides/manage-and-operate/api/first-steps#advanced-usage-pair-ovhcloud-apis-with-an-application).<br/>We advise you to set at least the following rights to your new token:<br/>`GET=/cloud/project/{YOUR_PROJECT_ID}*`<br/>`PUT=/cloud/project/{YOUR_PROJECT_ID}/kube*`<br/>`POST=/cloud/project/{YOUR_PROJECT_ID}/kube*`<br/>`DELETE=/cloud/project/{YOUR_PROJECT_ID}/kube*` |
-| Application Key | Yes | Refer to the guide provided above. Value is provided at the API keys generation step on <CreateToken>OVHcloud token creation page</CreateToken>. |
-| Consumer Key | Yes | Refer to the guide provided above. Value is provided at the API keys generation step on <CreateToken>OVHcloud token creation page</CreateToken>. |
-| Application Secret | Yes | Refer to the guide provided above. Value is provided at the API keys generation step on <CreateToken>OVHcloud token creation page</CreateToken>. |
-| Public Cloud project ID | Yes | The projectID of the OVHcloud project where your MKS cluster will be deployed. You can follow the guide on [How to create your first Project](/guides/public-cloud/cross-functional/create-a-public-cloud-project) or if already existing, you can copy/paste it from the OVHcloud Control Panel or <ApiLink section="/cloud" method="GET" route={"/cloud/project"}>API</ApiLink> |
-| OVH API Endpoint | Yes | Select the OVHcloud subsidiary (EU, US, CA) |
+| Name | Oui | Nom du cluster Managed Kubernetes Service qui sera créé. |
+| Member Roles | Oui, la valeur par défaut convient | Configurez les autorisations des utilisateurs pour le cluster. Cliquez sur <code className="action">Add Member</code> pour ajouter les utilisateurs pouvant accéder au cluster. Utilisez le menu déroulant Role pour définir les permissions de chaque utilisateur. |
+| Label & Annotations | Non | Ajoutez des labels ou des annotations Kubernetes au cluster. |
+| Account Configuration | Oui | Renseignez vos identifiants d'API OVHcloud. Vous pouvez suivre notre guide [Générer vos clés d'API OVHcloud](/guides/manage-and-operate/api/first-steps#advanced-usage-pair-ovhcloud-apis-with-an-application).<br/>Nous vous conseillons d'attribuer au minimum les droits suivants à votre nouveau token :<br/>`GET=/cloud/project/{YOUR_PROJECT_ID}*`<br/>`PUT=/cloud/project/{YOUR_PROJECT_ID}/kube*`<br/>`POST=/cloud/project/{YOUR_PROJECT_ID}/kube*`<br/>`DELETE=/cloud/project/{YOUR_PROJECT_ID}/kube*` |
+| Application Key | Oui | Consultez le guide indiqué ci-dessus. La valeur est fournie à l'étape de génération des clés d'API, sur la <CreateToken>page de création de token OVHcloud</CreateToken>. |
+| Consumer Key | Oui | Consultez le guide indiqué ci-dessus. La valeur est fournie à l'étape de génération des clés d'API, sur la <CreateToken>page de création de token OVHcloud</CreateToken>. |
+| Application Secret | Oui | Consultez le guide indiqué ci-dessus. La valeur est fournie à l'étape de génération des clés d'API, sur la <CreateToken>page de création de token OVHcloud</CreateToken>. |
+| Public Cloud project ID | Oui | Le projectID du projet OVHcloud dans lequel votre cluster MKS sera déployé. Vous pouvez suivre le guide [Créer votre premier projet](/guides/public-cloud/cross-functional/create-a-public-cloud-project) ou, si le projet existe déjà, copier-coller son identifiant depuis l'espace client OVHcloud ou l'<ApiLink section="/cloud" method="GET" route={"/cloud/project"}>API</ApiLink>. |
+| OVH API Endpoint | Oui | Sélectionnez la filiale OVHcloud (EU, US, CA). |
 
-4\. Move to **Cluster Configuration**
+4\. Passez à la section **Cluster Configuration**
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_config.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration du cluster avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_config.png" loading="lazy" />
 
-Provide the following parameters:
+Renseignez les paramètres suivants :
 
-- The **Region** where your cluster will be deployed.
-- The **Kubernetes Version**. Only versions supported by Rancher current version are listed (you can refer to the [Official Support Matrix](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)).
-- The **Update Policy** you want to define for your managed cluster (for more information, refer to the [Managed Kubernetes Update Policies](/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update) guide).
+- La **Region** dans laquelle votre cluster sera déployé.
+- La **Kubernetes Version**. Seules les versions prises en charge par la version courante de Rancher sont listées (vous pouvez consulter la [matrice de compatibilité officielle](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions)).
+- L'**Update Policy** que vous souhaitez définir pour votre cluster managé (pour plus d'informations, consultez le guide [Politiques de mise à jour Managed Kubernetes](/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update)).
 
-5\. Move to **Network Configuration**
+5\. Passez à la section **Network Configuration**
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_network_configuration.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration réseau avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_network_configuration.png" loading="lazy" />
 
-Provide the following parameters:
+Renseignez les paramètres suivants :
 
-- The **Private Network ID** for your MKS cluster. Select an existing OVHcloud Public Cloud private network or choose `None` to create a cluster with nodes using only public interfaces.
-- The **Default vRack Gateway** (optional). Leave it empty to use the default gateway of your Private Network.
-- The **Private Network Routing As Default** state. Activate this feature if you want to use an OVHcloud Managed Gateway or a custom Gateway as a single exit point for your MKS nodes.
+- Le **Private Network ID** de votre cluster MKS. Sélectionnez un réseau privé OVHcloud Public Cloud existant ou choisissez `None` pour créer un cluster dont les nœuds n'utilisent que des interfaces publiques.
+- La **Default vRack Gateway** (facultatif). Laissez ce champ vide pour utiliser la passerelle par défaut de votre réseau privé.
+- L'état **Private Network Routing As Default**. Activez cette fonctionnalité si vous souhaitez utiliser une passerelle managée OVHcloud ou une passerelle personnalisée comme point de sortie unique pour vos nœuds MKS.
 
-6\. Move to **NodePools Configuration**
+6\. Passez à la section **NodePools Configuration**
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_nodepool_configuration.png" loading="lazy" />
+<img className="thumbnail" alt="Configuration des pools de nœuds avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_nodepool_configuration.png" loading="lazy" />
 
-Provide the following parameters:
+Renseignez les paramètres suivants :
 
-- The **Name** of the NodePool. It must be unique inside a same MKS cluster.
-- The OVHcloud Instance **Flavor** used by this NodePool.
-- The **Autoscaling** state. If the autoscaling is enabled, it will display the minimum and maximum number of nodes instead.
-- The **Size** of your NodePool (number of nodes that will be created).
-- The **Monthly Billing** state (hourly by default).
+- Le **Name** du NodePool. Il doit être unique au sein d'un même cluster MKS.
+- Le **Flavor** de l'instance OVHcloud utilisée par ce NodePool.
+- L'état **Autoscaling**. Si l'autoscaling est activé, le nombre minimum et le nombre maximum de nœuds sont affichés à la place.
+- La **Size** de votre NodePool (nombre de nœuds qui seront créés).
+- L'état **Monthly Billing** (facturation horaire par défaut).
 
-Then click on <code className="action">Add Node Pool</code>. You can add multiple NodePools and then manage your list of Nodepools (note that the <code className="action">Delete</code> action button of your first NodePool is grayed out until a second one is created).
+Cliquez ensuite sur <code className="action">Add Node Pool</code>. Vous pouvez ajouter plusieurs NodePools, puis gérer votre liste de NodePools (notez que le bouton d'action <code className="action">Supprimer</code> de votre premier NodePool reste grisé jusqu'à la création d'un second).
 
-7\. Click on **Finish & Create Cluster**.
+7\. Cliquez sur **Finish & Create Cluster**.
 
-8\. From the home page your cluster is now in `Provisioning` state
+8\. Depuis la page d'accueil, votre cluster est désormais à l'état `Provisioning`.
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_provisioning.png" loading="lazy" />
+<img className="thumbnail" alt="Provisionnement avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_provisioning.png" loading="lazy" />
 
-From the Cluster Management page, wait for your cluster to become `Active`.
+Depuis la page Cluster Management, attendez que votre cluster passe à l'état `Active`.
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_provisioning.png" loading="lazy" />
+<img className="thumbnail" alt="Provisionnement du cluster avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_provisioning.png" loading="lazy" />
 
-<img className="thumbnail" alt="MKS Driver Cluster Configuration" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_provisioning_available.png" loading="lazy" />
+<img className="thumbnail" alt="Cluster disponible avec le driver MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/mksdriver_cluster_provisioning_available.png" loading="lazy" />
 
-Your cluster is now fully functional. You can click on the <code className="action">Explore</code> button to manage your MKS Cluster.
+Votre cluster est désormais pleinement opérationnel. Vous pouvez cliquer sur le bouton <code className="action">Explore</code> pour administrer votre cluster MKS.
 
-##### Use OVHcloud as an **Infrastructure Provider**
+##### Utiliser OVHcloud comme **fournisseur d'infrastructure**
 
-On this part we will detail how to use Rancher to create and manage Kubernetes clusters based on [OVHcloud Public Cloud Compute Instances](https://www.ovhcloud.com/fr/public-cloud/compute/).
+Cette partie détaille l'utilisation de Rancher pour créer et administrer des clusters Kubernetes reposant sur des [instances Public Cloud OVHcloud](https://www.ovhcloud.com/fr/public-cloud/compute/).
 
 :::warning
-Deploying to OVHcloud will incur charges.
-For more information, refer to the [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) and [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/) pricing pages.
+Le déploiement chez OVHcloud est facturé.
+Pour plus d'informations, consultez les pages tarifaires [MKS](https://www.ovhcloud.com/fr/public-cloud/prices/#568) et [Compute](https://www.ovhcloud.com/fr/public-cloud/prices/).
 
 :::
 
 
-1\. From the Rancher Homepage, click on <code className="action">Create</code>.
+1\. Depuis la page d'accueil de Rancher, cliquez sur <code className="action">Créer</code>.
 
-<img className="thumbnail" alt="Rancher Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage_create.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil de Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage_create.png" loading="lazy" />
 
-2\. Use the OVHcloud `Infrastructure Provider` by clicking on <code className="action">OVHcloud Public Cloud</code> under the "Provision new nodes and create using RKE2/k3s" section:
+2\. Utilisez le `fournisseur d'infrastructure` OVHcloud en cliquant sur <code className="action">OVHcloud Public Cloud</code> dans la section « Provision new nodes and create using RKE2/k3s » :
 
-<img className="thumbnail" alt="Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-creation.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-creation.png" loading="lazy" />
 
-3\. Create your cloud credentials
+3\. Créez vos cloud credentials.
 
-<img className="thumbnail" alt="Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_auth.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_auth.png" loading="lazy" />
 
-Provide the following parameters:
+Renseignez les paramètres suivants :
 
-- **Credential Name** (optional).
-- **OpenStack Authentication URL**, default value can't be changed.
-- Your OpenStack **Username**, please refer to our Documentation for [Creating and deleting OpenStack users](/guides/public-cloud/cross-functional/create-and-delete-a-user).
-- your OpenStack **Password**, please refer to our Documentation for [Creating and deleting OpenStack users](/guides/public-cloud/cross-functional/create-and-delete-a-user).
+- Le **Credential Name** (facultatif).
+- L'**OpenStack Authentication URL** : la valeur par défaut ne peut pas être modifiée.
+- Votre **Username** OpenStack : consultez notre documentation [Créer et supprimer des utilisateurs OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user).
+- Votre **Password** OpenStack : consultez notre documentation [Créer et supprimer des utilisateurs OpenStack](/guides/public-cloud/cross-functional/create-and-delete-a-user).
 
-Once created, the cloud credentials will be used to provision nodes in your cluster. You can reuse these credentials for other node templates or in other clusters.
+Une fois créés, les cloud credentials serviront à provisionner les nœuds de votre cluster. Vous pouvez les réutiliser pour d'autres modèles de nœuds ou dans d'autres clusters.
 
-4\. Click on <code className="action">Get Project List</code> and select the **Project** were you want to create your cluster.
+4\. Cliquez sur <code className="action">Get Project List</code> et sélectionnez le **Project** dans lequel vous souhaitez créer votre cluster.
 
-5\. Click on <code className="action">Continue</code>.
+5\. Cliquez sur <code className="action">Continuer</code>.
 
-6\. Set your **Cluster Name** and **Cluster Description**.
+6\. Renseignez le **Cluster Name** et la **Cluster Description**.
 
-<img className="thumbnail" alt="Public Cloud Driver - Cloud Credentials" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_cloud_credential.png" loading="lazy" />
+<img className="thumbnail" alt="Driver Public Cloud – cloud credentials" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_cloud_credential.png" loading="lazy" />
 
-7\. Create a **Machine Pool** for each Kubernetes role. Refer to the following guides for recommendations on role assignments and counts:
+7\. Créez un **Machine Pool** pour chaque rôle Kubernetes. Consultez les guides suivants pour les recommandations d'attribution des rôles et de nombre de nœuds :
 
 - [Best Practices](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider#node-roles)
 - [Node Requirements for Rancher Managed Clusters](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters)
 - [Requirements for RKE2 installation (flavors and OS)](https://docs.rke2.io/install/requirements)
 - [Recommended Cluster Architecture](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/recommended-cluster-architecture)
 
-<img className="thumbnail" alt="Cluster Creation" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_machine_pool.png" loading="lazy" />
+<img className="thumbnail" alt="Création du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/PublicCloudDriver_creation_machine_pool.png" loading="lazy" />
 
-For each machine pool, define the machine configuration by providing the following parameters:
+Pour chaque machine pool, définissez la configuration des machines en renseignant les paramètres suivants :
 
-- **Pool Name** - Name of the Machine Pool.
-- **Machine Count** - Number of instances.
-- **Roles** - `etcd`, `Control Plane` or `Worker`. You can refer to the [Node Roles](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider#node-roles) documentation.
-- **Region** - The OVHcloud Public Cloud region. If you want to check the availability of specific products that you plan to use alongside Kubernetes, you can refer to the [Availability of Public Cloud Product](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) page.
-- **Flavor** - The instance flavor used for your nodes. You can refer to the [OVHcloud Flavor list](https://www.ovhcloud.com/fr/public-cloud/prices/#13569).
-- **Image** - The Operating System image used for your nodes. Please refer to [Rancher Operating Systems and Container Runtime Requirements](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters).
-- **Key Pair** (optional) - The SSH Key Pair that should be used to access your nodes. Please refer to this guide on [how to create a SSH KeyPair and add it to your Public Cloud project](/guides/public-cloud/compute/first-steps-with-public-cloud-instance). If you leave this field empty, a new keypair will be generated automatically.
-- **Security Group** - The security group from your Public Cloud project that will be applied to created instances.
-- **Availability Zone** - Only `nova` is supported at the moment.
-- **Floating IP Pools** - Only `Ext-Net` is supported at the moment.
-- **Networks** - The Public Cloud private Network to which created instances will be attached. The selected network needs to have a gateway configured.
-- **SSH user ID** - Username that will be used to access your nodes through SSH.
+- **Pool Name** : nom du machine pool.
+- **Machine Count** : nombre d'instances.
+- **Roles** : `etcd`, `Control Plane` ou `Worker`. Vous pouvez consulter la documentation [Node Roles](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider#node-roles).
+- **Region** : la région OVHcloud Public Cloud. Si vous souhaitez vérifier la disponibilité de produits spécifiques que vous prévoyez d'utiliser avec Kubernetes, consultez la page [Disponibilité des produits Public Cloud](https://www.ovhcloud.com/fr/public-cloud/regions-availability/).
+- **Flavor** : le flavor d'instance utilisé pour vos nœuds. Vous pouvez consulter la [liste des flavors OVHcloud](https://www.ovhcloud.com/fr/public-cloud/prices/#13569).
+- **Image** : l'image du système d'exploitation utilisée pour vos nœuds. Consultez la documentation [Rancher Operating Systems and Container Runtime Requirements](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/node-requirements-for-rancher-managed-clusters).
+- **Key Pair** (facultatif) : la paire de clés SSH à utiliser pour accéder à vos nœuds. Consultez le guide [Créer une paire de clés SSH et l'ajouter à votre projet Public Cloud](/guides/public-cloud/compute/first-steps-with-public-cloud-instance). Si vous laissez ce champ vide, une nouvelle paire de clés sera générée automatiquement.
+- **Security Group** : le groupe de sécurité de votre projet Public Cloud qui sera appliqué aux instances créées.
+- **Availability Zone** : seule la zone `nova` est prise en charge pour le moment.
+- **Floating IP Pools** : seul `Ext-Net` est pris en charge pour le moment.
+- **Networks** : le réseau privé Public Cloud auquel les instances créées seront rattachées. Le réseau sélectionné doit disposer d'une passerelle configurée.
+- **SSH user ID** : nom d'utilisateur qui servira à accéder à vos nœuds en SSH.
 
-8\. Use the **Cluster Configuration** to choose the version of Kubernetes that will be installed, which network provider will be used and if you want to enable project network isolation. For help configuring the cluster, refer to the [RKE2 cluster configuration reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration).
-Use Member Roles to configure user authorization for the cluster. Click <code className="action">Add Member</code> to add users that can access the cluster. Use the `Role` drop-down menu to set permissions for each user.
+8\. Utilisez la section **Cluster Configuration** pour choisir la version de Kubernetes qui sera installée, le fournisseur réseau à utiliser et l'activation ou non de l'isolation réseau des projets. Pour vous aider à configurer le cluster, consultez la [référence de configuration des clusters RKE2](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration).
+Utilisez la section Member Roles pour configurer les autorisations des utilisateurs sur le cluster. Cliquez sur <code className="action">Add Member</code> pour ajouter les utilisateurs pouvant accéder au cluster. Utilisez le menu déroulant `Role` pour définir les permissions de chaque utilisateur.
 
-9\. Click <code className="action">Create</code>.
+9\. Cliquez sur <code className="action">Créer</code>.
 
-#### Importing an existing Kubernetes cluster
+#### Importer un cluster Kubernetes existant
 
-For organizations with pre-existing Kubernetes clusters, Rancher simplifies integration. Import your clusters seamlessly, wherever they are deployed, allowing Rancher to take over the management responsibilities. This process facilitates the transition to Rancher without disrupting your existing infrastructure.
+Pour les organisations disposant déjà de clusters Kubernetes, Rancher simplifie l'intégration. Importez vos clusters, où qu'ils soient déployés, afin de confier leur administration à Rancher. Ce processus facilite la transition vers Rancher sans perturber votre infrastructure existante.
 
-You can refer to the official Rancher documentation on how to [Register Existing Cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters).
+Vous pouvez consulter la documentation officielle de Rancher [Register Existing Cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters).
 
-##### Importing an existing OVHcloud Managed Kubernetes Service cluster
+##### Importer un cluster OVHcloud Managed Kubernetes Service existant
 
-If you already use our [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/), you can easily import an existing cluster.
-The workflow is similar to the one described on the official Rancher documentation on [how to register a cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters#registering-a-cluster) and it takes only a few minutes.
+Si vous utilisez déjà notre solution [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/), vous pouvez importer facilement un cluster existant.
+La procédure est semblable à celle décrite dans la documentation officielle de Rancher [how to register a cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters#registering-a-cluster) et ne prend que quelques minutes.
 
-1\. From the Rancher home page, click on <code className="action">Import Existing</code>.
+1\. Depuis la page d'accueil de Rancher, cliquez sur <code className="action">Import Existing</code>.
 
-<img className="thumbnail" alt="Rancher Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil de Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/rancher-homepage.png" loading="lazy" />
 
-2\. Select **Generic**
+2\. Sélectionnez **Generic**.
 
-<img className="thumbnail" alt="Import Cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/import-cluster.png" loading="lazy" />
+<img className="thumbnail" alt="Importer un cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/import-cluster.png" loading="lazy" />
 
-3\. Set the Cluster Name (it is not mandatory to match the name of your existing MKS cluster) then click on <code className="action">Create</code>
+3\. Renseignez le Cluster Name (il n'est pas obligatoire qu'il corresponde au nom de votre cluster MKS existant), puis cliquez sur <code className="action">Créer</code>.
 
-<img className="thumbnail" alt="Import Cluster Form" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/import-cluster-form.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire d'import de cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/import-cluster-form.png" loading="lazy" />
 
-4\. Follow the instructions provided on the **Registration** tab.
+4\. Suivez les instructions affichées dans l'onglet **Registration**.
 
-<img className="thumbnail" alt="Register Cluster Instructions" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/register-cluster-instructions.png" loading="lazy" />
+<img className="thumbnail" alt="Instructions d'enregistrement du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/register-cluster-instructions.png" loading="lazy" />
 
-Run the provided kubectl command on an existing Managed Kubernetes Service cluster that is running a supported Kubernetes version to import it into Rancher:
+Exécutez la commande kubectl fournie sur un cluster Managed Kubernetes Service existant utilisant une version de Kubernetes prise en charge, afin de l'importer dans Rancher :
 
 ```shell
 kubectl apply -f https://rancher.ovh.net/v3/import/file.yaml
@@ -269,42 +269,42 @@ kubectl apply -f https://rancher.ovh.net/v3/import/file.yaml
   service/cattle-cluster-agent created
 ```
 
-5\. Wait until your cluster becomes available:
+5\. Attendez que votre cluster soit disponible :
 
-<img className="thumbnail" alt="Cluster Dashboard" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-dashboard-explore.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/cluster-dashboard-explore.png" loading="lazy" />
 
-6\. Your cluster is now federated on your Rancher. You can click on **Explore** to manage your MKS cluster.
+6\. Votre cluster est désormais rattaché à votre Rancher. Vous pouvez cliquer sur **Explore** pour administrer votre cluster MKS.
 
-### Deploying applications with Rancher
+### Déployer des applications avec Rancher
 
-Now that your clusters are set up, leverage Rancher's user-friendly interface to deploy applications effortlessly. Define workloads, services, and deployment strategies within the Rancher UI. Explore the extensive catalog of pre-configured application templates to simplify and optimize your application deployment process.
-To access the application catalog, explore your federated downstream Kubernetes cluster and click on <code className="action">Apps/Charts</code> in the left panel.
+Vos clusters étant en place, utilisez l'interface de Rancher pour déployer vos applications. Définissez vos workloads, vos services et vos stratégies de déploiement depuis l'interface de Rancher. Parcourez le catalogue de modèles d'applications préconfigurés pour simplifier et optimiser le déploiement de vos applications.
+Pour accéder au catalogue d'applications, ouvrez votre « downstream cluster » Kubernetes rattaché, puis cliquez sur <code className="action">Apps/Charts</code> dans le panneau de gauche.
 
-<img className="thumbnail" alt="App Catalog" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/app-catalog.png" loading="lazy" />
+<img className="thumbnail" alt="Catalogue d'applications" src="/images/public-cloud/containers-orchestration/managed-rancher-service/getting-started/app-catalog.png" loading="lazy" />
 
-### Managing resources
+### Gérer les ressources
 
-Rancher empowers you with robust tools for resources management. Monitor the nodes health, track resources utilization, and scale applications dynamically as demand fluctuates. The centralized control provided by Rancher ensures efficient resource allocation across your Kubernetes clusters.
+Rancher met à votre disposition des outils complets de gestion des ressources. Surveillez l'état de santé des nœuds, suivez la consommation des ressources et faites évoluer vos applications dynamiquement au fil de la demande. Le pilotage centralisé assuré par Rancher garantit une allocation efficace des ressources sur l'ensemble de vos clusters Kubernetes.
 
-### Monitoring and troubleshooting
+### Superviser et diagnostiquer
 
-Dive into Rancher's monitoring capabilities to gain real-time insights into the performance of your clusters and applications. Use logging features and diagnostic tools to troubleshoot issues promptly. Rancher's comprehensive monitoring suite ensures you can proactively address potential challenges.
+Exploitez les fonctionnalités de monitoring de Rancher pour suivre en temps réel les performances de vos clusters et de vos applications. Utilisez les fonctions de journalisation et les outils de diagnostic pour résoudre rapidement les incidents. La suite de supervision de Rancher vous permet d'anticiper les problèmes potentiels.
 
-### Regular updates and maintenance
+### Mises à jour et maintenance régulières
 
-Stay informed about updates to Rancher and OVHcloud Managed Rancher Service features. Regularly check for new releases, security patches and optimizations. This proactive approach ensures that your container orchestration environment remains secure, efficient, and aligned with the latest industry standards.
+Tenez-vous informé des évolutions de Rancher et des fonctionnalités de Managed Rancher Service par OVHcloud. Consultez régulièrement les nouvelles versions, les correctifs de sécurité et les optimisations. Cette démarche préventive garantit que votre environnement d'orchestration de conteneurs reste sécurisé, performant et conforme aux standards les plus récents du secteur.
 
 ### Conclusion
 
-Rancher, when used within the OVHcloud Cloud environment, offers a fully managed solution for containers orchestration. By following these detailed steps, you will not only establish a robust Kubernetes infrastructure but also harness the full potential of Rancher's features within the unique context of OVHcloud Public Cloud.
-Happy Ranchering!
+Utilisé au sein de l'environnement OVHcloud, Rancher offre une solution entièrement managée pour l'orchestration de conteneurs. En suivant ces étapes détaillées, vous mettez en place une infrastructure Kubernetes robuste tout en tirant parti de l'ensemble des fonctionnalités de Rancher dans le contexte spécifique d'OVHcloud Public Cloud.
+Bon Ranchering !
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
+- Pour un aperçu de la solution OVHcloud Managed Kubernetes, consultez la page [OVHcloud Managed Kubernetes](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/import-kubernetes.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/import-kubernetes.mdx
@@ -1,42 +1,42 @@
 ---
-title: Importing an existing Kubernetes cluster in MRS
-description: Find out how to import an existing Kubernetes on a Managed Rancher Service
+title: Importer un cluster Kubernetes existant dans MRS
+description: Découvrez comment importer un cluster Kubernetes existant sur un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. In this guide we will explore how to import an existing Kubernetes cluster.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce guide explique comment importer un cluster Kubernetes existant.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un OVHcloud Managed Rancher Service (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'administrer (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
 
 ## Instructions
 
-#### Importing an existing OVHcloud Managed Kubernetes Service cluster
+#### Importer un cluster OVHcloud Managed Kubernetes Service existant
 
-If you already use our [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/), you can easily import an existing cluster.
+Si vous utilisez déjà notre solution [OVHcloud Managed Kubernetes Service](https://www.ovhcloud.com/fr/public-cloud/kubernetes/), vous pouvez importer facilement un cluster existant.
 
-Log in your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/rancher-ui.png" loading="lazy" />
 
-Click on the <code className="action">Import Existing</code> button and select **Generic** driver to import any Kubernetes cluster.
+Cliquez sur le bouton <code className="action">Import Existing</code> et sélectionnez le driver **Generic** afin d'importer n'importe quel cluster Kubernetes.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI generic" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/generic-driver.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service - driver Generic" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/generic-driver.png" loading="lazy" />
 
-Enter the Cluster Name (it is not mandatory to match the name of your existing MKS cluster), then click on <code className="action">Create</code> (at the bottom right of the screen).
+Saisissez le nom du cluster (il n'est pas obligatoire qu'il corresponde au nom de votre cluster MKS existant), puis cliquez sur <code className="action">Create</code> (en bas à droite de l'écran).
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI MKS name" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/mks-name.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service - nom du cluster MKS" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/mks-name.png" loading="lazy" />
 
-Follow the instructions provided on the **Registration** tab.
+Suivez les instructions fournies dans l'onglet **Registration**.
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI Register Cluster Instructions" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/register-cluster-instructions.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service - instructions d'enregistrement du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/register-cluster-instructions.png" loading="lazy" />
 
-Run the provided `kubectl` command on your existing Managed Kubernetes Service (MKS) cluster:
+Exécutez la commande `kubectl` fournie sur votre cluster Managed Kubernetes Service (MKS) existant :
 
 ```shell
 kubectl apply -f https://xxxxxx.xxxx.rancher.ovh.net/v3/import/xxxxxxxxxxxx/file.yaml
@@ -57,26 +57,26 @@ deployment.apps/cattle-cluster-agent created
 service/cattle-cluster-agent created
 ```
 
-Wait until your cluster becomes **Active**:
+Attendez que votre cluster passe à l'état **Active** :
 
-<img className="thumbnail" alt="Cluster Dashboard" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/cluster-dashboard-explore.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord du cluster" src="/images/public-cloud/containers-orchestration/managed-rancher-service/import-existing-kubernetes/cluster-dashboard-explore.png" loading="lazy" />
 
-Your existing Kubernetes cluster is now federated on your Rancher.
+Votre cluster Kubernetes existant est désormais fédéré sur votre Rancher.
 
-Now you can click on the **Explore** button to manage your MKS cluster.
+Vous pouvez maintenant cliquer sur le bouton **Explore** pour administrer votre cluster MKS.
 
-#### Importing an existing Kubernetes cluster
+#### Importer un cluster Kubernetes existant
 
-For organizations with pre-existing Kubernetes clusters, Rancher simplifies integration. Import your clusters seamlessly, wherever they're deployed, and let Rancher take over management responsibilities. This process facilitates the transition to Rancher without disrupting your existing infrastructure.
+Pour les organisations disposant déjà de clusters Kubernetes, Rancher simplifie l'intégration. Importez vos clusters, où qu'ils soient déployés, et confiez-en la gestion à Rancher. Cette opération facilite la transition vers Rancher sans perturber votre infrastructure existante.
 
-You can refer to the official Rancher documentation on how to [Register Existing Cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters).
+Vous pouvez consulter la documentation officielle Rancher relative à l'enregistrement d'un cluster existant : [Register Existing Cluster](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters).
 
-## Go further
+## Aller plus loin
 
-- To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
+- Pour obtenir une vue d'ensemble d'OVHcloud Managed Kubernetes Service, consultez la [page OVHcloud Managed Kubernetes](https://www.ovhcloud.com/fr/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/lifecycle-policy.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/lifecycle-policy.mdx
@@ -1,1 +1,88 @@
-../../../../../en/guides/public-cloud/containers-orchestration/managed-rancher-service/lifecycle-policy.mdx
+---
+title: Versions prises en charge et politique de cycle de vie de Managed Rancher Service
+description: Guide complet incluant la politique de cycle de vie, le calendrier des versions et les versions prises en charge pour OVHcloud Managed Rancher Service
+lastUpdated: 2026-08-06
+---
+
+## Objectif
+
+**Ce guide détaille la politique de cycle de vie de Managed Rancher Service, les versions prises en charge et le calendrier des versions.**
+
+### Politiques de cycle de vie de Managed Rancher Service
+
+Managed Rancher Service par OVHcloud respecte des politiques de cycle de vie destinées à garantir la fiabilité et la sécurité de votre service managé. De nouvelles versions stables sont régulièrement testées et publiées afin de fournir les derniers correctifs de sécurité et les nouvelles fonctionnalités.
+Les versions plus anciennes peuvent atteindre leur statut End-of-Support (EoS), puis End-of-Life (EoL), conformément à notre politique de cycle de vie. La compréhension de ces politiques aide les clients à planifier leurs mises à niveau et leurs transitions vers des versions plus récentes.
+
+En règle générale, OVHcloud prend en charge les versions mineures de Rancher pendant 12 mois à compter de leur date de publication upstream.
+
+#### End-of-Support (EoS)
+
+L'End-of-Support (EoS) correspond au moment à partir duquel une version spécifique de Rancher n'est plus officiellement couverte par le support OVHcloud, ni disponible pour de nouvelles installations.<br/>
+Lorsqu'une instance Rancher fonctionne avec une version ayant atteint sa date d'End-of-Support, OVHcloud n'imposera pas de mise à niveau de version pour la dernière version arrivée en End-of-Support. Gardez à l'esprit que, bien que nous les maintenions en fonctionnement, ces versions ne sont plus couvertes par le support OVHcloud.
+Dans le cas peu probable où l'une de ces versions exposerait une faille de sécurité mettant en danger sa propre infrastructure, OVHcloud pourra imposer une mise à jour mineure du service ou désactiver ce dernier si la mise à jour mineure imposée n'aboutit pas.
+
+En règle générale, OVHcloud continuera de proposer des mises à niveau de version mineure depuis toutes les versions non prises en charge vers une version prise en charge, afin que les clients puissent passer à leur rythme vers une version mineure prise en charge par OVHcloud.<br/>
+Il revient au client seul de s'assurer que sa configuration et les logiciels associés, y compris les versions de Kubernetes des « downstream clusters », sont compatibles avec la nouvelle version vers laquelle il effectue la mise à niveau. Veuillez consulter la section [Matrice des versions de Kubernetes prises en charge pour les « downstream clusters »](#supportmatrix).
+
+Dès qu'une version mineure atteint son End-of-Support par OVHcloud, elle atteint simultanément son End-of-Sales, ce qui signifie qu'OVHcloud cesse de proposer cette version mineure à l'installation sur Managed Rancher Service.
+
+À tout moment, les clients peuvent consulter les versions actuellement prises en charge dans la [section dédiée](#versions).
+
+#### End-of-Life (EoL)
+
+Il s'agit du moment auquel une version spécifique de Rancher sera automatiquement mise à niveau par l'équipe OVHcloud vers la version mineure suivante (n+1).
+En règle générale, OVHcloud fait passer les versions de Rancher en EoL 3 mois après leur date d'EoS.
+
+### Calendrier des versions de Rancher et versions prises en charge <a name="versions"></a>
+
+Le tableau suivant présente une vue d'ensemble du calendrier de publication estimé pour chaque version d'OVHcloud Managed Rancher Service (MRS) prise en charge.
+Ce calendrier est susceptible d'évoluer et est fourni à titre informatif uniquement. Les dates exactes de publication peuvent varier en fonction des besoins de développement, des tests et d'autres facteurs.
+
+| Version de Rancher | Date de publication upstream | Date de publication MRS | Fin du support MRS | Fin de vie MRS |
+|-----------------|-----------------------|------------------|--------------------|-----------------|
+| 2.14            | 2026-03-26            | 2026-08-05       | 2027-03            | 2027-06         |
+| 2.13            | 2025-11-25            | 2026-03-23       | 2026-11            | 2027-02         |
+| 2.12            | 2025-08-29            | 2025-12-18       | 2026-08            | 2026-11         |
+
+**Date de publication MRS :** date estimée à laquelle cette version de Rancher est disponible pour OVHcloud Managed Rancher Service.
+
+- Le **format de date** suit la [norme internationale des dates numériques](https://fr.wikipedia.org/wiki/ISO_8601). Les dates indiquées par [trimestre](https://fr.wikipedia.org/wiki/Trimestre) sont des estimations et seront mises à jour dès que les dates précises seront connues.
+- L'abréviation **TBD** est utilisée lorsqu'une date reste à déterminer.
+
+### Matrice des versions de Kubernetes prises en charge pour les « downstream clusters » <a name="supportmatrix"></a>
+
+Pour obtenir la liste des versions de Kubernetes prises en charge pour chaque version mineure de Rancher, veuillez consulter la [matrice de support SUSE](https://www.suse.com/suse-rancher/support-matrix/all-supported-versions).
+
+### Matrice des versions prises en charge par les drivers OVHcloud Managed Kubernetes Service (MKS)
+
+Selon la version de Rancher, les drivers OVHcloud Managed Kubernetes Service (MKS) prennent en charge les versions suivantes :
+
+- **Rancher 2.12.x** -> MKS 1.31 à 1.33
+- **Rancher 2.13.x** -> MKS 1.32 à 1.34
+- **Rancher 2.14.x** -> MKS 1.33 à 1.35
+
+#### Support
+
+Outre les sociétés affiliées d'OVHcloud listées dans les conditions particulières OVHcloud pour Public Cloud, SUSE Software Solutions Ireland Ltd, éditeur du logiciel Rancher, ainsi que ses filiales listées ci-dessous, peuvent, dans des cas exceptionnels et avec le consentement explicite du client, accéder à certaines données du client dans le cadre du support fourni à OVHcloud pour le Service.
+
+| Filiale SUSE | Localisation |
+|-----------------|-----------------------|
+| SUSE Software Solutions Germany GmbH      | Allemagne            |
+| SUSE Linux s.r.o.	SUSE LINUX | République tchèque           |
+| SUSE Software Solutions France Sarl          | France           |
+| SUSE Software Solutions Ireland   | Irlande            |
+| SUSE Software Solutions Japan          | Japon           |
+| SUSE (Bulgaria)          | Bulgarie           |
+| SUSE Software Solutions Australia         | Australie           |
+| SUSE Software Solutions Singapore          | Singapour           |
+| SUSE Software Solutions Brasil         | Brésil           |
+| SUSE Software Solutions Spain          | Espagne           |
+| SUSE Software Solutions India Private Ltd      | Inde           |
+| SUSE Software Solutions UK Ltd          | Royaume-Uni           |
+| SUSE Software Solutions New Zealand Branch      | Nouvelle-Zélande           |
+
+## Aller plus loin
+
+Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/managed-rancher-service-iam-authentication.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/managed-rancher-service-iam-authentication.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Configure access control using OVHcloud IAM on an OVHcloud Managed Rancher Service"
-description: "Learn how to enable and manage OVHcloud IAM authentication to control access to your Managed Rancher Service (MRS) using centralized identities and roles"
+title: "Configurer le contrôle d'accès avec OVHcloud IAM sur un Managed Rancher Service OVHcloud"
+description: "Découvrez comment activer et gérer l'authentification OVHcloud IAM pour contrôler l'accès à votre Managed Rancher Service (MRS) à l'aide d'identités et de rôles centralisés"
 lastUpdated: 2025-11-04
 ---
 
@@ -10,95 +10,95 @@ import Api from '@components/Api';
 
 
 
-## Objective
+## Objectif
 
-OVHcloud Managed Rancher Service (MRS) supports authentication through OVHcloud IAM, allowing you to manage access using centralized user identities and roles.
+Managed Rancher Service (MRS) d'OVHcloud prend en charge l'authentification via OVHcloud IAM, ce qui vous permet de gérer les accès à l'aide d'identités et de rôles utilisateurs centralisés.
 
-This guide explains how to enable IAM authentication and control user access to your Rancher service using OVHcloud IAM users and roles.
+Ce guide explique comment activer l'authentification IAM et contrôler l'accès des utilisateurs à votre service Rancher grâce aux utilisateurs et aux rôles OVHcloud IAM.
 
-## Requirements
+## Prérequis
 
-- An OVHcloud Managed Rancher Service (see the [Creating, updating and accessing a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information).
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer, mettre à jour et accéder à un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations).
 
 ## Instructions
 
-### Introduction to OVHcloud IAM
+### Introduction à OVHcloud IAM
 
-OVHcloud IAM (Identity and Access Management) is a centralized system that lets you control who can access your OVHcloud services and what actions they can perform. It provides fine-grained access management through users, groups, and roles.
+OVHcloud IAM (Identity and Access Management) est un système centralisé qui vous permet de contrôler qui peut accéder à vos services OVHcloud et quelles actions ces personnes peuvent effectuer. Il offre une gestion fine des accès à travers les utilisateurs, les groupes et les rôles.
 
-When integrated with the Managed Rancher Service (MRS), OVHcloud IAM replaces Rancher's local authentication system. This allows you to:
+Lorsqu'il est intégré à Managed Rancher Service (MRS), OVHcloud IAM remplace le système d'authentification local de Rancher. Cela vous permet de :
 
-- Use Single Sign-On (SSO) with your OVHcloud credentials to access Rancher.
-- Assign predefined IAM roles (such as base, ovhRestrictedAdmin, standard) to define access levels.
-- Manage permissions efficiently at scale using IAM groups and projects.
+- Utiliser l'authentification unique (SSO) avec vos identifiants OVHcloud pour accéder à Rancher.
+- Attribuer des rôles IAM prédéfinis (tels que base, ovhRestrictedAdmin, standard) afin de définir les niveaux d'accès.
+- Gérer les permissions à grande échelle grâce aux groupes et aux projets IAM.
 
-Integrating IAM with your Rancher service ensures consistent access control across all your OVHcloud resources, reducing manual management and improving overall security.
+L'intégration d'IAM à votre service Rancher garantit un contrôle d'accès homogène sur l'ensemble de vos ressources OVHcloud, réduisant la gestion manuelle et améliorant la sécurité globale.
 
-### Activate/disable authentication via OVHcloud IAM
+### Activer/désactiver l'authentification via OVHcloud IAM
 
 :::warning
-When you enable OVHcloud IAM authentication on your Managed Rancher Service:
+Lorsque vous activez l'authentification OVHcloud IAM sur votre Managed Rancher Service :
 
-- Local users will remain functional, so you can continue logging in with your usual Rancher accounts.
-- If the "admin" password is regenerated while IAM authentication is enabled, or if no user has ever logged in locally, the ability to log in with the IAM root user will be impossible. To restore access with the IAM root user, log in first with a local admin account.
+- Les utilisateurs locaux restent opérationnels : vous pouvez donc continuer à vous connecter avec vos comptes Rancher habituels.
+- Si le mot de passe « admin » est régénéré alors que l'authentification IAM est active, ou si aucun utilisateur ne s'est jamais connecté localement, la connexion avec l'utilisateur root IAM sera impossible. Pour rétablir l'accès avec l'utilisateur root IAM, connectez-vous d'abord avec un compte admin local.
 
-From this point on, IAM roles and policies control access for users authenticated via OVHcloud IAM.
+À partir de ce moment, les rôles et les politiques IAM régissent l'accès des utilisateurs authentifiés via OVHcloud IAM.
 :::
 
 <Tabs>
-<Tab label="Via the OVHcloud Control Panel (coming soon)">
+<Tab label="Depuis l'espace client OVHcloud (prochainement)">
 
 :::info
-Managing IAM from the OVHcloud Control Panel is not yet available and will be added in a future release.
+La gestion d'IAM depuis l'espace client OVHcloud n'est pas encore disponible et sera ajoutée dans une prochaine version.
 :::
 
 </Tab>
-<Tab label="Via the OVHcloud API">
+<Tab label="Via l'API OVHcloud">
 
 <Api version="v2" section="/publicCloud" method="PUT" route={"/publicCloud/project/\\{projectId\\}/rancher/\\{rancherId\\}"} />
 
-With the request body:
+Avec le corps de requête suivant :
 
 ```json
 {
 "targetSpec": {
-"iamAuthEnabled": true, // true to enable IAM, false to disable
-"name": "my_rancher", // Name of the Managed Rancher Service
-"plan": "STANDARD", // Plan of the Managed Rancher Service
-"version": "1.0.0" // Version of the Managed Rancher Service
+"iamAuthEnabled": true, // true pour activer IAM, false pour le désactiver
+"name": "my_rancher", // Nom du Managed Rancher Service
+"plan": "STANDARD", // Plan du Managed Rancher Service
+"version": "1.0.0" // Version du Managed Rancher Service
 }
 }
 ```
 
 :::info
-Make sure all the information in the JSON (service name, plan, version) is correct. Using incorrect values will result in an error when activating or disabling IAM.
+Assurez-vous que toutes les informations du JSON (nom du service, plan, version) sont correctes. L'utilisation de valeurs erronées provoquera une erreur lors de l'activation ou de la désactivation d'IAM.
 :::
 
-Replace:
+Remplacez :
 
-- `projectId` with the ID of your Public Cloud project.
-- `rancherId` with the ID of the Managed Rancher Service.
+- `projectId` par l'identifiant de votre projet Public Cloud.
+- `rancherId` par l'identifiant du Managed Rancher Service.
 
-You can retrieve the `rancherId` in two ways:
+Vous pouvez récupérer le `rancherId` de deux manières :
 
-- **Via API:**
+- **Via l'API :**
 
 <Api version="v2" section="/publicCloud" method="GET" route={"/publicCloud/project/\\{projectId\\}/rancher"} />
 
-- **Via the OVHcloud Control Panel:**
+- **Depuis l'espace client OVHcloud :**
 
-Log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, navigate to the `Public Cloud` section, and select the relevant project. Then, in the left-hand menu under **Containers & Orchestration**, click on `Managed Rancher Service`.
+Connectez-vous à l'<ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, accédez à la section `Public Cloud` et sélectionnez le projet concerné. Puis, dans le menu de gauche, sous **Containers & Orchestration**, cliquez sur `Managed Rancher Service`.
 
 </Tab>
 <Tab label="OVHcloud CLI">
 
-**1. Retrieve your Rancher service ID:**
+**1. Récupérez l'identifiant de votre service Rancher :**
 
 ```bash
 ovhcloud cloud managed-rancher list --cloud-project <project_id>
 ```
 
-**2. Enable IAM authentication:**
+**2. Activez l'authentification IAM :**
 
 ```bash
 ovhcloud cloud managed-rancher edit <rancher_id> \
@@ -106,7 +106,7 @@ ovhcloud cloud managed-rancher edit <rancher_id> \
   --iam-auth-enabled
 ```
 
-**3. Disable IAM authentication:**
+**3. Désactivez l'authentification IAM :**
 
 ```bash
 ovhcloud cloud managed-rancher edit <rancher_id> \
@@ -118,104 +118,104 @@ ovhcloud cloud managed-rancher edit <rancher_id> \
 </Tabs>
 
 
-Once IAM authentication is enabled on your Managed Rancher Service, access to the Rancher UI is managed via OVHcloud Single Sign-On (SSO). Users no longer log in with local Rancher credentials but authenticate directly using their OVHcloud IAM identity.
+Une fois l'authentification IAM activée sur votre Managed Rancher Service, l'accès à l'interface Rancher est géré par l'authentification unique (SSO) OVHcloud. Les utilisateurs ne se connectent plus avec des identifiants Rancher locaux, mais s'authentifient directement avec leur identité OVHcloud IAM.
 
 :::info
-Local Rancher users remain functional even after enabling OVHcloud IAM, but their use is not recommended. Access and permissions should be managed through OVHcloud IAM roles and policies for consistency and security.
+Les utilisateurs Rancher locaux restent opérationnels après l'activation d'OVHcloud IAM, mais leur usage n'est pas recommandé. Les accès et les permissions doivent être gérés via les rôles et les politiques OVHcloud IAM, par cohérence et pour des raisons de sécurité.
 :::
 
-To log in via SSO:
+Pour vous connecter via SSO :
 
-- Open the `Rancher user interface` from the Control Panel.
+- Ouvrez l'`interface utilisateur Rancher` depuis l'espace client.
 
-![rancher user interface](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/rancher_interface.png)
+![interface utilisateur Rancher](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/rancher_interface.png)
 
-- You will be redirected to the Managed Rancher Service authentication page.
+- Vous êtes redirigé vers la page d'authentification de Managed Rancher Service.
 
 <details>
 
-<summary>No user has ever logged in locally</summary>
+<summary>Aucun utilisateur ne s'est jamais connecté localement</summary>
 
 
-Click on `Use a local user` to go to the local login page.
+Cliquez sur `Use a local user` pour accéder à la page de connexion locale.
 
-To recover the admin password required for authentication, use the following API call:
+Pour récupérer le mot de passe admin requis pour l'authentification, utilisez l'appel d'API suivant :
 
 <Api version="v2" section="/publicCloud" method="POST" route={"/publicCloud/project/\\{projectId\\}/rancher/\\{rancherId\\}/adminCredentials"} />
 
-Replace:
+Remplacez :
 
-- `projectId` with the ID of your Public Cloud project.
-- `rancherId` with the ID of the Managed Rancher Service.
+- `projectId` par l'identifiant de votre projet Public Cloud.
+- `rancherId` par l'identifiant du Managed Rancher Service.
 
-Or with the OVHcloud CLI:
+Ou avec l'OVHcloud CLI :
 
 ```bash
 ovhcloud cloud managed-rancher reset-admin-credentials <rancher_id> --cloud-project <project_id>
 ```
 
-Copy the returned password, then paste it on the authentication page.
+Copiez le mot de passe retourné, puis collez-le sur la page d'authentification.
 
-Make sure to check the box to accept the `End User License Agreement & Terms & Conditions`, then click `Continue`.
+Veillez à cocher la case d'acceptation des `End User License Agreement & Terms & Conditions`, puis cliquez sur `Continue`.
 
-You can now log out and proceed with your normal workflow.
+Vous pouvez maintenant vous déconnecter et poursuivre votre utilisation habituelle.
 
 </details>
 
-Click on `Log in with OIDC`, which will take you to the OVHcloud authentication page. There, log in using your OVHcloud IAM credentials.
+Cliquez sur `Log in with OIDC` : vous êtes redirigé vers la page d'authentification OVHcloud. Connectez-vous alors avec vos identifiants OVHcloud IAM.
 
-![login with SSO](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/iam_authentication.png)
+![connexion avec le SSO](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/iam_authentication.png)
 
-- Access to Rancher is granted based on the IAM role associated with your user account.
+- L'accès à Rancher est accordé en fonction du rôle IAM associé à votre compte utilisateur.
 
 :::info
-Only users with the appropriate IAM role (base, standard and ovhRestrictedAdmin) can access the registry after IAM authentication is enabled.
+Seuls les utilisateurs disposant du rôle IAM approprié (base, standard et ovhRestrictedAdmin) peuvent accéder au registry une fois l'authentification IAM activée.
 :::
 
-### Managing access rights with OVHcloud IAM
+### Gérer les droits d'accès avec OVHcloud IAM
 
-OVHcloud IAM provides three predefined roles for managing access to your Managed Rancher Service (MRS):
+OVHcloud IAM propose trois rôles prédéfinis pour gérer l'accès à votre Managed Rancher Service (MRS) :
 
 - base
 - standard
 - ovhRestrictedAdmin
 
 :::info
-**base** role: Base users can only log in and do not have any additional permissions.
+Rôle **base** : les utilisateurs base peuvent uniquement se connecter et ne disposent d'aucune permission supplémentaire.
 
-**standard** role: Standard users can create new clusters and manage clusters and projects they have been granted access to.
+Rôle **standard** : les utilisateurs standard peuvent créer de nouveaux clusters et gérer les clusters et les projets auxquels un accès leur a été accordé.
 
-**ovhRestrictedAdmin** role: OVHcloud Restricted Admins have full control over all resources in downstream clusters but do not have access to the local cluster.
+Rôle **ovhRestrictedAdmin** : les OVHcloud Restricted Admins disposent d'un contrôle total sur toutes les ressources des « downstream clusters », mais n'ont pas accès au cluster local.
 :::
 
-These roles are assigned through IAM policies. To create and configure a policy, log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> and navigate to the `Identity, Security & Operations` section. Then, in the left-hand menu under **Identity and Access management**, click on `Policies` and click the `Create a policy` button.
+Ces rôles sont attribués au moyen de politiques IAM. Pour créer et configurer une politique, connectez-vous à l'<ManagerLink to="/">OVHcloud Control Panel</ManagerLink> et accédez à la section `Identity, Security & Operations`. Puis, dans le menu de gauche, sous **Identity and Access management**, cliquez sur `Policies`, puis sur le bouton `Create a policy`.
 
-![Create policy](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/managing_iam.png)
+![Créer une politique](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/managing_iam.png)
 
-Define users and groups, name your policy, add the users you want to include and optionally, add user groups if they have already been created.
+Définissez les utilisateurs et les groupes, nommez votre politique, ajoutez les utilisateurs à inclure et, si vous le souhaitez, ajoutez des groupes d'utilisateurs s'ils ont déjà été créés.
 
-![Create policy users](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy.png)
+![Créer une politique utilisateurs](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy.png)
 
-Set permissions for MRS: 
+Définissez les permissions pour MRS :
 
-- In the `Product types` section, select `Public Cloud / Managed Rancher Service (MRS) project`.
-- In the `Resources` section, choose the specific MRS service to which the policy will apply.
+- Dans la section `Product types`, sélectionnez `Public Cloud / Managed Rancher Service (MRS) project`.
+- Dans la section `Resources`, choisissez le service MRS précis auquel la politique s'appliquera.
 
-![Create policy product types](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy_product_types.png)
+![Créer une politique types de produits](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy_product_types.png)
 
-Expand `Public Cloud / Managed Rancher Service (MRS) project` and select the desired role for the users defined in the policy.
+Développez `Public Cloud / Managed Rancher Service (MRS) project` et sélectionnez le rôle souhaité pour les utilisateurs définis dans la politique.
 
-![Create policy roles](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy_action.png)
+![Créer une politique rôles](/images/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-iam-authentication/create_policy_action.png)
 
-### Go further
+### Aller plus loin
 
-To go further you can look at our guides on:
+Pour aller plus loin, consultez nos guides sur :
 
-- [Managing users and projects](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects).
-- [Creating and using a private image](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
+- [Gérer les utilisateurs et les projets](/guides/public-cloud/containers-orchestration/managed-private-registry/managing-users-projects).
+- [Créer et utiliser une image privée](/guides/public-cloud/containers-orchestration/managed-private-registry/create-private-image).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/managing-users-projects.mdx
@@ -1,123 +1,120 @@
 ---
-title: Managing users and projects in Managed Rancher Service
-description: Find out how to manage users and projects in your OVHcloud Managed Rancher Service
+title: Gérer les utilisateurs et les projets dans Managed Rancher Service
+description: Découvrez comment gérer les utilisateurs et les projets de votre OVHcloud Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
+## Objectif
 
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce guide explique comment gérer les utilisateurs et les projets de votre OVHcloud Managed Rancher Service.
 
-## Objective
+## Prérequis
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. This guide will explain how to manage users and projects on your OVHcloud Managed Rancher Service.
-
-## Requirements
-
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un Managed Rancher Service OVHcloud (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'utiliser (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
 
 ## Instructions
 
-You can manage projects, users and rights on your Managed Rancher Service by using the Rancher UI.
+Vous pouvez gérer les projets, les utilisateurs et les droits de votre Managed Rancher Service depuis l'interface Rancher.
 
-### Creating a new user
+### Créer un nouvel utilisateur
 
-Log in to your Managed Rancher Service UI.
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-<img className="thumbnail" alt="Rancher UI Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-ui.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil de l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-ui.png" loading="lazy" />
 
-In the menu, click on <code className="action">Users & Authentication</code>.
+Dans le menu, cliquez sur <code className="action">Users & Authentication</code>.
 
-<img className="thumbnail" alt="Rancher UI Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-menu.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil de l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-menu.png" loading="lazy" />
 
-A list of existing users is displayed. You should have at least a `Default Admin` user.
+La liste des utilisateurs existants s'affiche. Vous devriez disposer au moins d'un utilisateur `Default Admin`.
 
-To create a new user, click on the <code className="action">Create</code> button.
+Pour créer un nouvel utilisateur, cliquez sur le bouton <code className="action">Create</code>.
 
-<img className="thumbnail" alt="Rancher UI Users" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-user.png" loading="lazy" />
+<img className="thumbnail" alt="Utilisateurs de l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-user.png" loading="lazy" />
 
-Fill in the username, a new password and confirm the password. You can also optionally enter a display name and a description.
+Renseignez le nom d'utilisateur, un nouveau mot de passe et sa confirmation. Vous pouvez également saisir, de façon facultative, un nom d'affichage et une description.
 
-<img className="thumbnail" alt="Rancher UI SRE User" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-sre.png" loading="lazy" />
+<img className="thumbnail" alt="Utilisateur SRE dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-sre.png" loading="lazy" />
 
 :::warning
-The password needs to have at least 12 characters.
+Le mot de passe doit comporter au moins 12 caractères.
 :::
 
+Rancher propose plusieurs niveaux d'autorisations globales. Si votre utilisateur a besoin de droits pour créer et administrer de nouveaux clusters, vous pouvez choisir l'autorisation globale `Standard User`.
 
-Rancher has several levels of global permissions. If your user needs rights to create and managed new clusters, you can choose `Standard User` global permission.
+<img className="thumbnail" alt="Utilisateur standard dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-standard-user.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Standard User" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-standard-user.png" loading="lazy" />
+Veuillez consulter la documentation officielle pour en savoir plus sur les [autorisations globales](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions).
 
-Please refer to the official documentation to know more about [global permissions](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions).
+Une fois l'autorisation initiale choisie, si vous souhaitez définir des rôles intégrés plus fins, cliquez sur le bouton <code className="action">Create</code>.
 
-Once you chose the initial permission, if you want fine-grained built-in roles, click the <code className="action">Create</code> button.
+<img className="thumbnail" alt="Utilisateurs standard dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-standard-user.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Standard Users" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-standard-user.png" loading="lazy" />
+L'utilisateur est créé.
 
-The user has been created.
+### Créer un nouveau projet
 
-### Creating a new project
+Dans Rancher, un projet est un groupe de namespaces Kubernetes. Les projets vous permettent de gérer plusieurs namespaces comme un ensemble et d'y effectuer des opérations Kubernetes. Vous pouvez utiliser les projets pour mettre en place une architecture multi-tenant, afin qu'une équipe accède à un projet d'un cluster sans avoir accès aux autres projets du même cluster.
 
-A project in Rancher is a group of Kubernetes namespaces. Projects allow you to manage multiple namespaces as a group and perform Kubernetes operations in them. You can use projects to support multi-tenancy, so that a team can access a project within a cluster without having access to other projects in the same cluster.
+En termes de hiérarchie :
 
-In terms of hierarchy:
+- Les clusters contiennent des projets.
+- Les projets contiennent des namespaces.
 
-- Clusters contain projects.
-- Projects contain namespaces.
+Dans Kubernetes, des fonctionnalités telles que les droits d'accès basés sur les rôles (RBAC) ou les ressources de cluster sont attribuées à des namespaces individuels. Un projet vous permet de gagner du temps en donnant à une personne ou à une équipe l'accès à plusieurs namespaces simultanément.
 
-In Kubernetes, features like Role-Based Access Rights (RBAC) or cluster resources are assigned to individual namespaces. A project allows you to save time by giving an individual or a team access to multiple namespaces simultaneously.
+Créons un projet :
 
-Let's create a project:
+Connectez-vous à l'interface de votre Managed Rancher Service.
 
-Log in to your Managed Rancher Service UI.
+<img className="thumbnail" alt="Page d'accueil de l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-ui.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-ui.png" loading="lazy" />
+Cliquez sur le nom du cluster Kubernetes de votre choix.
 
-Click on the name of your choosen Kubernetes cluster.
+Dans le menu **Cluster**, cliquez sur <code className="action">Projects/Namespaces</code>.
 
-In the **Cluster** menu, click on <code className="action">Projects/Namespaces</code>.
+<img className="thumbnail" alt="Page d'accueil de l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-cluster.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Homepage" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-cluster.png" loading="lazy" />
+Vous constatez que notre cluster d'exemple comporte plusieurs projets existants : `Default` et `System`. Le projet Default contient le namespace par défaut et plusieurs namespaces n'appartiennent à aucun projet.
 
-You can see that our example cluster has several existing projects: `Default` and `System`. The Default project contains the default namespace and there are several namespaces that are not in a project.
+Vous allez créer un projet qui contiendra plusieurs namespaces destinés à une équipe particulière de votre entreprise.
 
-You will create a project that will contain several namespaces for a special team in your company.
+Cliquez sur le bouton <code className="action">Create Project</code>.
 
-Click the <code className="action">Create Project</code> button.
+Saisissez le nom du projet, puis cliquez sur le bouton <code className="action">Ajouter</code> pour ajouter un membre au projet `sre`.
 
-Enter the name of the project then click the <code className="action">Add</code> button to add a member to the `sre` project.
+<img className="thumbnail" alt="Projet dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-project.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Project" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-project.png" loading="lazy" />
+Sélectionnez l'utilisateur `sre` créé précédemment, puis sélectionnez les autorisations du projet. Vous pouvez choisir l'autorisation `Member` si vous souhaitez un utilisateur capable de gérer les ressources du projet, mais pas le projet lui-même.
 
-Select the user `sre` you previously created and select the project permissions. You can select the `Member` permission if you want a user that can manage the resources inside the project but not the project itself.
+<img className="thumbnail" alt="Projet SRE dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-sre-user.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Project SRE" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-sre-user.png" loading="lazy" />
+Cliquez ensuite sur le bouton <code className="action">Ajouter</code> pour ajouter le membre au projet.
 
-Then click the <code className="action">Add</code> button to add the member to the project.
+Cliquez enfin sur le bouton <code className="action">Créer</code> pour créer le projet.
 
-Finally, click the <code className="action">Create</code> button to create the project.
+Pour déplacer les namespaces existants souhaités dans votre projet `sre`, cliquez sur le bouton représenté par trois points, puis cliquez sur <code className="action">Déplacer</code>.
 
-To move the existing wanted namespaces in your `sre` project, click on the three dots button and click on <code className="action">Move</code>.
+<img className="thumbnail" alt="Projet SRE dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-falco.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Project SRE" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-falco.png" loading="lazy" />
+Sélectionnez le projet, puis cliquez sur le bouton <code className="action">Déplacer</code> pour déplacer le namespace `falco` dans votre projet.
 
-Select the project then click the <code className="action">Move</code> button to move the `falco` namepace in your project.
+Vous pouvez procéder de la même manière pour tous les namespaces souhaités.
 
-You can do the same thing for all of the namespaces you want.
+<img className="thumbnail" alt="Projet SRE dans l'interface Rancher" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-project-ns.png" loading="lazy" />
 
-<img className="thumbnail" alt="Rancher UI Project SRE project" src="/images/public-cloud/containers-orchestration/managed-rancher-service/managing-users-and-projects/rancher-project-ns.png" loading="lazy" />
+### Aller plus loin
 
-### Go further
+Pour obtenir une vue d'ensemble d'OVHcloud Managed Rancher Service, consultez la [page OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+Consultez la documentation officielle de Rancher pour en savoir plus sur :
 
-Follow the offical documentation from Rancher to know more about:
+- [Les projets](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces)
+- [L'ajout d'utilisateurs aux projets](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/add-users-to-projects)
+- [Les autorisations globales des utilisateurs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions)
 
-- [Projects](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/projects-and-namespaces)
-- [Adding users to projects](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/add-users-to-projects)
-- [Users global permissions](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions)
+Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
-
-Join our [community of users](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli.mdx
@@ -1,75 +1,73 @@
 ---
-title: How to use Rancher CLI
-description: Find out how to use the Rancher CLI to handle a Managed Rancher Service
+title: Utiliser la Rancher CLI
+description: Découvrez comment utiliser la Rancher CLI pour administrer un Managed Rancher Service
 lastUpdated: 2024-09-11
 ---
 
-## Objective
+## Objectif
 
-Managed Rancher Service by OVHcloud provides a powerful platform for orchestrating Kubernetes clusters seamlessly. In this tutorial we will discover that in addition to the Rancher UI you can handle your Kubernetes clusters through the Rancher CLI.
+Managed Rancher Service par OVHcloud vous permet d'orchestrer vos clusters Kubernetes. Ce tutoriel présente la Rancher CLI, qui vous permet d'administrer vos clusters Kubernetes en complément de l'interface Rancher.
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- An OVHcloud Managed Rancher Service (see the [creating a Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
-- An access to the Rancher UI to operate it (see the [connecting to the Rancher UI](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) guide for more information)
+- Un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project) dans votre compte OVHcloud
+- Un OVHcloud Managed Rancher Service (consultez le guide [Créer un Managed Rancher Service](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
+- Un accès à l'interface Rancher pour l'administrer (consultez le guide [Se connecter à l'interface Rancher](/guides/public-cloud/containers-orchestration/managed-rancher-service/creation) pour plus d'informations)
 
 ## Instructions
 
 ### Rancher CLI
 
-The [Rancher CLI (Command Line Interface)](https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher/rancher-cli) is a unified tool that you can use to interact with an OVHcloud Managed Rancher Service (MRS). With this tool, you can operate MRS using a command line rather than the UI.
+La [Rancher CLI (Command Line Interface)](https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher/rancher-cli) est un outil unifié qui vous permet d'interagir avec un OVHcloud Managed Rancher Service (MRS). Grâce à cet outil, vous administrez votre MRS en ligne de commande plutôt que via l'interface graphique.
 
-### Downoad and install Rancher CLI
+### Télécharger et installer la Rancher CLI
 
-To download the Rancher CLI, log in your Managed Rancher Service UI and click on the <code className="action">About</code> link at the bottom of the navigation sidebar menu:
+Pour télécharger la Rancher CLI, connectez-vous à l'interface de votre Managed Rancher Service et cliquez sur le lien <code className="action">About</code> en bas du menu latéral de navigation :
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-about-link.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-about-link.png" loading="lazy" />
 
-Under the **CLI Downloads** section, click to download the binaries for your OS (macOS, Linux or Windows), untar the package and copy the `rancher` binary in your PATH.
+Dans la section **CLI Downloads**, cliquez pour télécharger les binaires correspondant à votre système d'exploitation (macOS, Linux ou Windows), décompressez l'archive et copiez le binaire `rancher` dans votre PATH.
 
 :::info
-You can download the binaries directly in the [Rancher CLI GitHub repository](https://github.com/rancher/cli).
+Vous pouvez télécharger les binaires directement depuis le [dépôt GitHub de la Rancher CLI](https://github.com/rancher/cli).
 :::
 
+### Générer une clé d'API pour utiliser la Rancher CLI
 
-### Generate an API Key to use the Rancher CLI
+Pour utiliser la Rancher CLI et vous connecter à votre OVHcloud MRS, vous devez créer une clé d'API.
 
-To use the Rancher CLI and login to our OVHcloud MRS, you need to create an API Key.
+En haut à droite, cliquez sur votre avatar, puis sur le menu <code className="action">Account & API Keys</code>.
 
-On the top right, click on your avatar and then on the <code className="action">Account & API Keys</code> button menu. 
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-avatar-menu.png" loading="lazy" />
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-avatar-menu.png" loading="lazy" />
+La page Account and API Keys s'affiche.
 
-The Account and API Keys page is displayed. 
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-account.png" loading="lazy" />
 
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-account.png" loading="lazy" />
+Cliquez sur le bouton <code className="action">Create API Key</code> pour créer une clé d'API.
 
-Click on the <code className="action">Create API Key</code> button to create an API key.
+Renseignez une description permettant d'identifier votre clé d'API (`CLI` par exemple), conservez la valeur `No Scope` définie par défaut pour le scope et définissez la date d'expiration.
 
-Define a description that will identify your API Key (`CLI` for example), keep the scope value to `No Scope` by default and define the expiration date.
-
-<img className="thumbnail" alt="OVHcloud Managed Rancher Service UI" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-apikey-creation.png" loading="lazy" />
+<img className="thumbnail" alt="Interface OVHcloud Managed Rancher Service" src="/images/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli/rancher-apikey-creation.png" loading="lazy" />
 
 :::warning
-You can change the scope to allow the Rancher CLI to access only one of your Kubernetes clusters if you wish.
+Si vous le souhaitez, vous pouvez modifier le scope afin de n'autoriser la Rancher CLI à accéder qu'à un seul de vos clusters Kubernetes.
 :::
 
+Cliquez ensuite sur le bouton <code className="action">Create</code>.
 
-Then click on the <code className="action">Create</code> button.
+Une nouvelle clé d'API est créée.
+Copiez-collez l'`Access Key`, la `Secret Key` et le `Bearer Token` dans un gestionnaire de mots de passe.
 
-A new API Key has been created. 
-Copy and paste in a password manager the `Access Key`, the `Secret Key` and the `Bearer Token`.
+### Utiliser la Rancher CLI
 
-### Using the Rancher CLI
-
-Login with the CLI to your MRS:
+Connectez-vous à votre MRS avec la CLI :
 
 ```bash
 rancher login <MRS_URL> --token <BEARER_TOKEN>
 ```
 
-You should have the following result:
+Vous devriez obtenir le résultat suivant :
 
 ```bash
 rancher login https://xxxxxx.xxxx.rancher.ovh.net --token token-phbts:qhsdfuqsdfuhdsqfdqshfdsqhkfhsqdkjfhkqsj
@@ -83,7 +81,7 @@ Select a Project:1
 INFO[0044] Saving config to /Users/avache/.rancher/cli2.json
 ```
 
-Now you are authenticated in your MRS, you can display the list of Kubernetes clusters:
+Vous êtes maintenant authentifié sur votre MRS et pouvez afficher la liste de vos clusters Kubernetes :
 
 ```bash
 rancher clusters
@@ -93,9 +91,9 @@ CURRENT   ID             STATE     NAME                     PROVIDER   NODES    
           c-m-2brxmwcz   active    my-kube                  Imported   3         2.11/5.52   1.44/15.09 GB   31/330
 ```
 
-As you can see, in our example, we have one MKS cluster and one existing cluster we imported before.
+Dans notre exemple, nous disposons d'un cluster MKS et d'un cluster existant importé précédemment.
 
-Select one of the Kubernetes clusters:
+Sélectionnez l'un des clusters Kubernetes :
 
 ```bash
 rancher context switch
@@ -110,9 +108,9 @@ INFO[0004] Setting new context to project Default
 INFO[0004] Saving config to /Users/avache/.rancher/cli2.json
 ```
 
-By choosing 3, you switched in the `my-kube` cluster.
+En choisissant 3, vous avez basculé sur le cluster `my-kube`.
 
-List the pods in the `my_kube` cluster directly through the Rancher CLI:
+Listez les pods du cluster `my_kube` directement depuis la Rancher CLI :
 
 ```bash
 rancher kubectl get pod -A
@@ -151,14 +149,14 @@ trivy-system          trivy-operator-84b86599cb-tzmg4                1/1     Run
 velero                velero-55f979c9c-hmb7v                         1/1     Running   0               43d
 ```
 
-## Go further
+## Aller plus loin
 
-- If you want to know more about the Rancher CLI and all its commands, read the [Rancher CLI](https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher/rancher-cli) documentation.
+- Pour en savoir plus sur la Rancher CLI et l'ensemble de ses commandes, consultez la documentation [Rancher CLI](https://ranchermanager.docs.rancher.com/reference-guides/cli-with-rancher/rancher-cli).
 
-- To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
+- Pour obtenir une vue d'ensemble d'OVHcloud Managed Rancher Service, consultez la [page OVHcloud Managed Rancher Service](https://www.ovhcloud.com/fr/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-- Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
+- Notre équipe reste disponible sur notre chaîne Discord dédiée, n'hésitez pas à nous y rejoindre : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez vos questions, faites-nous part de vos commentaires et interagissez directement avec l'équipe qui développe nos services Container et Orchestration.
 
-- Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/data-platform/general-signin-signup.mdx
+++ b/docs/fr/guides/public-cloud/data-platform/general-signin-signup.mdx
@@ -1,98 +1,98 @@
 ---
-title: Sign-up to OVHcloud Data Platform
-description: Find out how to sign up and sign in to OVHcloud Data Platform
+title: S'inscrire à OVHcloud Data Platform
+description: Découvrez comment vous inscrire et vous connecter à OVHcloud Data Platform
 lastUpdated: 2025-04-03
 ---
 
-## Objective
+## Objectif
 
-You can sign up if you are new to Data Platform or sign in if you have an existing Data Platform organization.
+Vous pouvez vous inscrire si vous découvrez Data Platform, ou vous connecter si vous disposez déjà d'une organisation Data Platform.
 
-## Sign-up
+## Inscription
 
 :::info
-If you have received an invitation to join an existing Data Platform Organization from an admin, you can alternatively sign up with your email.
+Si vous avez reçu d'un administrateur une invitation à rejoindre une organisation Data Platform existante, vous pouvez également vous inscrire avec votre adresse e-mail.
 
 :::
 
 
-To access OVHcloud Data Platform for the first time, you need an [OVHcloud account](/guides/account-and-service-management/account-information/ovhcloud-account-creation) and a [Public Cloud project](/guides/public-cloud/cross-functional/create-a-public-cloud-project).
+Pour accéder à OVHcloud Data Platform pour la première fois, vous avez besoin d'un [compte OVHcloud](/guides/account-and-service-management/account-information/ovhcloud-account-creation) et d'un [projet Public Cloud](/guides/public-cloud/cross-functional/create-a-public-cloud-project).
 
-You have different options: sign up from the website or from the OVHcloud Control Panel.
+Vous avez plusieurs possibilités : vous inscrire depuis le site web ou depuis l'espace client OVHcloud.
 
-### Option 1: Sign-up from the OVHcloud Website Data Platform Product Page
+### Option 1 : inscription depuis la page produit Data Platform du site web OVHcloud
 
-1. Go to the [Data Platform website](https://www.ovhcloud.com/fr/public-cloud/data-platform/).
+1. Rendez-vous sur le [site web Data Platform](https://www.ovhcloud.com/fr/public-cloud/data-platform/).
 
-    <img className="thumbnail" alt="Data Platform website" src="/images/public-cloud/data-platform/general-signin-signup/signup-1.png" loading="lazy" />
+    <img className="thumbnail" alt="Site web Data Platform" src="/images/public-cloud/data-platform/general-signin-signup/signup-1.png" loading="lazy" />
 
-2. Click the <code className="action">Get started for free</code> button.
-3. If you are not logged in, you will be redirected to the OVHcloud account-creation/login-page.
+2. Cliquez sur le bouton <code className="action">Commencer gratuitement</code>.
+3. Si vous n'êtes pas connecté, vous serez redirigé vers la page de création de compte ou de connexion OVHcloud.
 
-    <img className="thumbnail" alt="Login page" src="/images/public-cloud/data-platform/general-signin-signup/signup-2.png" loading="lazy" />
+    <img className="thumbnail" alt="Page de connexion" src="/images/public-cloud/data-platform/general-signin-signup/signup-2.png" loading="lazy" />
 
-#### If you do not have any active Public Cloud project:
+#### Si vous n'avez aucun projet Public Cloud actif :
 
-1. Accept the Public Cloud service Terms and Conditions.
+1. Acceptez les conditions générales du service Public Cloud.
 
-    <img className="thumbnail" alt="Public Cloud terms and conditions" src="/images/public-cloud/data-platform/general-signin-signup/signup-3.png" loading="lazy" />
+    <img className="thumbnail" alt="Conditions générales Public Cloud" src="/images/public-cloud/data-platform/general-signin-signup/signup-3.png" loading="lazy" />
 
-2. Wait for your project to be created.
+2. Attendez la création de votre projet.
 
-    <img className="thumbnail" alt="Wait" src="/images/public-cloud/data-platform/general-signin-signup/signup-4.png" loading="lazy" />
+    <img className="thumbnail" alt="Attente" src="/images/public-cloud/data-platform/general-signin-signup/signup-4.png" loading="lazy" />
 
-3. You will then be asked to add a payment method - **You will benefit from a €200 credit to try the service for free during 30 days**
+3. Vous serez ensuite invité à ajouter un moyen de paiement - **Vous bénéficierez d'un crédit de 200 € pour essayer le service gratuitement pendant 30 jours**
 
-    <img className="thumbnail" alt="Payment method" src="/images/public-cloud/data-platform/general-signin-signup/signup-5.png" loading="lazy" />
+    <img className="thumbnail" alt="Moyen de paiement" src="/images/public-cloud/data-platform/general-signin-signup/signup-5.png" loading="lazy" />
 
-4. You are then invited to your Data Platform organization.
+4. Vous êtes ensuite invité à rejoindre votre organisation Data Platform.
 
-    <img className="thumbnail" alt="Data Platform landing page" src="/images/public-cloud/data-platform/general-signin-signup/signup-6.png" loading="lazy" />
+    <img className="thumbnail" alt="Page d'accueil Data Platform" src="/images/public-cloud/data-platform/general-signin-signup/signup-6.png" loading="lazy" />
 
 
-#### If you have at least one active Public Cloud project:
+#### Si vous avez au moins un projet Public Cloud actif :
 
-1. Select your Public Cloud project or create a new one.
+1. Sélectionnez votre projet Public Cloud ou créez-en un nouveau.
 
-    <img className="thumbnail" alt="Pic Public Cloud project" src="/images/public-cloud/data-platform/general-signin-signup/signup-7.png" loading="lazy" />
+    <img className="thumbnail" alt="Sélection du projet Public Cloud" src="/images/public-cloud/data-platform/general-signin-signup/signup-7.png" loading="lazy" />
 
-2. You are then invited to your Data Platform organization
+2. Vous êtes ensuite invité à rejoindre votre organisation Data Platform
 
-    <img className="thumbnail" alt="Data Platform landing page" src="/images/public-cloud/data-platform/general-signin-signup/signup-6.png" loading="lazy" />
+    <img className="thumbnail" alt="Page d'accueil Data Platform" src="/images/public-cloud/data-platform/general-signin-signup/signup-6.png" loading="lazy" />
 
 :::info
-Each Public Cloud project can only have one organization linked to it. Based on your project name, an organization will be automatically created for you when the Data Platform is launched.
+Chaque projet Public Cloud ne peut être lié qu'à une seule organisation. En fonction du nom de votre projet, une organisation sera automatiquement créée pour vous au lancement de la Data Platform.
 
 :::
 
 
-### Option 2: Sign-up from the OVHcloud Control Panel
+### Option 2 : inscription depuis l'espace client OVHcloud
 
-If you have an existing OVHcloud account and an active Public Cloud project, you can launch the Data Platform service from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
+Si vous disposez déjà d'un compte OVHcloud et d'un projet Public Cloud actif, vous pouvez lancer le service Data Platform depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
 
-You can access it via two links:
+Vous pouvez y accéder via deux liens :
 
-- From the left-side menu in the `Databases & Analytics section.
-- Directly via the <code className="action">Create a Data Platform</code> card on the right side.
+- Depuis le menu de gauche, dans la section `Databases & Analytics`.
+- Directement via la carte <code className="action">Créer une Data Platform</code> située sur la droite.
 
-<img className="thumbnail" alt="Public Cloud project landing page" src="/images/public-cloud/data-platform/general-signin-signup/signup-8.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil du projet Public Cloud" src="/images/public-cloud/data-platform/general-signin-signup/signup-8.png" loading="lazy" />
 
-## Sign-in
+## Connexion
 
-Click [here](https://eu.dataplatform.ovh.net/) to access the Data Platform sign-in page.
+Cliquez [ici](https://eu.dataplatform.ovh.net/) pour accéder à la page de connexion de la Data Platform.
 
-Click on <code className="action">SIGN-IN WITH MY OVH ACCOUNT</code>.
+Cliquez sur <code className="action">SIGN-IN WITH MY OVH ACCOUNT</code>.
 
-<img className="thumbnail" alt="Data Platform sign-in" src="/images/public-cloud/data-platform/general-signin-signup/signup-9.png" loading="lazy" />
+<img className="thumbnail" alt="Connexion à la Data Platform" src="/images/public-cloud/data-platform/general-signin-signup/signup-9.png" loading="lazy" />
 
 :::info
-Signing-in with email and password is only available for people who have been previously invited by their admin to an existing organization.
+La connexion par e-mail et mot de passe est uniquement disponible pour les personnes ayant préalablement été invitées par leur administrateur à rejoindre une organisation existante.
 
 :::
 
 
-##  Need help?
+## Besoin d'aide ?
 
-At any step, you can create a ticket to raise an incident or if you need support at the [OVHcloud Help Centre](https://help.ovhcloud.com/csm?id=csm_get_help).
+À chaque étape, vous pouvez créer un ticket pour signaler un incident ou si vous avez besoin d'assistance sur le [centre d'aide OVHcloud](https://help.ovhcloud.com/csm?id=csm_get_help).
 
-Additionally, you can ask for support by reaching out to us on the Data Platform Channel within the [Discord Server](https://discord.gg/ovhcloud).
+Vous pouvez également demander de l'aide en nous contactant sur le canal Data Platform de notre [serveur Discord](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/data-platform/general-what-is-the-data-platform.mdx
+++ b/docs/fr/guides/public-cloud/data-platform/general-what-is-the-data-platform.mdx
@@ -1,1 +1,74 @@
-../../../../en/guides/public-cloud/data-platform/general-what-is-the-data-platform.mdx
+---
+title: Documentation Data Platform
+description: Découvrez OVHcloud Data Platform
+lastUpdated: 2025-03-31
+---
+
+
+
+## Bienvenue sur le portail de documentation Data Platform !
+
+En parcourant cette documentation, vous découvrirez ce que **la Data Platform** peut vous apporter, comment maîtriser ses fonctionnalités et comment exploiter tout son potentiel pour **créer l'application Data** de votre choix.
+
+### Qu'est-ce que la Data Platform ?
+
+En résumé, la Data Platform est la première et la seule **plateforme cloud-native de bout en bout conçue pour vous aider à créer, déployer et faire évoluer toute application analytique ou Data** dont votre organisation a besoin.
+
+Il faut bien l'admettre : créer une application à forte intensité de données est une tâche très complexe et intimidante.
+La Data Platform **masque toutes les complexités techniques générées par votre projet et les gère automatiquement à votre place**, ce qui vous permet de vous concentrer sur vos besoins métier et sur la valeur créée. Elle accélère par 10 le délai de livraison de votre projet par rapport à d'autres outils et plateformes.
+
+La Data Platform est **entièrement cloud-native** dans son approche de la création, du déploiement et de la gestion d'applications modernes dans des environnements de cloud computing. Elle permet aux équipes logicielles modernes de concevoir des applications analytiques et Data hautement évolutives, flexibles et résilientes, sur lesquelles elles peuvent itérer rapidement.
+En utilisant la Data Platform, vous pouvez vous consacrer à la création de produits logiciels au lieu de vous préoccuper de l'infrastructure sous-jacente. Votre projet vivra et se développera sur n'importe quel cloud public dès le départ. Elle vous offre également la possibilité de déployer votre projet on-premise, sur vos propres serveurs, ce qui vous laisse une liberté totale dans la façon de définir votre architecture cloud et de gérer vos opérations de données.
+
+### Philosophie de conception de la plateforme
+
+La Data Platform permet aux organisations (entreprises entières, unités opérationnelles, services ou particuliers) de créer et de déployer des applications Data cloud-native robustes et évolutives, tout en tirant parti des dernières technologies, architectures et solutions logicielles du cloud.
+
+Lorsque nous avons entrepris de créer la Data Platform, nous avons suivi une philosophie de conception simple : **proposer une solution élégante permettant aux utilisateurs de relever n'importe quel défi lié aux données et d'accélérer le cycle de développement des applications**. Suivant cette inspiration, nous avons conçu une plateforme qui masque les complexités techniques et supprime la nécessité de prendre des décisions technologiques incertaines ou de se contorsionner pour les faire fonctionner, grâce à 4 niveaux d'automatisation simples :
+
+<img className="thumbnail" alt="Philosophie de conception de la plateforme" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/philosophy.png" loading="lazy" />
+
+Lorsqu'elles utilisent la Data Platform, les organisations créent leurs propres environnements personnels, appelés Projects. Les Projects hébergent l'ensemble de vos traitements de données, modèles, algorithmes et applications web. Les données physiques, quant à elles, sont stockées dans un moteur de stockage.
+
+:::info
+L'accès aux Projects est généralement partagé de manière collaborative, selon les **niveaux d'accès utilisateur** définis par votre organisation. Par exemple, un premier groupe d'utilisateurs peut travailler sur l'accès aux données et leur transformation, un deuxième sur les modèles d'IA et un troisième sur l'interface de l'application web.
+:::
+
+
+Un Project contient **tous les composants dont vous avez besoin pour gérer le cycle de vie de vos données**, les traitements et les règles, ainsi que les droits d'accès des utilisateurs, afin de faire de vos Projects de données une réussite. Tous ces composants figurent dans l'illustration ci-dessous. Vous pouvez cliquer sur un composant pour en savoir plus, ou simplement suivre le déroulé logique du guide, qui vous aidera à utiliser la Data Platform de la manière la plus utile.
+
+### Bien vous repérer dans cette documentation
+
+Nous sommes ravis de vous compter parmi nous ! Cette documentation comporte quatre sections que vous pouvez parcourir pour découvrir la Data Platform, des notions les plus élémentaires aux plus avancées. La Data Platform s'adresse à tous, des profils non techniques aux développeurs.
+
+<a href="https://docs.dataplatform.ovh.net/#/en/getting-started/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict1.png" alt="Premiers pas" style={{width:"175px", margin:"0 10px 0 0"}} />
+   <div>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>PREMIERS PAS</h3>
+      <p>Vous souhaitez être opérationnel le plus rapidement possible ? Aucun problème, nous avons ce qu'il vous faut ! Découvrez cet excellent tutoriel de prise en main, qui vous aidera à construire un Project à l'aide de jeux de données d'exemple.</p>
+   </div>
+</a>
+
+<a href="https://docs.dataplatform.ovh.net/#/en/getting-further/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict2.png" alt="Tutoriels" style={{width:"175px", margin:"0 10px 0 0"}} />
+   <div>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>TUTORIELS</h3>
+      <p>Vous ne vous lassez pas des guides de prise en main et souhaitez des tutoriels pratiques pour des cas d'usage plus avancés ? Consultez notre série de guides Getting Further !</p>
+   </div>
+</a>
+
+<a href="https://docs.dataplatform.ovh.net/#/en/product/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict3.png" alt="Documentation de la plateforme" style={{width:"175px", margin:"0 10px 0 0"}} />
+   <div>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>DOCUMENTATION DE LA PLATEFORME</h3>
+      <p>Vous débutez avec la plateforme ? Vous ne savez pas encore comment s'appelle chaque élément ni comment fonctionne chaque fonctionnalité ? Cette section est faite pour vous.</p>
+   </div>
+</a>
+
+<a href="https://docs.dataplatform.ovh.net/#/en/technical/index" target="_blank" rel="noopener noreferrer" style={{display:"flex", alignItems:"center", textDecoration:"none", color:"var(--rp-c-text-1)", backgroundColor:"var(--rp-c-bg-soft)", borderRadius:"8px", boxShadow:"0 3px 13px 0 rgba(151, 167, 183, 0.3)", margin:"10px 4px 25px", padding:"0 20px 0 0"}}>
+   <img className="no-zoom" src="/images/public-cloud/data-platform/general-what-is-the-data-platform/pict4.png" alt="Documentation développeur" style={{width:"175px", margin:"0 10px 0 0"}} />
+   <div>
+      <h3 style={{color:"#2199e8", paddingTop:"5px"}}>DOCUMENTATION DÉVELOPPEUR</h3>
+      <p>Vous êtes un utilisateur avancé et vous explorez les rouages de la plateforme ? Consultez la référence d'API et les fonctions du SDK de nos composants.</p>
+   </div>
+</a>

--- a/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
+++ b/docs/fr/guides/public-cloud/network-services/update-subnet-properties.mdx
@@ -1,69 +1,69 @@
 ---
-title: "Mettre à jour les propriétés d'un sous-réseau (EN)"
+title: "Mettre à jour les propriétés d'un sous-réseau"
 description: "Découvrez comment mettre à jour les propriétés d'un sous-réseau existant"
 lastUpdated: 2024-01-22
 ---
 
-## Objective
+## Objectif
 
-This page explains how to update the properties of an existing subnet. This can be needed if you want to comply with the prerequisites to be able to use the Public Cloud Gateway : have a gateway IP defined in your subnet.
+Cette page explique comment mettre à jour les propriétés d'un sous-réseau existant. Cela peut être nécessaire si vous souhaitez respecter les prérequis permettant d'utiliser la Public Cloud Gateway : disposer d'une IP de passerelle définie dans votre sous-réseau.
 
-For this example, we will use a private network and a subnet with the following properties:
+Pour cet exemple, nous utiliserons un réseau privé et un sous-réseau ayant les propriétés suivantes :
 
 - CIDR 10.1.0.0/16
-- DHCP enabled with allocation pool on the global range
-- No gateway IP 
+- DHCP activé avec un pool d'allocation sur la plage globale
+- Aucune IP de passerelle
 
-We will see how to update it to have a gateway IP set to `10.1.0.1` and remove that IP from the allocation pool. 
+Nous verrons comment le mettre à jour pour définir une IP de passerelle sur `10.1.0.1` et retirer cette IP du pool d'allocation.
 
-## Requirements
+## Prérequis
 
-You must have created a private network and a subnet as explained in [this guide](/guides/public-cloud/network-services/vrack).
+Vous devez avoir créé un réseau privé et un sous-réseau comme expliqué dans [ce guide](/guides/public-cloud/network-services/vrack).
 
-## Instructions
+## En pratique
 
-### Using the OVHcloud Control Panel
+### Depuis l'espace client OVHcloud
 
-It is currently not possible to update a subnet through this interface but you can use our Horizon interface instead (see the instructions below).
+Il n'est actuellement pas possible de mettre à jour un sous-réseau depuis cette interface, mais vous pouvez utiliser notre interface Horizon à la place (voir les instructions ci-dessous).
 
-### Using Horizon
+### Depuis Horizon
 
-Connect to Horizon & choose the region where the subnet is defined as explained in this [guide](/guides/public-cloud/cross-functional/introducing-horizon).
+Connectez-vous à Horizon et choisissez la région où le sous-réseau est défini, comme expliqué dans ce [guide](/guides/public-cloud/cross-functional/introducing-horizon).
 
-Click on `Project > Network > Networks`. The page will display the list of networks available which contain an OVHcloud managed network for public connectivity (`Ext-Net`) as well as your network.
+Cliquez sur `Project > Network > Networks`. La page affiche la liste des réseaux disponibles, qui contient un réseau géré par OVHcloud pour la connectivité publique (`Ext-Net`) ainsi que votre réseau.
 
-<img className="thumbnail" alt="network list" src="/images/public-cloud/network-services/configuration-04-update-subnet/network_list.png" loading="lazy" />
+<img className="thumbnail" alt="liste des réseaux" src="/images/public-cloud/network-services/configuration-04-update-subnet/network_list.png" loading="lazy" />
 
-In that list, click on your network name ("private_network_GRA11" in this example). The network detail page is then displayed.
+Dans cette liste, cliquez sur le nom de votre réseau (« private_network_GRA11 » dans cet exemple). La page de détail du réseau s'affiche alors.
 
-<img className="thumbnail" alt="network details" src="/images/public-cloud/network-services/configuration-04-update-subnet/network_details.png" loading="lazy" />
+<img className="thumbnail" alt="détails du réseau" src="/images/public-cloud/network-services/configuration-04-update-subnet/network_details.png" loading="lazy" />
 
-Click the `Subnets` tab: the subnets from the private network are listed.
+Cliquez sur l'onglet `Subnets` : les sous-réseaux du réseau privé sont listés.
 
-<img className="thumbnail" alt="subnets list" src="/images/public-cloud/network-services/configuration-04-update-subnet/subnets_list.png" loading="lazy" />
+<img className="thumbnail" alt="liste des sous-réseaux" src="/images/public-cloud/network-services/configuration-04-update-subnet/subnets_list.png" loading="lazy" />
 
-Click on your `Edit Subnet`. For this guide, our target is to add a gateway IP:
+Cliquez sur `Edit Subnet`. Pour ce guide, notre objectif est d'ajouter une IP de passerelle :
 
-- Untick the `Disable Gateway`. The field `Gateway IP` will appear. Fill it in with an IP within your CIDR (usually the first IP of the range is used). In our case, `10.1.0.1`.
+- Décochez la case `Disable Gateway`. Le champ `Gateway IP` apparaît. Renseignez-le avec une IP appartenant à votre CIDR (généralement la première IP de la plage). Dans notre cas, `10.1.0.1`.
 
-<img className="thumbnail" alt="gateway IP" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
+<img className="thumbnail" alt="IP de passerelle" src="/images/public-cloud/network-services/configuration-04-update-subnet/add_gateway_ip.png" loading="lazy" />
 
-- Click on `Subnet Details`. Update the `Allocation Pools` to remove the gateway IP that you entered in the previous step. In our case, we need to update from `10.1.0.1,10.1.255.254` to `10.1.0.2,10.1.255.254`
+- Cliquez sur `Subnet Details`. Mettez à jour les `Allocation Pools` afin de retirer l'IP de passerelle saisie à l'étape précédente. Dans notre cas, nous devons passer de `10.1.0.1,10.1.255.254` à `10.1.0.2,10.1.255.254`
 
-<img className="thumbnail" alt="subnet details" src="/images/public-cloud/network-services/configuration-04-update-subnet/subnet_details.png" loading="lazy" />
+<img className="thumbnail" alt="détails du sous-réseau" src="/images/public-cloud/network-services/configuration-04-update-subnet/subnet_details.png" loading="lazy" />
 
-Click on `Save` and your subnet is updated with a gateway IP !
+Cliquez sur `Save` : votre sous-réseau est mis à jour avec une IP de passerelle !
 
-### Using the OpenStack Command Line Interface
+### Depuis l'interface de ligne de commande OpenStack
 
-You need to have your [CLI environment set up](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) and your [variables defined](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
+Vous devez avoir [configuré votre environnement CLI](/guides/public-cloud/cross-functional/compute-prepare-openstack-api-environment) et [défini vos variables](/guides/public-cloud/cross-functional/compute-set-openstack-environment-variables).
 
-Run the following command (replace `private_network_GRA11` by the name of your private network):
+Exécutez la commande suivante (remplacez `private_network_GRA11` par le nom de votre réseau privé) :
 
 ```bash 
 ❯ openstack  network show private_network_GRA11
 +---------------------------+--------------------------------------+
-| Field                     | Value                                |
+| Champ                     | Valeur                               |
 +---------------------------+--------------------------------------+
 | admin_state_up            | UP                                   |
 | availability_zone_hints   |                                      |
@@ -97,13 +97,13 @@ Run the following command (replace `private_network_GRA11` by the name of your p
 +---------------------------+--------------------------------------+
 ```
 
-In this output, the `subnets` line provides the UID of your subnet. 
-You can check your subnet detail by running the following command (update the UID according to your value !):
+Dans cette sortie, la ligne `subnets` indique l'UID de votre sous-réseau.
+Vous pouvez vérifier le détail de votre sous-réseau en exécutant la commande suivante (adaptez l'UID à votre valeur !) :
 
 ```bash
 ❯ openstack subnet show 15a17e0e-6767-42ea-a345-3f65ee73b47c
 +----------------------+--------------------------------------+
-| Field                | Value                                |
+| Champ                | Valeur                               |
 +----------------------+--------------------------------------+
 | allocation_pools     | 10.1.0.1-10.1.255.254                |
 | cidr                 | 10.1.0.0/16                          |
@@ -130,18 +130,18 @@ You can check your subnet detail by running the following command (update the UI
 +----------------------+--------------------------------------+
 ```
 
-Now let's update the `gateway_ip` and the `allocation_pool`:
+Mettons à présent à jour le `gateway_ip` et l'`allocation_pool` :
 
 ```bash
 ❯ openstack subnet set  --gateway 10.1.0.1 --no-allocation-pool --allocation-pool start=10.1.0.2,end=10.1.255.254  15a17e0e-6767-42ea-a345-3f65ee73b47c
 ```
 
-You can check that the subnet has been updated:
+Vous pouvez vérifier que le sous-réseau a bien été mis à jour :
 
 ```bash
 ❯ openstack subnet show 15a17e0e-6767-42ea-a345-3f65ee73b47c
 +----------------------+--------------------------------------+
-| Field                | Value                                |
+| Champ                | Valeur                               |
 +----------------------+--------------------------------------+
 | allocation_pools     | 10.1.0.2-10.1.255.254                |
 | cidr                 | 10.1.0.0/16                          |
@@ -168,8 +168,8 @@ You can check that the subnet has been updated:
 +----------------------+--------------------------------------+
 ```
 
-## Go further
+## Aller plus loin
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/public-cloud/quantum-computing/billing.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/billing.mdx
@@ -1,1 +1,177 @@
-../../../../en/guides/public-cloud/quantum-computing/billing.mdx
+---
+title: Quantum - Facturation et cycle de vie
+description: Découvrez comment sont facturés les Quantum Notebooks
+lastUpdated: 2025-11-06
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+
+:::warning
+
+Certains liens de cette documentation renvoient vers la solution AI and Machine Learning. L'informatique quantique repose sur la même infrastructure as a service : vous pouvez donc être redirigé vers une autre section de cette documentation.
+
+:::
+
+
+## Objectif
+
+Les **Quantum Notebooks d'OVHcloud** sont des notebooks Jupyter et VS Code managés, dotés de ressources CPU ou GPU dédiées, qui vous évitent toute installation et toute maintenance. Cette documentation détaille le **cycle de vie et la facturation** des notebooks.
+
+## Introduction
+
+Les Quantum Notebooks sont rattachés à un projet Public Cloud. L'ensemble du projet est facturé à la fin du mois, selon le principe du **paiement à l'usage**. Cela signifie que vous ne payez que ce que vous consommez, en fonction des ressources de calcul utilisées (CPU et GPU), de leur durée d'exécution et de vos données.
+
+## Cycle de vie des Quantum Notebooks
+
+Au cours de son existence, le notebook passe par les statuts suivants :
+
+- `STARTING` : le notebook est en cours de démarrage et, le cas échéant, les données distantes sont synchronisées depuis l'Object Storage. Pour en savoir plus sur la synchronisation des données, consultez la documentation [Données - Concept et bonnes pratiques](/guides/public-cloud/ai-machine-learning/ai-data). Le système alloue ensuite les ressources de calcul nécessaires (CPU/GPU) à votre notebook. Enfin, le framework de base que vous avez choisi est téléchargé afin d'être utilisé dans le notebook.
+- `RUNNING` : le notebook est en cours d'exécution. Vous pouvez vous y connecter via son endpoint et profiter de vos ressources de calcul et des données qui y sont attachées.
+- `STOPPING` : le notebook est en cours d'arrêt, vos ressources de calcul sont libérées, votre travail et votre état sont sauvegardés et, le cas échéant, les données sont resynchronisées vers l'Object Storage.
+- `STOPPED` : le notebook s'est terminé normalement. Vous pouvez le redémarrer quand vous le souhaitez ou le supprimer. Il conservera le même endpoint.
+- `FAILED` : le notebook s'est terminé en erreur, par exemple parce que le processus exécuté dans le notebook s'est achevé avec un code de sortie différent de 0. Pour plus d'informations, reportez-vous à la section « CLI : mon notebook est en statut "failed" » de notre [documentation de résolution des problèmes](/guides/public-cloud/quantum-computing/troubleshooting).
+- `ERROR` : le notebook s'est terminé en raison d'une erreur du backend. Vous pouvez contacter notre [support](https://help.ovhcloud.com/csm?id=csm_get_help).
+- `DELETING` : le notebook est en cours de suppression. Une fois supprimé, il ne sera plus visible et n'existera plus.
+
+<img className="thumbnail" alt="cycle de vie" src="/images/public-cloud/quantum-computing/billing/lifecycle.png" loading="lazy" />
+
+## Principes de facturation
+
+Les Quantum Notebooks constituent une **solution facturée à l'usage**. Vous ne payez que la consommation des **ressources**.
+
+Sont **inclus** dans les ressources des Quantum Notebooks :
+
+- Les ressources de calcul CPU/GPU dédiées (selon la quantité sélectionnée lors de la création du notebook).
+- Pour les **Quantum QPU**, une ressource de calcul supplémentaire de type Quantum Processing Unit distante est disponible sur votre notebook.
+- Le stockage local éphémère du notebook (sa taille dépend des ressources de calcul sélectionnées). Les 10 premiers Go sont gratuits.
+- Le stockage distant du workspace (facultatif).
+- Le trafic réseau entrant/sortant (facultatif).
+
+Voici un schéma détaillé qui illustre chacune des étapes facturées ou non au cours du fonctionnement des Quantum Notebooks :
+
+<img className="thumbnail" alt="facturation" src="/images/public-cloud/quantum-computing/billing/billing.png" loading="lazy" />
+
+### Détail des ressources de calcul
+
+Lors de la création du notebook, vous pouvez sélectionner des **ressources de calcul**, à savoir des CPU ou des GPU. Leur tarification officielle est disponible dans l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> ou sur le [site web OVHcloud Public Cloud](/links/public-cloud/prices).
+
+Lorsque votre programme a besoin d'accéder au QPU distant, le temps QPU est facturé à la seconde. Vous n'êtes facturé que pour votre temps d'utilisation du QPU.
+
+Les tarifs des ressources de calcul sont indiqués à l'heure afin de faciliter la lecture des prix, mais la granularité de facturation reste **à la minute**.
+
+Comme indiqué ci-dessus et illustré sur l'image précédente, vous payez ces ressources tant que vous les consommez. C'est le cas lorsque l'image de votre notebook est téléchargée, pendant la phase `STARTING`, mais également pendant les phases `RUNNING` et `STOPPING`, jusqu'à ce que la phase `STOPPED` soit atteinte.
+
+### Détail du stockage
+
+Les Quantum Notebooks proposent trois types de stockage :
+
+- l'Object Storage distant ;
+- le stockage du workspace ;
+- le stockage local éphémère.
+
+La tarification de ces stockages est différente.
+
+#### Object Storage distant
+
+Les données distantes proviennent de la solution Object Storage d'OVHcloud. Lors de la création du notebook, vous pouvez monter des conteneurs Object Storage dans votre notebook.
+
+Si vous utilisez des notebooks auxquels des données distantes sont attachées, le stockage de ces données vous sera facturé séparément. Le coût de l'Object Storage est indépendant de la tarification des notebooks.
+
+#### Stockage du workspace
+
+Par défaut, votre notebook est monté dans un conteneur Object Storage distant à l'emplacement `/workspace`. Il s'agit du dossier par défaut lorsque vous accédez à votre notebook.
+
+Vous pouvez y stocker vos données.
+
+Les 10 premiers Go sont gratuits pendant 30 jours consécutifs après l'arrêt de votre notebook, puis facturés au prix de l'Object Storage d'OVHcloud.
+
+#### Stockage local éphémère
+
+Chaque ressource de calcul (CPU ou GPU) est fournie avec un stockage local, que l'on peut considérer comme éphémère puisque cet espace de stockage n'est pas conservé lorsque vous arrêtez ou supprimez votre notebook.
+
+Son dimensionnement dépend de la quantité de ressources de calcul sélectionnée. Consultez les détails sur le [site web OVHcloud Public Cloud](/links/public-cloud/prices).
+
+Cela concerne les emplacements situés en dehors de votre `/workspace`, ainsi qu'en dehors de tout autre conteneur Object Storage distant que vous auriez monté sur votre notebook.
+
+Ce stockage n'est pas facturé, car il est directement lié à la ou aux ressources de calcul que vous avez choisies.
+
+### Exemples de tarification
+
+<Tabs>
+  <Tab label="Pour les Emulators">
+    **Exemple 1 : un notebook GPU pendant 10 heures, puis supprimé**
+    
+    Nous démarrons un Quantum Notebook avec deux GPU et le laissons fonctionner pendant 10 heures, puis nous le **supprimons**.
+    
+    - Ressources de calcul : 2 x GPU NVIDIA V100s (1,93€ / heure)
+    - Stockage distant : aucun
+    - Durée : 10 heures, puis suppression
+    
+    Calcul du prix pour les ressources de calcul : 10 (heures) x 2 (GPU) x 1,93€ (prix / GPU) = **38,6 euros**, facturés à la fin du mois.
+    
+    **Exemple 2 : un notebook GPU pendant 10 heures, arrêté mais non supprimé**
+    
+    Nous démarrons un Quantum Notebook avec deux GPU et le laissons fonctionner pendant 10 heures, puis nous l'arrêtons et le **supprimons finalement au bout de 10 jours**.
+    
+    - Ressources de calcul : 2 x GPU NVIDIA V100s (1,93 / heure)
+    - Stockage distant : aucun
+    - Stockage du workspace : 100 Go utilisés. Les 10 premiers Go sont gratuits.
+    - Durée : 10 heures, puis arrêt pendant 10 jours
+    
+    Calcul du prix pour les ressources de calcul : 10 (heures) x 2 (GPU) x 1,93 (prix / GPU) = **38,6 euros**, facturés à la fin du mois.
+    Calcul du prix pour le workspace : 90 (Go) x 0,01€ (prix de l'object storage / Go) = **0,9 euros**, facturés à la fin du mois.
+    
+    **Exemple 3 : un notebook GPU pendant 10 heures avec 1 To de stockage distant**
+    
+    Nous démarrons un Quantum Notebook avec deux GPU et 1 To de stockage distant. Nous le laissons fonctionner pendant 10 heures, puis nous le supprimons.
+    
+    - Ressources de calcul : 2 x GPU NVIDIA V100s (1,93 / heure)
+    - Stockage distant : 1 To dans l'Object Storage d'OVHcloud
+    - Stockage du workspace : 100 Go utilisés. Les 10 premiers Go sont gratuits.
+    - Durée : 10 heures, puis suppression.
+    
+    Calcul du prix pour les ressources de calcul : 10 (heures) x 2 (GPU) x 1,93 (prix / GPU) = **38,6 euros**, facturés à la fin du mois.
+    Calcul du prix pour le workspace : 90 (Go) x 0,01€ (prix de l'object storage / Go) = **0,9 euros**, facturés à la fin du mois.
+    
+    Par ailleurs, calcul du prix pour l'Object Storage distant : 1000 (Go) x 0,01€ (prix de l'object storage / Go) = **10 euros**, facturés à la fin du mois.
+    
+    **Exemple 4 : 15 notebooks CPU pendant 5 heures, puis supprimés**
+    
+    Nous démarrons 15 Quantum Notebooks, chacun doté d'un vCPU.
+    
+    - Ressources de calcul : 1 x vCPU (0,03€ /heure /cpu)
+    - Stockage distant : aucun
+    - Durée : 5 heures, puis suppression.
+    
+    Calcul du prix pour les ressources de calcul : 15 (notebooks) x 5 (heures) x 1 (CPU) x 0,03€ (prix / CPU) = **2,25 euros**, facturés à la fin du mois.
+  </Tab>
+  <Tab label="Pour les QPUs">
+    La tarification des notebooks Quantum QPUs est identique à celle des Quantum Emulators, mais vous ne payez que le temps pendant lequel vous utilisez un QPU.
+    
+    **Exemple 1 : un CPU utilisé pendant 10 heures + un QPU Pasqal Orion Beta utilisé pendant 1 heure**
+    
+    Nous démarrons un Quantum Notebook QPU avec un CPU et le laissons fonctionner pendant 10 heures, puis nous le **supprimons**.
+    Nous utilisons une heure du QPU Orion de Pasqal, dont le coût est de 3000€ / heure.
+    
+    - Ressources de calcul : 1 x Intel CPU VCore (0,03€ / heure)
+    - Stockage distant : aucun
+    - Durée : 10 heures, puis suppression
+    - Utilisation du QPU : 1 x Pasqal QPU Orion Beta (3000€ / heure)
+    
+    Calcul du prix pour les ressources de calcul : 10 (heures) x 1 (CPU) x 0,03€ (prix / CPU) + 1 (heure) x 3000€ (prix / QPU) = **3000,3 euros**, facturés à la fin du mois.
+  </Tab>
+</Tabs>
+
+
+## Aller plus loin
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/quantum-computing/capabilities.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/capabilities.mdx
@@ -1,1 +1,209 @@
-../../../../en/guides/public-cloud/quantum-computing/capabilities.mdx
+---
+title: Quantum - Fonctionnalités, capacités et limites
+description: Découvrez les fonctionnalités, capacités et limites actuelles des Quantum Notebooks
+lastUpdated: 2025-06-17
+---
+
+:::info
+
+Les Quantum Notebooks sont couverts par les **[Conditions particulières OVHcloud Public Cloud](https://storage.gra.cloud.ovh.net/v1/AUTH_325716a587c64897acbef9a4a4726e38/contracts/d2a208c-Conditions_particulieres_OVH_Stack-WE-9.0.pdf)**.
+
+:::
+
+
+:::warning
+
+Certains liens de cette documentation renvoient vers la solution AI and Machine Learning. L'informatique quantique partage la même infrastructure as a service, vous pouvez donc être redirigé vers une autre section de cette documentation.
+
+:::
+
+
+## Objectif
+
+Cette page présente les fonctionnalités techniques, les capacités et les limites de l'offre Public Cloud d'informatique quantique.
+
+## Fonctionnalités
+
+### Fonctionnalités disponibles
+
+Les Quantum Notebooks sont des notebooks Jupyter ou VS Code managés, associés à des ressources de calcul (`CPUs`, `GPUs`) et à du stockage. Vous pouvez les comparer aux notebooks Google Colab ou Amazon Sagemaker.
+
+| Fonctionnalité                                    | Détails                                                                                                                                                                                                                                      |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Éditeur de code en direct et environnements Quantum**   |                                                                                                                                                                                                                                              |
+| Jupyter et VS Code                        | Vous pouvez utiliser Jupyter ou VS Code comme éditeur de code en direct. Si vous optez pour VS Code, vous pouvez également configurer une connexion distante (par exemple, depuis votre ordinateur portable).                                                                          |
+| Environnements Quantum préinstallés | Les Quantum Notebooks sont livrés avec un environnement Python générique (Conda) ou des environnements préinstallés, tels que Felis Alice & Bob, C12, myQLM, Pasqal, Perceval, Qiskit et bien d'autres                                                                                                |
+| Personnalisation simple                         | Les Quantum Notebooks permettent d'installer presque tous les paquets Conda ou Pip. Vous pouvez facilement personnaliser votre environnement selon vos besoins.                                                                                                          |
+| **Gestion**                             |                                                                                                                                                                                                                                              |
+| Plusieurs méthodes pour gérer vos notebooks     | Vous pouvez gérer vos Quantum Notebooks depuis l'espace client OVHcloud, via l'API ou la CLI. Selon vos besoins, vous pouvez également automatiser facilement leur création et leur suppression.                                                                           |
+| Démarrage et arrêt simples                        | Vous pouvez démarrer et arrêter un notebook en un clic. Une fois arrêté, votre environnement de notebook est conservé et vous pouvez le redémarrer plus tard, sans perdre vos données ni vos expérimentations.                                                                      |
+| **Ressources de calcul**                      |                                                                                                                                                                                                                                              |
+| Ressources de calcul garanties               | Sélectionnez la quantité de CPUs ou de GPUs nécessaire lors de la création des Quantum Notebooks. Une fois lancé, vous conservez ces ressources aussi longtemps que votre notebook fonctionne.                                                                        |
+| Exécution en arrière-plan                       | Vos tâches peuvent être exécutées en arrière-plan, ce qui signifie que la fermeture de votre navigateur web n'aura aucun effet sur votre travail.                                                                                                                            |
+| Aucune durée d'exécution maximale                         | Vos tâches peuvent durer aussi longtemps que votre notebook fonctionne.                                                                                                                                                                                     |
+| Outils de monitoring                           | Chaque service Quantum Notebooks est livré avec un tableau de bord Grafana natif, qui vous permet de suivre et de surveiller vos ressources CPU, GPU, RAM et de stockage.                                                                                            |
+| **Stockage**                                |                                                                                                                                                                                                                                              |
+| Stockage rapide et flexible                  | Chaque service Quantum Notebooks est livré avec un stockage local, mais aussi la possibilité d'attacher du stockage distant depuis Object Storage. De quelques Gio à plusieurs Tio, nous rapprochons vos données de notre puissance de calcul sur du stockage SSD rapide pour de meilleures performances. |
+| Import de dépôts Git               | Lors de la création de vos Quantum Notebooks, vous pouvez spécifier un ou plusieurs dépôts Git à télécharger dans votre environnement de notebook.                                                                                                     |
+| **Sécurité**                               |                                                                                                                                                                                                                                              |
+| Authentification ouverte ou restreinte          | Lors de la création de vos Quantum Notebooks, sélectionnez un accès ouvert ou restreint à votre notebook. Si l'accès est restreint, les utilisateurs peuvent y accéder de manière sécurisée via un token ou des identifiants.                                       |
+| Valeurs européennes                             | Nous respectons votre vie privée et n'utiliserons jamais vos données personnelles à nos propres fins.                                                                                                                                                                     |
+| **Disponibilité et facturation**               |                                                                                                                                                                                                                                              |
+| Facturation simple                               | Vous ne payez que ce que vous consommez, facturé à la minute.                                                                                                                                                                                        |
+| Disponible dans de nombreux pays                | Les Quantum Notebooks nécessitent un compte OVHcloud. Nous acceptons actuellement des dizaines de pays. Une fois votre compte créé, vous aurez accès à l'ensemble des fonctionnalités.                                                                                         |
+
+#### Interface en ligne de commande (CLI)
+
+Les Quantum Notebooks sont compatibles avec la CLI OVHcloud AI. Découvrez comment [installer la CLI OVHcloud AI](/guides/public-cloud/ai-machine-learning/ai-cli-install-client).
+
+#### **Outils de monitoring**
+
+Pour consulter les informations de votre notebook, utilisez la CLI `ovhai` avec la commande suivante :
+
+```console
+ovhai notebook get <notebook-id>
+```
+
+Vous pouvez ensuite accéder à vos métriques via le champ `Monitoring Url`.
+
+Vous pouvez également les consulter depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, dans les informations générales de votre notebook, en cliquant sur le bouton <code className="action">Go to Graph Dashboard</code>.
+
+### Fonctionnalités prévues
+
+Nous améliorons continuellement nos offres. Vous pouvez suivre, voter et soumettre des idées à ajouter à notre roadmap sur [https://github.com/orgs/ovh/projects/16/views/19](https://github.com/orgs/ovh/projects/16/views/19).
+
+## Capacités et limites
+
+### Régions prises en charge pour les notebooks
+
+Les Quantum Notebooks peuvent être utilisés depuis n'importe quel pays du monde, à condition que vous disposiez d'un compte OVHcloud.
+Physiquement, deux datacentres sont disponibles :
+
+- `BHS` (Beauharnois, Canada, Amérique)
+- `GRA` (Gravelines, France, Europe)
+
+### Ressources attachées
+
+#### Ressources de calcul
+
+Vous pouvez choisir le nombre de `GPUs` ou de `CPUs` pour un notebook, mais pas les deux.
+Par défaut, un notebook utilise un GPU.
+La ressource mémoire n'est pas personnalisable.
+
+Si vous choisissez `GPU` :
+
+- Les ressources CPU, mémoire et de stockage local ne sont pas personnalisables, mais évoluent de façon linéaire avec chaque GPU supplémentaire.
+
+Si vous choisissez `CPU` :
+
+- Les ressources mémoire et de stockage local ne sont pas personnalisables, mais évoluent de façon linéaire avec chaque CPU supplémentaire.
+
+La quantité maximale de CPU/GPU, la mémoire par CPU/GPU et le stockage local sont indiqués sur le [site web OVHcloud](/links/public-cloud/prices), dans l'espace client OVHcloud et via la CLI `ovhai`.
+
+```console
+ovhai capabilities flavor list
+```
+
+À titre d'information, les limites actuelles sont les suivantes :
+
+- CPU : 12 par notebook.
+- GPU : 4 par notebook.
+
+##### **Matériel disponible pour les Quantum Notebooks**
+
+Nous proposons actuellement :
+
+- **NVIDIA V100S** ([tarifs disponibles ici](/links/public-cloud/prices)).
+
+#### Stockage disponible
+
+##### **Stockage local**
+
+Chaque Quantum Notebook est livré avec un espace de stockage local, qui est éphémère. Lorsque vous supprimez votre notebook, cet espace de stockage est également supprimé.
+Cet espace de stockage dépend des instances sélectionnées lors de la création du notebook. Consultez la section relative aux ressources de calcul pour plus d'informations.
+
+:::info
+
+Le **stockage local** est limité et n'est pas la méthode recommandée pour gérer des données. Consultez la [documentation OVHcloud sur les données](/guides/public-cloud/ai-machine-learning/ai-data) pour plus d'informations.
+
+:::
+
+
+##### **Stockage attaché**
+
+Vous pouvez attacher des volumes de données depuis le Public Cloud Object Storage. Le bucket Object Storage doit se trouver dans la même région que vos Quantum Notebooks.
+Le stockage attaché vous permet de travailler sur plusieurs To de données, tout en restant persistant lorsque vous supprimez vos Quantum Notebooks.
+
+#### Durée d'exécution maximale
+
+Il n'existe aucune limitation de durée pour l'exécution des Quantum Notebooks.
+
+### Éditeurs de code en direct
+
+Vous pouvez choisir entre deux **éditeurs de code en direct** pour lancer et modifier votre notebook :
+
+- Jupyterlab
+- VS Code
+
+Vous ne pouvez pas installer votre propre éditeur de code sur les Quantum Notebooks.
+
+Avec VS Code, vous bénéficiez de la possibilité d'utiliser des connexions distantes (depuis un ordinateur local).
+
+### Environnements Quantum préinstallés
+
+Les OVHcloud Quantum Notebooks sont livrés avec des environnements Quantum préinstallés.
+
+Liste des environnements Quantum disponibles :
+
+- Alice & Bob Felis
+- Atos myQLM
+- C12
+- IBM Qiskit
+- IQM SQK
+- Pasqal Pulser
+- Pasqal Pulser for QPU
+- QPerfect MIMIQ
+- Quandela Perceval
+- Quobly
+
+#### Personnalisation de l'environnement
+
+Chaque environnement peut être personnalisé directement avec PIP ou CONDA (nous prenons en charge presque tous les paquets et bibliothèques).
+
+**Limites** :
+
+- Vous n'êtes **pas administrateur (root)**. Vous ne pouvez pas installer de paquets Linux (tels que *apt-get*).
+- Les Quantum Notebooks **n'autorisent pas l'utilisation d'images Docker personnalisées**.
+
+### Réseau
+
+- Le **réseau public** peut être utilisé pour tous les Quantum Notebooks.
+- Le **réseau privé (OVHcloud vRack)** n'est pas pris en charge.
+
+#### Ports disponibles vers le réseau public
+
+Chaque notebook dispose d'une URL publique. Par défaut, cette URL accède au port 8080 du notebook. Le port par défaut ne peut pas être modifié.
+
+URL du notebook pour accéder au port par défaut (commençant par l'ID du notebook) :
+
+-  `https://00000000-0000-0000-0000-000000000000.notebook.gra.ai.cloud.ovh.net`
+
+Seule la couche HTTP est accessible.
+
+### Quotas par projet Public Cloud
+
+Chaque projet Public Cloud accorde par défaut à un client un maximum de 4 GPUs utilisés simultanément. Contactez notre [support](https://help.ovhcloud.com/csm?id=csm_get_help) si vous avez besoin d'augmenter cette limite.
+
+## Aller plus loin
+
+Parcourez l'ensemble de la documentation Quantum Notebooks pour mieux comprendre les concepts principaux et démarrer.
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/quantum-computing/emulators/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/emulators/getting-started.mdx
@@ -1,1 +1,478 @@
-../../../../../en/guides/public-cloud/quantum-computing/emulators/getting-started.mdx
+---
+title: Quantum - Premiers pas avec les notebooks Emulators
+description: Découvrez comment configurer un Quantum Emulators Notebook
+lastUpdated: 2025-11-06
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+
+:::warning
+Certains liens de cette documentation renvoient vers la solution AI and Machine Learning. L'informatique quantique partage la même infrastructure as a service, vous pouvez donc être redirigé vers une autre section de cette documentation.
+:::
+
+## Introduction
+
+Un **notebook** est un document qui intègre du code, des éléments de texte enrichi et du multimédia, ce qui en fait un outil pratique pour l'analyse et la visualisation quantiques.
+
+**OVHcloud Quantum Emulators** est notre solution managée de notebooks Jupyter et VS Code. Vous pouvez lancer facilement des notebooks avec les ressources CPU et GPU nécessaires, tout en bénéficiant d'avantages tels que des dépendances et des frameworks Quantum préinstallés, un accès utilisateur sécurisé et une gestion des données simplifiée.
+
+## Objectif
+
+Ce guide explique comment créer, configurer, consulter, arrêter, redémarrer et supprimer un Quantum Emulators Notebook depuis l'**espace client OVHcloud (UI)**. Cette méthode est simple d'utilisation et idéale pour les débutants.
+
+Vous pouvez également utiliser l'une des méthodes suivantes :
+
+- L'interface en ligne de commande (CLI) **ovhai**
+- L'**API Quantum**
+- Le SDK Python **ovhai**
+
+Chaque méthode présente ses propres avantages, selon votre niveau d'expertise et le workflow que vous préférez.
+
+## Prérequis
+
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
+- Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+- Un utilisateur Public Cloud disposant du rôle **Administrator** ou **Quantum Operator & Objectstore Operator**.
+
+## En pratique
+
+### Processus d'autorisation OVHcloud Quantum Solutions
+
+Si vous utilisez la CLI, l'API ou le SDK, vous devrez suivre un processus d'autorisation avant de créer un Quantum Emulators Notebook. Pour ce faire, procédez comme suit :
+
+1. Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et accédez à la section `Public Cloud`.
+2. Sélectionnez le projet Public Cloud que vous souhaitez utiliser et cliquez sur la catégorie `Quantum Emulators`.
+3. Cliquez sur le bouton `Créer un notebook`. Le processus d'autorisation s'effectue silencieusement en arrière-plan.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 01" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-01.png" loading="lazy" />
+
+### Lancer votre premier Quantum Notebook
+
+Pour créer un Quantum Notebook, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez à la section `Public Cloud` de l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, puis cliquez sur la catégorie `Quantum Emulators`.
+Cliquez sur le bouton `Créer un notebook` et suivez les instructions pour définir la configuration de votre Quantum Notebook.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 01" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-01.png" loading="lazy" />
+
+**1\. Nom du notebook**
+
+Donnez un nom à votre notebook. Cela facilitera sa gestion lorsque vous aurez créé plusieurs Quantum Notebooks.
+
+**2\. Localisation du notebook**
+
+Sélectionnez ensuite une localisation.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 02" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-02.png" loading="lazy" />
+
+**3\. Ressources de calcul**
+
+Définissez et ajustez le type et la quantité de ressources de calcul (CPU / GPU) pour votre Quantum Notebook. Utilisez les boutons `+` et `-` pour augmenter ou diminuer le nombre de CPUs et de GPUs, selon vos besoins.
+
+Cliquez sur `Suivant`.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 03" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-03.png" loading="lazy" />
+
+**4\. Frameworks préconfigurés**
+
+Choisissez le framework Python Quantum que vous souhaitez utiliser : il sera préinstallé et prêt à l'emploi au lancement de votre notebook. Un large choix de frameworks Quantum est disponible en différentes versions. Sélectionnez la version qui correspond à vos besoins. Cliquez ensuite sur `Suivant` pour continuer.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 04" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-04.png" loading="lazy" />
+
+**5\. Éditeur de code en direct**
+
+Choisissez l'éditeur de code souhaité.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 05" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-05.png" loading="lazy" />
+
+**6\. Paramètres de confidentialité**
+
+Sélectionnez ensuite vos paramètres de confidentialité et cliquez sur `Suivant`.
+
+:::warning
+L'*accès public* exposera vos données et votre code à toute personne disposant du lien du Quantum Notebook. Veillez à ne pas l'utiliser avec des données sensibles. À l'inverse, l'*accès restreint* nécessitera une combinaison utilisateur/mot de passe ou un token Quantum pour accéder au contenu du notebook, afin de garantir un environnement sécurisé.
+:::
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 06" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-06.png" loading="lazy" />
+
+**7\. Configuration avancée**
+
+Par défaut, votre Quantum Notebook est livré avec un **stockage éphémère** (stockage local). Mais à cette étape, vous pouvez également associer des conteneurs Object Storage et des dépôts Git à votre notebook afin d'accéder facilement à vos données distantes.
+
+Si vous souhaitez en savoir plus sur la configuration des conteneurs et des dépôts Git dans le notebook, vous pouvez consulter cette [documentation AI & Machine Learning](/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui). Pour l'instant, nous allons lancer un notebook classique, sans aucun volume externe ajouté.
+
+Cliquez sur `Suivant`.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 07" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-07.png" loading="lazy" />
+
+Les **clés publiques SSH** vous permettent d'accéder à distance à votre notebook. Cette section est facultative : cliquez sur `Suivant`.
+
+**9\. Lancer le Quantum Notebook**
+
+À la fin du processus, vérifiez vos paramètres et cliquez sur le bouton `Order now` pour confirmer et lancer la création de votre notebook. Vous serez redirigé vers le tableau de bord de votre notebook :
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 10" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-08b.png" loading="lazy" />
+
+:::info
+Notez en bas de l'écran la commande CLI *ovhai* équivalente. Cette commande vous permet de lancer exactement le même notebook depuis la CLI.
+:::
+
+Lorsque votre notebook est créé, il apparaît dans votre onglet Quantum Emulators :
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 11" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-UI-09.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Si vous préférez utiliser l'interface en ligne de commande pour lancer votre Quantum Notebook, procédez comme suit :
+
+1. Suivez cette [documentation AI & Machine Learning](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) pour installer la CLI `ovhai` et vous connecter.
+2. Consultez cette seconde documentation pour découvrir [comment créer votre Quantum Notebook à l'aide de commandes](/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook).
+
+<img className="thumbnail" alt="Créer un notebook depuis la CLI ovhai" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-ovhai-CLI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via l'API AI Solution">
+
+1. Créez un bearer token depuis la CLI *ovhai*. Pour des instructions plus détaillées sur la création d'un token, consultez la documentation [gérer les tokens d'accès](/guides/public-cloud/ai-machine-learning/ai-cli-app-token).
+2. Accédez à la région souhaitée et suivez les instructions pour créer un Quantum Notebook.
+- [API AI Solution GRA](https://gra.ai.cloud.ovh.net/#/), pour Gravelines, France.
+- [API AI Solution BHS](https://bhs.ai.cloud.ovh.net/#/), pour Beauharnois, Canada.
+3. Méthode POST `Submit a new notebook`
+
+:::warning
+Veillez à sélectionner `Bearer Auth` au lieu d'`OAuth 2.0`, qui est sélectionné par défaut.
+:::
+
+<img className="thumbnail" alt="Créer un notebook avec l'authentification par token de l'API" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/creating-a-notebook-using-API-01.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+:::warning
+**Avertissement version alpha** : ce paquet est actuellement en **phase alpha** de développement. Les API et les fonctionnalités du paquet peuvent ne pas être entièrement testées.
+:::
+
+1. Créez un bearer token depuis la CLI *ovhai*. Pour des instructions plus détaillées sur la création d'un token, consultez la documentation [gérer les tokens d'accès](/guides/public-cloud/ai-machine-learning/ai-cli-app-token).
+2. Installez le SDK Python `ovhai` et suivez les instructions de la page [ovhai PyPI](https://pypi.org/project/ovhai/) pour créer un Quantum Notebook.
+3. Enfin, ouvrez votre terminal et exécutez `pip install ovhai`.
+
+Voici un exemple simple pour vous aider à démarrer facilement :
+
+```python
+from ovhai import AuthenticatedClient
+from ovhai.api.notebook import notebook_new
+from ovhai.models import NotebookSpec, Notebook
+from ovhai.ovhai_types import Response
+
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+
+# Définition des paramètres du notebook
+editor_id = "jupyterlab"
+framework_id = "alicebob"
+framework_version = "1.2.0-py312-cpu"
+nb_cpu = 1
+
+# Création de la requête de création du notebook
+notebook_specs = {
+"env": {"editorId": editor_id, "frameworkId": framework_id, "frameworkVersion": framework_version},
+"resources": {"cpu": nb_cpu},
+}
+
+with client as client:
+response: Response[Notebook] = notebook_new.sync_detailed(
+client=client, body=NotebookSpec.from_dict(notebook_specs)
+)
+
+import json
+response_content = response.content.decode('utf-8')  # Décodage des octets en chaîne de caractères
+response_dict = json.loads(response_content)
+
+status_code = response.status_code
+id_ = response_dict['id']
+spec = response_dict['spec']
+status = response_dict['status']
+state = status['state']
+info = status['info']
+url = response_dict['status']['url']
+
+print(f"Status code: {status_code}")
+print(f"ID: {id_}")
+print(f"Spec: {spec}")
+print(f"State: {state}")
+print(f"Info: {info}")
+print(f"URL: {url}")
+```
+
+</Tab>
+</Tabs>
+
+
+Une fois votre Quantum Notebook créé et en cours d'exécution, vous pouvez y accéder via le lien `JupyterLab` du tableau des Quantum Notebooks ou via la CLI `ovhai`, l'API Quantum ou le SDK Python.
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Cliquez sur le lien `JupyterLab` dans la colonne `Publisher` :
+
+<img className="thumbnail" alt="Accéder à un notebook depuis l'espace client OVHcloud 1" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/accessing-a-notebook-using-UI-1.png" loading="lazy" />
+
+Vous pouvez également accéder au notebook depuis sa page dédiée :
+
+<img className="thumbnail" alt="Accéder à un notebook depuis l'espace client OVHcloud 2" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/accessing-a-notebook-using-UI-2.png" loading="lazy" />
+
+Sur la page du notebook, vous trouverez des informations sur celui-ci, notamment ses caractéristiques, sa facturation et les données attachées, ainsi qu'une URL de monitoring pour consulter les métriques en temps réel.
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+L'`URL` de votre notebook devrait s'afficher dans votre terminal et vous pouvez l'afficher en exécutant `ovhai notebook list` pour récupérer l'`URL`.
+
+<img className="thumbnail" alt="Accéder à un notebook depuis la CLI ovhai" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/accessing-a-notebook-using-ovhai-CLI.png" loading="lazy" />
+
+Vous pouvez également obtenir les informations du notebook avec `ovhai notebook get <NOTEBOOK_UUID>`.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+L'`URL` de votre notebook devrait apparaître dans le panneau `Response` :
+
+<img className="thumbnail" alt="Accéder à un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/accessing-a-notebook-using-API.png" loading="lazy" />
+
+Si ce n'est pas le cas, utilisez la méthode GET du endpoint `Paginated list of notebooks` :
+
+Vous pouvez également obtenir les informations du notebook à l'aide de la méthode GET du endpoint `Get notebook information`.
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Exécutez le code suivant pour lister tous les Quantum Notebooks :
+
+```python
+from ovhai.api.notebook import notebook_get_all
+from ovhai.models import NotebookList
+from ovhai.ovhai_types import Response
+
+from ovhai import AuthenticatedClient
+
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+
+with client as client:
+response: Response[NotebookList] = notebook_get_all.sync_detailed(client=client)
+import json
+response = json.loads(response.content.decode())
+for notebook_info in response["items"]:
+print(f"ID: {notebook_info['id']}")
+print(f"Name: {notebook_info['spec']['name']}")
+print(f"Status: {notebook_info['status']['state']}")
+print(f"Framework: {notebook_info['spec']['env']['frameworkId']}")
+print(f"Framework version: {notebook_info['spec']['env']['frameworkVersion']}")
+print(f"Editor: {notebook_info['spec']['env']['editorId']}")
+print(f"Access link: {notebook_info['status']['url']}")
+print("---------------")
+```
+
+Vous pouvez également obtenir les informations du notebook avec cet exemple de code :
+
+```python
+from ovhai.api.notebook import notebook_get
+from ovhai import AuthenticatedClient
+import json
+
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_get.sync_detailed(
+id=id, client=client
+)
+
+print(json.loads(response.content.decode()))
+```
+
+</Tab>
+</Tabs>
+
+
+Pour vous connecter à votre Quantum Notebook, vous devrez vous authentifier à l'aide d'une combinaison nom d'utilisateur/mot de passe ou d'un token d'accès.
+
+**Avec un nom d'utilisateur et un mot de passe**
+
+Saisissez les identifiants de l'utilisateur de votre projet Public Cloud pour vous connecter à votre Quantum Notebook.
+
+<img className="thumbnail" alt="Authentification du notebook par identifiants" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/notebook-authentication-creds.png" loading="lazy" />
+
+**Avec un token d'accès**
+
+Cliquez sur le bouton `Login with token` et saisissez votre token d'accès pour vous connecter à votre Quantum Notebook.
+
+<img className="thumbnail" alt="Authentification du notebook par token" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/notebook-authentication-token.png" loading="lazy" />
+
+### Arrêter un Quantum Notebook
+
+Vous pouvez arrêter votre Quantum Notebook à tout moment afin de libérer ses ressources de calcul. Cela libère ses ressources de calcul, mais conserve les données de votre notebook et les bibliothèques installées. Par conséquent, aucun frais de calcul supplémentaire ne vous sera facturé, sauf si vous redémarrez le notebook. En revanche, le stockage attaché sera facturé au tarif de l'Object Storage OVHcloud (consultez la [documentation sur la facturation des Quantum Notebooks](/guides/public-cloud/quantum-computing/billing) pour plus d'informations). Pour ce faire, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez arrêter.
+Cliquez sur le bouton `Arrêter` pour arrêter le notebook. Vous pouvez également, depuis le tableau du notebook, cliquer sur le `bouton rouge` en haut de la page.
+
+<img className="thumbnail" alt="Arrêter un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/stopping-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook stop <NOTEBOOK_UUID>` pour arrêter le notebook.
+
+Si vous ne connaissez pas son UUID, rappelez-vous que vous pouvez facilement lister tous vos Quantum Notebooks existants en exécutant `ovhai notebook list`.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Stop a running notebook` et indiquez l'UUID du notebook que vous souhaitez arrêter.
+
+<img className="thumbnail" alt="Arrêter un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/stopping-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_stop` pour arrêter le notebook.
+
+```python
+from ovhai.api.notebook import notebook_stop
+from ovhai import AuthenticatedClient
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_stop.sync_detailed(client=client, id=id)
+```
+
+</Tab>
+</Tabs>
+
+
+Pour redémarrer un notebook arrêté, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez redémarrer.
+Cliquez sur le bouton `Démarrer` pour redémarrer le notebook. Vous pouvez également, depuis le tableau du notebook, cliquer sur le `bouton bleu` en haut de la page.
+
+<img className="thumbnail" alt="Redémarrer un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/restarting-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook start <NOTEBOOK_UUID>` pour redémarrer le notebook.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Start a stopped notebook` et indiquez l'UUID du notebook que vous souhaitez redémarrer.
+
+<img className="thumbnail" alt="Redémarrer un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/restarting-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_start` pour redémarrer le notebook.
+
+```python
+from ovhai.api.notebook import notebook_start
+from ovhai import AuthenticatedClient
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_start.sync_detailed(
+id=id, client=client
+)
+```
+
+</Tab>
+</Tabs>
+
+
+Le notebook doit être arrêté avant de pouvoir être supprimé. Pour supprimer un notebook, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez supprimer.
+Cliquez sur le bouton `Supprimer` pour supprimer le notebook. Vous pouvez également cliquer sur le bouton `Delete notebook` en bas de la page.
+
+<img className="thumbnail" alt="Supprimer un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/deleting-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook delete <NOTEBOOK_UUID>` pour supprimer le notebook.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Delete permanently a notebook` et indiquez l'UUID du notebook que vous souhaitez supprimer.
+
+<img className="thumbnail" alt="Supprimer un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/emulators/getting-started/deleting-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_delete` pour supprimer le notebook.
+```python
+from ovhai.api.notebook import notebook_delete
+from ovhai import AuthenticatedClient
+
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_delete.sync_detailed(
+id=id, client=client, force=False
+)
+
+print(response.content.decode())
+```
+
+</Tab>
+</Tabs>
+
+
+- Découvrez comment accéder à vos données Object Storage et à vos dépôts Git depuis vos notebooks via l'interface graphique [ici](/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui).
+- Découvrez les fonctionnalités techniques, les capacités et les limites de l'offre Public Cloud Quantum Notebooks [ici](/guides/public-cloud/quantum-computing/capabilities).
+- Obtenez des conseils pour déboguer vos notebooks en cas de problème [ici](/guides/public-cloud/quantum-computing/troubleshooting).
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/quantum-computing/qpus/getting-started.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/qpus/getting-started.mdx
@@ -1,1 +1,481 @@
-../../../../../en/guides/public-cloud/quantum-computing/qpus/getting-started.mdx
+---
+title: Quantum - Premiers pas avec les notebooks QPUs
+description: Découvrez comment configurer un Quantum QPUs Notebook
+lastUpdated: 2025-11-06
+---
+
+import { Tab, Tabs } from '@rspress/core/theme';
+
+
+:::warning
+Certains liens de cette documentation renvoient vers la solution AI and Machine Learning. L'informatique quantique partage la même infrastructure as a service, vous pouvez donc être redirigé vers une autre section de cette documentation.
+:::
+
+## Introduction
+
+Un **notebook** est un document qui intègre du code, des éléments de texte enrichi et du multimédia, ce qui en fait un outil pratique pour l'analyse et la visualisation quantiques.
+
+**OVHcloud Quantum QPUs** est notre solution managée de notebooks Jupyter et VS Code, conçue pour exécuter des tâches sur un véritable processeur quantique (Quantum Processing Unit). Le notebook fonctionne de la même manière qu'un notebook OVHcloud Quantum Emulators, mais avec un token managé permettant d'accéder à un QPU distant. Des frais supplémentaires seront calculés pour l'utilisation de ce QPU.
+
+## Objectif
+
+Ce guide explique comment créer, configurer, consulter, arrêter, redémarrer et supprimer un Quantum QPUs Notebook depuis l'**espace client OVHcloud (UI)**. Cette méthode est simple d'utilisation et idéale pour les débutants.
+
+Vous pouvez également utiliser l'une des méthodes suivantes :
+
+- L'interface en ligne de commande (CLI) **ovhai**
+- L'**API Quantum**
+- Le SDK Python **ovhai**
+
+Chaque méthode présente ses propres avantages, selon votre niveau d'expertise et le workflow que vous préférez.
+
+## Prérequis
+
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
+- Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>.
+- Un utilisateur Public Cloud disposant du rôle **Administrator** ou **Quantum Operator & Objectstore Operator**.
+
+## En pratique
+
+### Processus d'autorisation OVHcloud Quantum Solutions
+
+Si vous utilisez la CLI, l'API ou le SDK, vous devrez suivre un processus d'autorisation avant de créer un Quantum QPUs Notebook. Pour ce faire, procédez comme suit :
+
+1. Connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et accédez à la section `Public Cloud`.
+2. Sélectionnez le projet Public Cloud que vous souhaitez utiliser et cliquez sur la catégorie `Quantum QPUs`.
+3. Cliquez sur le bouton `Créer un notebook`. Le processus d'autorisation s'effectue silencieusement en arrière-plan.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 01" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-01.png" loading="lazy" />
+
+### Lancer votre premier Quantum Notebook
+
+Pour créer un Quantum Notebook, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez à la section `Public Cloud` de l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et cliquez sur la catégorie `Quantum QPUs`.
+Cliquez sur le bouton `Créer un notebook` et suivez les instructions pour définir la configuration de votre Quantum Notebook.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 01" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-01.png" loading="lazy" />
+
+**1\. Nom du notebook**
+
+Donnez un nom à votre notebook. Cela facilitera sa gestion lorsque vous aurez créé plusieurs Quantum Notebooks.
+
+**2\. Localisation du notebook**
+
+Sélectionnez ensuite une localisation.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 02" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-02.png" loading="lazy" />
+
+**3\. Ressources de calcul**
+
+Définissez et ajustez le type et la quantité de ressources de calcul (CPU / GPU) pour votre Quantum Notebook. Utilisez les boutons `+` et `-` pour augmenter ou diminuer le nombre de CPUs et de GPUs, selon vos besoins.
+
+Cliquez sur `Suivant`.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 03" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-03.png" loading="lazy" />
+
+**4\. Frameworks préconfigurés**
+
+Choisissez le framework Python Quantum que vous souhaitez utiliser : il sera préinstallé et prêt à l'emploi au lancement de votre notebook. Sélectionnez la version qui correspond à vos besoins. Cliquez ensuite sur `Suivant` pour continuer.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 04" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-04.png" loading="lazy" />
+
+**5\. Éditeur de code en direct**
+
+Choisissez l'éditeur de code souhaité.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 05" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-05.png" loading="lazy" />
+
+**6\. Paramètres de confidentialité**
+
+Sélectionnez ensuite vos paramètres de confidentialité et cliquez sur `Suivant`.
+
+:::warning
+L'*accès public* exposera vos données et votre code à toute personne disposant du lien du Quantum Notebook. Veillez à ne pas l'utiliser avec des données sensibles. À l'inverse, l'*accès restreint* nécessitera une combinaison utilisateur/mot de passe ou un token Quantum pour accéder au contenu du notebook, afin de garantir un environnement sécurisé.
+:::
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 06" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-06.png" loading="lazy" />
+
+**7\. Configuration avancée**
+
+Par défaut, votre Quantum Notebook est livré avec un **stockage éphémère** (stockage local). Mais à cette étape, vous pouvez également associer des conteneurs Object Storage et des dépôts Git à votre notebook afin d'accéder facilement à vos données distantes.
+
+Si vous souhaitez en savoir plus sur la configuration des conteneurs et des dépôts Git dans le notebook, vous pouvez consulter cette [documentation AI & Machine Learning](/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui). Pour l'instant, nous allons lancer un notebook classique, sans aucun volume externe ajouté.
+
+Cliquez sur `Suivant`.
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 07" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-07.png" loading="lazy" />
+
+Les **clés publiques SSH** vous permettent d'accéder à distance à votre notebook. Cette section est facultative : cliquez sur `Suivant`.
+
+**9\. Lancer le Quantum Notebook**
+
+À la fin du processus, vérifiez vos paramètres et cliquez sur le bouton `Order now` pour confirmer et lancer la création de votre notebook. Vous serez redirigé vers le tableau de bord de votre notebook :
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 10" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-08b.png" loading="lazy" />
+
+:::info
+Notez en bas de l'écran la commande CLI *ovhai* équivalente. Cette commande vous permet de lancer exactement le même notebook depuis la CLI.
+:::
+
+Lorsque votre notebook est créé, il apparaît dans votre onglet Quantum QPUs :
+
+<img className="thumbnail" alt="Créer un notebook depuis l'espace client OVHcloud 11" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-UI-09.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Si vous préférez utiliser l'interface en ligne de commande pour lancer votre Quantum Notebook, procédez comme suit :
+
+1. Suivez cette [documentation AI & Machine Learning](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) pour installer la CLI `ovhai` et vous connecter.
+2. Consultez cette seconde documentation pour découvrir [comment créer votre Quantum Notebook à l'aide de commandes](/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook).
+
+<img className="thumbnail" alt="Créer un notebook depuis la CLI ovhai" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-ovhai-CLI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via l'API AI Solution">
+
+1. Créez un bearer token depuis la CLI *ovhai*. Pour des instructions plus détaillées sur la création d'un token, consultez la documentation [gérer les tokens d'accès](/guides/public-cloud/ai-machine-learning/ai-cli-app-token).
+2. Accédez à la région souhaitée et suivez les instructions pour créer un Quantum Notebook.
+- [API AI Solution GRA](https://gra.ai.cloud.ovh.net/#/), pour Gravelines, France.
+- [API AI Solution BHS](https://bhs.ai.cloud.ovh.net/#/), pour Beauharnois, Canada.
+3. Méthode POST `Submit a new notebook`
+
+:::warning
+Veillez à sélectionner `Bearer Auth` au lieu d'`OAuth 2.0`, qui est sélectionné par défaut.
+:::
+
+<img className="thumbnail" alt="Créer un notebook avec l'authentification par token de l'API" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/creating-a-notebook-using-API-01.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+:::warning
+**Avertissement version alpha** : ce paquet est actuellement en **phase alpha** de développement. Les API et les fonctionnalités du paquet peuvent ne pas être entièrement testées.
+:::
+
+1. Créez un bearer token depuis la CLI *ovhai*. Pour des instructions plus détaillées sur la création d'un token, consultez la documentation [gérer les tokens d'accès](/guides/public-cloud/ai-machine-learning/ai-cli-app-token).
+2. Installez le SDK Python `ovhai` et suivez les instructions de la page [ovhai PyPI](https://pypi.org/project/ovhai/) pour créer un Quantum Notebook.
+3. Enfin, ouvrez votre terminal et exécutez `pip install ovhai`.
+
+Voici un exemple simple pour vous aider à démarrer facilement :
+
+```python
+from ovhai import AuthenticatedClient
+from ovhai.api.notebook import notebook_new
+from ovhai.models import NotebookSpec, Notebook
+from ovhai.ovhai_types import Response
+
+client = AuthenticatedClient(
+base_url="https://bhs.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+
+# Définition des paramètres du notebook
+editor_id = "jupyterlab"
+framework_id = "pasqal-qpu"
+framework_version = "1.6.2-py312-cpu"
+framework_qpu_flavor_id = "orion-beta"
+nb_cpu = 1
+
+# Création de la requête de création du notebook
+notebook_specs = {
+"env": {"editorId": editor_id, "frameworkId": framework_id, "frameworkVersion": framework_version},
+"quantumResources": {"qpuFlavorId": framework_qpu_flavor_id},
+"resources": {"cpu": nb_cpu},
+}
+
+with client as client:
+response: Response[Notebook] = notebook_new.sync_detailed(
+client=client, body=NotebookSpec.from_dict(notebook_specs)
+)
+
+import json
+response_content = response.content.decode('utf-8')  # Décodage des octets en chaîne de caractères
+response_dict = json.loads(response_content)
+
+status_code = response.status_code
+id_ = response_dict['id']
+spec = response_dict['spec']
+status = response_dict['status']
+state = status['state']
+info = status['info']
+url = response_dict['status']['url']
+
+print(f"Status code: {status_code}")
+print(f"ID: {id_}")
+print(f"Spec: {spec}")
+print(f"State: {state}")
+print(f"Info: {info}")
+print(f"URL: {url}")
+```
+
+</Tab>
+</Tabs>
+
+
+Une fois votre Quantum Notebook créé et en cours d'exécution, vous pouvez y accéder via le lien `JupyterLab` du tableau des Quantum Notebooks ou via la CLI `ovhai`, l'API Quantum ou le SDK Python.
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Cliquez sur le lien `JupyterLab` dans la colonne `Access` :
+
+<img className="thumbnail" alt="Accéder à un notebook depuis l'espace client OVHcloud 1" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/accessing-a-notebook-using-UI-1.png" loading="lazy" />
+
+Vous pouvez également accéder au notebook depuis sa page dédiée :
+
+<img className="thumbnail" alt="Accéder à un notebook depuis l'espace client OVHcloud 2" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/accessing-a-notebook-using-UI-2.png" loading="lazy" />
+
+Sur la page du notebook, vous trouverez des informations sur celui-ci, notamment ses caractéristiques, sa facturation et les données attachées, ainsi qu'une URL de monitoring pour consulter les métriques en temps réel.
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+L'`URL` de votre notebook devrait s'afficher dans votre terminal et vous pouvez l'afficher en exécutant `ovhai notebook list` pour récupérer l'`URL`.
+
+<img className="thumbnail" alt="Accéder à un notebook depuis la CLI ovhai" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/accessing-a-notebook-using-ovhai-CLI.png" loading="lazy" />
+
+Vous pouvez également obtenir les informations du notebook avec `ovhai notebook get <NOTEBOOK_UUID>`.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+L'`URL` de votre notebook devrait apparaître dans le panneau `Response` :
+
+<img className="thumbnail" alt="Accéder à un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/accessing-a-notebook-using-API.png" loading="lazy" />
+
+Si ce n'est pas le cas, utilisez la méthode GET du endpoint `Paginated list of notebooks` :
+
+Vous pouvez également obtenir les informations du notebook à l'aide de la méthode GET du endpoint `Get notebook information`.
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Exécutez le code suivant pour lister tous les Quantum Notebooks :
+
+```python
+from ovhai import AuthenticatedClient
+from ovhai.api.notebook import notebook_get_all
+from ovhai.models import NotebookList
+from ovhai.ovhai_types import Response
+
+from ovhai import AuthenticatedClient
+
+client = AuthenticatedClient(
+base_url="https://bhs.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+
+with client as client:
+response: Response[NotebookList] = notebook_get_all.sync_detailed(client=client)
+import json
+response = json.loads(response.content.decode())
+for notebook_info in response["items"]:
+print(f"ID: {notebook_info['id']}")
+print(f"Name: {notebook_info['spec']['name']}")
+print(f"Status: {notebook_info['status']['state']}")
+print(f"Framework: {notebook_info['spec']['env']['frameworkId']}")
+print(f"Framework version: {notebook_info['spec']['env']['frameworkVersion']}")
+print(f"Editor: {notebook_info['spec']['env']['editorId']}")
+print(f"Access link: {notebook_info['status']['url']}")
+print("---------------")
+```
+
+Vous pouvez également obtenir les informations du notebook avec cet exemple de code :
+
+```python
+from ovhai.api.notebook import notebook_get
+from ovhai import AuthenticatedClient
+import json
+
+client = AuthenticatedClient(
+base_url="https://bhs.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_get.sync_detailed(
+id=id, client=client
+)
+
+print(json.loads(response.content.decode()))
+```
+
+</Tab>
+</Tabs>
+
+
+Pour vous connecter à votre Quantum Notebook, vous devrez vous authentifier à l'aide d'une combinaison nom d'utilisateur/mot de passe ou d'un token d'accès.
+
+**Avec un nom d'utilisateur et un mot de passe**
+
+Saisissez les identifiants de l'utilisateur de votre projet Public Cloud pour vous connecter à votre Quantum Notebook.
+
+<img className="thumbnail" alt="Authentification du notebook par identifiants" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/notebook-authentication-creds.png" loading="lazy" />
+
+**Avec un token d'accès**
+
+Cliquez sur le bouton `Login with token` et saisissez votre token d'accès pour vous connecter à votre Quantum Notebook.
+
+<img className="thumbnail" alt="Authentification du notebook par token" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/notebook-authentication-token.png" loading="lazy" />
+
+### Arrêter un Quantum Notebook
+
+Vous pouvez arrêter votre Quantum Notebook à tout moment afin de libérer ses ressources de calcul. Cela libère ses ressources de calcul, mais conserve les données de votre notebook et les bibliothèques installées. Par conséquent, aucun frais de calcul supplémentaire ne vous sera facturé, sauf si vous redémarrez le notebook. En revanche, le stockage attaché sera facturé au tarif de l'Object Storage OVHcloud (consultez la [documentation sur la facturation des Quantum Notebooks](/guides/public-cloud/quantum-computing/billing) pour plus d'informations). Pour ce faire, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez arrêter.
+Cliquez sur le bouton `Arrêter` pour arrêter le notebook. Vous pouvez également, depuis le tableau du notebook, cliquer sur le `bouton rouge` en haut de la page.
+
+<img className="thumbnail" alt="Arrêter un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/stopping-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook stop <NOTEBOOK_UUID>` pour arrêter le notebook.
+
+Si vous ne connaissez pas son UUID, rappelez-vous que vous pouvez facilement lister tous vos Quantum Notebooks existants en exécutant `ovhai notebook list`.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Stop a running notebook` et indiquez l'UUID du notebook que vous souhaitez arrêter.
+
+<img className="thumbnail" alt="Arrêter un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/stopping-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_stop` pour arrêter le notebook.
+
+```python
+from ovhai.api.notebook import notebook_stop
+from ovhai import AuthenticatedClient
+client = AuthenticatedClient(
+base_url="https://bhs.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_stop.sync_detailed(client=client, id=id)
+```
+
+</Tab>
+</Tabs>
+
+
+Pour redémarrer un notebook arrêté, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez redémarrer.
+Cliquez sur le bouton `Démarrer` pour redémarrer le notebook. Vous pouvez également, depuis le tableau du notebook, cliquer sur le `bouton bleu` en haut de la page.
+
+<img className="thumbnail" alt="Redémarrer un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/restarting-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook start <NOTEBOOK_UUID>` pour redémarrer le notebook.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Start a stopped notebook` et indiquez l'UUID du notebook que vous souhaitez redémarrer.
+
+<img className="thumbnail" alt="Redémarrer un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/restarting-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_start` pour redémarrer le notebook.
+
+```python
+from ovhai.api.notebook import notebook_start
+from ovhai import AuthenticatedClient
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_start.sync_detailed(
+id=id, client=client
+)
+```
+
+</Tab>
+</Tabs>
+
+
+Le notebook doit être arrêté avant de pouvoir être supprimé. Pour supprimer un notebook, procédez comme suit :
+
+<Tabs>
+<Tab label="Via l'espace client OVHcloud">
+
+Accédez au tableau des Quantum Notebooks et cliquez sur le bouton `...` à côté du notebook que vous souhaitez supprimer.
+Cliquez sur le bouton `Supprimer` pour supprimer le notebook. Vous pouvez également cliquer sur le bouton `Delete notebook` en bas de la page.
+
+<img className="thumbnail" alt="Supprimer un notebook depuis l'espace client OVHcloud" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/deleting-a-notebook-using-UI.png" loading="lazy" />
+
+</Tab>
+<Tab label="Depuis la CLI ovhai">
+
+Exécutez la commande `ovhai notebook delete <NOTEBOOK_UUID>` pour supprimer le notebook.
+
+</Tab>
+<Tab label="Via l'API Quantum">
+
+Sélectionnez le endpoint `Delete permanently a notebook` et indiquez l'UUID du notebook que vous souhaitez supprimer.
+
+<img className="thumbnail" alt="Supprimer un notebook via l'API" src="/images/guides/public-cloud/quantum-computing/qpus/getting-started/deleting-a-notebook-using-API.png" loading="lazy" />
+
+</Tab>
+<Tab label="Via le SDK Python">
+
+Utilisez la méthode `notebook_delete` pour supprimer le notebook.
+```python
+from ovhai.api.notebook import notebook_delete
+from ovhai import AuthenticatedClient
+
+client = AuthenticatedClient(
+base_url="https://gra.ai.cloud.ovh.net",
+token="YOUR_QUANTUM_TOKEN",
+)
+id = "YOUR_NOTEBOOK_UUID"
+
+with client as client:
+response = notebook_delete.sync_detailed(
+id=id, client=client, force=False
+)
+
+print(response.content.decode())
+```
+
+</Tab>
+</Tabs>
+
+
+- Découvrez comment accéder à vos données Object Storage et à vos dépôts Git depuis vos notebooks via l'interface graphique [ici](/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui).
+- Découvrez les fonctionnalités techniques, les capacités et les limites de l'offre Public Cloud Quantum Notebooks [ici](/guides/public-cloud/quantum-computing/capabilities).
+- Obtenez des conseils pour déboguer vos notebooks en cas de problème [ici](/guides/public-cloud/quantum-computing/troubleshooting).
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/quantum-computing/quantum-computing-users.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/quantum-computing-users.mdx
@@ -1,1 +1,63 @@
-../../../../en/guides/public-cloud/quantum-computing/quantum-computing-users.mdx
+---
+title: Quantum - Utilisateurs et rôles
+description: Découvrez comment gérer les utilisateurs et les rôles
+lastUpdated: 2025-06-17
+---
+
+:::warning
+Certains liens de cette documentation renvoient vers la solution AI and Machine Learning. L'informatique quantique repose sur la même infrastructure as a service : vous pouvez donc être redirigé vers une autre section de cette documentation.
+:::
+
+## Objectif
+
+Les **utilisateurs** de l'**informatique quantique d'OVHcloud** sont les mêmes que ceux de votre [projet Public Cloud](/links/public-cloud/public-cloud), qui peuvent être créés et gérés dans l'<ManagerLink to="/">espace client OVHcloud (UI)</ManagerLink>. Ce guide vous explique comment créer, configurer et supprimer des utilisateurs Quantum et leurs rôles.
+
+## Prérequis
+
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
+- Un accès à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>
+
+## En pratique
+
+### Créer et modifier des utilisateurs Quantum
+
+Pour accorder l'accès aux **Quantum Notebooks d'OVHcloud**, attribuez aux utilisateurs le rôle **Quantum Operator** ou **Quantum Reader**.
+
+- **Quantum Operator** : fournit un accès complet aux **Quantum Notebooks**. Les utilisateurs peuvent lancer, arrêter et supprimer des Quantum Notebooks, ainsi que s'authentifier auprès de Quantum Notebooks existants. La [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) utilise leurs identifiants.
+- **Quantum Reader** : permet aux utilisateurs d'accéder aux Quantum Notebooks existants, mais pas de les lancer, de les arrêter ou de les supprimer.
+
+Nous vous recommandons d'ajouter le rôle **ObjectStore Operator** aux utilisateurs Quantum, afin de leur fournir un accès en lecture/écriture à l'**Object Storage d'OVHcloud**.
+
+Pour appliquer ces rôles, connectez-vous à l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et accédez à la section `Public Cloud`. Sélectionnez votre projet Public Cloud, puis cliquez sur `Project Management` > `Users & Roles` :
+
+<img className="thumbnail" alt="image" src="/images/guides/public-cloud/quantum-computing/users-roles/03_users_menu.png" loading="lazy" />
+
+Sur cette page, vous pouvez créer un nouvel utilisateur ou modifier les rôles d'un utilisateur existant.
+
+**1. Créer un nouvel utilisateur**
+
+Cliquez sur `+ Add user`, indiquez un nom et attribuez les rôles requis (**Quantum Operator** ou **Quantum Reader** et **ObjectStore Operator**) :
+
+<img className="thumbnail" alt="image" src="/images/guides/public-cloud/quantum-computing/users-roles/04_users_roles.png" loading="lazy" />
+
+Cette opération génère un mot de passe permettant de s'authentifier auprès des Quantum Notebooks existants et de la CLI `ovhai`.
+
+:::info
+Si vous perdez le mot de passe d'un utilisateur, vous pouvez le régénérer en cliquant sur le bouton `...` situé à côté de l'utilisateur, puis en sélectionnant `Regénérer un mot de passe`. L'accès à un notebook peut être révoqué en supprimant l'utilisateur ou en lui retirant son rôle **Quantum Operator / Reader**.
+:::
+
+**2. Modifier les rôles d'un utilisateur existant**
+
+Cliquez sur le bouton `...` situé à côté de l'utilisateur et sélectionnez `Éditer les rôles` pour modifier ses rôles existants.
+
+## Aller plus loin
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/public-cloud/quantum-computing/troubleshooting.mdx
+++ b/docs/fr/guides/public-cloud/quantum-computing/troubleshooting.mdx
@@ -1,1 +1,272 @@
-../../../../en/guides/public-cloud/quantum-computing/troubleshooting.mdx
+---
+title: Quantum - Résolution des problèmes
+description: Découvrez comment déboguer vos notebooks
+lastUpdated: 2025-06-17
+---
+
+
+
+## Objectif
+
+Ce tutoriel vous donne quelques pistes pour déboguer vos notebooks en cas de problème.
+
+## Prérequis
+
+- Un notebook que vous souhaitez démarrer avec les **Quantum Notebooks**
+- Un [conteneur Object Storage](/guides/storage-and-backup/object-storage/pcs-create-container) dans votre compte OVHcloud
+- Un utilisateur Public Cloud disposant du rôle **Administrator** ou **Quantum Operator**
+
+## En pratique
+
+
+<details>
+
+<summary>Qu'est-ce qu'un émulateur de notebook Quantum et comment en lancer un ?</summary>
+
+
+Toutes les étapes permettant de démarrer et de travailler sur les Quantum Notebooks sont décrites dans le guide « [Quantum Notebooks - Premiers pas](/guides/public-cloud/quantum-computing/emulators/getting-started) ».
+
+</details>
+
+
+<details>
+
+<summary>Je ne parviens pas à me connecter à mon notebook</summary>
+
+
+Si vous ne parvenez pas à vous connecter aux Quantum Notebooks, vérifiez les points suivants :
+
+- **Votre notebook est démarré et en cours d'exécution :** pour vous connecter à votre notebook, celui-ci doit être en statut `RUNNING` ou `IN SERVICE` (couleur verte dans l'espace client OVHcloud). Si votre notebook est en cours de démarrage, patientez quelques instants, le temps que vos données se synchronisent, puis vous pourrez vous y connecter. Le temps de démarrage peut varier selon certains paramètres. Plus vous synchronisez de données, plus l'opération prend de temps.
+- **Vous disposez d'un utilisateur autorisé ou d'un token autorisé :** pour pouvoir vous connecter à votre notebook, vous devez avoir créé un utilisateur ou un token. Pour créer un nouvel utilisateur, connectez-vous à l'espace client OVHcloud et ouvrez votre projet Public Cloud. Dans le menu de gauche, cliquez sur la section <code className="action">Quantum</code>. Cela vous permet de gérer et de créer des utilisateurs Quantum. Pour un simple accès à l'informatique quantique, utilisez le rôle `Quantum reader`. Pour un usage plus avancé, incluant la gestion, sélectionnez le rôle `Quantum operator`.
+
+Pour suivre toutes les étapes en détail, reportez-vous à cette [documentation](/guides/public-cloud/quantum-computing/quantum-computing-users).
+
+</details>
+
+
+<details>
+
+<summary>Je ne parviens pas à installer de paquets via une commande APT</summary>
+
+
+Les Quantum Notebooks ne permettent pas d'utiliser `apt-get install`, car vous n'êtes pas root. Vous pouvez installer vos différents paquets à l'aide de ces commandes :
+
+1\. La commande `pip` :
+
+```console
+pip install package-name
+```
+
+2\. La commande `conda` :
+
+```console
+conda install package-name
+```
+
+- **Installer des paquets dans un terminal :** ouvrez tout d'abord un nouveau terminal.
+
+Si vous avez choisi l'éditeur `Jupyterlab`, ouvrez un nouveau terminal : <code className="action">File</code> > <code className="action">New</code> > <code className="action">Terminal</code>.
+Si vous avez choisi l'éditeur `VScode`, ouvrez un nouveau terminal en cliquant sur l'icône de menu > <code className="action">Terminal</code> > <code className="action">New Terminal</code>.
+
+Vous pouvez ensuite exécuter directement dans votre terminal l'une des deux commandes suivantes :
+
+```console
+pip install package-name
+```
+
+ou
+
+```console
+conda install package-name
+```
+
+- **Installer des paquets directement dans une cellule de notebook :** si vous souhaitez installer un paquet directement dans une cellule de notebook, n'oubliez pas de faire précéder votre commande d'un point d'exclamation. Vous pourrez alors installer un paquet avec :
+
+```console
+!pip install package-name
+```
+
+ou
+
+```console
+!conda install package-name
+```
+
+Il reste préférable d'installer ou de désinstaller les paquets dans un terminal, en particulier pour les autorisations. Vous pouvez y autoriser (ou non) l'installation ou la désinstallation des paquets par un oui ou un non. Cela est impossible dans une cellule de notebook.
+
+</details>
+
+
+<details>
+
+<summary>Je rencontre des problèmes de compatibilité entre les paquets que j'ai installés</summary>
+
+
+Vérifiez la compatibilité entre le framework que vous avez choisi lors du lancement de votre notebook et le paquet que vous avez installé.
+
+Si votre framework n'est pas compatible avec la version du paquet :
+
+- Vous pouvez désinstaller le paquet à l'aide d'une commande `pip uninstall <package_name>` ou `conda remove <package_name>`. Réinstallez ensuite le paquet dans une version compatible avec votre framework.
+- Sinon, plusieurs versions sont disponibles pour certains frameworks. Choisissez celle qui correspond le mieux à votre projet.
+
+</details>
+
+
+<details>
+
+<summary>Comment utiliser ma propre image Docker avec les Quantum Notebooks ?</summary>
+
+
+Les Quantum Notebooks ne permettent pas d'utiliser des images Docker personnalisées.
+
+</details>
+
+
+<details>
+
+<summary>J'ai des doutes sur la facturation des notebooks</summary>
+
+
+Vous ne payez que les ressources que vous utilisez et, le cas échéant, le stockage local. Consultez [cette documentation](/guides/public-cloud/quantum-computing/billing) pour des exemples détaillés.
+
+</details>
+
+
+<details>
+
+<summary>Je ne vois pas mes données synchronisées dans l'Object Storage</summary>
+
+
+Lorsque vous créez un Quantum Notebook, nous copions vos données dans les conteneurs Object Storage attachés, au plus près de vos ressources de calcul (`CPU` et `GPU`), afin d'améliorer les performances et de réduire la latence.
+
+:::info
+
+Lorsque vous écrivez des données dans un volume attaché, nous attendons l'arrêt du Quantum Notebook pour resynchroniser vos données.
+
+:::
+
+
+Si vous ne parvenez pas à voir vos données synchronisées, vérifiez les points suivants :
+
+- **Votre notebook est arrêté :** pour voir vos données synchronisées dans l'Object Storage, votre notebook doit être arrêté au préalable. Le statut de votre notebook doit être « stopped » (de couleur rouge). Si votre notebook est en statut `STOPPING`, patientez un peu et vous pourrez voir vos données synchronisées.
+- **Votre conteneur object n'est pas vide :** si votre conteneur object est vide, il est possible que vous n'ayez pas enregistré vos données au bon endroit lors de leur utilisation dans votre notebook. Vérifiez la manière dont le volume a été monté au démarrage de votre notebook.
+
+</details>
+
+
+<details>
+
+<summary>J'ai peut-être atteint les limites de ressources</summary>
+
+
+Chaque service Quantum Notebooks est fourni avec un tableau de bord de monitoring, qui vous permet de suivre de près vos consommations de calcul, de stockage et de réseau.
+
+Pour vérifier vos métriques d'utilisation, accédez à la section <code className="action">Public Cloud</code> de l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> et sélectionnez <code className="action">Quantum Notebooks</code>. Tous vos notebooks sont alors listés. Cliquez sur votre notebook pour consulter ses informations. Dans <code className="action">Ressources</code>, vous pouvez ensuite accéder au monitoring de vos ressources via le `Graph Dashboard`.
+
+Notez que chaque Quantum Notebook est limité à un nombre maximal de CPU et de GPU. Vous pouvez vous reporter au guide [Capacités et limites](/guides/public-cloud/quantum-computing/capabilities) des Quantum Notebooks.
+
+</details>
+
+
+<details>
+
+<summary>Je constate des lenteurs</summary>
+
+
+Des lenteurs peuvent être constatées dans deux cas principaux : vous exécutez des tâches intensives qui consomment toutes vos ressources, ou il s'agit d'un incident côté OVHcloud.
+
+Dans le premier cas, vous pouvez vous reporter à la question *« J'ai peut-être atteint les limites de ressources »*.
+
+Dans le second cas, vous pouvez vérifier sur la page [OVHcloud status](https://public-cloud.status-ovhcloud.com/) si une opération affecte notre infrastructure.
+
+Si ce n'est pas le cas, contactez notre [support](https://help.ovhcloud.com/csm?id=csm_get_help).
+
+</details>
+
+
+<details>
+
+<summary>Puis-je installer un nouvel éditeur de notebook ?</summary>
+
+
+Actuellement, vous pouvez choisir entre trois éditeurs de code en direct pour lancer et modifier votre notebook :
+
+- VSCode
+- JupyterLab
+- JupyterLab Real Time (environnement collaboratif)
+
+Vous pouvez obtenir la liste des éditeurs disponibles à l'aide de la CLI ovhai, avec la commande suivante : `ovhai capabilities editor list`
+
+Vous ne pouvez pas installer votre propre éditeur de code sur les Quantum Notebooks.
+
+</details>
+
+
+<details>
+
+<summary>Quels sont les ports accessibles depuis le réseau public ?</summary>
+
+
+Chaque notebook dispose d'une URL publique. Par défaut, cette URL accède au port 8080 du notebook. Le port par défaut ne peut pas être modifié.
+
+Vous pouvez toutefois accéder à d'autres ports en les ajoutant à l'URL. Par exemple, l'URL du notebook (commençant par l'identifiant du notebook, ici rempli de 0) permettant d'accéder au port 8501 est `https://00000000-0000-0000-0000-000000000000-8501.job.gra.ai.cloud.ovh.net/`
+
+</details>
+
+
+<details>
+
+<summary>CLI : mon notebook est en statut "failed"</summary>
+
+
+- Vérifiez que vous disposez de la permission de vous connecter au Public Cloud Object Storage (PCS) : si vous supprimez la permission de connexion au PCS, la synchronisation des données échouera, et le notebook également.
+- Vérifiez que vous avez accès aux données du volume que vous tentez de connecter à votre notebook : si vous tentez de vous connecter à un volume (depuis le PCS) sans disposer des droits d'accès, votre notebook passera en statut `failed`.
+
+Pour le déboguer vous-même, exécutez la commande suivante dans la CLI :
+
+```console
+ovhai notebook get <notebook_id>
+```
+
+Vous saurez ainsi si le statut `failed` est lié à la synchronisation des données et quel volume n'a pas pu être synchronisé.
+
+</details>
+
+
+<details>
+
+<summary>Pendant combien de temps puis-je utiliser mon notebook Quantum ?</summary>
+
+
+Un notebook Quantum fonctionne en continu jusqu'à son interruption manuelle par l'utilisateur, sauf s'il dépasse **7 jours d'exécution**. Il est alors automatiquement arrêté. Vous pouvez choisir de le redémarrer automatiquement grâce à l'option `auto-restart` (définissez ce paramètre sur `True`). Le notebook redémarre alors en l'état. Pour augmenter cette limite de 7 jours, vous devez contacter le [support](https://help.ovhcloud.com/csm?id=csm_get_help) afin de demander une augmentation de ce quota pour votre projet Public Cloud.
+
+</details>
+
+
+<details>
+
+<summary>Mon notebook s'est arrêté de manière inattendue</summary>
+
+
+Bien que nous fassions notre possible pour éviter cette situation, des interruptions de service peuvent survenir, comme pour tout service.
+
+Veuillez ouvrir un ticket auprès de notre [support](https://help.ovhcloud.com/csm?id=csm_get_help).
+
+Si votre notebook s'est arrêté de manière inattendue, cela peut être dû à un incident sur notre backend. En général, vos données distantes sont en sécurité et seront synchronisées dans le Public Cloud Object Storage.
+
+Votre stockage local éphémère sera perdu.
+
+</details>
+
+
+## Aller plus loin
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+## Nous voulons vos retours !
+
+Nous serions ravis de répondre à vos questions et apprécions tout retour que vous pourriez nous faire.
+
+N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant les Quantum Notebooks :
+
+- Dans le canal #quantum-computing du [serveur Discord OVHcloud](https://discord.gg/ovhcloud).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -1,48 +1,48 @@
 ---
-title: How to Access a Cloud Disk Array Cluster from a Client Machine
-description: Connect a client to your OVHcloud Cloud Disk Array, add its IP to the ACL, install Ceph, configure ceph.conf, add the keyring and test
+title: Accéder à un cluster Cloud Disk Array depuis une machine cliente
+description: Découvrez comment connecter un client à votre Cloud Disk Array OVHcloud, ajouter son adresse IP à l'ACL, installer Ceph, configurer ceph.conf, ajouter le keyring et tester la connexion
 lastUpdated: 2025-09-18
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
 
-## Objective
+## Objectif
 
-This guide shows how to configure a client (such as a Public Cloud instance or any server with a public IP) to connect to your OVHcloud Cloud Disk Array cluster using Ceph CLI tools.
+Ce guide vous explique comment configurer un client (par exemple une instance Public Cloud ou tout serveur disposant d'une adresse IP publique) afin de le connecter à votre cluster Cloud Disk Array OVHcloud à l'aide des outils en ligne de commande Ceph.
 
-## Requirements
+## Prérequis
 
-- A [Cloud Disk Array](https://www.ovhcloud.com/fr/storage-solutions/cloud-disk-array/) solution
-- The public IP address of the client machine you want to grant access to.
-- Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- The Ceph monitor IPs, a Ceph user, and its secret key from the Control Panel. You can follow [this guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user) to manage dedicated users.
+- Une solution [Cloud Disk Array](https://www.ovhcloud.com/fr/storage-solutions/cloud-disk-array/)
+- L'adresse IP publique de la machine cliente à laquelle vous souhaitez accorder l'accès.
+- Un accès à l'<ManagerLink to="/">OVHcloud Control Panel</ManagerLink> ou à l'<ApiLink>API OVHcloud</ApiLink>
+- Les adresses IP des moniteurs Ceph, un utilisateur Ceph et sa clé secrète, disponibles dans l'espace client. Vous pouvez suivre [ce guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user) pour gérer des utilisateurs dédiés.
 
-## Instructions
+## En pratique
 
-### Step 1: Authorize Your Client's IP in the ACL
+### Étape 1 : Autoriser l'adresse IP de votre client dans l'ACL
 
-You must add your client machine's public IP address to the cluster's Access Control List (ACL) to allow it to connect. Follow [this guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl) to add the IP in your Clous Disk Arry ACL.
+Vous devez ajouter l'adresse IP publique de votre machine cliente à la liste de contrôle d'accès (ACL) du cluster pour lui permettre de se connecter. Suivez [ce guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl) pour ajouter l'adresse IP dans l'ACL de votre Cloud Disk Array.
 
 :::warning
 
-Without this step, all connection attempts from your client will be blocked by the firewall.
+Sans cette étape, toutes les tentatives de connexion depuis votre client seront bloquées par le pare-feu.
 
 :::
 
 
-### Step 2: Install Ceph Common Packages
+### Étape 2 : Installer les paquets Ceph Common
 
-Make sure the ceph-common package is installed on your client machine.
+Assurez-vous que le paquet ceph-common est installé sur votre machine cliente.
 
 <Tabs>
-  <Tab label="On Debian/Ubuntu">
+  <Tab label="Sous Debian/Ubuntu">
     ```shell
     sudo apt update
     sudo apt install -y ceph-common
     ```
   </Tab>
-  <Tab label="On RHEL/CentOS Stream/Rocky Linux">
+  <Tab label="Sous RHEL/CentOS Stream/Rocky Linux">
     ```shell
     sudo dnf install -y ceph-common
     ```
@@ -50,23 +50,23 @@ Make sure the ceph-common package is installed on your client machine.
 </Tabs>
 
 
-### Step 3: Create the Ceph Configuration File
+### Étape 3 : Créer le fichier de configuration Ceph
 
-This configuration file tells your client how to reach the cluster’s monitors over the public network.
+Ce fichier de configuration indique à votre client comment joindre les moniteurs du cluster via le réseau public.
 
-1. Create the Ceph configuration directory:
+1. Créez le répertoire de configuration Ceph :
 
     ```shell
     sudo mkdir -p /etc/ceph
     ```
 
-2. Create and edit the ceph.conf file:
+2. Créez et éditez le fichier ceph.conf :
 
     ```shell
     sudo nano /etc/ceph/ceph.conf
     ```
 
-3. Add a [global] section with your monitors’ public IPs, found on your Cloud Disk Array main Control Panel page.
+3. Ajoutez une section [global] avec les adresses IP publiques de vos moniteurs, disponibles sur la page principale de votre Cloud Disk Array dans l'espace client.
 
     ```ini
     [global]
@@ -83,34 +83,34 @@ This configuration file tells your client how to reach the cluster’s monitors 
     mon_host =A.B.X.Y:6789,A.B.X.Y:6789,A.B.X.Y:6789
     ```
 
-4. Save and close the file.
+4. Enregistrez et fermez le fichier.
 
-### Step 4: Create the Ceph Keyring File
+### Étape 4 : Créer le fichier keyring Ceph
 
-Store the secret key in a keyring file to authenticate your user.
+Stockez la clé secrète dans un fichier keyring pour authentifier votre utilisateur.
 
-1. Create the keyring file for your user:
+1. Créez le fichier keyring pour votre utilisateur :
 
     ```shell
     sudo nano /etc/ceph/ceph.client.[USERID].keyring
     ```
 
-2. Enter the key using the correct format:
+2. Saisissez la clé en respectant le format suivant :
 
     ```ini
     [client.[USERID]]
     key = YOUR_SECRET_KEY_FOR_USER
     ```
 
-3. Restrict file permissions for security:
+3. Restreignez les permissions du fichier pour des raisons de sécurité :
 
     ```shell
     sudo chmod 600 /etc/ceph/ceph.client.[USERID].keyring
     ```
 
-### Step 5: Test the Connection
+### Étape 5 : Tester la connexion
 
-Test your configuration, the ceph command will use the config file and keyring automatically.
+Testez votre configuration. La commande ceph utilise automatiquement le fichier de configuration et le keyring.
 
 ```shell
 # Check the overall health and status of the cluster
@@ -120,12 +120,12 @@ sudo ceph --id [USERID] status
 sudo ceph --id [USERID] osd lspools
 ```
 
-If these commands show cluster information, your client is successfully configured to access the Cloud Disk Array over the public internet.
+Si ces commandes affichent les informations du cluster, votre client est correctement configuré pour accéder au Cloud Disk Array via Internet.
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
+Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -1,69 +1,69 @@
 ---
-title: CephFS distributed filesystem
-description: Learn how to create, manage, and mount a CephFS file system on OVHcloud using the API
+title: Système de fichiers distribué CephFS
+description: Découvrez comment créer, gérer et monter un système de fichiers CephFS chez OVHcloud à l'aide de l'API
 lastUpdated: 2025-09-18
 ---
 
 import Api from '@components/Api';
 
 
-## Objective
+## Objectif
 
-This guide provides detailed instructions on how to create, manage, and mount a CephFS file system for your OVHcloud services. It covers the full setup process using the OVHcloud API, ensuring you can efficiently integrate CephFS into your cloud environment.
+Ce guide fournit des instructions détaillées pour créer, gérer et monter un système de fichiers CephFS destiné à vos services OVHcloud. Il couvre l'intégralité du processus de configuration via l'API OVHcloud, afin de vous permettre d'intégrer efficacement CephFS à votre environnement cloud.
 
-## Requirements
+## Prérequis
 
-- A [Cloud Disk Array](https://www.ovhcloud.com/fr/storage-solutions/cloud-disk-array/) solution
+- Disposer d'une solution [Cloud Disk Array](https://www.ovhcloud.com/fr/storage-solutions/cloud-disk-array/)
 
 {/* CP-NAV-START:storage-cloud-disk-array */}
 ---
 
-### OVHcloud Control Panel Access
+### Accès à l'espace client OVHcloud
 
-- **Direct link:** <ManagerLink to="/#/dedicated/cda">Cloud Disk Array</ManagerLink>
-- **Navigation path:** <code className="action">Bare Metal Cloud</code> > <code className="action">Cloud Disk Array</code> > Select your service
+- **Lien direct :** <ManagerLink to="/#/dedicated/cda">Cloud Disk Array</ManagerLink>
+- **Chemin de navigation :** <code className="action">Bare Metal Cloud</code> > <code className="action">Cloud Disk Array</code> > Sélectionnez votre service
 
 ---
 {/* CP-NAV-END:storage-cloud-disk-array */}
 
-### What is CephFS?
+### Qu'est-ce que CephFS ?
 
-CephFS is a distributed POSIX-compliant file system built on top of Ceph. To use CephFS, you need a client that supports it—modern Linux distributions include the CephFS driver by default.
+CephFS est un système de fichiers distribué, conforme à la norme POSIX et bâti sur Ceph. Pour utiliser CephFS, vous avez besoin d'un client qui le prend en charge : les distributions Linux modernes incluent le pilote CephFS par défaut.
 
-You can enable and manage CephFS on your Cloud Disk Array (CDA) via the OVHcloud API. Once enabled, CephFS functions like a private, dedicated file system for your use. You can use both RBD and CephFS simultaneously, but note that they share the same underlying hardware.
+Vous pouvez activer et gérer CephFS sur votre Cloud Disk Array (CDA) via l'API OVHcloud. Une fois activé, CephFS fonctionne comme un système de fichiers privé et dédié à votre usage. Vous pouvez utiliser RBD et CephFS simultanément, mais notez qu'ils partagent le même matériel sous-jacent.
 
-## Instructions
+## En pratique
 
-### Enabling CephFS
+### Activer CephFS
 
 :::info
-Enabling and managing CephFS is only possible through the OVHcloud API.
+L'activation et la gestion de CephFS ne sont possibles que via l'API OVHcloud.
 
-If you are not familiar with the OVHcloud API, see our [First Steps with the OVHcloud API guide](/guides/manage-and-operate/api/first-steps).
+Si vous n'êtes pas familier avec l'API OVHcloud, consultez notre guide « [Premiers pas avec l'API OVHcloud](/guides/manage-and-operate/api/first-steps) ».
 
 :::
 
 
-Currently, only a single file system can be enabled, and it must be named fs-default.
+Actuellement, un seul système de fichiers peut être activé, et il doit être nommé fs-default.
 
-The first step is to list your existing CephFS instances. Here, `serviceName` corresponds to the fsid of your cluster:
+La première étape consiste à lister vos instances CephFS existantes. Ici, `serviceName` correspond au fsid de votre cluster :
 
 <Api version="v1" section="/dedicated/ceph" method="GET" route={"/dedicated/ceph/\{serviceName\}/cephfs"} />
 
 
-<img className="thumbnail" alt="api request 01" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_01.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 01" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_01.png" loading="lazy" />
 
-By default, this request returns an empty list. To create your first file system, you need to enable it:
+Par défaut, cette requête renvoie une liste vide. Pour créer votre premier système de fichiers, vous devez l'activer :
 
 <Api version="v1" section="/dedicated/ceph" method="POST" route={"/dedicated/ceph/\{serviceName\}/cephfs/\{fsName\}/enable"} />
 
 
-<img className="thumbnail" alt="api request 02" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_02.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 02" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_02.png" loading="lazy" />
 
-Your CephFS should be available within a few minutes. You can verify its status directly on your cluster by running:
+Votre CephFS devrait être disponible en quelques minutes. Vous pouvez vérifier son état directement sur votre cluster en exécutant :
 
 :::info
-To access your Ceph cluster directly, please refer to [this guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd).
+Pour accéder directement à votre cluster Ceph, veuillez consulter [ce guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd).
 
 :::
 
@@ -72,19 +72,19 @@ To access your Ceph cluster directly, please refer to [this guide](/guides/stora
 sudo ceph --id [USERID] fs ls
 ```
 
-The result should look similar to:
+Le résultat doit ressembler à ceci :
 
 ```bash
 name: fs-default, metadata pool: cephfs.fs-default.meta, data pools: [cephfs.fs-default.data ]
 ```
 
-If you want to retrieve more details about your CephFS, run:
+Si vous souhaitez obtenir davantage de détails sur votre CephFS, exécutez :
 
 ```bash
 sudo ceph --id [USERID] fs get fs-default
 ```
 
-The result should look similar to:
+Le résultat doit ressembler à ceci :
 
 ```bash
 Filesystem 'fs-default' (1)
@@ -115,66 +115,66 @@ balancer
 standby_count_wanted    2
 ```
 
-### Disabling and removing CephFS
+### Désactiver et supprimer CephFS
 
-When your file system is no longer needed, you can remove it in two steps:
+Lorsque votre système de fichiers n'est plus nécessaire, vous pouvez le supprimer en deux étapes :
 
-- **Disable your file system** - This blocks access to CephFS, but your data remains intact. If needed, you can re-enable it later.
+- **Désactiver votre système de fichiers** - Cette opération bloque l'accès à CephFS, mais vos données restent intactes. Si besoin, vous pouvez le réactiver ultérieurement.
 
 <Api version="v1" section="/dedicated/ceph" method="POST" route={"/dedicated/ceph/\{serviceName\}/cephfs/\{fsName\}/disable"} />
 
 
-<img className="thumbnail" alt="api request 03" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_03.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 03" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_03.png" loading="lazy" />
 
-- **Purge file system data** – This permanently deletes all data, and can only be done on a disabled file system.
+- **Purger les données du système de fichiers** – Cette opération supprime définitivement toutes les données et ne peut être effectuée que sur un système de fichiers désactivé.
 
 <Api version="v1" section="/dedicated/ceph" method="DELETE" route={"/dedicated/ceph/\{serviceName\}/cephfs/\{fsName\}"} />
 
 
-<img className="thumbnail" alt="api request 04" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_04.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 04" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_04.png" loading="lazy" />
 
-### CephFS access management
+### Gestion des accès à CephFS
 
-To manage access to CephFS, the same IP ACL rules used for your CDA apply. However, to write to CephFS, you must create a dedicated user. You can follow [this guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user).
+Pour gérer l'accès à CephFS, les mêmes règles d'ACL IP que celles utilisées pour votre CDA s'appliquent. En revanche, pour écrire dans CephFS, vous devez créer un utilisateur dédié. Vous pouvez suivre [ce guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user).
 
-Next, grant this user read and write access to the CephFS data and metadata pools:
+Accordez ensuite à cet utilisateur les droits de lecture et d'écriture sur les pools de données et de métadonnées de CephFS :
 
 - cephfs.fs-default.data
 - cephfs.fs-default.meta
 
-For details, see [this guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights).
+Pour plus de détails, consultez [ce guide](/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights).
 
 :::info
-Required permissions: read and write on both the data and metadata pools.
+Permissions requises : lecture et écriture sur les pools de données et de métadonnées.
 
 :::
 
 
-### Mounting CephFS on your host
+### Monter CephFS sur votre hôte
 
-Install the **ceph-common** package, which provides the **/sbin/mount.ceph** binary. The package name may vary depending on your Linux distribution.
+Installez le paquet **ceph-common**, qui fournit le binaire **/sbin/mount.ceph**. Le nom du paquet peut varier selon votre distribution Linux.
 
-In the example below, we use a Debian-based system:
+Dans l'exemple ci-dessous, nous utilisons un système basé sur Debian :
 
 ```bash
 sudo apt install --no-install-recommends ceph-common
 ```
 
-Next, configure your client to connect to the CDA cluster by editing (or creating) the **/etc/ceph/ceph.conf** file.
+Configurez ensuite votre client pour qu'il se connecte au cluster CDA, en modifiant (ou en créant) le fichier **/etc/ceph/ceph.conf**.
 
-1\. Create the Ceph configuration directory:
+1\. Créez le répertoire de configuration de Ceph :
 
 ```bash
 sudo mkdir -p /etc/ceph
 ```
 
-2\. Create and edit the ceph.conf file:
+2\. Créez et modifiez le fichier ceph.conf :
 
 ```bash
 sudo nano /etc/ceph/ceph.conf
 ```
 
-3\. Add the `[global]` section with the public IP addresses of your monitors. You can find these IPs on the main page of your Cloud Disk Array in the OVHcloud Control Panel.
+3\. Ajoutez la section `[global]` avec les adresses IP publiques de vos moniteurs. Vous trouverez ces adresses IP sur la page principale de votre Cloud Disk Array, dans l'espace client OVHcloud.
 
 ```bash
 [global]
@@ -192,53 +192,53 @@ ms_bind_msgr2 = true
 mon_host =A.B.X.Y:6789,A.B.X.Y:6789,A.B.X.Y:6789
 ```
 
-The FSID corresponds to the service name of your CDA. The monitor host IPs can be retrieved using the following API call:
+Le FSID correspond au nom de service de votre CDA. Les adresses IP des hôtes moniteurs peuvent être récupérées à l'aide de l'appel API suivant :
 
 <Api version="v1" section="/dedicated/ceph" method="GET" route={"/dedicated/ceph/\{serviceName\}"} />
 
 
-<img className="thumbnail" alt="api request 05" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_05.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 05" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_05.png" loading="lazy" />
 
-4\. Save and close the file.
+4\. Enregistrez et fermez le fichier.
 
-You will also need a second file containing the key for the user that connects to the cluster. Fetch the user key with the following API call:
+Vous aurez également besoin d'un second fichier contenant la clé de l'utilisateur qui se connecte au cluster. Récupérez la clé de l'utilisateur à l'aide de l'appel API suivant :
 
 <Api version="v1" section="/dedicated/ceph" method="GET" route={"/dedicated/ceph/\{serviceName\}/user/\{userName\}"} />
 
 
-<img className="thumbnail" alt="api request 06" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_06.png" loading="lazy" />
+<img className="thumbnail" alt="requête API 06" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs/api_request_06.png" loading="lazy" />
 
-Then, create a secret file for this user:
+Créez ensuite un fichier de secret pour cet utilisateur :
 
-1\. Create a file called /etc/ceph/[USERID].secret
+1\. Créez un fichier nommé /etc/ceph/[USERID].secret
 
 ```bash
 sudo nano /etc/ceph/[USERID].secret
 ```
 
-2\. Add the user key to the file in the correct format:
+2\. Ajoutez la clé de l'utilisateur dans le fichier, au format approprié :
 
 ```bash
 YOUR_SECRET_KEY_FOR_USER
 ```
 
-3\. Set strict permissions on the secret file to ensure security:
+3\. Appliquez des permissions strictes sur le fichier de secret afin de garantir la sécurité :
 
 ```bash
 sudo chmod 600 /etc/ceph/[USERID].secret
 ```
 
-Finally you can mount your filesystem:
+Vous pouvez enfin monter votre système de fichiers :
 
 ```bash
 mkdir /mnt/cephfs
 mount -t ceph -o name=[USERID],secretfile=/etc/ceph/[USERID].secret :/ /mnt/cephfs/
 ```
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
+Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cluster status
+title: État du cluster
 description: "Ce guide vous présente comment vérifier l'état du Cluster CEPH"
 lastUpdated: 2020-12-22
 ---
@@ -7,48 +7,48 @@ lastUpdated: 2020-12-22
 import Api from '@components/Api';
 
 
-## Using web interface
-First, connect to the [Cloud Disk Array manager](https://www.ovh.com/manager/cloud/index.html). Under 'Platforms and services' select your Ceph cluster. You will see two differents parts: **cluster details** and **cluster health**.
+## Utiliser l'interface web
+Connectez-vous d'abord au [manager Cloud Disk Array](https://www.ovh.com/manager/cloud/index.html). Sous « Plateformes et services », sélectionnez votre cluster Ceph. Deux parties distinctes s'affichent : **les détails du cluster** et **l'état de santé du cluster**.
 
-### Cluster details
+### Détails du cluster
 
-<img className="thumbnail" alt="Ceph users" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status/check_cluster_status_1.png" loading="lazy" />
+<img className="thumbnail" alt="Utilisateurs Ceph" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status/check_cluster_status_1.png" loading="lazy" />
 
-Additional explanations:
+Explications complémentaires :
 
-| Field | Description |
+| Champ | Description |
 |-------|-------------|
-| **Label** | Name given to you cluster |
-| **Region** | We currently deliver Ceph clusters on Strasbourg, Gravelines and Beauharnois. |
-| **Version** | We currently deliver clusters up to version 9.2.1 ([official Ceph releases](https://docs.ceph.com/en/latest/releases/general/)) |
-| **Tunable** | It's the algorithm used to place datas. |
-| **Status** | Installed means that all tasks requested are done. |
+| **Label** | Nom attribué à votre cluster |
+| **Region** | Nous proposons actuellement des clusters Ceph à Strasbourg, Gravelines et Beauharnois. |
+| **Version** | Nous proposons actuellement des clusters jusqu'à la version 9.2.1 ([versions officielles de Ceph](https://docs.ceph.com/en/latest/releases/general/)) |
+| **Tunable** | Il s'agit de l'algorithme utilisé pour placer les données. |
+| **Status** | La valeur Installed signifie que toutes les tâches demandées ont été effectuées. |
 | **State** | Active |
-| **Monitors** | IP that you have to use to reach your monitors. |
-| **Create date** | Creation date of your cluster |
-| **Update date** | Date of the last task applied to your cluster |
+| **Monitors** | Adresse IP que vous devez utiliser pour joindre vos moniteurs. |
+| **Create date** | Date de création de votre cluster |
+| **Update date** | Date de la dernière tâche appliquée à votre cluster |
 
-### Cluster health
+### État de santé du cluster
 
-<img className="thumbnail" alt="Ceph users" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status/check_cluster_status_2.png" loading="lazy" />
+<img className="thumbnail" alt="Utilisateurs Ceph" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status/check_cluster_status_2.png" loading="lazy" />
 
-Additional explanations:
+Explications complémentaires :
 
-| Field | Description |
+| Champ | Description |
 |-------|-------------|
-| **Status** | HEALTH_OK means that every objects are at the right place and have 3 replicates. HEALTH_WARN means that some objects are missplaced (like after a growth) or that some object are not replicated three times. In this case cluster is recovering |
-| **Healthy** | Boolean indicating if everything is ok with Ceph cluster or not |
-| **Availables bytes** | Free bytes available in the cluster (before replication) |
-| **Used bytes** | Bytes currently used in the cluster (after replication) |
-| **Space usage [%]** | Percentage of *used bytes* in relation to *total bytes* |
-| **Cluster active tasks** | List of user-initiated tasks that are currently being processed for this cluster |
+| **Status** | HEALTH_OK signifie que tous les objets sont au bon emplacement et disposent de 3 réplicas. HEALTH_WARN signifie que certains objets sont mal placés (par exemple après une extension) ou que certains objets ne sont pas répliqués trois fois. Dans ce cas, le cluster est en cours de reconstruction |
+| **Healthy** | Booléen indiquant si tout fonctionne correctement sur le cluster Ceph ou non |
+| **Availables bytes** | Octets disponibles dans le cluster (avant réplication) |
+| **Used bytes** | Octets actuellement utilisés dans le cluster (après réplication) |
+| **Space usage [%]** | Pourcentage d'*octets utilisés* par rapport au *nombre total d'octets* |
+| **Cluster active tasks** | Liste des tâches lancées par l'utilisateur et actuellement en cours de traitement pour ce cluster |
 
-## Using API
-Get Ceph cluster details with a simple HTTP call.
+## Utiliser l'API
+Récupérez les détails du cluster Ceph à l'aide d'un simple appel HTTP.
 
 <Api version="v1" section="/dedicated/ceph" method="GET" route={"/dedicated/ceph/\{serviceName\}"} />
 
-Example:
+Exemple :
 
 ```bash
 GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15
@@ -70,7 +70,7 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15
 }
 ```
 
-Get Ceph cluster health:
+Récupérez l'état de santé du cluster Ceph :
 
 <Api version="v1" section="/dedicated/ceph" method="GET" route={"/dedicated/ceph/\{serviceName\}/health"} />
 
@@ -85,10 +85,10 @@ Get Ceph cluster health:
 }
 ```
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
+Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-faq.mdx
@@ -1,64 +1,64 @@
 ---
 title: FAQ
-description: Frequently asked questions
+description: Questions fréquentes
 lastUpdated: 2020-11-05
 ---
 
-## What is Cloud Disk Array?
-Cloud Disk Array (CDA) is a private, dedicated (on disk level) storage system powered by Ceph. During development and testing it was known as Ceph-as-a-Service. CDA gives you storage space that can be utilized in a number of ways:
+## Qu'est-ce que Cloud Disk Array ?
+Cloud Disk Array (CDA) est un système de stockage privé et dédié (au niveau des disques), propulsé par Ceph. Pendant sa phase de développement et de test, il était connu sous le nom de Ceph-as-a-Service. CDA vous fournit un espace de stockage qui peut être utilisé de plusieurs manières :
 
-- RADOS (low-level Ceph-specific object storage) - when building a custom application that depends on Ceph
-- RBD (block devices) - can be used in dedicated servers with Linux or for VM disks in OpenStack and Proxmox environments
-- CephFS (NFS-like filesystem) - provides distributed filesystem for all modern Linux distributions
+- RADOS (stockage objet bas niveau spécifique à Ceph) - pour développer une application personnalisée qui dépend de Ceph
+- RBD (périphériques en mode bloc) - utilisable sur des serveurs dédiés sous Linux ou pour des disques de machines virtuelles dans des environnements OpenStack et Proxmox
+- CephFS (système de fichiers de type NFS) - fournit un système de fichiers distribué pour toutes les distributions Linux modernes
 
-There are also other ways to access Ceph which are not currently available for CDA:
+Il existe également d'autres moyens d'accéder à Ceph, qui ne sont pas disponibles actuellement pour CDA :
 
-- iSCSI gateway for RBD - for integration with existing environment with iSCSI support
-- RGW (REST object storage) - can be used to build a CDN (with an OVH provided load-balancer)
-- NFS and CIFS (SAMBA) gateways for CephFS - for integration with existing Windows or Linux environments
-- inter-DC replication
+- passerelle iSCSI pour RBD - pour l'intégration à un environnement existant prenant en charge iSCSI
+- RGW (stockage objet REST) - utilisable pour construire un CDN (avec un load balancer fourni par OVHcloud)
+- passerelles NFS et CIFS (SAMBA) pour CephFS - pour l'intégration à des environnements Windows ou Linux existants
+- réplication inter-datacentres
 
-Our goal is to provide to customers all features of Ceph inside a service managed by OVH. Let us know which interfaces you're interested in.
+Notre objectif est de fournir à nos clients toutes les fonctionnalités de Ceph au sein d'un service géré par OVHcloud. N'hésitez pas à nous indiquer les interfaces qui vous intéressent.
 
-## Where is my data stored?
-Once you select a Data Center, your data will be replicated three times. Those replicas are placed on three different server machines on three different racks.
+## Où mes données sont-elles stockées ?
+Une fois que vous avez sélectionné un datacentre, vos données sont répliquées trois fois. Ces répliques sont placées sur trois serveurs différents, répartis sur trois baies différentes.
 
-To reduce latency when accessing your cluster, your clients should be in the same OVH datacenter as your Ceph cluster.
+Afin de réduire la latence lors de l'accès à votre cluster, vos clients doivent se trouver dans le même datacentre OVHcloud que votre cluster Ceph.
 
-## Can I increase my Cloud Disk Array storage capacity?
-Yes, you can increase size of you CDA through an API.
+## Puis-je augmenter la capacité de stockage de mon Cloud Disk Array ?
+Oui, vous pouvez augmenter la taille de votre CDA via une API.
 
-## Can I decrease my Cloud Disk Array storage capacity?
-No - at the moment it is not possible.
+## Puis-je réduire la capacité de stockage de mon Cloud Disk Array ?
+Non, cela n'est pas possible pour le moment.
 
-## Can I deploy a filesystem over my Cloud Disk Array?
-You can enable CephFS using API to have fully managed distributed filestystem.
+## Puis-je déployer un système de fichiers sur mon Cloud Disk Array ?
+Vous pouvez activer CephFS via l'API afin de disposer d'un système de fichiers distribué entièrement géré.
 
-## Is it possible to access a Cloud Disk Array from a service not hosted by OVH?
-Short answer is: No - at the moment it is not possible.
+## Est-il possible d'accéder à un Cloud Disk Array depuis un service qui n'est pas hébergé par OVHcloud ?
+La réponse courte est : non, cela n'est pas possible pour le moment.
 
-In order to maximize performance and minimize latency for block devices (RBD) and fileystem (CephFS) it is only possible to use it inside OVH network - from other OVH services. If you need external access please contact us.
+Afin de maximiser les performances et de réduire la latence des périphériques en mode bloc (RBD) et du système de fichiers (CephFS), leur utilisation n'est possible qu'au sein du réseau OVHcloud, depuis d'autres services OVHcloud. Si vous avez besoin d'un accès externe, veuillez nous contacter.
 
-Please keep in mind that there are plans to add another mechanism for accessing CDA data storage - Rados Gateway. Rados Gateway will be able to expose CDA access to services located outside OVH via SWIFT API.
+Notez qu'il est prévu d'ajouter un autre mécanisme d'accès au stockage de données CDA : Rados Gateway. Rados Gateway permettra d'exposer l'accès au CDA à des services situés en dehors d'OVHcloud, via l'API SWIFT.
 
-## Which OVH solutions are compatible with Cloud Disk Array?
-Any solutions that can connect to the OVH local network.
+## Quelles solutions OVHcloud sont compatibles avec Cloud Disk Array ?
+Toutes les solutions capables de se connecter au réseau local OVHcloud.
 
-Public Cloud, Dedicated Server, Private Cloud Computing (PCC), VPS.
+Public Cloud, serveur dédié, Private Cloud Computing (PCC), VPS.
 
-## How is ensured the High Availability of the Cloud Disk Array solution?
-Cloud Disk Array is powered by Ceph, which is a storage solution with no single point of failure.
+## Comment la haute disponibilité de la solution Cloud Disk Array est-elle assurée ?
+Cloud Disk Array est propulsé par Ceph, une solution de stockage sans point de défaillance unique.
 
-Whichever protocol you use to store your data in Ceph, it is stored internally as RADOS objects. Each object is replicated 3 times across 3 different servers in 3 different racks.
+Quel que soit le protocole utilisé pour stocker vos données dans Ceph, celles-ci sont stockées en interne sous forme d'objets RADOS. Chaque objet est répliqué 3 fois sur 3 serveurs différents, répartis sur 3 baies différentes.
 
-In case of 1 replica failure, there is no disruption for client (except for slight performance degradation because of recovery).
+En cas de défaillance d'une réplique, il n'y a aucune interruption pour le client (hormis une légère dégradation des performances due à la restauration).
 
-In case of 2 replica failures, client access is blocked to the degraded objects until they are replicated at least 2 times. This is done in order to prevent data loss.
+En cas de défaillance de 2 répliques, l'accès du client aux objets dégradés est bloqué jusqu'à ce qu'ils soient répliqués au moins 2 fois. Cette mesure vise à éviter toute perte de données.
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
+Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/fr/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -1,34 +1,34 @@
 ---
-title: Utiliser Ceph avec Proxmox (EN)
-description: Find out how to set up the Cloud Disk Array on Proxmox
+title: Utiliser Ceph avec Proxmox
+description: Découvrez comment configurer le Cloud Disk Array sur Proxmox
 lastUpdated: 2021-07-01
 ---
 
-## Objective
+## Objectif
 
-**This guide explains how to set up the Cloud Disk Array on Proxmox.**
+**Ce guide explique comment configurer le Cloud Disk Array sur Proxmox.**
 
-## Requirements
+## Prérequis
 
-Fist of all, you need your Cloud Disk Array up and ready. Make sure you have:
+Tout d'abord, votre Cloud Disk Array doit être opérationnel. Assurez-vous d'avoir :
 
-- created a cluster pool for storing data
-- created a Ceph user that Proxmox will use to access the CDA cluster
-- configured permissions for this user and pool (allow read and write)
-- configured your IP access control list to allow Proxmox nodes to access the CDA
+- créé un pool de cluster pour stocker les données
+- créé un utilisateur Ceph que Proxmox utilisera pour accéder au cluster CDA
+- configuré les permissions pour cet utilisateur et ce pool (autoriser la lecture et l'écriture)
+- configuré votre liste de contrôle d'accès IP pour autoriser les nœuds Proxmox à accéder au CDA
 
-## Instructions
+## En pratique
 
 :::info
-In this guide we assume you already have your Proxmox installation up and running. This guide has been tested with Proxmox 6.4.
+Dans ce guide, nous partons du principe que votre installation Proxmox est déjà opérationnelle. Ce guide a été testé avec Proxmox 6.4.
 :::
 
 
-### Ceph RBD storage setup
+### Configurer le stockage Ceph RBD
 
-In order to use Cloud Disk Array, Proxmox needs to know how to access it. This is done by adding the necessary data to the `/etc/pve/storage.cfg` file.
+Pour utiliser le Cloud Disk Array, Proxmox doit savoir comment y accéder. Cela se fait en ajoutant les données nécessaires au fichier `/etc/pve/storage.cfg`.
 
-Log in to your Proxmox node, open the file and enter the following lines:
+Connectez-vous à votre nœud Proxmox, ouvrez le fichier et saisissez les lignes suivantes :
 
 ```bash
 rbd: ovhcloud-cda
@@ -38,16 +38,16 @@ rbd: ovhcloud-cda
         username proxmox
 ```
 
-- `monhost`: the IP list of CDA cluster monitors
-- `content`: the content type you want to host on the CDA
-- `pool`: the CDA pool name that will be used to store data
-- `username`: the username of the user connecting to the CDA
+- `monhost` : la liste des adresses IP des moniteurs du cluster CDA
+- `content` : le type de contenu que vous souhaitez héberger sur le CDA
+- `pool` : le nom du pool CDA qui sera utilisé pour stocker les données
+- `username` : le nom de l'utilisateur qui se connecte au CDA
 
-### Ceph keyring setup
+### Configurer le keyring Ceph
 
-Your cluster is now configured. To be able to authenticate, Proxmox will also need the keyring.
+Votre cluster est désormais configuré. Pour pouvoir s'authentifier, Proxmox aura également besoin du keyring.
 
-In order to add the keyring, edit the file `/etc/pve/priv/ceph/<STORAGE_ID>.keyring`. Replace `<STORAGE_ID>` with the actual name you used in the `storage.cfg` file. In the following example output, the name is `ovhcloud-cda`.
+Pour ajouter le keyring, modifiez le fichier `/etc/pve/priv/ceph/<STORAGE_ID>.keyring`. Remplacez `<STORAGE_ID>` par le nom que vous avez réellement utilisé dans le fichier `storage.cfg`. Dans l'exemple de résultat ci-dessous, ce nom est `ovhcloud-cda`.
 
 ```bash
 root@proxmox:~$ cat /etc/pve/priv/ceph/ovhcloud-cda.keyring
@@ -55,17 +55,17 @@ root@proxmox:~$ cat /etc/pve/priv/ceph/ovhcloud-cda.keyring
         key = KLChQNJYQJCuXMBBrbsz2XllPn+5+cuXdIfJLg==
 ```
 
-You can now see your cluster info using the Proxmox web interface and create a VM on this storage.
+Vous pouvez à présent consulter les informations de votre cluster depuis l'interface web de Proxmox et créer une machine virtuelle sur cet espace de stockage.
 
-<img className="thumbnail" alt="Ceph info" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_1.png" loading="lazy" />
+<img className="thumbnail" alt="informations Ceph" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_1.png" loading="lazy" />
 
-<img className="thumbnail" alt="VM disk on ceph" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_2.png" loading="lazy" />
+<img className="thumbnail" alt="disque de machine virtuelle sur ceph" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_2.png" loading="lazy" />
 
-### CephFS storage setup
+### Configurer le stockage CephFS
 
-In order to use CephFS, you need to enable it through the Cloud Disk Array API. The user defined in the first step can be used to access both RBD and CephFS.
+Pour utiliser CephFS, vous devez l'activer via l'API Cloud Disk Array. L'utilisateur défini à la première étape peut être utilisé pour accéder à la fois à RBD et à CephFS.
 
-The user has to be granted access to the `cephfs.fs-default.data` and `cephfs.fs-default.meta` pools. After that, add the following lines to your `/etc/pve/storage.cfg` config file.
+Cet utilisateur doit disposer d'un accès aux pools `cephfs.fs-default.data` et `cephfs.fs-default.meta`. Ajoutez ensuite les lignes suivantes à votre fichier de configuration `/etc/pve/storage.cfg`.
 
 ```bash
 cephfs: ovhcloud-cda-cephfs
@@ -75,24 +75,24 @@ cephfs: ovhcloud-cda-cephfs
         username proxmox
 ```
 
-- `monhost`: the IP list of CDA cluster monitors
-- `content`: the content type you want to host on the CDA
-- `username`: the username of the user connecting to the CDA
+- `monhost` : la liste des adresses IP des moniteurs du cluster CDA
+- `content` : le type de contenu que vous souhaitez héberger sur le CDA
+- `username` : le nom de l'utilisateur qui se connecte au CDA
 
-### CephFS secret
+### Secret CephFS
 
-CephFS is now configured. You need to add the secret of your Proxmox user (`proxmox` in this example), so Proxmox can authenticate.
+CephFS est désormais configuré. Vous devez ajouter le secret de votre utilisateur Proxmox (`proxmox` dans cet exemple), afin que Proxmox puisse s'authentifier.
 
-Edit the file `/etc/pve/priv/ceph/<STORAGE_ID>.secret`. Replace `<STORAGE_ID>` with the actual name you used in the `storage.cfg` file. In the following example output, the name is `ovhcloud-cda-cephfs`.
+Modifiez le fichier `/etc/pve/priv/ceph/<STORAGE_ID>.secret`. Remplacez `<STORAGE_ID>` par le nom que vous avez réellement utilisé dans le fichier `storage.cfg`. Dans l'exemple de résultat ci-dessous, ce nom est `ovhcloud-cda-cephfs`.
 
-Unlike with the RBD keyring, you need to provide only the secret.
+Contrairement au keyring RBD, vous ne devez fournir que le secret.
 
 ```bash
 root@proxmox:~$ cat /etc/pve/priv/ceph/ovhcloud-cda-cephfs.secret
 KLChQNJYQJCuXMBBrbsz2XllPn+5+cuXdIfJLg==
 ```
 
-You can now download container templates and store them on CephFS:
+Vous pouvez à présent télécharger des modèles de conteneurs et les stocker sur CephFS :
 
 ```sh
 root@pve:~$ pveam update
@@ -100,16 +100,16 @@ root@pve:~$ pveam available --section system
 root@pve:~$ pveam download ovhcloud-cda-cephfs ubuntu-20.04-standard_20.04-1_amd64.tar.gz
 ```
 
-Once a template has been downloaded, you can start using it to create containers.
+Une fois un modèle téléchargé, vous pouvez l'utiliser pour créer des conteneurs.
 
-<img className="thumbnail" alt="CephFS informations" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_3.png" loading="lazy" />
+<img className="thumbnail" alt="informations CephFS" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_3.png" loading="lazy" />
 
-<img className="thumbnail" alt="Container template" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_4.png" loading="lazy" />
+<img className="thumbnail" alt="modèle de conteneur" src="/images/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox/use_ceph_with_proxmox_4.png" loading="lazy" />
 
-## Go further
+## Aller plus loin
 
-Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
+Rendez-vous sur notre chaîne Discord dédiée : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
-Join our [community of users](/links/community).
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
@@ -1,1 +1,136 @@
-../../../../en/guides/storage-and-backup/object-storage/cold-storage-responsibility-model.mdx
+---
+title: Cold Storage - Responsabilité partagée pour les services d'archivage et de restauration
+description: Découvrez la répartition des responsabilités entre OVHcloud et le client pour Cold Storage concernant les services d'archivage et de restauration
+lastUpdated: 2024-02-26
+---
+
+## Objectif
+
+Le RACI ci-dessous détaille la répartition des responsabilités entre OVHcloud et le client pour Cold Storage concernant les services d'archivage et de restauration fournis.
+
+| Rôles |
+| --- |
+|R : est chargé de réaliser le processus|
+|A : est responsable de la bonne réalisation du processus|
+|C : est consulté pendant le processus|
+|I : est informé des résultats du processus|
+
+### 1. Avant la souscription
+
+#### 1.1. Définir le service en fonction des besoins
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Prendre connaissance des capacités et des limitations liées au service | RA | C |
+| Fournir les données personnelles nécessaires à la souscription du service | RA | I |
+| Héberger le service sur les sites suivants : Tours, Bordeaux, Croix, Grenoble |  | RA |
+
+### 2. Mise à disposition du service
+
+#### 2.1. Installer le service
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Produire, acheminer, livrer et maintenir les instances physiques et virtuelles pour l'hébergement du service | I | RA |
+| Créer les identifiants Object Storage pour un utilisateur OpenStack | RA |  |
+
+#### 2.2. Modèle de réversibilité
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Utiliser l'API Object Storage pour importer les données dans un bucket | RA |  |
+
+### 3. Utilisation du service
+
+#### 3.1. Opérations
+
+##### **3.1.1. Opérations quotidiennes**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Fournir l'accès au service en communiquant les premiers identifiants  | I | RA |
+| Gérer la sécurité des conteneurs et des objets créés à l'entrée du serveur avec la fonctionnalité SSE-C, après la remise des clés par le client  | R | A |
+| Administrer le stockage du service |  | RA |
+| Administrer les données | RA |   |
+| Activer la commande d'archivage des données et gérer les backups selon les besoins | RA |  |
+
+##### **3.1.2. Gestion des accès**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer les droits d'accès à l'espace client OVHcloud | RA | I |
+| Gérer les accès physiques et logiques aux infrastructures pour les équipes OVHcloud |  | RA |
+| Gérer la politique de sécurité Object Storage des conteneurs et des objets créés avant l'activation de la commande d'archivage des données | RA |  |
+
+##### **3.1.3. Supervision**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer et superviser les serveurs physiques et virtuels qui prennent en charge les services d'archivage et de restauration |  | RA |
+| Conserver les journaux des services d'infrastructure de gestion   |   | RA |
+| Conserver les journaux à l'aide de la fonctionnalité dédiée (activation du cold storage sur un stream)  |   | RA |
+| Créer, modifier, contrôler, restaurer et supprimer les archives et les backups | RI  | A |
+| Maintenir les équipements de stockage utilisés pour le service |  | RA |
+
+##### **3.1.4. Stockage**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer le chiffrement des données avant leur import dans l'Object Storage alloué, en utilisant la fonctionnalité SSE-C et après la remise des clés par le client  | AI | R |
+| Définir une politique de rétention des données conforme aux obligations légales | RA |  |
+
+##### **3.1.5. Gestion**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Fournir l'inventaire des conteneurs et des objets utilisés | I | RA |
+| Gérer la sécurité de l'infrastructure de gestion (API, plan de contrôle) |   | RA |
+| Gérer la sécurité physique des équipements et des infrastructures hébergées |  | RA |
+
+##### **3.1.6. Continuité d'activité**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Réaliser les tests de restauration des archives | RA | I |
+| Maintenir un plan de continuité et de reprise d'activité pour le SI hébergé | RA |  |
+| Gérer les systèmes de gestion automatique de l'infrastructure fournie |  | RA |
+
+#### 3.2. Gestion des événements
+
+##### **3.2.1. Incidents**
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Traiter les incidents sur le service (tickets et contacts) | AI | RA |
+
+### 4. Réversibilité
+
+#### 4.1. Modèle de réversibilité
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Planifier les opérations de réversibilité | RA |  |
+| Choisir les infrastructures de repli | RA | CI |
+| Choisir le format des données à exporter | RA |  |
+
+#### 4.2. Récupération des données
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Gérer les opérations de réversibilité | RA |  |
+| Migrer/transférer les données à l'aide de l'API Object Storage | RA |  |
+
+### 5. Fin de service
+
+#### 5.1. Destruction des données
+
+| **Activité** | **Client** | **OVHcloud** |
+| --- | --- | --- |
+| Détruire les données du service Object Storage Containers via l'API Object Storage | RA |  |
+| Libérer les ressources allouées à la suite de la résiliation du service |  | RA |
+
+## Aller plus loin
+
+- Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+
+- Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/email-pro/responsibility-model.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/email-pro/responsibility-model.mdx
@@ -1,173 +1,173 @@
 ---
-title: Email Pro - Responsibility model
-description: Shared responsibilities between OVHcloud and the customer
+title: Email Pro - Modèle de responsabilité
+description: Répartition des responsabilités entre OVHcloud et le client
 lastUpdated: 2022-11-17
 availableIn: [eu]
 ---
 
-The Email Pro service is a Microsoft Exchange email solution hosted in Europe, based on a shared infrastructure with 10BG storage capacity.
+Le service Email Pro est une solution de messagerie Microsoft Exchange hébergée en Europe, basée sur une infrastructure mutualisée offrant une capacité de stockage de 10 Go.
 
-The RACI below details shared responsibilities between OVHcloud and the customer for Email Pro service.
-This shared model can help relieve the customer’s operational burden.
+Le RACI ci-dessous détaille la répartition des responsabilités entre OVHcloud et le client pour le service Email Pro.
+Ce modèle de responsabilité partagée contribue à alléger la charge opérationnelle du client.
 
-## RACI definition
+## Définition du RACI
 
-| Roles |
+| Rôles |
 | --- |
-| R: Is in charge of carrying out the process |
-| A: Accountable for the successful completion of the process |
-| C: Is consulted during the process |
-| I: Is informed of the results of the process |
+|R : est chargé de réaliser le processus|
+|A : est responsable de la bonne réalisation du processus|
+|C : est consulté pendant le processus|
+|I : est informé des résultats du processus|
 
-### 1. Before subscription
+### 1. Avant la souscription
 
-#### 1.1. Specify service as needed
+#### 1.1. Définir le service en fonction des besoins
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and configure a domain name before service subscription | RA |  |
-| Choose the service's sizing 10GB | RA | I |
-| Define the version of Exchange and the mutualized infrastructure that supports the service |  | RA |
-| Choose service location in EU | I | RA |
+| Définir et configurer un nom de domaine avant la souscription du service | RA |  |
+| Choisir le dimensionnement du service, à savoir 10 Go | RA | I |
+| Définir la version d'Exchange et l'infrastructure mutualisée qui supporte le service |  | RA |
+| Choisir la localisation du service en Europe | I | RA |
 
-### 2. Service availability
+### 2. Mise à disposition du service
 
-#### 2.1. Install service
+#### 2.1. Installer le service
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Install, configure, and deliver functional bricks of the service | I | RA |
-| Provide service licences | I | RA |
-| Produce, route, deliver and maintain physical machines, virtual machines and hosting buildings |  | RA |
-| Deliver a preconfigured service with requested number of mailboxes that needs additional configuration by the client | I | RA |
+| Installer, configurer et livrer les briques fonctionnelles du service | I | RA |
+| Fournir les licences du service | I | RA |
+| Produire, acheminer, livrer et maintenir les machines physiques, les machines virtuelles et les bâtiments d'hébergement |  | RA |
+| Livrer un service préconfiguré avec le nombre de comptes e-mail demandé, nécessitant une configuration complémentaire par le client | I | RA |
 
-#### 2.2. Reversibility model
+#### 2.2. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Choose a migrator tool to import email accounts from another service | RA |  |
+| Choisir un outil de migration pour importer les comptes e-mail depuis un autre service | RA |  |
 
-#### 2.3. Customer Information System setup
+#### 2.3. Mise en place du système d'information client
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Customize the service following business needs (domain alerts, quota of accounts, number of accounts, aliases management, define password policy, ...) | RA | I |
+| Personnaliser le service en fonction des besoins métier (alertes de domaine, quota des comptes, nombre de comptes, gestion des alias, définition de la politique de mots de passe, etc.) | RA | I |
 
-### 3. Service usage
+### 3. Utilisation du service
 
-#### 3.1. Operations
+#### 3.1. Exploitation
 
-##### **3.1.1. Daily operations**
+##### **3.1.1. Exploitation quotidienne**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage confidentiality, integrity of data hosted on the service | RA |  |
-| Manage data availability on the hosted service following OVHcloud SLA |  | RA |
-| Manage security risks related client personal data following OVHcloud DPA and ISSP | I | RA |
-| Manage security risks of different components of the service |  | RA |
-| Manage risks of the client software being used (Outlook, Thunderbird, etc.) | RA |  |
-| Manage network accessibility of the Exchange service interface |  | RA |
-| Administrate the service infrastructure (servers, OS, antivirus, storage) | RA | IR |
-| Administrate domain, mailboxes, aliases, external contacts | RA | IR |
-| Manage backups on the service |  | RA |
+| Gérer la confidentialité et l'intégrité des données hébergées sur le service | RA |  |
+| Gérer la disponibilité des données du service hébergé conformément au SLA OVHcloud |  | RA |
+| Gérer les risques de sécurité liés aux données personnelles du client conformément au DPA et à la PSSI d'OVHcloud | I | RA |
+| Gérer les risques de sécurité des différents composants du service |  | RA |
+| Gérer les risques liés au logiciel client utilisé (Outlook, Thunderbird, etc.) | RA |  |
+| Gérer l'accessibilité réseau de l'interface du service Exchange |  | RA |
+| Administrer l'infrastructure du service (serveurs, OS, antivirus, stockage) | RA | IR |
+| Administrer le domaine, les comptes e-mail, les alias et les contacts externes | RA | IR |
+| Gérer les sauvegardes du service |  | RA |
 
-##### **3.1.2. Access management**
+##### **3.1.2. Gestion des accès**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage access to the OVHcloud Control Panel and to mailboxes following access control policy defined | RA | I |
-| Define and implement security protocols on the service (IMAP, POP, MAPI, EWS) and security associated | I | RA |
-| Manage access to control plane | A | RI |
-| Manage access to mail service and data plane | RA | I |
-| Manage physical and logical access to infrastructures for OVHcloud teams |  | RA |
+| Gérer les accès à l'espace client OVHcloud et aux comptes e-mail conformément à la politique de contrôle d'accès définie | RA | I |
+| Définir et mettre en œuvre les protocoles de sécurité du service (IMAP, POP, MAPI, EWS) et la sécurité associée | I | RA |
+| Gérer les accès au control plane | A | RI |
+| Gérer les accès au service de messagerie et au data plane | RA | I |
+| Gérer les accès physiques et logiques aux infrastructures pour les équipes OVHcloud |  | RA |
 
-##### **3.1.3. Monitoring**
+##### **3.1.3. Supervision**
     
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Monitor and manage alerts for the functioning of systems in support of the Exchange service | I | RA |
-| Manage storage conception following Exchange service sizing (deleting emails once sizing capacity is overused)  |  RA |  |
-| Manage hardware sizing on the service |   | RA |
-| Manage the functioning of the Exchange service | I  | RA |
-| Maintain logs generated by Exchange service |   | RA |
-| Monitor the proper functioning of physical devices (utilities) in support of the Exchange service |   | RA |
-| Monitor service backups |   | RA |
-| Monitor business process hosted on the Exchange service |   | RA |
+| Superviser et gérer les alertes relatives au fonctionnement des systèmes qui supportent le service Exchange | I | RA |
+| Gérer la conception du stockage en fonction du dimensionnement du service Exchange (suppression des e-mails lorsque la capacité est dépassée)  |  RA |  |
+| Gérer le dimensionnement matériel du service |   | RA |
+| Gérer le fonctionnement du service Exchange | I  | RA |
+| Conserver les logs générés par le service Exchange |   | RA |
+| Superviser le bon fonctionnement des équipements physiques (utilités) qui supportent le service Exchange |   | RA |
+| Superviser les sauvegardes du service |   | RA |
+| Superviser les processus métier hébergés sur le service Exchange |   | RA |
 
-##### **3.1.4. Storage**
+##### **3.1.4. Stockage**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Encrypt data on storage media |  | RA |
+| Chiffrer les données sur les supports de stockage |  | RA |
 
-##### **3.1.5. Connectivity**
+##### **3.1.5. Connectivité**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage IP addressing plan and network systems (architecture, protocols, network traffic and access to the service) |  | RA |
+| Gérer le plan d'adressage IP et les systèmes réseau (architecture, protocoles, trafic réseau et accès au service) |  | RA |
 
-##### **3.1.6. Management**
+##### **3.1.6. Gestion**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Provide inventory of the service used | I | RA |
-| Maintain in operational and security condition the Exchange service |  | RA |
+| Fournir l'inventaire du service utilisé | I | RA |
+| Maintenir le service Exchange en condition opérationnelle et de sécurité |  | RA |
 
-##### **3.1.7. Business continuity**
+##### **3.1.7. Continuité d'activité**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and maintain a business continuity and recovery plan following business needs |  | RA |
+| Définir et maintenir un plan de continuité et de reprise d'activité en fonction des besoins métier |  | RA |
 
-#### 3.2. Event management
+#### 3.2. Gestion des événements
 
 ##### **3.2.1. Incidents**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Notify, qualify, and manage incidents on the Exchange service  | I | RA |
-| Notify incidents on the Exchange service with ticketing system  | RA | I |
-| Realize backup recovery  | I | RA |
+| Notifier, qualifier et gérer les incidents sur le service Exchange  | I | RA |
+| Notifier les incidents sur le service Exchange via le système de tickets  | RA | I |
+| Réaliser la restauration des sauvegardes  | I | RA |
 
-##### **3.2.2. Changes**
+##### **3.2.2. Changements**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Plan and deploy updates and patches on Exchange service, OS, and software in support of the service |  | RA |
-| Replace deficient hardware in support of the Exchange service | I | RA |
-| Add and delete hardware and software configuration on the Exchange service |  | RA |
+| Planifier et déployer les mises à jour et les correctifs sur le service Exchange, l'OS et les logiciels qui supportent le service |  | RA |
+| Remplacer le matériel défectueux qui supporte le service Exchange | I | RA |
+| Ajouter et supprimer des configurations matérielles et logicielles sur le service Exchange |  | RA |
 
-### 4. Reverting
+### 4. Réversibilité
 
-#### 4.1. Reversibility model
+#### 4.1. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Choose a migrator tool to export email accounts from old infrastructure  | RA |  |
-| Choose the format of extraction file following the software used for the migration | RA |  |
+| Choisir un outil de migration pour exporter les comptes e-mail depuis l'ancienne infrastructure  | RA |  |
+| Choisir le format du fichier d'extraction en fonction du logiciel utilisé pour la migration | RA |  |
 
-#### 4.2. Data recovery
+#### 4.2. Récupération des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and plan reversion operations | RA | I |
+| Définir et planifier les opérations de réversibilité | RA | I |
 
-### 5. End of service
+### 5. Fin de service
 
-#### 5.1. Configuration destruction
+#### 5.1. Destruction des configurations
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Destroy configurations at end of service following contract termination| I | RA |
+| Détruire les configurations en fin de service, suite à la résiliation du contrat| I | RA |
 
-#### 5.2. Data destruction
+#### 5.2. Destruction des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Destroy client's data | I | RA |
+| Détruire les données du client | I | RA |
 
-## Go further
+## Aller plus loin
 
-All our Email Pro documentation
+Toute notre documentation sur Email Pro
 
-Join our [community of users](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/hosted-exchange-responsibility-model.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/hosted-exchange-responsibility-model.mdx
@@ -1,174 +1,174 @@
 ---
-title: Hosted Exchange - Responsibility model
-description: "Shared responsibilities between OVHcloud and the customer"
+title: Hosted Exchange - Modèle de responsabilité
+description: "Répartition des responsabilités entre OVHcloud et le client"
 lastUpdated: 2022-11-15
 availableIn: [eu, ca]
 ---
 
-The Hosted Exchange service is a Microsoft Exchange email solution. You can use it to manage your emails, calendars and tasks wherever you are.
+Le service Hosted Exchange est une solution de messagerie Microsoft Exchange. Il vous permet de gérer vos e-mails, vos calendriers et vos tâches où que vous soyez.
 
-The RACI below details shared responsibilities between OVHcloud and the customer for Hosted Exchange service.
-This shared model can help relieve the customer's operational burden.
+Le RACI ci-dessous détaille la répartition des responsabilités entre OVHcloud et le client pour le service Hosted Exchange.
+Ce modèle de responsabilité partagée contribue à alléger la charge opérationnelle du client.
 
-## RACI definition
+## Définition du RACI
 
-| Roles |
+| Rôles |
 | --- |
-| R: Is in charge of carrying out the process |
-| A: Accountable for the successful completion of the process |
-| C: Is consulted during the process |
-| I: Is informed of the results of the process |
+|R : est chargé de réaliser le processus|
+|A : est responsable de la bonne réalisation du processus|
+|C : est consulté pendant le processus|
+|I : est informé des résultats du processus|
 
-### 1. Before subscription
+### 1. Avant la souscription
 
-#### 1.1. Specify service as needed
+#### 1.1. Définir le service en fonction des besoins
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and configure a domain name before service subscription | RA |  |
-| Choose the service's sizing (50GB or 300GB) without downgrade option | RA | I |
-| Define the version of Exchange and the mutualized infrastructure that supports the service |  | RA |
-| Choose service location in EU (or in CA if the client uses CA website) | I | RA |
+| Définir et configurer un nom de domaine avant la souscription du service | RA |  |
+| Choisir le dimensionnement du service (50 Go ou 300 Go), sans possibilité de réduction ultérieure | RA | I |
+| Définir la version d'Exchange et l'infrastructure mutualisée qui supporte le service |  | RA |
+| Choisir la localisation du service en Europe (ou au Canada si le client utilise le site canadien) | I | RA |
 
-### 2. Service availability
+### 2. Mise à disposition du service
 
-#### 2.1. Install service
+#### 2.1. Installer le service
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Install, configure, and deliver functional bricks of the service | I | RA |
-| Provide service licences | I | RA |
-| Produce, route, deliver and maintain physical machines, virtual machines and hosting buildings |  | RA |
-| Deliver a preconfigured service with requested number of mailboxes that needs additional configuration by the client | I | RA |
+| Installer, configurer et livrer les briques fonctionnelles du service | I | RA |
+| Fournir les licences du service | I | RA |
+| Produire, acheminer, livrer et maintenir les machines physiques, les machines virtuelles et les bâtiments d'hébergement |  | RA |
+| Livrer un service préconfiguré avec le nombre de comptes e-mail demandé, nécessitant une configuration complémentaire par le client | I | RA |
 
-#### 2.2. Reversibility model
+#### 2.2. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Choose a migrator tool to import email accounts from another service | RA |  |
+| Choisir un outil de migration pour importer les comptes e-mail depuis un autre service | RA |  |
 
-#### 2.3. Customer Information System setup
+#### 2.3. Mise en place du système d'information client
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Customize the service following business needs (domain alerts, quota of accounts, number of accounts, aliases management, define password policy, ...) | RA | I |
+| Personnaliser le service en fonction des besoins métier (alertes de domaine, quota des comptes, nombre de comptes, gestion des alias, définition de la politique de mots de passe, etc.) | RA | I |
 
-### 3. Service usage
+### 3. Utilisation du service
 
-#### 3.1. Operations
+#### 3.1. Exploitation
 
-##### **3.1.1. Daily operations**
+##### **3.1.1. Exploitation quotidienne**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage confidentiality, integrity of data hosted on the service | RA |  |
-| Manage data availability on the hosted service following OVHcloud SLA |  | RA |
-| Manage security risks related client personal data following OVHcloud DPA and ISSP | I | RA |
-| Manage security risks of different components of the service |  | RA |
-| Manage risks of the client software being used (Outlook, Thunderbird, etc.) | RA |  |
-| Manage network accessibility of the Exchange service interface |  | RA |
-| Administrate the service infrastructure (servers, OS, antivirus, storage) |  | RA |
-| Administrate domain, mailboxes, distribution groups, etc. | RA | IR |
-| Manage backups on the service |  | RA |
+| Gérer la confidentialité et l'intégrité des données hébergées sur le service | RA |  |
+| Gérer la disponibilité des données du service hébergé conformément au SLA OVHcloud |  | RA |
+| Gérer les risques de sécurité liés aux données personnelles du client conformément au DPA et à la PSSI d'OVHcloud | I | RA |
+| Gérer les risques de sécurité des différents composants du service |  | RA |
+| Gérer les risques liés au logiciel client utilisé (Outlook, Thunderbird, etc.) | RA |  |
+| Gérer l'accessibilité réseau de l'interface du service Exchange |  | RA |
+| Administrer l'infrastructure du service (serveurs, OS, antivirus, stockage) |  | RA |
+| Administrer le domaine, les comptes e-mail, les groupes de distribution, etc. | RA | IR |
+| Gérer les sauvegardes du service |  | RA |
 
-##### **3.1.2. Access management**
+##### **3.1.2. Gestion des accès**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage access to the OVHcloud Control Panel and to mailboxes following access control policy defined | RA | I |
-| Define and implement security protocols on the service (IMAP, POP, MAPI, EWS) and security associated | I | RA |
-| Manage access to control plane | A | RI |
-| Manage access to mail service and data plane | RA | I |
-| Manage physical and logical access to infrastructures for OVHcloud teams |  | RA |
+| Gérer les accès à l'espace client OVHcloud et aux comptes e-mail conformément à la politique de contrôle d'accès définie | RA | I |
+| Définir et mettre en œuvre les protocoles de sécurité du service (IMAP, POP, MAPI, EWS) et la sécurité associée | I | RA |
+| Gérer les accès au control plane | A | RI |
+| Gérer les accès au service de messagerie et au data plane | RA | I |
+| Gérer les accès physiques et logiques aux infrastructures pour les équipes OVHcloud |  | RA |
 
-##### **3.1.3. Monitoring**
+##### **3.1.3. Supervision**
     
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Monitor and manage alerts for the functioning of systems in support of the Exchange service | I | RA |
-| Manage storage conception following Exchange service sizing (deleting emails once sizing capacity is overused)  |  RA |  |
-| Manage hardware sizing on the service |   | RA |
-| Manage the functioning of the Exchange service | I  | RA |
-| Maintain logs generated by Exchange service |   | RA |
-| Monitor the proper functioning of physical devices (utilities) in support of the Exchange service |   | RA |
-| Monitor service backups |   | RA |
-| Monitor business process hosted on the Exchange service |   | RA |
+| Superviser et gérer les alertes relatives au fonctionnement des systèmes qui supportent le service Exchange | I | RA |
+| Gérer la conception du stockage en fonction du dimensionnement du service Exchange (suppression des e-mails lorsque la capacité est dépassée)  |  RA |  |
+| Gérer le dimensionnement matériel du service |   | RA |
+| Gérer le fonctionnement du service Exchange | I  | RA |
+| Conserver les logs générés par le service Exchange |   | RA |
+| Superviser le bon fonctionnement des équipements physiques (utilités) qui supportent le service Exchange |   | RA |
+| Superviser les sauvegardes du service |   | RA |
+| Superviser les processus métier hébergés sur le service Exchange |   | RA |
 
-##### **3.1.4. Storage**
+##### **3.1.4. Stockage**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Encrypt data on storage media |  | RA |
+| Chiffrer les données sur les supports de stockage |  | RA |
 
-##### **3.1.5. Connectivity**
+##### **3.1.5. Connectivité**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Manage IP addressing plan and network systems (architecture, protocols, network traffic and access to the service) |  | RA |
+| Gérer le plan d'adressage IP et les systèmes réseau (architecture, protocoles, trafic réseau et accès au service) |  | RA |
 
-##### **3.1.6. Management**
+##### **3.1.6. Gestion**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Provide inventory of the service used | I | RA |
-| Maintain in operational and security condition the Exchange service |  | RA |
+| Fournir l'inventaire du service utilisé | I | RA |
+| Maintenir le service Exchange en condition opérationnelle et de sécurité |  | RA |
 
-##### **3.1.7. Business continuity**
+##### **3.1.7. Continuité d'activité**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and maintain a business continuity and recovery plan following business needs |  | RA |
+| Définir et maintenir un plan de continuité et de reprise d'activité en fonction des besoins métier |  | RA |
 
-#### 3.2. Event management
+#### 3.2. Gestion des événements
 
 ##### **3.2.1. Incidents**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Notify, qualify, and manage incidents on the Exchange service  | I | RA |
-| Notify incidents on the Exchange service with ticketing system  | RA | I |
-| Realize backup recovery  | I | RA |
+| Notifier, qualifier et gérer les incidents sur le service Exchange  | I | RA |
+| Notifier les incidents sur le service Exchange via le système de tickets  | RA | I |
+| Réaliser la restauration des sauvegardes  | I | RA |
 
-##### **3.2.2. Changes**
+##### **3.2.2. Changements**
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Plan and deploy updates and patches on Exchange service, OS, and software in support of the service |  | RA |
-| Replace deficient hardware in support of the Exchange service | I | RA |
-| Add and delete hardware and software configuration on the Exchange service |  | RA |
+| Planifier et déployer les mises à jour et les correctifs sur le service Exchange, l'OS et les logiciels qui supportent le service |  | RA |
+| Remplacer le matériel défectueux qui supporte le service Exchange | I | RA |
+| Ajouter et supprimer des configurations matérielles et logicielles sur le service Exchange |  | RA |
 
-### 4. Reverting
+### 4. Réversibilité
 
-#### 4.1. Reversibility model
+#### 4.1. Modèle de réversibilité
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Choose a migrator tool to export email accounts from old infrastructure  | RA |  |
-| Choose the format of extraction file following the software used for the migration | RA |  |
-| Deliver PST file following client request  | A | RI |
+| Choisir un outil de migration pour exporter les comptes e-mail depuis l'ancienne infrastructure  | RA |  |
+| Choisir le format du fichier d'extraction en fonction du logiciel utilisé pour la migration | RA |  |
+| Livrer un fichier PST à la demande du client  | A | RI |
 
-#### 4.2. Data recovery
+#### 4.2. Récupération des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Define and plan reversion operations | RA | I |
+| Définir et planifier les opérations de réversibilité | RA | I |
 
-### 5. End of service
+### 5. Fin de service
 
-#### 5.1. Configuration destruction
+#### 5.1. Destruction des configurations
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Destroy configurations at end of service following contract termination| I | RA |
+| Détruire les configurations en fin de service, suite à la résiliation du contrat| I | RA |
 
-#### 5.2. Data destruction
+#### 5.2. Destruction des données
 
-| **Activity** | **Customer** | **OVHcloud** |
+| **Activité** | **Client** | **OVHcloud** |
 | --- | --- | --- |
-| Destroy client's data | I | RA |
+| Détruire les données du client | I | RA |
 
-## Go further
+## Aller plus loin
 
-[All our Microsoft collaborative solutions documentation](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/landing-page-microsoft-exchange)
+[Toute notre documentation sur les solutions collaboratives Microsoft](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/landing-page-microsoft-exchange)
 
-Join our [community of users](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
Clears the French translation backlog identified in the 21 August KPI, excluding
Managed Kubernetes (already done in #613).

**56 guides / ~51,000 prose words** across 8 products, as 7 reviewable commits —
one per product, each with a green `pnpm build:fr`, so the branch is bisectable.

## What changed

| Commit | Product | Files | Words |
|---|---|---|---|
| `fdc8110b` | Managed Rancher Service | 13 | 12,865 |
| `6bfb0329` | Dedicated Servers (firmware) | 4 | 6,637 |
| `94a0b126` | Managed Private Registry | 16 | 9,536 |
| `1d5af4c2` | MPR responsibility model — `Service` definition fix | 1 | — |
| `5ef6361e` | Quantum Computing | 6 | 8,509 |
| `4395086f` | Block Storage + Object Storage | 6 | 3,648 |
| `67fb4bf2` | Remaining backlog (8 products) | 11 | 8,588 |

The last commit groups Data Platform, Terraform, Network Services, API, Hosted
Exchange, Email Pro, Responsibility Sharing and Account Information — one or two
files each, so separate commits would have been noise.

## Two kinds of gap, both closed

- **31 files** had French frontmatter with an English body.
- **25 files** were symlinks to the English source and are now real translated
  files.

FR guide symlinks go from **40 to 15**. The 15 that remain are all accounted for:
11 Managed Kubernetes (pending #613), 3 `vulnerability-*` guides and
`hds-garanties` (all deliberately out of scope).

## `lastUpdated` is untouched

**0 removals, 25 additions.** A translation is not a content update, so no
existing date moved. The 25 additions are exactly the symlink conversions, each
inheriting its English file's date verbatim.

## Scope discipline

- **`docs/en` is untouched** — 0 files. English-source defects found while
  translating are logged separately and fixed on their own branch.
- **Other locales untouched** — de/es/it/pl/pt keep their English-fallback status.

## Vocabulary: scoped to the UI that owns each label

Each product was translated against its own Manager app rather than a shared
word list, which repeatedly gave different answers for the same English string:

- **Managed Rancher Service** — 40 of 50 action labels belong to the SUSE Rancher
  console, not the OVHcloud Control Panel, so they stay English. `apps/pci-rancher`
  has no node-pool string, so the Managed Kubernetes ruling `node pool` →
  `pool de nœuds` deliberately does **not** apply here.
- **Managed Private Registry** — 20 of 30 labels belong to the Harbor console,
  including three `Save` buttons that sit on Harbor screens. The product name
  stays English while the generic concept renders `registre privé`; the Manager's
  own `Créer un registre privé` button is translated because it names an action.
- **Quantum Computing** — cross-checked against the AI & Machine Learning
  glossary, since the two products share infrastructure. That corrected two
  boilerplate blocks to the established house forms and 22 backticked UI labels:
  each was looked up in the Manager, 7 resolved and were translated, 6 are absent
  there and stay English on that evidence.
- **Dedicated Servers** — `firmware` stays English (556 uses against 1
  `micrologiciel`), and section three uses this family's own `## En pratique`.

## Tables were the bulk of the work

Eight guides are more table than prose, and their cells are mostly identifiers a
reader copies:

- **Terraform** (86 rows) maps Control Panel concepts to provider and resource
  names — only the concept column is translated; `ovh/ovh`, `ovh_*` and every
  `registry.terraform.io` URL are byte-identical.
- **Network Services** (76 rows) is an API field dump — headers only.
- **Four RACI models** (89/88/78 rows) — role codes verified byte-identical to
  English; the two certification pages' 38 product rows are identical to each
  other.

## Also normalised while translating

- **55 images** converted from the deprecated markdown form to the canonical
  `<img className="thumbnail" … loading="lazy" />`, which is what carries the
  thumbnail styling and lazy loading.
- **Four `/links` conversions** replacing hardcoded pricing URLs.
- **Two missing descriptions** authored, so those pages now ship a French meta
  description where English still has none.
- **A heading whose non-breaking space** stopped it rendering as a heading at all
  in English — the French page now has the section and its anchor.

## Verification

- `pnpm build:fr` green after **every** commit; `build:en` green.
- Structural parity with the English source on all 56 files — images, code
  fences, callouts, tables, anchors, `<Api>`, `<Tabs>`, `<ManagerLink>`, CP-NAV.
- Every intra-document anchor resolves against built HTML in `dist/`.
- All 28 code blocks in the Ceph guides byte-identical to English.
- Every file read against its English source; a `/proofread` pass on Managed
  Private Registry.
- Merges cleanly into `develop`.

## Known follow-ups (not in this PR)

**62 English-source defects** were logged while translating
(`data/upstream-defects/en-source-defects.md` in the tooling repo). The most
repeated is a hardcoded `en-gb` Professional Services URL — 86 of 102 occurrences
in Storage & Backup alone — which one sweep would close.
