### PR TITLE
chore(links): use the /links key for Professional Services URLs

### DIFF
--- a/docs/en/guides/account-and-service-management/reversibility/ai-managed-containers-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/ai-managed-containers-reversibility.mdx
@@ -50,7 +50,7 @@ The product is based on managed Kubernetes clusters, with full orchestration of 
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/ai-notebook-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/ai-notebook-reversibility.mdx
@@ -49,7 +49,7 @@ Notebooks are isolated by user and project, with a persistent storage on an S3-c
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/bm-pod-snc-reversbility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/bm-pod-snc-reversbility.mdx
@@ -52,7 +52,7 @@ Public connectivity is currently provided through an additional Managed Dedicate
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -50,7 +50,7 @@ OVHcloud's Cold Storage product is based on a geo-distributed architecture acros
 
 OVHcloud partners are listed under the keyword **"Cloud Migration"** in the [dedicated partner directory](https://partner.ovhcloud.com/en-gb/directory/).
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/data-platform-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/data-platform-reversibility.mdx
@@ -48,7 +48,7 @@ OVHcloud Unified Data Platform service is based on open-source technologies such
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Costs and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/db-web-hosting-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/db-web-hosting-reversibility.mdx
@@ -50,7 +50,7 @@ The product is based on VPS with Linux OS, DBMS engines and PostgreSQL modules u
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/ddb-mongo.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/ddb-mongo.mdx
@@ -52,7 +52,7 @@ Data is distributed across multiple nodes with regular backups, continuous monit
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/) directory under the **"cloud migration"** keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/dedicated-servers-3az-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/dedicated-servers-3az-reversibility.mdx
@@ -49,7 +49,7 @@ Dedicated servers are deployed in 3 datacentres across 3 physically independent 
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the **"Data center expansion and migration"** filter.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/file-storage-reversibility-policy.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/file-storage-reversibility-policy.mdx
@@ -47,7 +47,7 @@ OVHcloud's File Storage relies on NetApp® ONTAP® (Enterprise File Storage) or 
 
 OVHcloud partners are listed with the keyword "Cloud Migration" in the [dedicated directory](https://partner.ovhcloud.com/en-gb/directory/).
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/idb-reversibility-policy.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/idb-reversibility-policy.mdx
@@ -49,7 +49,7 @@ It supports replication, fault tolerance, and automatic failovers to ensure serv
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/logs-data-platform-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/logs-data-platform-reversibility.mdx
@@ -55,7 +55,7 @@ The product is divided into two service offers:
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/mutualized-virtualization-vcd-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/mutualized-virtualization-vcd-reversibility.mdx
@@ -46,7 +46,7 @@ The product is based on a VMware hypervisor and enables isolated VMs to run on s
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/object-storage-3az-reversibility-policy.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/object-storage-3az-reversibility-policy.mdx
@@ -49,7 +49,7 @@ Object Storage 3-AZ by OVHcloud is based on a multi-AZ architecture, with automa
 
 OVHcloud partners are listed with the keyword "Cloud Migration" in the [dedicated directory](https://partner.ovhcloud.com/en-gb/directory/).
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/object-storage-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/object-storage-reversibility.mdx
@@ -51,7 +51,7 @@ Asynchronous replication is available as an option (Asynchronous Replication), a
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the **"Data center expansion and migration"** filter.
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/rdb-mysql-postgre.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/rdb-mysql-postgre.mdx
@@ -59,7 +59,7 @@ The **Business** and **Enterprise** plans offer **high availability** with multi
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/) directory under the **"cloud migration"** keywords.
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and Fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/reversibility-mdb.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/reversibility-mdb.mdx
@@ -50,7 +50,7 @@ The Managed Kafka service is based on a distributed architecture with Kafka brok
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**cloud migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Costs and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/reversibility-obs-data-visualization.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/reversibility-obs-data-visualization.mdx
@@ -53,7 +53,7 @@ Managed Grafana service offer is deployed in single-node mode (essential plan). 
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**cloud migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/reversibility-oci-registry.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/reversibility-oci-registry.mdx
@@ -50,7 +50,7 @@ The OVHcloud Managed Private Registry service (based on Harbor) supports a multi
 
 OVHcloud partners are listed under the keyword **Migrate to the cloud** in the [Dedicated Partner Directory](https://partner.ovhcloud.com/en-gb/directory/).
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/reversibility-orchestration.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/reversibility-orchestration.mdx
@@ -56,7 +56,7 @@ The managed orchestration service runs in a single region from among several reg
 
 OVHcloud partners are listed under the keyword **“Migrate to the cloud”** in the [Dedicated Partner directory](https://partner.ovhcloud.com/en-gb/directory/).
 
-OVHcloud also offers a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also offers a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/sdb-opensearch-reversibility.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/sdb-opensearch-reversibility.mdx
@@ -56,7 +56,7 @@ Architectures include:
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/snc-vmware-reversibility-policy.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/snc-vmware-reversibility-policy.mdx
@@ -53,7 +53,7 @@ The product is based on a dedicated SecNumCloud-qualified VMware Software-Define
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/account-and-service-management/reversibility/web-hosting-reversibility-policy.mdx
+++ b/docs/en/guides/account-and-service-management/reversibility/web-hosting-reversibility-policy.mdx
@@ -51,7 +51,7 @@ All components of an OVHcloud Web product are accessible through the <ManagerLin
 
 The OVHcloud partners concerned are listed in the [OVHcloud partners directory](https://partner.ovhcloud.com/en-gb/directory/) under the "**Data center expansion and Migration**" keywords.
 
-OVHcloud also has a dedicated service: [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/).
+OVHcloud also has a dedicated service: [OVHcloud Professional Services](/links/professional-services).
 
 ## Cost and fees
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-game-ddos.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/firewall-game-ddos.mdx
@@ -289,6 +289,6 @@ You will need to share relevant network traffic dumps as examples for such attac
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-familiar-with-ovhcloud-control-panel.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-familiar-with-ovhcloud-control-panel.mdx
@@ -114,6 +114,6 @@ In practice, here are some guides to help you get started:
 
 [What are the IP addresses of the OVHcloud monitoring?](/guides/bare-metal-cloud/dedicated-servers/network-ip-monitoring)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server-eco.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server-eco.mdx
@@ -320,6 +320,6 @@ To activate and use the backup storage, please refer to [this guide](/guides/bar
 
 [OVHcloud API & OS installation](/guides/bare-metal-cloud/dedicated-servers/api-os-installation)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/getting-started-with-dedicated-server.mdx
@@ -317,6 +317,6 @@ To activate and use the backup storage, please refer to [this guide](/guides/bar
 
 [OVHcloud API & OS installation](/guides/bare-metal-cloud/dedicated-servers/api-os-installation)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/ipmi.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/ipmi.mdx
@@ -273,6 +273,6 @@ Afterwards, access the [IPMI console](#procedure) in your <ManagerLink to="/">OV
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/micron-7500-fw-upgrade.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/micron-7500-fw-upgrade.mdx
@@ -447,7 +447,7 @@ Now your NVMe drives should have have the firmware version **E3MQ005**.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 [Upgrading Samsung NVMe PM9A1 Firmware on Dedicated Servers](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/migrate-a-server-to-another.mdx
@@ -94,6 +94,6 @@ For more information, please read our documentation on domains and DNS.
 
 If you would like assistance migrating your server, please contact our network of [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/opennebula-deployment.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/opennebula-deployment.mdx
@@ -281,6 +281,6 @@ Finally, as a cleanup step, terminate the virtual server by clicking the red "Tr
 - If you need more information about Ansible, you may consult the [Ansible page on the RedHat website](https://www.redhat.com/en/ansible-collaborative?) or the [official Ansible documentation](https://docs.ansible.com/).
 - The OpenNebula deployment repository used and referenced in this guide is [Hosted Cloud OVHcloud](https://github.com/OpenNebula/hosted-cloud-ovhcloud).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case and project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assistance on your specific use case and project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/raid-soft-uefi.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/raid-soft-uefi.mdx
@@ -1359,6 +1359,6 @@ For specialised services (SEO, development, etc.), contact [OVHcloud partners](h
  
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts to assist with your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts to assist with your specific use case.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/raid-soft.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/raid-soft.mdx
@@ -697,6 +697,6 @@ For specialised services (SEO, development, etc.), contact [OVHcloud partners](h
  
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts to assist with your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts to assist with your specific use case.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/rtm-uninstall.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/rtm-uninstall.mdx
@@ -102,7 +102,7 @@ rm -f /etc/yum.repos.d/OVH-metrics.repo /etc/yum.repos.d/OVH-rtm.repo
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 [OVHcloud Monitoring IP Addresses for Dedicated Servers](/guides/bare-metal-cloud/dedicated-servers/network-ip-monitoring)
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade.mdx
@@ -398,6 +398,6 @@ Your NVMe drive now should have the firmware version **GXA7802Q**.
 
 [Dedicated Server - Upgrading Solidigm D7-P5520 SSD Firmware](/guides/bare-metal-cloud/dedicated-servers/solidigm-d7-p5520-fw-update)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -252,6 +252,6 @@ For more information on our backup storage solutions, please see our [backup sto
 
 [Securing a Dedicated Server with a Memcached service](/guides/bare-metal-cloud/dedicated-servers/memcache-secure)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/solidigm-d7-p5520-fw-update.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/solidigm-d7-p5520-fw-update.mdx
@@ -771,6 +771,6 @@ Status : The selected drive contains current firmware as of this tool release.
 
 [Upgrading WD SS530 SSD Firmware on a Dedicated Server](/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/wd-sas-fw-upgrade.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/wd-sas-fw-upgrade.mdx
@@ -750,6 +750,6 @@ The firmware version displayed for each disk must be B17D, corresponding to the 
 
 [Upgrading Samsung NVMe PM9A1 Firmware on Dedicated Servers](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/wdc-sas-ss530-fw-upgrade.mdx
@@ -707,6 +707,6 @@ The firmware version displayed for each disk must be B969, corresponding to the 
 
 [Upgrading Samsung NVMe PM9A1 Firmware on Dedicated Servers](/guides/bare-metal-cloud/dedicated-servers/samsung-nvme-fw-upgrade)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/bmpod-secnumcloud-backup-instance.mdx
@@ -111,7 +111,7 @@ A backup has been created and stored in the S3 bucket.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you need training or technical assistance to implement our solutions, contact your sales representative or go to the [Professional Services page](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-getting-started.mdx
@@ -140,6 +140,6 @@ For more information on how networks work with OpenStack, we recommend you consu
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
+++ b/docs/en/guides/hosted-private-cloud/baremetal-pod/snc-iam-manage.mdx
@@ -318,6 +318,6 @@ A no-script alternative is available directly in the Keycloak interface: **Clien
 
 ## Go further
 
-For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and a custom project analysis from our experts.
+For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and a custom project analysis from our experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol.mdx
@@ -11,7 +11,7 @@ lastUpdated: 2022-11-16
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -217,6 +217,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-windows-vm.mdx
@@ -75,6 +75,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -17,7 +17,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -210,7 +210,7 @@ You can go even further by reading these guides:
 
 [Nutanix Node Addition Guide](https://portal.nutanix.com/page/documents/details?targetId=Web-Console-Guide-Prism-v7_0:wc-cluster-expand-wc-t.html)
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/advanced-tools.mdx
@@ -773,6 +773,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/alert-management.mdx
@@ -138,6 +138,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/available-services.mdx
@@ -52,6 +52,6 @@ Below is a summary table of the licences included in the Nutanix on OVHcloud pac
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/change-vrack-postinstall.mdx
@@ -13,7 +13,7 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -105,6 +105,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-custom-redeployment.mdx
@@ -225,6 +225,6 @@ The **Load Balancer** is reconfigured during redeployment, and points the FQDN a
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/guides/hosted-private-cloud/nutanix-on-ovhcloud/activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-firmware-update.mdx
@@ -258,6 +258,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/cluster-information.mdx
@@ -209,6 +209,6 @@ Use the [Plik tool](https://plik.ovhcloud.com/#/) tool to upload your .zip files
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/first-steps.mdx
@@ -16,7 +16,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 :::warning
 OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/en-gb/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](https://partner.ovhcloud.com/en-gb/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 
 :::
 
@@ -521,6 +521,6 @@ You can also [secure access to Prism Central](/guides/hosted-private-cloud/nutan
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/flow.mdx
@@ -409,6 +409,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/global-high-level-doc.mdx
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hardware-gateway-replacement.mdx
@@ -403,6 +403,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/hycu-backup.mdx
@@ -15,7 +15,7 @@ HYCU for Nutanix is a backup software available for Nutanix.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 
-This guide is designed to assist you as much as possible with common tasks. However, we recommend reaching out to the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialized provider](https://partner.ovhcloud.com/en-gb/directory/) if you encounter difficulties or have doubts regarding the administration, use, or setup of a service on a server.>
+This guide is designed to assist you as much as possible with common tasks. However, we recommend reaching out to the [OVHcloud Professional Services team](/links/professional-services) or a [specialized provider](https://partner.ovhcloud.com/en-gb/directory/) if you encounter difficulties or have doubts regarding the administration, use, or setup of a service on a server.>
 
 :::
 
@@ -858,6 +858,6 @@ The database is restored into a new database.
 
 [Our OVHcloud Object Storage solutions](https://www.ovhcloud.com/en-gb/public-cloud/object-storage/)
 
-If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
+If you need training or technical assistance for implementing our solutions, contact your sales representative or click [this link](/links/professional-services) to get a quote and request a personalized analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/image-import.mdx
@@ -80,6 +80,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -989,6 +989,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/isolate-management-vm.mdx
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 
@@ -52,6 +52,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/kms-configuration.mdx
@@ -96,6 +96,6 @@ By following this guide, you will learn how to leverage **Nutanix's data-at-rest
 - [Getting started with OVHcloud Key Management Service (KMS)](/guides/manage-and-operate/kms/quick-start)
 - [Nutanix Compatibility Matrix](https://portal.nutanix.com/page/documents/compatibility-interoperability-matrix/software?partnerName=OVHCloud&solutionType=KMS%20%28Key%20Management%20Solutions%29&componentVersion=External%20Key%20Managers&hypervisor=all&validationType=all)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/metro-availability.mdx
@@ -1100,6 +1100,6 @@ The list of events appears, click <code className="action">Close</code> to close
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/move-to-nutanix.mdx
@@ -13,11 +13,11 @@ Nutanix provides a tool called **Nutanix Move** that allows migrations from othe
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 
-This guide is designed to assist you as much as possible with common tasks. However, we recommend reaching out to the [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team or a [specialized provider](https://partner.ovhcloud.com/en-gb/directory/) if you encounter difficulties or have any doubts about managing, using, or setting up a service on a server.
+This guide is designed to assist you as much as possible with common tasks. However, we recommend reaching out to the [OVHcloud Professional Services](/links/professional-services) team or a [specialized provider](https://partner.ovhcloud.com/en-gb/directory/) if you encounter difficulties or have any doubts about managing, using, or setting up a service on a server.
 
 Some options, such as the use of compression or deduplication, require specific licences provided by Nutanix through OVHcloud. Please contact OVHcloud Sales for more information.
 
-Finally, if the procedure involves a VMware on OVHcloud service, the intervention of [OVHcloud Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) is mandatory.
+Finally, if the procedure involves a VMware on OVHcloud service, the intervention of [OVHcloud Professional Services](/links/professional-services) is mandatory.
 
 :::
 
@@ -428,6 +428,6 @@ The disk controller has been modified and the virtual machine boots properly.
 
 [Installation and configuration of Move](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Move-v4_3:Nutanix-Move-v4_3)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-aos-supported-versions.mdx
@@ -70,6 +70,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/guides/manage-and-operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -113,7 +113,7 @@ This 1U configuration supports Emerald Rapids CPUs and NVMe-only storage, design
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hci.mdx
@@ -118,6 +118,6 @@ Click <code className="action">Diagrams</code> for a graphical summary as shown 
 
 Visit the website [https://www.nutanixbible.com/](https://www.nutanixbible.com/) for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-leap.mdx
@@ -513,6 +513,6 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-veeam-backup.mdx
@@ -396,7 +396,7 @@ A preview of the status of the restoration is launched, it takes some time depen
 
 OVHcloud storage solutions
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/objects.mdx
@@ -256,7 +256,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ovh-gateway-doc.mdx
@@ -299,6 +299,6 @@ Wait a few minutes for the VM to take into account all settings.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -250,6 +250,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/public-ip.mdx
@@ -13,7 +13,7 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -435,6 +435,6 @@ You can now connect to your VM with SSH through the public IP address.
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/secure-prism-web-access.mdx
@@ -13,7 +13,7 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -68,6 +68,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -224,7 +224,7 @@ Once you have deployed an MST and connected it to your Object Storage bucket, yo
 
 [Cloud Clusters (NC2) Hosted - Deploying Multicloud Snapshot Technology](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Clusters-AWS:aws-cluster-protect-deploying-mst-t.html)
 
-If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -221,7 +221,7 @@ The first backup starts immediately after validating the S3 target and lasts **a
 
 [Prism pc.7.5 - Configuring Point-in-Time Backup to Generic S3-Compliant Object Store official documentation](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_7_5:mul-configuring-pointintime-backup-to-generic-s3-compliant-t.html)
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalized analysis of your project by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a personalized analysis of your project by our Professional Services team experts.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -498,6 +498,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/storage.mdx
@@ -118,6 +118,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/upgrade-prismcentral.mdx
@@ -18,7 +18,7 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 
@@ -199,6 +199,6 @@ The update process can be very long, it is possible that some slowdowns occur bu
 
 [Nutanix official documentation](https://www.nutanix.com/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/virtual-machine-management.mdx
@@ -285,6 +285,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/vrack-interconnection.mdx
@@ -241,7 +241,7 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovhcloud.com/en-gb/network/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/opcp/cloudstore-getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/cloudstore-getting-started.mdx
@@ -180,6 +180,6 @@ Landing Zone Manager users authenticate through their account-specific Keycloak 
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](https://community.ovhcloud.com/).

--- a/docs/en/guides/hosted-private-cloud/opcp/getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/getting-started.mdx
@@ -139,6 +139,6 @@ To find out more about how networks work with OpenStack, we recommend reading th
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-see-node-inventory.mdx
@@ -176,6 +176,6 @@ openstack baremetal node show `<node-id>`
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli.mdx
@@ -385,6 +385,6 @@ The operation may take several minutes before the node is `Available` again and 
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-instance.mdx
@@ -181,6 +181,6 @@ To learn more, refer to the [official OpenStack documentation](https://docs.open
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-lacp-on-node.mdx
@@ -356,6 +356,6 @@ Your instance is now ready to leverage the full available bandwidth of the aggre
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-setup-softraid-on-node.mdx
@@ -266,7 +266,7 @@ Disabling RAID will erase all data on the disks used for the RAID configuration.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project reviewed by our Professional Services experts.
+If you need training or technical assistance to implement our solutions, please contact your sales representative or click on [this link](/links/professional-services) to request a quote and have your project reviewed by our Professional Services experts.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -221,6 +221,6 @@ If these commands return results, the **Keycloak ↔ OpenStack** integration is 
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/iam-rights-management.mdx
@@ -434,6 +434,6 @@ These commands only return users who have **already authenticated** at least onc
 
 ## Go further
 
-For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/node-lifecycle.mdx
@@ -144,6 +144,6 @@ baremetal node maintenance unset $BAREMETAL_NODE_ID
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/s3-opcp-limitations.mdx
@@ -68,6 +68,6 @@ Improvements for user policy management are planned for future updates.
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/setup-trunk-on-node.mdx
@@ -383,6 +383,6 @@ Your instance can now communicate on multiple isolated networks through a single
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/storage-ceph-rbd-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/storage-ceph-rbd-overview.mdx
@@ -93,6 +93,6 @@ The **Ceph RBD** backend offers advanced tools for volume lifecycle management, 
 
 ## Go further
 
-If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and have your project analyzed by our Professional Services team experts.
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/opcp/use-terraform.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/use-terraform.mdx
@@ -285,6 +285,6 @@ terraform destroy
 
 ## Go further
 
-For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) page to request a quote and have your project analyzed by our experts.
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/datamotive-intro.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/datamotive-intro.mdx
@@ -75,7 +75,7 @@ You will access this interface:
 
 ## Go further
 
-If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Ask questions, give feedback and interact directly with the team building the Datamotive solution on the official [website](https://www.datamotive.io/).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/how-to-use-vscope.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/how-to-use-vscope.mdx
@@ -105,6 +105,6 @@ This section provides a detailed view of each virtual machine:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-add-new-tier1-gateway.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-add-new-tier1-gateway.mdx
@@ -116,6 +116,6 @@ Then click <code className="action">Network Topology</code>.
 
 [VMware documentation for adding a Tier-1 Gateway](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-EEBA627A-0860-477A-95A7-7645BA562D62.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-dhcp-onsegment.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-dhcp-onsegment.mdx
@@ -161,6 +161,6 @@ The DHCP server is active on this VLAN segment.
 
 [Segment management in NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-dns-forwarder.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-dns-forwarder.mdx
@@ -109,6 +109,6 @@ Your segment's DHCP settings now use the DNS forwarder you created earlier.
 
 [VMware documentation on DNS in NSX](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-A0172881-BB25-4992-A499-14F9BE3BE7F2.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-loadbalancing.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-configure-loadbalancing.mdx
@@ -211,7 +211,7 @@ Your rule is active. If you click on `http://virtual-ip-address-on-T0` you will 
 
 [VMware NSX Load Balancer documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-D39660D9-278B-4D08-89DF-B42C5400FEB2.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-faq.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-faq.mdx
@@ -389,7 +389,7 @@ This will depend on which services are enabled (LoadBalancer/NAT/Firewall, etc.)
 
 All packs are based on a day/hour count, e.g.: 1 day = 8 hours, 2 days = 16 hours (sometimes more).
 The first approach is the same for all packs with a discovery phase, but the duration of the pack will depend on the complexity of the environment and the maturity of your current managed offer.
-This issue will be explored with the [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team in a first evaluation call.
+This issue will be explored with the [Professional Services](/links/professional-services) team in a first evaluation call.
 
 </details>
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-filter-logs.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-filter-logs.mdx
@@ -106,7 +106,7 @@ To make NSX-T firewall logs easier to read and closer to the simplicity of NSX-V
 - [VMware NSX-T official documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/index.html)
 - [How to configure Syslog in NSX-T](https://kb.vmware.com/s/article/74656)
 
-If you require training or technical assistance in implementing our solutions, contact your sales representative or [click here](https://www.ovhcloud.com/en-gb/professional-services/) for a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical assistance in implementing our solutions, contact your sales representative or [click here](/links/professional-services) for a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord channel](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps.mdx
@@ -157,6 +157,6 @@ You have just seen the default configuration. You can refer to the other OVHclou
 
 [Managing segments in NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-manage-distributed-firewall.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-manage-distributed-firewall.mdx
@@ -240,6 +240,6 @@ Your rule is active, the traffic between the virtual machine member of the g-vm 
 
 [VMware Distributed Firewall in NSX documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-6AB240DB-949C-4E95-A9A7-4AC6EF5E3036.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-manage-gateway-firewall.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-manage-gateway-firewall.mdx
@@ -74,7 +74,7 @@ Your rule is active on the **ovh-T0-gw** gateway, it blocks all outgoing traffic
 
 [VMware Gateway Firewall in NSX Documentation](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-A52E1A6F-F27D-41D9-9493-E3A75EC35481.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-pricing.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-pricing.mdx
@@ -114,6 +114,6 @@ For detailed information on NSX Edge features, consult the [VMware NSX technical
 
 Pricing details for NSX Edges are not included in this documentation. To access up-to-date pricing or request a quote, visit the [OVHcloud website](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/prices/) or contact support via the [Help Center](https://help.ovhcloud.com/csm?id=csm_get_help).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/nsx-segment-management.mdx
@@ -209,6 +209,6 @@ Go back to the NSX interface, go to the <code className="action">Networking</cod
 
 [Getting started with NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/okms-vm-encrypt.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/okms-vm-encrypt.mdx
@@ -832,6 +832,6 @@ print(body['cert'])
 " | openssl x509 -text; echo $?
 ```
 
-If you require training or technical support to implement your migration with Public VCF as-a-Service, please contact your TAM or [click here](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement your migration with Public VCF as-a-Service, please contact your TAM or [click here](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/service-migration-vdc.mdx
@@ -374,7 +374,7 @@ If you still need this organisation, you will need to create it again in the des
 As part of an NSX-V to NSX-T migration, several NSX-V services need to be migrated to NSX-T. If you are using any of the services listed below, here is a step-by-step guide on how to migrate them. 
 
 :::info
-If you need technical support, our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team can help you rebuild your network architecture with customised services.
+If you need technical support, our [Professional Services](/links/professional-services) team can help you rebuild your network architecture with customised services.
 
 :::
 
@@ -411,7 +411,7 @@ Generally, depending on the number of edges deployed via NSX-V in the source vDC
 
 Additionally, if your production requires zero service interruption, solutions can be implemented to avoid these disruptions.
 
-In both cases mentioned above, our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team can assist you in this process.
+In both cases mentioned above, our [Professional Services](/links/professional-services) team can assist you in this process.
 
 <a name="t1seg"></a>
 ##### Step 4.8.3.1 Create T1 and segments
@@ -989,6 +989,6 @@ A session is scheduled and counted in 1-hour blocks. For example, a session sche
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-overview.mdx
@@ -46,6 +46,6 @@ The VPN-SPN manages the external network connectivity through the IPsec protocol
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-spn-connector.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-spn-connector.mdx
@@ -47,6 +47,6 @@ Only forwarding of IP traffic (i.e routing) is supported through InterDC/SPN Con
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-spn.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-spn.mdx
@@ -67,6 +67,6 @@ Expected topology:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-vpn-spn.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-concepts-vpn-spn.mdx
@@ -113,6 +113,6 @@ A eBGP session is to be configured inside IPsec tunnel:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-faq.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/snc-connectivity-faq.mdx
@@ -71,6 +71,6 @@ There is no impact on latency.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-declare-public-gateway.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-declare-public-gateway.mdx
@@ -84,7 +84,7 @@ In the current VCF version, the **Gateway CIDR** field may display the first gat
 
 First step guide: [Public VCF as-a-Service - Linking a public IP block with vRack](/guides/hosted-private-cloud/powered-by-vmware/vcd-link-ip-to-vrack).
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-get-concepts.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-get-concepts.mdx
@@ -144,6 +144,6 @@ All Cluster Management features are fully managed by OVHcloud.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-getting-started-dashboard-overview.mdx
@@ -203,6 +203,6 @@ See here for all recent actions in your organization.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-limitations.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-limitations.mdx
@@ -65,7 +65,7 @@ However, supporting HDS, ISO27001, SOC2, or PCI-DSS certifications is one of the
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-link-ip-to-vrack.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-link-ip-to-vrack.mdx
@@ -58,7 +58,7 @@ This IP block is not directly linked to your vRack. You will need to link it man
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-migration-use-cases.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-migration-use-cases.mdx
@@ -197,7 +197,7 @@ You can go even further by reading these guides, to get a better understanding o
 - [Public VCF as-a-Service - Creating network components via Public VCF as-a-Service](/guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation)
 - [Public VCF as-a-Service - Veeam Data Platform backup](/guides/hosted-private-cloud/powered-by-vmware/vcd-backup)
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-network-concepts.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-network-concepts.mdx
@@ -308,7 +308,7 @@ You can now follow the steps in the following guide: [“Guide 2 - Public VCF as
 
 To strengthen your network knowledge within the OVHcloud universe, please visit [our dedicated page](https://www.ovhcloud.com/en-gb/network/).
 
-If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated channel [Discord](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-network-creation.mdx
@@ -404,7 +404,7 @@ You can now follow the steps of the next guide :
 
 If you experience any network issues within Public VCF as-a-Service, please read our guide « [Public VCF as-a-Service - Network - Concepts](/guides/hosted-private-cloud/powered-by-vmware/vcd-network-concepts) »
 
-If you require training or technical assistance in implementing our solutions, contact your sales representative or [click here](https://www.ovhcloud.com/en-gb/professional-services/) for a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical assistance in implementing our solutions, contact your sales representative or [click here](/links/professional-services) for a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord channel](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-post-migration.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vcd-post-migration.mdx
@@ -61,7 +61,7 @@ This can lead to IP assignment issues if not addressed post-migration.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/veeam-encrypt-backup-job-with-okms.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/veeam-encrypt-backup-job-with-okms.mdx
@@ -155,7 +155,7 @@ openssl s_client -connect eu-west-rbx.okms.ovh.net:443 2>/dev/null </dev/null | 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your Technical Account Manager or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to request a quote and get personalized support from our Professional Services team.
+If you need training or technical assistance to implement our solutions, contact your Technical Account Manager or click [this link](/links/professional-services) to request a quote and get personalized support from our Professional Services team.
 
 Ask questions, share feedback, and interact directly with the Hosted Private Cloud team on our [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-datastore-upload.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-datastore-upload.mdx
@@ -355,7 +355,7 @@ These are the environment variables that will be required to configure Govc auth
 
 - [IAM for VMware on OVHcloud - Overview and FAQ](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-getting-started)
 
-If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the [dedicated Discord channel](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-activation.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-activation.mdx
@@ -101,6 +101,6 @@ You can now follow the guide [IAM for VMware on OVHcloud - How to create an IAM 
 - Guide 4: [IAM for VMware on OVHcloud - How to associate a vSphere role with an IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy)
 - Guide 5: [IAM for VMware on OVHcloud - How to associate a user with a global IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-getting-started.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-getting-started.mdx
@@ -130,6 +130,6 @@ You can now follow the steps in the guide [IAM for VMware on OVHcloud - How to a
 - Guide 4: [IAM for VMware on OVHcloud - How to associate a vSphere role with an IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy)
 - Guide 5: [IAM for VMware on OVHcloud - How to associate a user with a global IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy.mdx
@@ -88,6 +88,6 @@ You can now follow the steps in the guide [IAM for VMware on OVHcloud - How to a
 - Guide 4: IAM for VMware on OVHcloud - How to associate a vSphere role with an IAM policy
 - Guide 5: [IAM for VMware on OVHcloud - How to associate a user with a global IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role.mdx
@@ -129,6 +129,6 @@ You can now follow the steps in the guide [IAM for VMware on OVHcloud - How to a
 - Guide 4: [IAM for VMware on OVHcloud - How to associate a vSphere role with an IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy)
 - Guide 5: [IAM for VMware on OVHcloud - How to associate a user with a global IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-user-policy.mdx
@@ -73,6 +73,6 @@ If your identity is not present, you will need to add it first in the OVHcloud C
 - Guide 4: [IAM for VMware on OVHcloud - How to associate a vSphere role with an IAM policy](/guides/hosted-private-cloud/powered-by-vmware/vmware-iam-role-policy)
 - Guide 5: IAM for VMware on OVHcloud - How to associate a user with a global IAM policy
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-omnios.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-omnios.mdx
@@ -175,7 +175,7 @@ The migration schedule is as follows:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-veeam-secnumcloud.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-veeam-secnumcloud.mdx
@@ -189,7 +189,7 @@ nc -vz [PCC_Host_IP] 950
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-veeam.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-veeam.mdx
@@ -265,7 +265,7 @@ You can explore these additional resources to enhance your backup, replication, 
 - [Veeam Managed Backup](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/veeam-managed-backup/): A fully managed backup solution by OVHcloud.
 - [Zerto for VMware on OVHcloud](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/zerto/): Disaster recovery and replication across regions.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-zerto-secnumcloud.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-zerto-secnumcloud.mdx
@@ -319,7 +319,7 @@ You have 2 options:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-zerto.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-migration-zerto.mdx
@@ -353,7 +353,7 @@ You have 2 options:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-overall-vm-encrypt.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-overall-vm-encrypt.mdx
@@ -195,6 +195,6 @@ Official documentation:
 
 You can also follow the OVHcloud KMS labs: [OVHcloud KMS labs](https://labs.ovhcloud.com/en/key-management-service/).
 
-If you require training or technical support to implement your migration with Public VCF as-a-Service, please contact your TAM or [click here](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement your migration with Public VCF as-a-Service, please contact your TAM or [click here](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-update-esxi-vlcm.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-update-esxi-vlcm.mdx
@@ -83,7 +83,7 @@ The update process is now running. It may take several minutes per host.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, please contact your Technical Account Manager or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-vsan.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vmware-vsan.mdx
@@ -136,6 +136,6 @@ vSAN is now off.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vrops-monitoring-by-smtp.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vrops-monitoring-by-smtp.mdx
@@ -96,6 +96,6 @@ You can modify an existing alert by clicking on it from the menu.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connection.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vsphere-interface-connection.mdx
@@ -142,6 +142,6 @@ On the <code className="action">Home</code> page, you can view your managed vSph
 
 To ensure access, please refer to the VMware documentation, in which the different ports to be opened in your firewall are listed: [Client access](https://kb.vmware.com/kb/1012382).
 
-If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/vsphere-resilience-mode.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/vsphere-resilience-mode.mdx
@@ -74,6 +74,6 @@ Host connectivity will be restored once the test is complete, and your VMware on
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-multi-site.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-multi-site.mdx
@@ -113,7 +113,7 @@ This setup ensures secure VPN connectivity between on-premises Zerto and OVHclou
 
 ## Go further 
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-virtual-replication-customer-to-ovh.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-virtual-replication-customer-to-ovh.mdx
@@ -341,7 +341,7 @@ The most probable cause is that the OVHcloud ZVM is not authorised to contact yo
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-virtual-replication-vmware-vsphere-drp.mdx
+++ b/docs/en/guides/hosted-private-cloud/powered-by-vmware/zerto-virtual-replication-vmware-vsphere-drp.mdx
@@ -385,7 +385,7 @@ Depending on failover options, the failback (if needed) may require different st
 
 ## Go further 
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Ask questions, give your feedback and interact directly with the team building our Hosted Private Cloud services on the dedicated [Discord](https://discord.gg/ovhcloud) channel.
 

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-sap-on-secnumcloud.mdx
@@ -171,6 +171,6 @@ Configuring the secondary SAProuter requires the same care and vigilance as the 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/concept-vmware-for-sap.mdx
@@ -145,6 +145,6 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 - [Install and use OVHcloud Backint Agent for SAP HANA](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent)
 - [Use OVHcloud Backint Agent with several Object Storage buckets](/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-configure-sap-hana-cluster.mdx
@@ -769,6 +769,6 @@ In this case, the expected behaviour is only the detection of the loss of the se
 - [Setting Up a SAP HANA Cluster](https://documentation.suse.com/sles-sap/15-SP1/html/SLES4SAP-guide/cha-s4s-cluster.html)
 - [Configuring SAP HANA System Replication with hdbnsutil](https://help.sap.com/docs/SAP_HANA_PLATFORM/4e9b18c116aa42fc84c7dbfd02111aba/2dd26de6360046309e1579accbd9e527.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent.mdx
@@ -378,6 +378,6 @@ Otherwise, please set paths.
 - To improve the security of your backups, we advise you to set the [object immutability](/guides/storage-and-backup/object-storage/s3-managing-object-lock).
 - You also have the possibility to [trigger SAP HANA backup to several Object Storage buckets](/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-sles-sap-hana-dedicated-server.mdx
@@ -261,6 +261,6 @@ You can proceed to its installation following the [official SAP guide](https://h
 
 [How to configure LACP link aggregation on SLES 15](/guides/bare-metal-cloud/dedicated-servers/lacp-enable-sles15)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-hana-template-vmware.mdx
@@ -282,6 +282,6 @@ systemctl enable chronyd.service
 - [SAP Note 2779240 - Workload-based sizing for virtualized environments](https://me.sap.com/notes/2779240)
 - [SAP HANA on VMware vSphere](https://wiki.scn.sap.com/wiki/display/VIRTUALIZATION/SAP+HANA+on+VMware+vSphere)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs.mdx
@@ -111,6 +111,6 @@ The <ApiLink>OVHcloud API</ApiLink> can help you to retrieve your data to use th
 - [Logs Data Platform - Archive mirror](https://github.com/ovh/ldp-archive-mirror)
 - [SAP logs on OVHcloud Logs Data Platform - Index of SAP logs](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-index-of-sap-logs.mdx
@@ -77,6 +77,6 @@ If you haven't configured your OVHcloud Logs Data Platform service, please take 
 - [SAP logs on OVHcloud Logs Data Platform - Solution Setup](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup)
 - [SAP logs on OVHcloud Logs Data Platform - Analyze and work with your logs](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-solution-setup.mdx
@@ -332,6 +332,6 @@ rm -r /etc/systemd/system/ovhcloud-sap-audit.service.d
 - [Quick start for Logs Data Platform](/guides/manage-and-operate/observability/logs-data-platform/getting-started-quick-start)
 - [SAP logs on OVHcloud Logs Data Platform - Analyze and work with your logs](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-logs-on-ovhcloud-logs-data-platform-analyze-and-work-with-your-logs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-sap-preinstallation-wizard.mdx
@@ -252,6 +252,6 @@ The OVHcloud SAP pre-installation wizard does not support adding additional comp
 
 ## Go Further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-application-server.mdx
@@ -239,6 +239,6 @@ Destroy complete! Resources: 1 destroyed.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-hana-database.mdx
@@ -264,6 +264,6 @@ Destroy complete! Resources: 1 destroyed.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-terraform-sap-system.mdx
@@ -348,6 +348,6 @@ Destroy complete! Resources: 2 destroyed.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/?_gl=1*1vve3gg*_gcl_au*MzU3MTAzMzA5LjE2ODY1NTk4MTE.) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
   
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-veeam-backup-sap-hana.mdx
@@ -471,6 +471,6 @@ If you want to perform communication via the HTTPS protocol, the ports are:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-vmware-saprouter.mdx
@@ -194,6 +194,6 @@ Find more information about the firewall rule with an NSX gateway in [our guide]
 - [Install SAProuter](https://support.sap.com/en/tools/connectivity-tools/saprouter/install-saprouter.html)
 - [Gateway Firewall Management in NSX](/guides/hosted-private-cloud/powered-by-vmware/nsx-manage-gateway-firewall)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-dedicated-server-sap-as-hpc.mdx
@@ -147,6 +147,6 @@ To guarantee the connection continuity with the SAP Support, we recommend config
 - [Install and use OVHcloud Backint Agent for SAP HANA](/guides/hosted-private-cloud/sap-on-ovhcloud/cookbook-install-ovhcloud-backint-agent)
 - [Use OVHcloud Backint Agent with several Object Storage buckets](/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
+++ b/docs/en/guides/hosted-private-cloud/sap-on-ovhcloud/hana-use-ovhcloud-backint-agent-several-buckets.mdx
@@ -214,6 +214,6 @@ The steps are the same, even if you use different Object Storage buckets for you
 
 To improve the security of your backups, we advise you to set the [object immutability](/guides/storage-and-backup/object-storage/s3-managing-object-lock).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/migration.mdx
+++ b/docs/en/guides/migration.mdx
@@ -42,7 +42,7 @@ cta:
   description: "If you would like to consult experts to help you migrate your workloads, our teams and partners are here to help."
   actions:
     - text: "Professional Services"
-      link: "https://www.ovhcloud.com/en-gb/professional-services/"
+      link: "/links/professional-services"
       theme: brand
     - text: "Certified Partners"
       link: "https://partner.ovhcloud.com/en-gb/"

--- a/docs/en/guides/network/load-balancer/use-api-logs-customers.mdx
+++ b/docs/en/guides/network/load-balancer/use-api-logs-customers.mdx
@@ -198,6 +198,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/api.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/api.mdx
@@ -189,6 +189,6 @@ If a DC configuration is shared between two or more OVHcloud Connect services, d
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/faq.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/faq.mdx
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/logs-to-customers.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/logs-to-customers.mdx
@@ -182,6 +182,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-diagnostics.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-diagnostics.mdx
@@ -88,6 +88,6 @@ This limit has been set in order to restrict the amount of resources used by the
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-direct-control-panel.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-direct-control-panel.mdx
@@ -195,6 +195,6 @@ Deleting a PoP configuration will delete the related AZ and routing configuratio
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-layer2.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-layer2.mdx
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-layer3.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-layer3.mdx
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-limits.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-limits.mdx
@@ -62,6 +62,6 @@ lastUpdated: 2025-10-03
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/occ-provider-control-panel.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/occ-provider-control-panel.mdx
@@ -169,6 +169,6 @@ Deleting a PoP configuration will delete the AZ and routing configurations.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/ovhcloud-connect-overview.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/ovhcloud-connect-overview.mdx
@@ -82,6 +82,6 @@ The following table lists regions that can be accessed from each PoP location:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/ovhcloud-connect/troubleshooting.mdx
+++ b/docs/en/guides/network/ovhcloud-connect/troubleshooting.mdx
@@ -164,6 +164,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/network/vrack-services/global.mdx
+++ b/docs/en/guides/network/vrack-services/global.mdx
@@ -500,6 +500,6 @@ Please note that creating vRack Services, Subnets, or Service Endpoints on a pro
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
+++ b/docs/en/guides/public-cloud/compute/activate-windows-license-private-mode.mdx
@@ -190,6 +190,6 @@ slmgr.vbs -dli
 
 [Find out how to change the activation key of your Windows Server](/guides/bare-metal-cloud/dedicated-servers/windows-key).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/apps-first-steps.mdx
+++ b/docs/en/guides/public-cloud/compute/apps-first-steps.mdx
@@ -224,6 +224,6 @@ No further steps are necessary to complete the first configuration of this appli
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
+++ b/docs/en/guides/public-cloud/compute/faq-change-of-monthly-billing-method.mdx
@@ -36,6 +36,6 @@ With a monthly commitment, any month you start is payable in full. But this inst
 
 ## Go further <a name="go-further"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/first-steps-with-public-cloud-instance.mdx
@@ -183,6 +183,6 @@ Consult our [Getting started guide](/guides/public-cloud/compute/getting-started
 
 [Introducing Horizon](/guides/public-cloud/cross-functional/introducing-horizon)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/rescue-mode-metal-instance.mdx
@@ -69,6 +69,6 @@ $ openstack server unrescue SERVERID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/adapt-inotify-parameters-deployments.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/adapt-inotify-parameters-deployments.mdx
@@ -93,6 +93,6 @@ Congratulations! You've successfully modified the maximum inotify "max_user_watc
 
 To deploy your first application on your Kubernetes cluster, we suggest you refer to our guide to [Deploying an application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-application).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/add-ip-restrictions.mdx
@@ -304,6 +304,6 @@ Destroy complete! Resources: 1 destroyed.
 
 To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/apiserver-flags-configuration.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/apiserver-flags-configuration.mdx
@@ -459,6 +459,6 @@ To have an overview of the OVHcloud Managed Kubernetes service, you can go to th
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to look at our tutorials.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
@@ -586,6 +586,6 @@ with the following information:
 
 To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/available-upcoming-features.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/available-upcoming-features.mdx
@@ -27,6 +27,6 @@ For more information, see:
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-cluster-velero.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-cluster-velero.mdx
@@ -593,7 +593,7 @@ Please refer to [official Velero documentation](https://velero.io/docs/) to lear
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backing-up-volumes-stash.mdx
@@ -761,7 +761,7 @@ release "stash" uninstalled
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-cloudcasa.mdx
@@ -275,6 +275,6 @@ Now you can sit back and relax, knowing that you can now take ad-hoc or schedule
 
 In case you have questions, you can read the [FAQ page](https://cloudcasa.io/faq/) and access the [dedicated forum](https://cloudcasa.io/forum/forum/cloudcasa/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-cluster-trilio.mdx
@@ -1384,7 +1384,7 @@ All the basic tasks and operations explained in this tutorial, are meant to give
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/backup-restore-pv-volume-snapshot.mdx
@@ -374,6 +374,6 @@ kubectl delete namespace nginx-example
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/change-security-update.mdx
@@ -404,6 +404,6 @@ To have an overview of the OVHcloud Managed Kubernetes service, you can go to th
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to look at our [tutorials](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/cluster-autoscaler-example.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/cluster-autoscaler-example.mdx
@@ -312,6 +312,6 @@ To have an overview of OVHcloud Managed Kubernetes service, you can go to the [O
 
 Otherwise to skip it and learn more about using your Kubernetes cluster the practical way, we invite you to look at our [tutorials](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl.mdx
@@ -120,6 +120,6 @@ Or you can install and use [kubectx](https://github.com/ahmetb/kubectx).
 
 To deploy your first application on your Kubernetes cluster, we suggest you refer to our guide to [Deploying an application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-application).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-multi-attach-persistent-volumes-cloud-disk-array.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-multi-attach-persistent-volumes-cloud-disk-array.mdx
@@ -332,6 +332,6 @@ Congratulations, you have successfully set up a multi-attach persistent volume w
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our [OVHcloud Managed Kubernetes documentation](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-multi-attach-persistent-volumes-nas-ha.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-multi-attach-persistent-volumes-nas-ha.mdx
@@ -406,6 +406,6 @@ Congratulations, you have successfully set up a multi-attach persistent volume w
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes doc site.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-oidc-provider.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-oidc-provider.mdx
@@ -473,6 +473,6 @@ Destroy complete! Resources: 1 destroyed.
 
 To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-pods-services-ip-allocation-policy.mdx
@@ -123,6 +123,6 @@ Once the cluster is reset, use this call to verify the IP allocation policy:
 
 [First steps with the OVHcloud API](/guides/manage-and-operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-cilium.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-cilium.mdx
@@ -163,6 +163,6 @@ To have an overview of the OVHcloud Managed Kubernetes Service, see [this page](
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to read our tutorials.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-coredns.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-coredns.mdx
@@ -162,6 +162,6 @@ To have an overview of the OVHcloud Managed Kubernetes service, you can go to th
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to read our tutorials.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-kubeproxy.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/customizing-kubeproxy.mdx
@@ -616,6 +616,6 @@ Destroy complete! Resources: 1 destroyed.
 
 To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-application.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-application.mdx
@@ -229,6 +229,6 @@ No resources found in hello-app namespace.
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes doc site.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -1413,6 +1413,6 @@ The [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) 
 
 The operator [SDK](https://operatorframework.io/operator-capabilities/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world.mdx
@@ -320,6 +320,6 @@ For more details about this process, you can refer to the [deploying an applicat
 
 As you can see in the Kubernetes section of the <ApiLink>API Explorer</ApiLink>, a lot of useful API endpoints exist to manage your Kubernetes clusters. Feel free to use the API endpoints depending on your use cases.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-helm-operator.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-helm-operator.mdx
@@ -859,6 +859,6 @@ The [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) 
 
 The operator [SDK](https://operatorframework.io/operator-capabilities/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/encrypt-secret-sealed-secrets-kubeseal.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/encrypt-secret-sealed-secrets-kubeseal.mdx
@@ -410,6 +410,6 @@ helm uninstall sealed-secrets-controller sealed-secrets/sealed-secrets --namespa
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/etcd-quota-error.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/etcd-quota-error.mdx
@@ -201,6 +201,6 @@ Running the command may take several seconds, depending on your Kubernetes clust
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes doc site.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/expose-applications-using-load-balancer.mdx
@@ -601,6 +601,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/exposed-apis-feature-gates.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/exposed-apis-feature-gates.mdx
@@ -39,6 +39,6 @@ Feature gates:
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/formating-nvme-disk-iops-nodes.mdx
@@ -380,6 +380,6 @@ kubectl delete -f format-nvme-configmap.yaml
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/getting-source-ip-behind-loadbalancer.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/getting-source-ip-behind-loadbalancer.mdx
@@ -489,6 +489,6 @@ The precedent method should work in a similar way for any Ingress Controller. We
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-agones.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-agones.mdx
@@ -298,6 +298,6 @@ kubectl delete clusterrolebinding cluster-admin-binding
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-artifactory.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-artifactory.mdx
@@ -207,6 +207,6 @@ To have an overview of the OVHcloud Managed Kubernetes service, you can go to th
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to look at our tutorials.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-cert-manager.mdx
@@ -187,6 +187,6 @@ Please refer to our tutorial on [How to secure a Nginx Ingress with cert-manager
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-helm.mdx
@@ -207,6 +207,6 @@ release "test-redis" uninstalled
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-istio.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-istio.mdx
@@ -429,6 +429,6 @@ namespace "istio-apps" deleted
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-jenkins.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-jenkins.mdx
@@ -161,6 +161,6 @@ release "my-first-jenkins" uninstalled
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-knative.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-knative.mdx
@@ -466,6 +466,6 @@ kubectl delete namespace knative-apps
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kubernetes-dashboard.mdx
@@ -206,6 +206,6 @@ kubectl delete -f dashboard-cluster-role-binding.yml
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kyverno.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-kyverno.mdx
@@ -607,6 +607,6 @@ helm uninstall kyverno kyverno/kyverno --namespace kyverno
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-nginx-ingress.mdx
@@ -208,6 +208,6 @@ So now if you point your browser to `http://$INGRESS_URL/`, you will see your Wo
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-openfaas.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-openfaas.mdx
@@ -262,6 +262,6 @@ To learn more about OpenFaaS, please refer to the [official OpenFaaS documentati
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-popeye.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-popeye.mdx
@@ -529,7 +529,7 @@ You can check on your OVHcloud Object Storage `popeye` container that the report
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-trivy.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-trivy.mdx
@@ -527,6 +527,6 @@ It thus allows you to automate a way to access reports, export the metrics from 
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/install-wordpress.mdx
@@ -221,6 +221,6 @@ Don't hesitate to go to our Managed Kubernetes guides and tutorials.
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/label-nodeaffinity-node-pools.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/label-nodeaffinity-node-pools.mdx
@@ -300,6 +300,6 @@ But do you know that you can do several others Node operations like taint, drain
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our [OVHcloud Managed Kubernetes documentation site](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/migrate-iolb-to-public-cloud-loadbalancer.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/migrate-iolb-to-public-cloud-loadbalancer.mdx
@@ -252,6 +252,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/migration-to-ovhcloud.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/migration-to-ovhcloud.mdx
@@ -14,14 +14,14 @@ We will cover the essential phases of migration, including:
 - Cluster Provisioning: Selecting and deploying your new Kubernetes cluster on OVHcloud.
 - Post-Migration Validation: Ensuring your applications are fully functional on the new environment.
 
-This guide is designed to provide you with the necessary knowledge to successfully manage the migration of your Kubernetes environment. For complex scenarios or specialized assistance, the OVHcloud [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team is available to provide expert support.
+This guide is designed to provide you with the necessary knowledge to successfully manage the migration of your Kubernetes environment. For complex scenarios or specialized assistance, the OVHcloud [Professional Services](/links/professional-services) team is available to provide expert support.
 
 ## Requirements
 
 To successfully migrate your Kubernetes cluster to OVHcloud, ensure you have the following in place:
 
 - **Velero setup:** Velero, along with its Helm chart, should be installed and configured on your source Kubernetes cluster. It's crucial that Velero is connected to an OVHcloud S3<sup>1</sup>-compatible Object Storage endpoint for backup storage. You can find detailed instructions for Velero installation and configuration in the official [Velero Helm chart documentation](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/README.md).
-- **OVHcloud S3-compatible Endpoint:** Ensure your Velero setup correctly references the OVHcloud S3-compatible endpoints as the BackupStorageLocation. If you encounter any difficulties with these settings, don't hesitate to reach out to our [Professional Services experts](https://www.ovhcloud.com/en-gb/professional-services/) for assistance.
+- **OVHcloud S3-compatible Endpoint:** Ensure your Velero setup correctly references the OVHcloud S3-compatible endpoints as the BackupStorageLocation. If you encounter any difficulties with these settings, don't hesitate to reach out to our [Professional Services experts](/links/professional-services) for assistance.
 - **kubectl:** You'll need the kubectl command-line tool installed to interact with your Kubernetes clusters. Refer to the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/) for installation instructions.
 
 ## Instructions
@@ -45,7 +45,7 @@ Let's now dive into the detailed steps for migrating your Kubernetes cluster to 
 
     - Follow the instructions in the OVHcloud documentation for [creating a Kubernetes cluster](/guides/public-cloud/containers-orchestration/managed-kubernetes/create-cluster).
     - Choose your preferred deployment mode and proceed with the cluster creation.
-    - **Optional:** OVHcloud [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) can assist you in creating an Infrastructure-as-Code script for your new Kubernetes deployment using OpenTofu, streamlining the provisioning process.
+    - **Optional:** OVHcloud [Professional Services](/links/professional-services) can assist you in creating an Infrastructure-as-Code script for your new Kubernetes deployment using OpenTofu, streamlining the provisioning process.
 
 4. **Pick a flavour and node pool for your new OVHcloud cluster**
 
@@ -65,7 +65,7 @@ Let's now dive into the detailed steps for migrating your Kubernetes cluster to 
     - After restoration, carefully update all your DNS records to point to the new cluster's services.
     - Ensure your ingress controllers and Load Balancers are properly configured and ready on the new cluster.
     - Map the source cluster's storage class to the target cluster's equivalent using [Velero configuration](https://velero.io/docs/v1.16/restore-reference/) if your storage classes differ between environments.
-    - **Optional:** If the deployment process appears overly complex, or if you require assistance with migration and rollback strategies, reach out to the OVHcloud [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team.
+    - **Optional:** If the deployment process appears overly complex, or if you require assistance with migration and rollback strategies, reach out to the OVHcloud [Professional Services](/links/professional-services) team.
 
 7. **Run integration tests to ensure restore is complete**
 
@@ -75,7 +75,7 @@ Let's now dive into the detailed steps for migrating your Kubernetes cluster to 
 
 8. **Seek Professional Services assistance (if needed)**
 
-    If certain resources from your source cluster are particularly complex or require specialized knowledge for migration, the OVHcloud Professional Services team is available to provide expert assistance. You can find more information about their services [here](https://www.ovhcloud.com/en-gb/professional-services/).
+    If certain resources from your source cluster are particularly complex or require specialized knowledge for migration, the OVHcloud Professional Services team is available to provide expert assistance. You can find more information about their services [here](/links/professional-services).
 
 9. **Set up Saving Plans (if needed)**
 
@@ -91,7 +91,7 @@ To have an overview of the OVHcloud Managed Kubernetes service, visit the [OVHcl
 
 To deploy your first application on your Kubernetes cluster, we invite you to follow our guides to [configure default settings for kubectl](/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl) and to [deploy a Hello World application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/mks-plans.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/mks-plans.mdx
@@ -76,6 +76,6 @@ To explore detailed quotas, resource limits, and regional restrictions for the F
 
 To deploy your first application on your Kubernetes cluster, we invite you to follow our guides to [configure default settings for kubectl](/guides/public-cloud/containers-orchestration/managed-kubernetes/configure-kubectl) and to [deploy a Hello World application](/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-hello-world).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/monitoring-gpu-application.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/monitoring-gpu-application.mdx
@@ -409,6 +409,6 @@ Prometheus and Grafana are very powerful monitoring tools, but also have alertin
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes documentation.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/monitoring-instances-prometheus-grafana.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/monitoring-instances-prometheus-grafana.mdx
@@ -291,6 +291,6 @@ For more information, please read the following links
 - [Prometheus operator OpenStackSDConfig API Reference](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.OpenStackSDConfig)
 - [Prometheus operator OVHCloudSDConfig API Reference](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1alpha1.OVHCloudSDConfig)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/objects.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/objects.mdx
@@ -136,6 +136,6 @@ kube-system   wormhole-vh7pk                               1/1     Running   0  
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/persistentvolumes-permission-errors.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/persistentvolumes-permission-errors.mdx
@@ -113,6 +113,6 @@ my-first-k8s-wordpress-2-mariadb-0          1/1     Running            0        
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes documentation.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/plugins-software-versions-reserved-resources.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/plugins-software-versions-reserved-resources.mdx
@@ -141,6 +141,6 @@ This table sums up the reserved resources on b2 and b3 flavors:
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/rbac-custom-kubeconfig-limited-access.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/rbac-custom-kubeconfig-limited-access.mdx
@@ -157,6 +157,6 @@ You can also use an [OIDC provider to authenticate your users and automatically 
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/reset-cluster.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/reset-cluster.mdx
@@ -164,6 +164,6 @@ To have an overview of OVHcloud Managed Kubernetes service, you can go to the [O
 
 Otherwise to skip it and learn more about using your Kubernetes cluster the practical way, we invite you to look at our [tutorials](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/resize-persistent-volumes.mdx
@@ -409,6 +409,6 @@ Now you can expand the Persistent Volumes on your OVHcloud Managed Kubernetes cl
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our OVHcloud Managed Kubernetes documentation site.
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/runtime-security-falco.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/runtime-security-falco.mdx
@@ -458,7 +458,7 @@ helm uninstall falco -n falco
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/secure-nginx-ingress-cert-manager.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/secure-nginx-ingress-cert-manager.mdx
@@ -447,6 +447,6 @@ $ kubectl get certificate -o yaml | grep renew
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/set-up-persistent-volume.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/set-up-persistent-volume.mdx
@@ -321,6 +321,6 @@ It will not be automatically deleted when a user deletes PVC `default/test-pvc`
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/sticky-session-nginx-ingress.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/sticky-session-nginx-ingress.mdx
@@ -321,6 +321,6 @@ The tips with using `curl` with cookies is to store the received cookie in a fil
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/taint-drain-node-pools.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/taint-drain-node-pools.mdx
@@ -411,6 +411,6 @@ In this tutorial you saw how to do some operations on Nodes, taint, drain, cordo
 
 To learn more about using your Kubernetes cluster the practical way, we invite you to look at our [OVHcloud Managed Kubernetes documentation site](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/tracing-jaeger.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/tracing-jaeger.mdx
@@ -491,6 +491,6 @@ kubectl delete -f svc.yaml
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/traffic-management-istio.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/traffic-management-istio.mdx
@@ -323,7 +323,7 @@ Now you have seem some of the traffic management capabilities of Istio, you can 
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/upgrading-version.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/upgrading-version.mdx
@@ -74,6 +74,6 @@ To have an overview of the OVHcloud Managed Kubernetes service, you can go to th
 
 To learn more about how to use your Kubernetes cluster the practical way, we invite you to look at our [tutorials](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-cluster-autoscaler.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-cluster-autoscaler.mdx
@@ -227,6 +227,6 @@ To have an overview of OVHcloud Managed Kubernetes service, you can go to the [O
 
 Otherwise to skip it and learn more about using your Kubernetes cluster the practical way, we invite you to look at our  [tutorials](/guides/public-cloud/containers-orchestration/managed-kubernetes/overview) .
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-codefresh.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-codefresh.mdx
@@ -157,6 +157,6 @@ Now you can follow [Codefresh official tutorial](https://codefresh.io/docs/docs/
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-lb.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-lb.mdx
@@ -294,6 +294,6 @@ No resources found
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-vrack-between-private-networks.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-vrack-between-private-networks.mdx
@@ -85,6 +85,6 @@ With this setup, if in our schema *Pod 3* wants to communicate with the PCI *vm1
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-vrack.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/using-vrack.mdx
@@ -49,6 +49,6 @@ In the Managed Kubernetes service dashboard, you will see the cluster, with the 
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-custom-gateway.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-custom-gateway.mdx
@@ -643,6 +643,6 @@ To delete an Openstack router, you must first remove the linked ports.
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-example-between-private-networks.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-example-between-private-networks.mdx
@@ -534,6 +534,6 @@ Commercial support is available at
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-example-k8s-pci.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/vrack-example-k8s-pci.mdx
@@ -434,6 +434,6 @@ And putting the URL in the browser will take us to the new blog, accessing the M
 
 ## Go further
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/add-ip-restrictions.mdx
@@ -178,6 +178,6 @@ Wait about 30 seconds for the IP restriction to propagate.
 
 To have an overview of OVHcloud Managed Private Registry service, read the OVHcloud Managed Private Registry documentation.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-private-registry/configure-oidc-provider-authentication.mdx
@@ -266,6 +266,6 @@ You can generate again the users credentials via the OVHcloud Control Panel, the
 
 To have an overview of OVHcloud Managed Private Registry service, read the OVHcloud Managed Private Registry documentation.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/backup-restore-etcd-s3.mdx
@@ -166,7 +166,7 @@ A correct Object Storage endpoint should be `s3.gra.io.cloud.ovh.net`.
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-compute-instances.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-compute-instances.mdx
@@ -177,7 +177,7 @@ You can now install applications in your Kubernetes cluster though the `kubectl`
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-custom-nodes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/create-kubernetes-custom-nodes.mdx
@@ -103,7 +103,7 @@ After executing these commands to the machines/nodes, wait until the cluster is 
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/creating-mks.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/creating-mks.mdx
@@ -94,7 +94,7 @@ Once your Managed Kubernetes clusters are created, we do recommend performing al
 
 - To have an overview of the OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/deploy-monitoring-prometheus-grafana-metrics.mdx
@@ -142,7 +142,7 @@ If it's the case, you can add more nodes in your Kubernetes cluster and try the 
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/edit-kubernetes-cluster.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/edit-kubernetes-cluster.mdx
@@ -60,7 +60,7 @@ The cluster will be in `Updating` state during the changing period and `Active` 
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/getting-started.mdx
@@ -303,7 +303,7 @@ Happy Ranchering!
 
 - To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/import-kubernetes.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/import-kubernetes.mdx
@@ -75,7 +75,7 @@ You can refer to the official Rancher documentation on how to [Register Existing
 
 - To have an overview of OVHcloud Managed Kubernetes service, you can go to the [OVHcloud Managed Kubernetes page](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-rancher-service/using-rancher-cli.mdx
@@ -157,7 +157,7 @@ velero                velero-55f979c9c-hmb7v                         1/1     Run
 
 - To have an overview of OVHcloud Managed Rancher Service, you can go to the [OVHcloud Managed Rancher Service page](https://www.ovhcloud.com/en-gb/public-cloud/managed-rancher-service/).
 
-- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+- If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 - Our team remains available on our dedicated Discord Channel, do not hesitate to join and reach us : [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Container and Orchestration services.
 

--- a/docs/en/guides/public-cloud/cross-functional/compute-essential-information.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/compute-essential-information.mdx
@@ -149,6 +149,6 @@ One of the big advantages of using standard and open technologies, like OpenStac
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|
 |[Kubernetes APIs Overview](https://kubernetes.io/docs/reference/using-api/)| The documentation of the Kubernetes API, useful for an overview of the possibilities.|
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/delegate-projects.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/delegate-projects.mdx
@@ -64,6 +64,6 @@ To revoke an access, click on the <code className="action">...</code> button and
 
 [Access and Security in Horizon](/guides/public-cloud/cross-functional/compute-horizon-access-security)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/iaas-migration-steps.mdx
@@ -119,7 +119,7 @@ After uploading the image, you can deploy a new instance from it using the OVHcl
 
 You can then connect the instance to your defined private network, attach block storage, and configure any required load balancers.
 
-If you’re migrating several VMs, consider automating the process using scripts or infrastructure-as-code tools. You can also contact our [Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) to get support or delegate the migration process entirely.
+If you’re migrating several VMs, consider automating the process using scripts or infrastructure-as-code tools. You can also contact our [Professional Services team](/links/professional-services) to get support or delegate the migration process entirely.
 
 #### 6b. Perform a replatforming with clean deployments
 
@@ -144,7 +144,7 @@ Once your volumes are ready, use a tool such as [rsync](/guides/bare-metal-cloud
 
 This method allows you to migrate data progressively and validate it as you go.
 
-If you need help setting up this process or automating it across multiple instances, you can contact the OVHcloud [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team.
+If you need help setting up this process or automating it across multiple instances, you can contact the OVHcloud [Professional Services](/links/professional-services) team.
 
 ### 8. Migrate object storage using rclone (or a similar tool)
 
@@ -158,7 +158,7 @@ Start by ensuring you have the correct permissions to access both the source and
 
 This method ensures reliable and resumable transfers for large datasets. Follow our guide [Object Storage - Use Object Storage with Rclone](/guides/storage-and-backup/object-storage/s3-rclone) for the necessary steps.
 
-If your setup includes versioning, lifecycle rules, or other advanced features, or if you require automation, the OVHcloud [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team can help you design a tailored migration process.
+If your setup includes versioning, lifecycle rules, or other advanced features, or if you require automation, the OVHcloud [Professional Services](/links/professional-services) team can help you design a tailored migration process.
 
 ### 9. Re-link endpoints and validate applications
 
@@ -188,6 +188,6 @@ Explore our guide "[How do Savings Plans work?](/guides/public-cloud/cross-funct
 
 ## Go Further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
 Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/cross-functional/landing-zone-migration.mdx
+++ b/docs/en/guides/public-cloud/cross-functional/landing-zone-migration.mdx
@@ -187,7 +187,7 @@ Use tagging, IAM roles, and alerts to link costs to teams, environments, or serv
 
 ## Go Further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
 Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -189,7 +189,7 @@ When ready, click on <code className="action">Execute</code> to update the advan
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -52,6 +52,6 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
 Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/backups.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/backups.mdx
@@ -88,7 +88,7 @@ Backup settings must respect the following rules:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/capabilities.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/capabilities.mdx
@@ -70,7 +70,7 @@ For the latest updates, please refer to our [Github changelog](https://github.co
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-capabilities-limitations.mdx
@@ -136,7 +136,7 @@ The only specific privilege you can set is `replication`.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -186,7 +186,7 @@ Replace `<password>` with your actual password and the hostname with the one fro
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -110,6 +110,6 @@ Join our [community of users](/links/community).
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -88,7 +88,7 @@ Messages in the OVHcloud Control Panel will inform you when the ClickHouse clust
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -42,6 +42,6 @@ Some UI tools for ClickHouse are also available:
 
 Visit our Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our database services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](https://www.ovhcloud.com/en-gb/professional-services/) for a quote and custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or our [Professional Services experts](/links/professional-services) for a quote and custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -67,7 +67,7 @@ Optionally, you can configure access control lists (ACL) for granular permission
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -116,6 +116,6 @@ Join our [community of users](/links/community).
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/concepts-security-overview.mdx
@@ -162,4 +162,4 @@ Public Cloud Analytics documentation
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/database-operator.mdx
@@ -142,7 +142,7 @@ kubectl label nodes NODENAME1 NODENAME2 ... LABELNAME=LABELVALUE
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
@@ -52,7 +52,7 @@ You can reclaim disk space by deleting a `Kafka` topic or an `OpenSearch` index.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/lifecycle-policy.mdx
@@ -81,6 +81,6 @@ Analytics for Kafka *major.minor* version will reach its EOL approximately one y
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -88,7 +88,7 @@ There are 2 methods to delete a subscription:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/maintenance.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/maintenance.mdx
@@ -62,7 +62,7 @@ This might be a good idea if e.g. you want to prepare for a busy period and thus
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -70,7 +70,7 @@ Other engines using a storage space provide similar endpoints, e.g.:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/responsibility-model.mdx
@@ -159,6 +159,6 @@ For your information, a **Service** is considered a Public Cloud Analytics servi
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -142,7 +142,7 @@ The newly created service does not duplicate IP restrictions nor users which wer
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
@@ -79,7 +79,7 @@ Prometheus endpoints are subject to the same networking limitations the associat
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/troubleshooting.mdx
@@ -87,6 +87,6 @@ Analytics documentation,
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Analytics services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -56,7 +56,7 @@ For instance, if you have an OpenSearch cluster with db1-15 as flavor and less t
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our Analytics service!
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -62,7 +62,7 @@ If you downgrade to an Essential plan, your current flavor and/or number of node
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!
 

--- a/docs/en/guides/public-cloud/databases/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/databases/advanced-configuration.mdx
@@ -245,6 +245,6 @@ Execute the advanced configuration retrieval call from above again. The response
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/backups.mdx
+++ b/docs/en/guides/public-cloud/databases/backups.mdx
@@ -100,6 +100,6 @@ On-Site: within the same region
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/capabilities.mdx
@@ -85,7 +85,7 @@ For the latest updates, please refer to our [Github changelog](https://github.co
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/concepts-security-overview.mdx
+++ b/docs/en/guides/public-cloud/databases/concepts-security-overview.mdx
@@ -165,4 +165,4 @@ As the encryption keys are unique for each project, they will be deleted after s
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/configure-vrack.mdx
+++ b/docs/en/guides/public-cloud/databases/configure-vrack.mdx
@@ -137,6 +137,6 @@ redis-2612345abc-abcd1234defg.database.cloud.ovh.net:20185> GET mykey.test
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/database-operator.mdx
+++ b/docs/en/guides/public-cloud/databases/database-operator.mdx
@@ -141,7 +141,7 @@ kubectl label nodes NODENAME1 NODENAME2 ... LABELNAME=LABELVALUE
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 

--- a/docs/en/guides/public-cloud/databases/databases-cross-service-integration.mdx
+++ b/docs/en/guides/public-cloud/databases/databases-cross-service-integration.mdx
@@ -360,6 +360,6 @@ Then open your new dashboard:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/databases-deletion-protection.mdx
+++ b/docs/en/guides/public-cloud/databases/databases-deletion-protection.mdx
@@ -35,6 +35,6 @@ The boolean property `deletionProtection` should be set to `true` to activate th
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/databases-move-to-cloud.mdx
+++ b/docs/en/guides/public-cloud/databases/databases-move-to-cloud.mdx
@@ -48,7 +48,7 @@ This method requires shutting down your application. Please note that some downt
 
 8. Decommission the previous database instance once it is confirmed that it is no longer in use.
 
-9. Reach out to our [Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) for assistance with complex network configurations or architecture setup.
+9. Reach out to our [Professional Services team](/links/professional-services) for assistance with complex network configurations or architecture setup.
 
 ### Via Live or hot migration with PostgreSQL
 
@@ -62,12 +62,12 @@ Before initiating replication, ensure that the existing database schema has been
 
 For detailed instructions on setting up logical replication, refer to this [Aiven guide](https://aiven.io/docs/products/postgresql/howto/setup-logical-replication).
 
-If your setup involves complex configurations or specific requirements, contact our [Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) for assistance.
+If your setup involves complex configurations or specific requirements, contact our [Professional Services team](/links/professional-services) for assistance.
 
 ## We want your feedback!
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-advanced-parameters-references.mdx
@@ -81,6 +81,6 @@ Below you can find a summary of every configuration option available for Dashboa
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/grafana-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-capabilities.mdx
@@ -117,6 +117,6 @@ Only one user is created by default and its name is `admin`. You must reset its 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-prepare-for-incoming-connections.mdx
@@ -85,6 +85,6 @@ Learn more about Grafana® in the following tutorial: [Grafana fundamentals](htt
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -130,6 +130,6 @@ Connect to your https reverse proxy server with your browser (accept the SSL cer
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/grafana-tuto-using-api.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-tuto-using-api.mdx
@@ -98,6 +98,6 @@ Here it is, you can now use all the power of the Grafana® API.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/handling-disk-full.mdx
+++ b/docs/en/guides/public-cloud/databases/handling-disk-full.mdx
@@ -91,6 +91,6 @@ Be careful **not** to use that write window to continue to increase the disk usa
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-advanced-parameters-references.mdx
@@ -89,6 +89,6 @@ Below you can find a summary of every configuration option available for Kafka s
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/kafka-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-capabilities.mdx
@@ -173,6 +173,6 @@ For each topic you can specify:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!

--- a/docs/en/guides/public-cloud/databases/kafka-getting-started.mdx
+++ b/docs/en/guides/public-cloud/databases/kafka-getting-started.mdx
@@ -44,4 +44,4 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-advanced-parameters-references.mdx
@@ -57,6 +57,6 @@ Below you can find a summary of every configuration option available for Kafka C
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/kafkaconnect-capabilities.mdx
@@ -108,6 +108,6 @@ Please note that if the cluster is deleted, logs and metrics are also automatica
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!

--- a/docs/en/guides/public-cloud/databases/lifecycle-policy.mdx
+++ b/docs/en/guides/public-cloud/databases/lifecycle-policy.mdx
@@ -85,6 +85,6 @@ Valkey EOL will coincide with the official Valkey Community Releases policy : [h
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/logs-to-customers.mdx
+++ b/docs/en/guides/public-cloud/databases/logs-to-customers.mdx
@@ -162,6 +162,6 @@ You have 2 methods to delete a subscription:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/maintenance.mdx
+++ b/docs/en/guides/public-cloud/databases/maintenance.mdx
@@ -62,6 +62,6 @@ This might be a good idea if e.g. you want to prepare for a busy period and thus
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/migrate-from-gen2-to-gen3.mdx
+++ b/docs/en/guides/public-cloud/databases/migrate-from-gen2-to-gen3.mdx
@@ -193,6 +193,6 @@ Follow these instructions to delete the old 1-AZ service:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mirrormaker-capabilities.mdx
@@ -132,6 +132,6 @@ You can specify a username for each user. By default, the role is **admin**.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our analytics service!

--- a/docs/en/guides/public-cloud/databases/mongodb-analytics.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-analytics.mdx
@@ -88,5 +88,5 @@ Join our [community of users](/links/community).
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-benchmark.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-benchmark.mdx
@@ -204,7 +204,7 @@ Now that you have selected MongoDB as your database, it is time to setup the app
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-bi-connector.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-bi-connector.mdx
@@ -57,7 +57,7 @@ Refer to the MongoDB documentation for [connecting the BI tool](https://www.mong
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-cluster-sizing.mdx
@@ -218,7 +218,7 @@ You can refer to the [Connect with MongoDB Compass](/guides/public-cloud/databas
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-concept-capabilities.mdx
@@ -147,7 +147,7 @@ Furthermore, user creation from the MongoDB Shell is **not** supported: You need
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-cli.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-cli.mdx
@@ -115,6 +115,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-compass.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-compass.mdx
@@ -123,5 +123,5 @@ Join our [community of users](/links/community).
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-php.mdx
@@ -173,6 +173,6 @@ They can really help your work with PHP.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-connect-python.mdx
@@ -167,6 +167,6 @@ Congratulations! Everything is working properly.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-deploy-with-terraform.mdx
@@ -302,4 +302,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 Join our [community of users](/links/community).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-developer-best-practices.mdx
@@ -73,7 +73,7 @@ By following these best practices, developers can design efficient and scalable 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-developer-tools.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-developer-tools.mdx
@@ -83,7 +83,7 @@ While Compass and Studio 3T both offer graphical interfaces for MongoDB, Studio 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-getting-started.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-getting-started.mdx
@@ -74,6 +74,6 @@ Other integration examples can be found on the following repository: [https://gi
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-howto-backup-restore.mdx
@@ -72,6 +72,6 @@ Again, depending on the volume of data and your network connection, this operati
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project. Join our [community of users](/links/community).
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-kafka-connector.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-kafka-connector.mdx
@@ -68,7 +68,7 @@ Learn how to resolve issues you may encounter while running the MongoDB Kafka Co
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-manage-control-panel.mdx
@@ -116,6 +116,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-migrate-to-ovhcloud.mdx
@@ -17,7 +17,7 @@ This guide covers the essential tools and processes required for a successful mi
 
 Migrating to MongoDB can be a complex process, but professional services are available to ensure a seamless transition with training or technical assistance. Our experts can assist with every step of the migration, from assessing your current database architecture to designing an optimized schema for MongoDB. They provide guidance on data extraction, transformation, and loading, ensuring data integrity and minimal downtime. Additionally, professional services offer customized solutions, performance tuning, and training to empower your team with the skills needed to manage MongoDB effectively. Leveraging their expertise can save time, reduce risk, and maximize the benefits of migrating to MongoDB.
 
-Contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services.
+Contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services.
 
 ## Migration Tools
 
@@ -111,7 +111,7 @@ Use one of the tools mentioned in the previous section.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-monitoring.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-monitoring.mdx
@@ -129,4 +129,4 @@ Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://disco
 
 Join our [community of users](/links/community).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-operational-best-practices.mdx
@@ -122,7 +122,7 @@ This article discusses essential best practices for managing MongoDB post-deploy
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-read-preference-and-write-concern.mdx
@@ -88,7 +88,7 @@ result = db.collection.with_options(write_concern=WriteConcern("majority")).inse
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-relational-migrator.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-relational-migrator.mdx
@@ -41,7 +41,7 @@ You can use Relational Migrator to migrate one legacy application at a time to M
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -578,6 +578,6 @@ describe('get messages from particular user', () => {
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mongodb-why-mongodb.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-why-mongodb.mdx
@@ -176,7 +176,7 @@ MongoDB also offers comprehensive security features, including encryption at res
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project. 
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-advanced-parameters-references.mdx
@@ -72,6 +72,6 @@ Below you can find a summary of every configuration option available for a MySQL
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-capabilities.mdx
@@ -154,6 +154,6 @@ Creation of users is allowed via the Control Panel and API with default admin ro
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mysql-connect-cli.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-cli.mdx
@@ -147,6 +147,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/mysql-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-php.mdx
@@ -145,6 +145,6 @@ array(1) {
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-python.mdx
@@ -111,6 +111,6 @@ If not, your CLI should give you more details about the issue, for example:
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-connect-workbench.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-connect-workbench.mdx
@@ -71,6 +71,6 @@ Once connected, MySQL Workbench facilitates many actions such as querying your d
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-external-database-migration.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-external-database-migration.mdx
@@ -86,6 +86,6 @@ Currently the users are not migrated in this process and need to be recreated in
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-prepare-for-incoming-connections.mdx
@@ -109,6 +109,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -313,6 +313,6 @@ release "my-wordpress" uninstalled
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-advanced-parameters-references.mdx
@@ -232,6 +232,6 @@ Below you can find a summary of every configuration option available for OpenSea
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-capabilities.mdx
@@ -166,6 +166,6 @@ In practice, for OpenSearch Dashboards to function properly, you must grant the 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/opensearch-getting-started.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-getting-started.mdx
@@ -352,4 +352,4 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/opensearch-logstash.mdx
+++ b/docs/en/guides/public-cloud/databases/opensearch-logstash.mdx
@@ -257,4 +257,4 @@ Congratulations, you are now able to collect data from multiple sources and push
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-advanced-parameters-references.mdx
@@ -106,6 +106,6 @@ Below you can find a summary of every configuration option available for a Postg
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-capabilities.mdx
@@ -158,6 +158,6 @@ The only specific privilege you can set is `replication`.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-concept-high-availability.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-concept-high-availability.mdx
@@ -154,6 +154,6 @@ In both cases the Recovery Time Objective will vary, depending on multiple param
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-cli.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-cli.mdx
@@ -161,6 +161,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-pgadmin.mdx
@@ -75,6 +75,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-php.mdx
@@ -131,6 +131,6 @@ array(4) {
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-connect-python.mdx
@@ -87,6 +87,6 @@ After executing your Python code, result shown in the CLI should be like this:
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-extensions.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-extensions.mdx
@@ -164,6 +164,6 @@ defaultdb=> \dx
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-pool.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-pool.mdx
@@ -141,6 +141,6 @@ pgstatactivity outputs the two psql sessions, which uses the same PostgreSQL ser
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-prepare-for-incoming-connections.mdx
@@ -100,6 +100,6 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-terminate-queries.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-terminate-queries.mdx
@@ -105,6 +105,6 @@ As explained here, the query will disappear if you check again the statistics, b
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -488,6 +488,6 @@ To clean your PostgreSQL, use the OVHcloud Control Panel to delete your managed 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -220,6 +220,6 @@ To clean your PostgreSQL, use the OVHcloud Control Panel to delete your managed 
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-migrate-ecdb.mdx
@@ -145,6 +145,6 @@ Once you verified that the database migration was successful, update client appl
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/databases/public-cloud-databases-regions-comparison.mdx
@@ -52,6 +52,6 @@ A 1-AZ Region consists of a **single availability zone covering multiple data ce
 
 ## Go Further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
 Join our [community of users](/links/community) and visit our [Discord channel](https://discord.gg/ovhcloud).

--- a/docs/en/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-advanced-parameters-references.mdx
@@ -130,6 +130,6 @@ Below you can find a summary of every configuration option available for Valkey 
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-capabilities.mdx
@@ -159,6 +159,6 @@ Update of user ACLs is allowed only via API. Follow this [guide](/guides/public-
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/redis-connect-cli.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-cli.mdx
@@ -115,7 +115,7 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or [click on this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or [click on this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!
 

--- a/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-php.mdx
@@ -92,6 +92,6 @@ Congratulations! Everything is working properly.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-connect-python.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-python.mdx
@@ -79,6 +79,6 @@ Congratulations! Everything is working properly.
 
 Join our Discord: Visit our dedicated [Discord channel](https://discord.gg/ovhcloud) to ask questions, provide feedback, and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-connect-redisinsight.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-connect-redisinsight.mdx
@@ -78,6 +78,6 @@ Learn more about them [here](https://redis.com/redis-enterprise/redis-insight/).
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-prepare-for-incoming-connections.mdx
@@ -100,7 +100,7 @@ Visit the [Github examples repository](https://github.com/ovh/public-cloud-datab
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -193,6 +193,6 @@ Join our [community of users](/links/community).
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/redis-update-acls.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-update-acls.mdx
@@ -162,6 +162,6 @@ The result should be displayed similarly to the example below.
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/resize-cluster-storage.mdx
+++ b/docs/en/guides/public-cloud/databases/resize-cluster-storage.mdx
@@ -76,6 +76,6 @@ Other engines using a storage space provide similar endpoints, e.g.:
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/responsibility-model.mdx
+++ b/docs/en/guides/public-cloud/databases/responsibility-model.mdx
@@ -159,6 +159,6 @@ For your information, a **Service** is considered a Public Cloud Databases servi
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/databases/service-metrics-with-prometheus.mdx
+++ b/docs/en/guides/public-cloud/databases/service-metrics-with-prometheus.mdx
@@ -96,6 +96,6 @@ Prometheus endpoints are subject to the same networking limitations the associat
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/troubleshooting.mdx
+++ b/docs/en/guides/public-cloud/databases/troubleshooting.mdx
@@ -85,4 +85,4 @@ To troubleshoot an outage:
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.

--- a/docs/en/guides/public-cloud/databases/update-cluster-flavor.mdx
+++ b/docs/en/guides/public-cloud/databases/update-cluster-flavor.mdx
@@ -67,6 +67,6 @@ For instance, if you have a PostgreSQL cluster with db1-15 as flavor and less th
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/databases/update-cluster-plan.mdx
+++ b/docs/en/guides/public-cloud/databases/update-cluster-plan.mdx
@@ -73,6 +73,6 @@ If you downgrade to an Essential plan, your current flavor and/or number of node
 
 We would love to help answer questions and appreciate any feedback you may have.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Are you on Discord? Connect to our channel at [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud) and interact directly with the team that builds our databases service!

--- a/docs/en/guides/public-cloud/network-services/buy-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/buy-additional-ip.mdx
@@ -96,6 +96,6 @@ The next step will be the IP configuration in your OS; please refer to our [guid
 
 [Configuring an Additional IP](/guides/public-cloud/network-services/configure-additional-ip)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -387,6 +387,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/guides/public-cloud/network-services/migrate-additional-ip)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance with your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assistance with your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/import-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/import-additional-ip.mdx
@@ -87,6 +87,6 @@ The next step will be the IP configuration in your OS; please refer to our [guid
 
 [Configuring an Additional IP](/guides/public-cloud/network-services/configure-additional-ip)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/ipv6-configuration.mdx
+++ b/docs/en/guides/public-cloud/network-services/ipv6-configuration.mdx
@@ -356,6 +356,6 @@ In any case, please feel free to reach out to our [support team](https://help.ov
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts to assist you with your use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts to assist you with your use case.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
+++ b/docs/en/guides/public-cloud/network-services/load-balancer-third-party-certificat.mdx
@@ -221,6 +221,6 @@ You can now access your Load Balancer securely. However, you will need to renew 
 
 [Getting started with Load Balancer on Public Cloud](/guides/public-cloud/network-services/getting-started-load-balancer)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
+++ b/docs/en/guides/public-cloud/network-services/migrate-additional-ip.mdx
@@ -74,6 +74,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/guides/public-cloud/network-services/import-additional-ip)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/en/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -586,6 +586,6 @@ PING <ip_address> (<ip_address>) 56(84) bytes of data.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
+++ b/docs/en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/veeam/veeam-veeam-backup-replication.mdx
@@ -276,6 +276,6 @@ You can now disable the user that you have created to create the registration.
 
 ## Go further
 
-If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your Technical Account Manager or visit [this page](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/block-storage-the-right-storage-class.mdx
@@ -108,6 +108,6 @@ Choosing the right deployment option ensures optimal performance, redundancy, an
 
 [Change your Block Storage volume type](/guides/public-cloud/compute/switch-volume-type)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or reach out to our [Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a personalised analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or reach out to our [Professional Services team](/links/professional-services) to get a quote and request a personalised analysis of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-access-cluster.mdx
@@ -126,6 +126,6 @@ If these commands show cluster information, your client is successfully configur
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-cephfs.mdx
@@ -239,6 +239,6 @@ mount -t ceph -o name=[USERID],secretfile=/etc/ceph/[USERID].secret :/ /mnt/ceph
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-change-user-rights.mdx
@@ -51,6 +51,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-check-cluster-status.mdx
@@ -89,6 +89,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-a-user.mdx
@@ -91,6 +91,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-create-an-ip-acl.mdx
@@ -94,6 +94,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/acl
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-grow-with-api.mdx
@@ -202,6 +202,6 @@ Open the provided URL, complete the payment process, and your upgrade will begin
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-io-benchmarking.mdx
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-ceph-with-proxmox.mdx
@@ -110,6 +110,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
+++ b/docs/en/guides/storage-and-backup/block-storage/cloud-disk-array/ceph-use-your-cluster-with-rbd.mdx
@@ -170,6 +170,6 @@ The RBD image is now safely detached from the client.
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-clone-volume.mdx
@@ -121,6 +121,6 @@ Depending on the snapshot size, the volume creation may take some time.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts-performances.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts-performances.mdx
@@ -112,6 +112,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud)

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-concepts.mdx
@@ -136,6 +136,6 @@ What is the difference between Terabyte (TB) and Tebibyte (TiB)?
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on Discord: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-control-panel.mdx
@@ -235,6 +235,6 @@ If you are new to using Enterprise File Storage, you can follow this sequence of
 
 [Enterprise File Storage - FAQ](/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq.mdx
@@ -132,6 +132,6 @@ Enterprise File Storage is a service that is billed monthly by volume (from 1 TB
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-hold-automatic-snapshot.mdx
@@ -59,6 +59,6 @@ Please take note of the new `id` if you want to perform further operations with 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-network-config.mdx
@@ -116,6 +116,6 @@ You can now follow the guides below to create and manage your volumes, snapshots
 
 [Enterprise File Storage - Managing volume snapshots](/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-nfs-client-considerations.mdx
@@ -56,6 +56,6 @@ However, if you get "invalid device error" errors during certain write operation
 
 ## Go further
 
-If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+If you require training or technical support to implement our solutions, please contact your sales representative or click [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-pci-connection-via-vrack.mdx
@@ -257,6 +257,6 @@ If no errors occur, the EFS volume will now automatically mount on boot.
 
 [Enterprise File Storage - Managing volume snapshots](/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-quick-start.mdx
@@ -148,6 +148,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-revert-snapshot.mdx
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-snapshot-policy.mdx
@@ -99,6 +99,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-terraform.mdx
@@ -1165,6 +1165,6 @@ Destroy complete! Resources: 2 destroyed.
 
 [Enterprise File Storage - FAQ](/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-trident-csi.mdx
@@ -624,6 +624,6 @@ The snapshot is created on the Enterprise File Storage service and can be used f
 
 [Enterprise File Storage - FAQ](/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-acl.mdx
@@ -95,6 +95,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volume-snapshots.mdx
@@ -104,6 +104,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/enterprise-file-storage/netapp-volumes.mdx
@@ -122,6 +122,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-cifs.mdx
@@ -87,6 +87,6 @@ mount: /mnt/FolderMount: mount(2) system call failed: No route to host.
 
 [NAS - Frequently Asked Questions](/guides/storage-and-backup/file-storage/ha-nas/nas-faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-faq.mdx
@@ -384,6 +384,6 @@ The subscription periods offered are 1 month, 12 months, 24 months and 36 months
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-get-started.mdx
@@ -123,6 +123,6 @@ To delete a partition, click on the <code className="action">...</code> button t
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-manage-acls.mdx
@@ -101,6 +101,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/guides/storage-and-backup/file-storage/ha-nas/nas-cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-migration.mdx
@@ -38,6 +38,6 @@ Warning: if you add other options to `rsync`, these may not be compatible with t
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -335,6 +335,6 @@ Some Linux kernels use a default `read_ahead_kb` value of 128 KB. We recommend t
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-partitions-api.mdx
@@ -151,6 +151,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/guides/storage-and-backup/file-storage/ha-nas/nas-cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-quick-api.mdx
@@ -117,6 +117,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/guides/storage-and-backup/file-storage/ha-nas/nas-cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-snapshots-api.mdx
@@ -168,6 +168,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/guides/storage-and-backup/file-storage/ha-nas/nas-cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-archive-getting-started.mdx
@@ -313,7 +313,7 @@ This command returns detailed configuration info which can be useful for debuggi
 
 Check out our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, share feedback, and interact directly with the team behind our storage and backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/cold-archive-overview.mdx
@@ -183,7 +183,7 @@ Operate your lifecycle and learn how to create buckets, archive, retrieve data, 
 
 Visit our dedicated Discord channel: [https://discord.gg/ovhcloud](https://discord.gg/ovhcloud). Ask questions, provide feedback, and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assistance on your specific use case or project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network.mdx
@@ -78,6 +78,6 @@ To set this new policy to your S3 user, please follow the different steps shared
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-capabilities-and-limitations.mdx
@@ -266,6 +266,6 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -67,6 +67,6 @@ In case of connection difficulties, you can download the Cyberduck connection pr
 
 [Getting started with the Swift API](/guides/storage-and-backup/object-storage/pcs-create-container)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-rsync.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-rsync.mdx
@@ -83,6 +83,6 @@ Additionally, only a subset of options are allowed on the client side:
 
 [Rsync main page](https://linux.die.net/man/1/rsync)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-sftp.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-sftp.mdx
@@ -66,6 +66,6 @@ Data recovery requires that the object be unlocked first. A GET request must be 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pca-unlock.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-unlock.mdx
@@ -187,6 +187,6 @@ swift download <pca_container> <object> | at now + ${RETRIEVAL_DELAY} minutes
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-capabilities-and-limitations.mdx
@@ -258,6 +258,6 @@ The current version of Keystone is version 3, v2 being obsolete for several year
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-configure-automatic-object-deletion.mdx
@@ -47,7 +47,7 @@ The file will therefore be deleted on the 19th November 2022.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
  

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-configure-owncloud-with-object-storage.mdx
@@ -109,6 +109,6 @@ Once you've entered all the information and checked that it is correct, the red 
 
 ## Go further
  
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-link-domain.mdx
@@ -112,6 +112,6 @@ You cannot use the following characters in your container name:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -65,6 +65,6 @@ In case of connection difficulties, you can download the Cyberduck connection pr
 
 [Getting started with the Swift API](/guides/storage-and-backup/object-storage/pcs-create-container)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-optimised-method-for-uploading-files-to-object-storage.mdx
@@ -37,7 +37,7 @@ You can measure the upload speed using iftop.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
  

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-pcs-syno.mdx
@@ -63,6 +63,6 @@ You can find this information in the OpenRC file which you downloaded in the pre
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-sync-object-containers.mdx
@@ -171,6 +171,6 @@ You can also use this guide for migrating RunAbove objects to the OVHcloud Publi
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-sync-rclone-object-storage.mdx
@@ -56,6 +56,6 @@ You can find more detailed instructions on how to synchronise your object storag
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-use-s3ql-to-mount-object-storage-containers.mdx
@@ -92,6 +92,6 @@ You cannot use S3QL in offline mode, you should not configure persistance via th
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-asynchronous-replication.mdx
@@ -671,7 +671,7 @@ You can access the details of the Offsite Replication pricing on the global Obje
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-bucket-acl.mdx
@@ -301,6 +301,6 @@ ACLs and policies can be combined. However the principle of least privilege will
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs.mdx
@@ -169,7 +169,7 @@ The list of all API endpoints can be found [here](/guides/storage-and-backup/obj
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-cohesity-netbackup.mdx
@@ -100,6 +100,6 @@ You will be guided through the entire process, from selecting the Storage Server
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage.mdx
@@ -673,7 +673,7 @@ A bucket can only be deleted if it is empty.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-identity-and-access-management.mdx
@@ -327,7 +327,7 @@ The following policy to attempt to deny read access to objects to specific IPs b
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-limitations.mdx
@@ -59,6 +59,6 @@ Read our guide on [Object Storage - Compatibility](/guides/storage-and-backup/ob
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-local-zones-limitations.mdx
@@ -61,6 +61,6 @@ The OVHcloud development team is working on implementing this API.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-location.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-location.mdx
@@ -379,7 +379,7 @@ The mapping for **READ(GET/LIST/HEAD)** operations on the **perf** endpoint is t
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-managing-object-lock.mdx
@@ -347,6 +347,6 @@ This command will fail if the object is protected by Object Lock in Compliance o
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -143,7 +143,7 @@ rclone size ovhcloud-s3:<destination_bucket_name>/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -65,7 +65,7 @@ Keep in mind that several factors could affect how long migration takes. Conside
 
 ### Data volume
 
-This guide mainly **focuses on data migration for small to medium volumes (generally under 200 TB)**. For applications needing migration of hundreds or thousands of terabytes, we suggest contacting our [Professional Services](https://www.ovhcloud.com/en-gb/professional-services/) team for identifying the best approaches for migrating your data.
+This guide mainly **focuses on data migration for small to medium volumes (generally under 200 TB)**. For applications needing migration of hundreds or thousands of terabytes, we suggest contacting our [Professional Services](/links/professional-services) team for identifying the best approaches for migrating your data.
 
 ## Instructions 
 
@@ -198,7 +198,7 @@ rclone size ovhcloud:<destination_bucket_name>/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -180,7 +180,7 @@ Edit your `config/config.php` file and add:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model.mdx
@@ -136,7 +136,7 @@ The RACI below details shared responsibilities between OVHcloud and the customer
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files.mdx
@@ -51,7 +51,7 @@ aws configure set default.s3.max_concurrent_requests 20
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -83,6 +83,6 @@ The result should be similar to this:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-performance-optimization.mdx
@@ -320,6 +320,6 @@ When applicable, we recommend that you increase the object/part size as much as 
 
 ## Go further <a name="go-further"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -91,6 +91,6 @@ You will find on the official Rclone website a detailed documentation of the pos
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-regions-comparison.mdx
@@ -116,7 +116,7 @@ Local Zones are designed to bring OVHcloud services closer to end-users, minimiz
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case.
 
 Visit our [Discord channel](https://discord.gg/ovhcloud).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-restoring-objects.mdx
@@ -81,7 +81,7 @@ You can restore an object in the Cold Archive storage class by using the <Manage
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-s3-compliancy.mdx
@@ -533,7 +533,7 @@ This guide lists the features supported by OVHcloud Object Storage.
 
 [Object Storage - Local Zones specifications](/guides/storage-and-backup/object-storage/s3-local-zones-limitations)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -131,7 +131,7 @@ You will find a detailed documentation of the possible actions on the [official 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-server-access-logging.mdx
@@ -250,7 +250,7 @@ aws --profile `<profile_name>` s3api put-bucket-logging --bucket `<bucket_name>`
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-setting-up-cors.mdx
@@ -102,7 +102,7 @@ The Object Storage server will expose the `Access-Control-Allow-Origin` header i
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-share-object-externally.mdx
@@ -93,7 +93,7 @@ OVHcloud Object Storage offers three main ways to share objects externally. Choo
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-terraform.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-terraform.mdx
@@ -114,7 +114,7 @@ This process may fail if the bucket contains locked objects. In this case, you'l
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -94,7 +94,7 @@ At the **Summary** step of the wizard, complete the object storage repository co
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-website-https.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-website-https.mdx
@@ -202,6 +202,6 @@ Check that the website and the redirect work properly. Open a private browser to
 
 [How to configure your DNS zone](/guides/web-cloud/domains/dns-zone-edit)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/storage-and-backup/object-storage/s3-website.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-website.mdx
@@ -111,7 +111,7 @@ Find more information on OVHcloud domain name offers on the [OVHcloud website](h
 
 [Enable HTTPS on a static website using a custom fqdn](/guides/storage-and-backup/object-storage/s3-website-https)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).
 


### PR DESCRIPTION
Replace 501 hardcoded Professional Services URLs across docs/en with the existing /links/professional-services key.

Every occurrence hardcoded a locale path, almost always en-gb, so each non-English locale that inherits or copies the block sent its readers to the English page. The key in config/links.ts already maps all seven locales, and it resolves to the same en-gb URL for English, so the rendered output is unchanged: the built pages still emit 854 identical hrefs. Only the source becomes locale-aware.

Three occurrences also carried a stray Google Analytics query string (?_gl=...), an artefact of a copy-paste from a browser address bar rather than a real link target. Those are dropped.

This was found while translating the FR backlog, where the same defect appeared independently in four product families. Rather than fix it four times, this sweeps docs/en once so no family can regress.

Mechanical and scoped: only Professional Services URL lines are touched, docs/fr and the other locale trees are untouched, and pnpm build:en is green.