### PR TITLE
docs(databases): require the administrator contact to enable Web Cloud Databases

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/de/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit Web Cloud Databases
 description: Erfahren Sie, wie Sie mit der Lösung Web Cloud Databases starten
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Standardmäßig ist Ihre Web Cloud Databases Lösung mit dem OVHcloud Webhosting
 ### Aktivierung Ihres im Webhosting enthaltenen Web Cloud Databases Servers
 
 Wenn Ihr Hosting die Option Web Cloud Databases beinhaltet, klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+:::warning
+Für die Aktivierung dieser Option müssen Sie mindestens Administrator-Kontakt des Webhostings sein, das den Dienst Web Cloud Databases beinhaltet. Weitere Informationen zur Verwaltung der Kontakte finden Sie in unserer Anleitung "[Die Kontakte Ihrer Dienste verwalten](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Schritt 1">

--- a/docs/en/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/en/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the Web Cloud Databases service
 description: Find out how to get started with the Web Cloud Databases service
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ By default, your Web Cloud Databases solution is linked to the OVHcloud web host
 ### Activating your Web Cloud Databases server included with your web hosting plan
 
 If your hosting plan includes the Web Cloud Databases option, click on the tabs below to view each of the **3** steps.
+
+:::warning
+Enabling this option requires you to be at least the Administrator contact of the web hosting plan that includes the Web Cloud Databases service. For more information on managing contacts, refer to our guide "[Managing contacts for your services](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Step 1">

--- a/docs/es/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/es/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con Web Cloud Databases
 description: Descubra cómo empezar a utilizar la solución Web Cloud Databases
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Por defecto, su solución Web Cloud Databases está asociada a la red de alojami
 ### Activación de su servidor Web Cloud Databases incluido con su plan de alojamiento web
 
 Si su plan de alojamiento incluye la opción Web Cloud Databases, haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+
+:::warning
+Para activar esta opción, debe ser como mínimo contacto administrador del alojamiento web que incluye el servicio Web Cloud Databases. Para más información sobre la gestión de los contactos, consulte nuestra guía "[Gestionar los contactos de los servicios](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Paso 1">

--- a/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Premiers pas avec le service Web Cloud Databases
 description: Découvrez comment bien débuter avec la solution Web Cloud Databases
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Par défaut, votre solution Web Cloud Databases est liée au réseau d’héberg
 ### Activation de votre serveur Web Cloud Databases inclus avec votre offre d’hébergement web
 
 Si votre offre d’hébergement inclut l’option Web Cloud Databases, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+:::warning
+L’activation de cette option nécessite que vous soyez au minimum contact administrateur de l’hébergement web qui inclut le service Web Cloud Databases. Pour plus d’informations sur la gestion des contacts, consultez notre guide « [Gérer les contacts de ses services](/guides/account-and-service-management/account-information/managing-contacts) ».
+
+:::
 
 <Tabs>
   <Tab label="Étape 1">

--- a/docs/it/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/it/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare Web Cloud Databases
 description: Scopri come iniziare a utilizzare la soluzione Web Cloud Databases
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Di default, la soluzione Web Cloud Databases è associata alla rete di hosting W
 ### Attivazione del server Web Cloud Databases incluso con il piano di hosting Web
 
 Se il piano di hosting include l'opzione Web Cloud Databases, clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+
+:::warning
+L'attivazione di questa opzione richiede che tu sia almeno contatto amministratore dell'hosting Web che include il servizio Web Cloud Databases. Per ulteriori informazioni sulla gestione dei contatti, consulta la nostra guida "[Gestire i contatti dei servizi OVHcloud](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Step 1">

--- a/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z usługą Web Cloud Databases
 description: Dowiedz się, jak rozpocząć korzystanie z rozwiązania Web Cloud Databases
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Domyślnie rozwiązanie Web Cloud Databases jest powiązane z siecią hostingów
 ### Aktywacja serwera Web Cloud Databases zawartego w ofercie hostingu WWW
 
 Jeśli Twoja oferta hostingu obejmuje opcję Web Cloud Databases, kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
+
+:::warning
+Aktywacja tej opcji wymaga posiadania co najmniej kontaktu administracyjnego hostingu, który obejmuje usługę Web Cloud Databases. Więcej informacji na temat zarządzania kontaktami znajdziesz w naszym przewodniku "[Zarządzanie kontaktami swoich usług](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Krok 1">

--- a/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Primeira utilização
 description: Saiba como começar a utilizar a solução Web Cloud Databases
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-26
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -33,6 +33,11 @@ Por predefinição, a solução Web Cloud Databases está associada à rede de a
 ### Ativação do servidor Web Cloud Databases incluído no plano de alojamento web
 
 Se o seu plano de alojamento inclui a opção Web Cloud Databases, clique nos separadores abaixo para ver cada um dos **3** passos.
+
+:::warning
+Para ativar esta opção, deve ser, no mínimo, contacto administrador do alojamento web que inclui o serviço Web Cloud Databases. Para obter mais informações sobre a gestão dos contactos, consulte o nosso guia "[Como gerir os contactos (gestores) dos serviços OVHcloud](/guides/account-and-service-management/account-information/managing-contacts)".
+
+:::
 
 <Tabs>
   <Tab label="Passo 1">


### PR DESCRIPTION

Activating the Web Cloud Databases option included with a web hosting plan is reserved to the hosting's administrator contact. Nothing in the guide said so, so a reader without that role followed the three steps only to find the action unavailable.

Add the warning to the seven locales and point to the contacts guide, using each locale's own title for the link label.

Every phrasing is taken from the locale's existing corpus rather than translated freely — de "mindestens" / "Administrator-Kontakt", pl "co najmniej", es "contacto administrador" — and the pt sentence is built on "deve ser" so the subject stays explicit, as that corpus does.