### PR TITLE
SK-2715 - WEB - DNS - Restrict the automatic DKIM section to the zones where it exists

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -152,7 +152,7 @@ Damit dieses Prinzip der Rotation funktioniert, werden **DKIM-Selektoren** einge
 
 **Beispiel einer DKIM-Signatur**
 
-```
+```text
 DKIM-Signature: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -1076,34 +1076,34 @@ selector-name._domainkey.mydomain.ovh.
 Das Feld **Übersicht des Eintrags** zeigt den entstehenden Eintrag an, während Sie das Formular ausfüllen. Wenn Sie einen DKIM-Tag benötigen, den das Formular nicht anbietet (zum Beispiel `g=`, `n=` oder `s=`), fügen Sie den Eintrag stattdessen als [TXT-Eintrag](#txt-record) hinzu oder verwenden Sie die Funktion <code className="action">Erweiterter Bearbeitungsmodus</code>.
 
 - **Version (v=)**: Zur Angabe der DKIM-Version Die Verwendung wird empfohlen und der Standardwert ist `DKIM1`.<br/>
-Wenn genutzt, muss dieser Tag am Anfang stehen und muss "DKIM1" sein. Einträge, die einen "v=" Tag mit einem anderen Wert beginnen, werden ignoriert.
+Wenn genutzt, muss dieser Tag am Anfang stehen und muss "DKIM1" sein. Einträge, die einen `v=` Tag mit einem anderen Wert beginnen, werden ignoriert.
 
 - **Granularität (g=)**: Erlaubt die Angabe des "lokalen" Teils einer E-Mail-Adresse, also vor dem `@`.<br/>
 Damit können eine oder mehrere E-Mail-Adressen angegeben werden, die zur Signatur einer E-Mail mit dem DKIM-Schlüssel des Selektors autorisiert sind.<br/>
-Der Standardwert von "g=" ist "\*", was bedeutet, dass alle E-Mail-Adressen den DKIM-Signaturschlüssel verwenden dürfen.<br/>
-Durch die Angabe eines spezifischen Wertes für "g=" kann die Verwendung des Schlüssels auf einen bestimmten lokalen Teil der E-Mail-Adresse oder auf einen bestimmten Bereich von E-Mail-Adressen unter Verwendung von Wildcards beschränkt werden (Beispiel: "\*-group").
+Der Standardwert von `g=` ist `\*`, was bedeutet, dass alle E-Mail-Adressen den DKIM-Signaturschlüssel verwenden dürfen.<br/>
+Durch die Angabe eines spezifischen Wertes für `g=` kann die Verwendung des Schlüssels auf einen bestimmten lokalen Teil der E-Mail-Adresse oder auf einen bestimmten Bereich von E-Mail-Adressen unter Verwendung von Wildcards beschränkt werden (Beispiel: `\*-group`).
 
 - **Algorithmus (Hash) (h=)**: Erlaubt die Angabe der Hash-Algorithmen, die zur Signatur der E-Mail-Header verwendet werden. Erstellen Sie hiermit eine Liste von Hash-Algorithmen, die für die DKIM-Signatur einer Nachricht verwendet werden.
 
 - **Key-Typ (k=)**: Bestimmt den Signaturalgorithmus, der zur Signatur ausgehender E-Mails verwendet wird. Er teilt Empfängern mit, wie die Nachricht signiert wurde und welche Methode zur Echtheitsüberprüfung eingesetzt wird.<br/>
-Die möglichen Werte für "k=" beinhalten "rsa" für den Signaturalgorithmus RSA und "ed25519" für den Signaturalgorithmus Ed25519. Die Wahl des Algorithmus hängt von den Sicherheitsrichtlinien des Absenders und der Unterstützung beim Empfänger ab.
+Die möglichen Werte für `k=` beinhalten `rsa` für den Signaturalgorithmus RSA und `ed25519` für den Signaturalgorithmus Ed25519. Die Wahl des Algorithmus hängt von den Sicherheitsrichtlinien des Absenders und der Unterstützung beim Empfänger ab.
 
 - **Anmerkungen (n=)**: Zur Beifügung von Zusatzinformationen für Administratoren, die das DKIM-Schlüsselsystem verwalten.<br/>
-Diese Anmerkungen können der Dokumentation dienen oder zur Verständlichkeit der DKIM-Funktion beitragen, etwa um Administratoren bei der Verwaltung zu helfen. In "n=" enthaltene Informationen werden softwareseitig nicht interpretiert und beeinträchtigen nicht die Funktionsweise von DKIM.
+Diese Anmerkungen können der Dokumentation dienen oder zur Verständlichkeit der DKIM-Funktion beitragen, etwa um Administratoren bei der Verwaltung zu helfen. In `n=` enthaltene Informationen werden softwareseitig nicht interpretiert und beeinträchtigen nicht die Funktionsweise von DKIM.
 
 - **Public Key (base64) (p=)**: Enthält den Public Key für DKIM, in Base64 kodiert.<br/>
 Dieser Tag ist in der DKIM-Signatur zwingend erforderlich und erlaubt es den Empfängern der Signatur, den öffentlichen Schlüssel zu generieren, um damit die Authentizität der signierten Nachricht zu überprüfen.
 
-- **Den Public Key widerrufen**: Wenn ein öffentlicher DKIM-Schlüssel zurückgezogen wurde (z.B. wenn der private Schlüssel kompromittiert ist), muss für "p=" ein leerer Wert verwendet werden, um anzugeben, dass dieser öffentliche Schlüssel nicht mehr gültig ist. Beim Empfänger wird dann ein Fehler bei jeder DKIM-Signatur produziert, die sich auf einen zurückgezogenen Schlüssel stützt.
+- **Den Public Key widerrufen**: Wenn ein öffentlicher DKIM-Schlüssel zurückgezogen wurde (z.B. wenn der private Schlüssel kompromittiert ist), muss für `p=` ein leerer Wert verwendet werden, um anzugeben, dass dieser öffentliche Schlüssel nicht mehr gültig ist. Beim Empfänger wird dann ein Fehler bei jeder DKIM-Signatur produziert, die sich auf einen zurückgezogenen Schlüssel stützt.
 
-- **Dienstleistungstypen (s=)**: Der Tag "s=" ist optional und standardmäßig leer. Er erlaubt es, die Art(en) der Dienste anzugeben, für die der DKIM-Eintrag gilt.<br/>
-Die Diensttypen werden anhand einer Liste von Schlüsselwörtern definiert, je mit einem ":" getrennt.<br/>
+- **Dienstleistungstypen (s=)**: Der Tag `s=` ist optional und standardmäßig leer. Er erlaubt es, die Art(en) der Dienste anzugeben, für die der DKIM-Eintrag gilt.<br/>
+Die Diensttypen werden anhand einer Liste von Schlüsselwörtern definiert, je mit einem `:` getrennt.<br/>
 Der Empfänger soll diese Liste ignorieren, wenn der entsprechende Diensttyp nicht aufgeführt ist.<br/>
-Mit "s=" kann die Verwendung von Schlüsseln für andere Zwecke eingeschränkt werden, wenn die Verwendung von DKIM in Zukunft für andere Dienste definiert wird.<br/>
-Die derzeit definierten Diensttypen sind "\*" (alle Arten von Diensten) und "email" (E-Mail).
+Mit `s=` kann die Verwendung von Schlüsseln für andere Zwecke eingeschränkt werden, wenn die Verwendung von DKIM in Zukunft für andere Dienste definiert wird.<br/>
+Die derzeit definierten Diensttypen sind `\*` (alle Arten von Diensten) und "email" (E-Mail).
 
-- **Testmodus (t=y)**: Erlaubt es Domain-Inhabern, die Konfiguration von DKIM zu testen, ohne zu riskieren, dass Nachrichten zurückgewiesen oder als SPAM gekennzeichnet werden, wenn die Überprüfung der DKIM-Signatur fehlschlägt.<br/>
-Wenn "t=y" aktiv ist, soll der Empfänger Nachrichten, die zum Test signiert wurden, nicht anders behandeln als nicht signierte. Der Empfänger kann jedoch das Ergebnis des Tests nachverfolgen, um den Signatoren zu helfen.
+- **Testmodus (t=y)**: Erlaubt es Domain-Inhabern, die Konfiguration von DKIM zu testen, ohne zu riskieren, dass Nachrichten zurückgewiesen oder als Spam gekennzeichnet werden, wenn die Überprüfung der DKIM-Signatur fehlschlägt.<br/>
+Wenn `t=y` aktiv ist, soll der Empfänger Nachrichten, die zum Test signiert wurden, nicht anders behandeln als nicht signierte. Der Empfänger kann jedoch das Ergebnis des Tests nachverfolgen, um den Signatoren zu helfen.
 
 - **Subdomains (t=s)**: Erlaubt es, die Verwendung der DKIM-Signatur auf den Domainnamen zu beschränken (Beispiel: @mydomain.ovh) oder zusätzlich den Versand über Subdomains zu erlauben (Beispiel: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.)
 
@@ -1141,7 +1141,7 @@ Wir empfehlen, eine E-Mail von einem Exchange-Account aus an eine E-Mail-Adresse
 
 Im Header der empfangenen E-Mail finden Sie folgendes:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1151,6 +1151,8 @@ Return-Path: <test-dkim@mydomain.ovh>
 Um den Header einer E-Mail einzusehen, lesen Sie unsere Anleitung "[E-Mail-Header extrahieren](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers)".
 
 ### Einsatzzwecke <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### Wie und warum sollte ich mein DKIM-Schlüsselpaar ändern? <a name="2selectors"></a>
 
@@ -1187,6 +1189,10 @@ Klicken Sie auf den Tab für Ihren Dienst:
 </ZoneTabs>
 
 Nach dem Wechseln des Selektors können Sie den alten Selektor sieben Tage lang beibehalten, bevor er gelöscht und ersetzt wird.
+
+</Region>
+
+<Region zones={['eu', 'ca']}>
 
 #### Warum funktioniert der DKIM nicht und wird im Kundencenter rot angezeigt? <a name="reddkim"></a>
 
@@ -1260,6 +1266,10 @@ Hier sind die 4 Zustände, die zu dem roten DKIM-Symbol in Ihrem Kundencenter f�
   </Tab>
 </Tabs>
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### Wie kann ich über die OVHcloud API den Zustand eines nicht funktionierenden DKIM verstehen? <a name="api-error"></a>
 
 Wenn Sie DKIM mithilfe der OVHcloud API konfigurieren und es nicht funktioniert, finden Sie im Abschnitt "[API - Die verschiedenen Zustände des DKIM](#dkim-status)" dieser Anleitung Informationen zum Status Ihrer Selektoren.
@@ -1286,6 +1296,8 @@ Im Folgenden finden Sie die Zustände, die den Betrieb Ihres DKIM blockieren kö
     - `toFix`: Der Selektor wurde erfolgreich in der DNS-Zone der Domain konfiguriert, aber die Werte sind falsch. Gehen Sie zu [Schritt 4. "Vollständige Konfiguration von DKIM" für MX Plan und Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Weiterführende Informationen
 

--- a/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Sicherheit durch DKIM-Eintrag verbessern
 description: Erfahren Sie hier, wie Sie einen DKIM-Eintrag für Domainnamen und E-Mail-Dienste bei OVHcloud einrichten
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ Der DKIM-Eintrag (**D**omain**K**eys **I**dentified **M**ail) ermöglicht die Si
 - Sie verfügen über einen der folgenden E-Mail-Dienste:
     <Region zones={['eu']}>
     - OVHcloud MX Plan E-Mail, verfügbar mit den Angeboten [Webhosting](/links/web/hosting), [Kostenloses Hosting](/links/web/domains-free-hosting) oder als separater Dienst
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - OVHcloud MX Plan E-Mail, verfügbar mit dem Angebot [Webhosting](/links/web/hosting) oder als separater Dienst
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Hosted Exchange](/links/web/emails-hosted-exchange) oder [Private Exchange](/links/web/emails-hosted-exchange)
@@ -65,7 +62,9 @@ Wenn Ihr Domainname bei OVHcloud registriert ist, können Sie im <ManagerLink to
     - [Warum müssen die DNS-Server konfiguriert werden?](#dns-and-dkim)
     - [Beispiel einer unter Verwendung von DKIM gesendeten E-Mail](#example)
     - [Was ist ein DKIM-Selektor?](#selector)
+<Region zones={['eu', 'ca']}>
 - [DKIM automatisch für ein E-Mail-Angebot von OVHcloud konfigurieren](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [DKIM manuell für OVHcloud Exchange oder E-Mail Pro konfigurieren](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ Der Empfänger **recipient@otherdomain.ovh** kann diese Signatur mit dem in der 
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### DKIM automatisch für ein E-Mail-Angebot von OVHcloud konfigurieren <a name="auto-dkim"></a>
 
 Die automatische DKIM-Konfiguration ist für alle unsere E-Mail-Angebote verfügbar:
 
 <Region zones={['eu']}>
 - MX Plan enthalten in einem [Webhosting](/links/web/hosting), [Kostenloses Hosting](/links/web/domains-free-hosting) oder separat bestellt
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan enthalten in einem [Webhosting](/links/web/hosting) oder separat bestellt
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange)
@@ -201,7 +199,7 @@ Wenn DKIM nicht aktiviert wurde, als Sie einen Domainnamen zu Ihrer E-Mail-Platt
 Klicken Sie auf das unten stehende Registerblatt, das zu Ihrem Angebot passt.
 
 <ZoneTabs>
-  <Tab label="E-Mails (MX Plan)">
+  <Tab label="E-Mails (MX Plan)" availableIn={['eu']}>
     1. Loggen Sie sich in Ihr <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> ein.
     1. Öffnen Sie den Bereich <code className="action">Web Cloud</code>.
     1. Klicken Sie auf <code className="action">MX Plan</code>.
@@ -278,13 +276,15 @@ Klicken Sie auf das unten stehende Registerblatt, das zu Ihrem Angebot passt.
 Die automatische DKIM-Aktivierung dauert zwischen 30 Minuten und 24 Stunden. Um zu prüfen, ob Ihr DKIM funktioniert, kehren Sie einfach in den Bereich zur Domainverwaltung zurück, der in den oben genannten Tabs erwähnt wird, und stellen Sie sicher, dass die Schaltfläche `DKIM` grün ist oder für Zimbra, dass `DKIM` keine Warnung mehr anzeigt.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 Die automatische DKIM-Aktivierung dauert zwischen 30 Minuten und 24 Stunden. Um zu prüfen, ob Ihr DKIM funktioniert, kehren Sie einfach in den Bereich zur Domainverwaltung zurück, der in den oben genannten Tabs erwähnt wird, und stellen Sie sicher, dass die Schaltfläche `DKIM` grün ist.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Falls nach 24 Stunden die Schaltfläche `DKIM` immer noch rot ist, konsultieren Sie den Abschnitt ["Warum ist DKIM nicht funktional und erscheint rot im Kundencenter?"](#reddkim) in dieser Anleitung.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### DKIM per API für eine E-Mail von OVHcloud konfigurieren <a name="internal-dkim"></a>

--- a/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to improve email security with a DKIM record
 description: Find out how to configure a DKIM record on your OVHcloud domain name and email service
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ The DKIM (**D**omain**K**eys **I**dentified **M**ail) record allows you to sign 
 - You have signed up to one of these email offers:
     <Region zones={['eu']}>
     - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting), a [free hosting plan](/links/web/domains-free-hosting), or a separate MX Plan solution
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting) or a separate MX Plan solution
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) or [Private Exchange](/links/web/emails-hosted-exchange)
@@ -65,7 +62,9 @@ If your domain name is registered with OVHcloud, you can check if it is using th
     - [Why do we need to configure DNS servers?](#dns-and-dkim)
     - [Example of an email sent using DKIM](#example)
     - [What is a DKIM selector?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Automatically configure DKIM for an OVHcloud email offer](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Configure DKIM via API for an OVHcloud email offer](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ The recipient **recipient@otherdomain.ovh** can decrypt this signature with the 
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Automatically configure DKIM for an OVHcloud email offer <a name="auto-dkim"></a>
 
 Automatic DKIM configuration is available for all our email offers:
 
 <Region zones={['eu']}>
 - MX Plan included with a [Web Hosting](/links/web/hosting), a [free hosting](/links/web/domains-free-hosting) or ordered separately
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan included with a [Web Hosting](/links/web/hosting) or ordered separately
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange)
@@ -201,7 +199,7 @@ If DKIM was not enabled when you added a domain name to your email platform, you
 Click on the tab below corresponding to your offer.
 
 <ZoneTabs>
-  <Tab label="MX Plan">
+  <Tab label="MX Plan" availableIn={['eu']}>
     1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
     1. Open the <code className="action">Web Cloud</code> section.
     1. Click <code className="action">MX Plan</code>.
@@ -281,13 +279,15 @@ Open the <code className="action">DNS zone</code> tab, then click <code classNam
 Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green, or for a Zimbra offer, that the `DKIM` tab no longer displays the warning icon.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 If after 24 hours your `DKIM` badge is still red, refer to the section "[Why is DKIM not working and appears red in the Control Panel?](#reddkim)" of this guide.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Configure DKIM via API for an OVHcloud email offer <a name="internal-dkim"></a>

--- a/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -152,7 +152,7 @@ For this rotation principle to work, we're going to use something called **DKIM 
 
 **Example of a DKIM signature part**
 
-```
+```text
 DKIM-Signature: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -210,7 +210,7 @@ Click on the tab below corresponding to your offer.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/emails/general-information/dkim-auto01.png" loading="lazy" />
 
-    To enable DKIM, simply click on the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
+    To enable DKIM, click the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
 
@@ -231,11 +231,11 @@ Click on the tab below corresponding to your offer.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto01.png" loading="lazy" />
 
-    To enable DKIM, simply click on the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
+    To enable DKIM, click the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
-  <Tab label="E-mail Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
     1. Open the <code className="action">Web Cloud</code> section.
     1. Click <code className="action">Email Pro</code>.
@@ -246,7 +246,7 @@ Click on the tab below corresponding to your offer.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto01.png" loading="lazy" />
 
-    To enable DKIM, simply click on the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
+    To enable DKIM, click the red `DKIM` badge and then click on <code className="action">Validate</code> from the activation window that appears.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
@@ -276,11 +276,11 @@ Open the <code className="action">DNS zone</code> tab, then click <code classNam
 </ZoneTabs>
 
 <Region zones={['eu']}>
-Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green, or for a Zimbra offer, that the `DKIM` tab no longer displays the warning icon.
+Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green, or for a Zimbra offer, that the `DKIM` tab no longer displays the warning icon.
 </Region>
 
 <Region zones={['ca']}>
-Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, simply return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green.
+Automatic DKIM activation takes between 30 minutes and a maximum of 24 hours. To check that your DKIM is working, return to the domain management section mentioned in the tabs above and check that the `DKIM` badge is green.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
@@ -316,7 +316,7 @@ Click on the tab below corresponding to your solution.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/general-information/dns-dkim-platform-exchange.png" loading="lazy" />
   </Tab>
-  <Tab label="E-mail Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
     1. Open the <code className="action">Web Cloud</code> section.
     1. Click <code className="action">Email Pro</code>.
@@ -1088,34 +1088,34 @@ selector-name._domainkey.mydomain.ovh.
 The **Overview of the recording** box shows the resulting record as you fill in the form. If you need a DKIM tag that the form does not expose (for example `g=`, `n=` or `s=`), add the record as a [TXT record](#txt-record) instead, or use the <code className="action">Advanced editing mode</code>.
 
 - **Version (v=)**: It is used to specify the DKIM version. It is recommended that you use it and its default value is "DKIM1".<br/>
-If specified, this tag must be placed first in the record and must be equal to "DKIM1" (without quotes). Records that begin with a "v=" tag with another value should be ignored.
+If specified, this tag must be placed first in the record and must be equal to "DKIM1" (without quotes). Records that begin with a `v=` tag with another value should be ignored.
 
 - **Granularity (g=)**: Allows you to specify the "local" part of an email address, i.e. the part before the "@".<br/>
 It allows you to specify the email address or email addresses that are authorised to sign an email message with the selector's DKIM key.<br/>
-The default value for "g=" is "\*", which means that all email addresses are allowed to use the DKIM signature key.<br/>
-By specifying a value for "g=", you can limit the use of the key to a specific local portion of an email address or a range of email addresses by using wildcards (for example: "\*-group").
+The default value for `g=` is `\*`, which means that all email addresses are allowed to use the DKIM signature key.<br/>
+By specifying a value for `g=`, you can limit the use of the key to a specific local portion of an email address or a range of email addresses by using wildcards (for example: `\*-group`).
 
 - **Algorithm (hash) (h=)**: Directive to specify the hash algorithms used to sign email headers. Use this tag to define a list of hash algorithms that will be used to generate a DKIM signature for a given message.
 
 - **Key type (k=)**: Specifies the signature algorithm used to sign outgoing email messages. It allows recipients to know how the message was signed and what method is used to verify its authenticity.<br/>
-Possible values for the tag "k=" include "rsa" for the RSA signature algorithm and "ed25519" for the ed25519 signature algorithm. The choice of algorithm depends on the sender's security policy and the recipient's support.
+Possible values for the tag `k=` include `rsa` for the RSA signature algorithm and `ed25519` for the ed25519 signature algorithm. The choice of algorithm depends on the sender's security policy and the recipient's support.
 
 - **Notes (n=)**: It is used to include notes of interest for administrators who manage the DKIM key system.<br/>
-These notes may be useful for documentation purposes or to help administrators understand or manage how DKIM works. The notes in "n=" are not interpreted by software and do not affect the operation of DKIM.
+These notes may be useful for documentation purposes or to help administrators understand or manage how DKIM works. The notes in `n=` are not interpreted by software and do not affect the operation of DKIM.
 
 - **Public key (base64) (p=)**: It is used to populate DKIM public key data, which is encoded in base64.<br/>
 This tag is mandatory in the DKIM signature, and allows signature recipients to retrieve the public key needed to verify the authenticity of the signed message.
 
-- **Revoke public key**: If a DKIM public key has been revoked (for example, if the private key is compromised), an empty value must be used for the "p=" tag, indicating that this public key is no longer valid. Recipients must then return an error for any DKIM signature that references a revoked key.
+- **Revoke public key**: If a DKIM public key has been revoked (for example, if the private key is compromised), an empty value must be used for the `p=` tag, indicating that this public key is no longer valid. Recipients must then return an error for any DKIM signature that references a revoked key.
 
-- **Type of service (s=)**: The "s=" tag is optional and is not present by default. It allows you to specify the type or types of services to which this DKIM record applies.<br/>
+- **Type of service (s=)**: The `s=` tag is optional and is not present by default. It allows you to specify the type or types of services to which this DKIM record applies.<br/>
 Service types are defined using a colon-separated list of keywords.<br/>
 The recipient should ignore this record if the appropriate service type is not listed.<br/>
-The "s=" tag is intended to restrict the use of keys for other purposes, in case the use of DKIM is defined for other services in the future.<br/>
+The `s=` tag is intended to restrict the use of keys for other purposes, in case the use of DKIM is defined for other services in the future.<br/>
 The service types currently defined are "email" and "*" (all service types).
 
 - **Test mode (t=y)**: Allows domain name holders to test a DKIM setup without the risk of having messages rejected or marked as spam if DKIM signature verification fails.<br/>
-When the "t=y" flag is used, the recipient should not treat test signed messages differently than unsigned messages. However, the recipient can follow the test result to help the signatories.
+When the `t=y` flag is used, the recipient should not treat test signed messages differently than unsigned messages. However, the recipient can follow the test result to help the signatories.
 
 - **Sub-domains (t=s)**: Allows the use of the DKIM signature to be restricted to the domain name only (for example: @mydomain.ovh) or allow sending from the domain name and its subdomains (e.g.: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.).
 
@@ -1153,7 +1153,7 @@ We recommend sending an email from an account on your Exchange platform to an em
 
 Here is what you will find in the header of the received email:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1163,6 +1163,8 @@ Return-Path: <test-dkim@mydomain.ovh>
 To retrieve the header of an email, please read our guide on [Retrieving email headers](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers).
 
 ### Use cases <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### How and why change the DKIM key pair on my solution? <a name="2selectors"></a>
 
@@ -1200,6 +1202,10 @@ Click on the tab below corresponding to your solution.
 
 After switching to the new selector, keep the old one for 7 days before deleting it and creating a new one.
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### Why is the DKIM not functional and appears in red in the Control Panel? <a name="reddkim"></a>
 
 :::warning
@@ -1222,7 +1228,7 @@ Click on the tab below corresponding to your solution to check the status of the
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/red-dkim.png" loading="lazy" />
   </Tab>
-  <Tab label="E-mail Pro" availableIn={['eu']}>
+  <Tab label="Email Pro" availableIn={['eu']}>
     1. Log in to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>.
     1. Open the <code className="action">Web Cloud</code> section.
     1. Click <code className="action">Email Pro</code>.
@@ -1273,6 +1279,10 @@ Here are the 4 states that result in a red DKIM icon in your Control Panel. Clic
   </Tab>
 </Tabs>
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### From the OVHcloud API interface, how do I understand the status when DKIM is not working? <a name="api-error"></a>
 
 If you are using the OVHcloud API to configure your DKIM and it is not functional, please use the section "[API - The different states of DKIM](#dkim-status)" of this guide to identify the status of your selectors.
@@ -1299,6 +1309,8 @@ Below, you will find the states that may block your DKIM from working, and the a
     - `toFix`: The selector has been configured in the domain name's DNS zone, but the values are incorrect. See [Step 4 in "Configuring the DKIM in full" for MX Plan and Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Go further
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -152,7 +152,7 @@ Para que funcione este principio de rotación, usaremos lo que se llama **select
 
 **Ejemplo de una parte de la firma DKIM**
 
-```
+```text
 DKIM-Firma: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relajación/relajación; t=1681877341;
 ```
 
@@ -1086,17 +1086,17 @@ selector-name._domainkey.mydomain.ovh.
 El recuadro **Vista del registro** muestra el registro resultante a medida que rellena el formulario. Si necesita una etiqueta DKIM que el formulario no muestra (por ejemplo `g=`, `n=` o `s=`), añada el registro como un [registro TXT](#txt-record) en su lugar, o utilice el <code className="action">Modo de edición avanzado</code>.
 
 - **Versión (v=)**: sirve para indicar la versión del DKIM. Se recomienda usarlo y su valor predeterminado es `DKIM1`.<br/>
-Si se especifica, esta etiqueta debe colocarse primero en el registro y debe ser igual a "DKIM1" (sin comillas). Los registros que comiencen con la etiqueta "v=" con otro valor deben ser ignorados.
+Si se especifica, esta etiqueta debe colocarse primero en el registro y debe ser igual a "DKIM1" (sin comillas). Los registros que comiencen con la etiqueta `v=` con otro valor deben ser ignorados.
 
 - **Granularidad (g=)**: permite especificar la parte "local parte" de una dirección de correo electrónico, es decir, la parte situada antes de la "@".<br/>
 Permite especificar la dirección de correo o las direcciones de correo electrónico a las que se permite firmar un mensaje de correo electrónico con la clave DKIM del selector.<br/>
-El valor predeterminado de "g=" es "\*", lo que significa que todas las direcciones de correo electrónico están autorizadas a utilizar la clave de firma DKIM.<br/>
-Indicando un valor específico para "g=", se puede limitar el uso de la llave a una parte local de una dirección de correo electrónico específica o a un rango de direcciones de correo específicas utilizando caracteres genéricos (por ejemplo: "\*-group").
+El valor predeterminado de `g=` es `\*`, lo que significa que todas las direcciones de correo electrónico están autorizadas a utilizar la clave de firma DKIM.<br/>
+Indicando un valor específico para `g=`, se puede limitar el uso de la llave a una parte local de una dirección de correo electrónico específica o a un rango de direcciones de correo específicas utilizando caracteres genéricos (por ejemplo: `\*-group`).
 
 - **Algoritmo (hash) (h=)**: permite especificar los algoritmos hash utilizados para firmar las cabeceras de un email. Esta etiqueta permite definir una lista de algoritmos de hackeo que se utilizarán para generar una firma DKIM para un mensaje dado.
 
 - **Tipo de llave (k=)**: especifica el algoritmo de firma utilizado para firmar los mensajes de correo electrónico salientes. Permite a los destinatarios saber cómo se ha firmado el mensaje y cuál es el método utilizado para verificar su autenticidad.<br/>
-Los valores posibles para la etiqueta "k=" incluyen "rsa" para el algoritmo de firma RSA y "ed25519" para el algoritmo de firma Ed25519. La elección del algoritmo depende de la política de seguridad del remitente y de la aceptación por el destinatario.
+Los valores posibles para la etiqueta `k=` incluyen `rsa` para el algoritmo de firma RSA y `ed25519` para el algoritmo de firma Ed25519. La elección del algoritmo depende de la política de seguridad del remitente y de la aceptación por el destinatario.
 
 - **Notas (n=)**: sirve para incluir notas de interés para los administradores que gestionan el sistema de claves DKIM.<br/>
 Estas notas pueden ser útiles por motivos de documentación o para ayudar a los administradores a entender o gestionar el funcionamiento de DKIM. Las notas incluidas en n= no son interpretadas por los programas y no afectan al funcionamiento del DKIM.
@@ -1104,16 +1104,16 @@ Estas notas pueden ser útiles por motivos de documentación o para ayudar a los
 - **Clave pública (base 64) (p=)**: se utiliza para introducir los datos de la clave pública DKIM, que están codificados en base64.<br/>
 Esta etiqueta es obligatoria en la firma DKIM y permite a los destinatarios de la firma recuperar la clave pública necesaria para verificar la autenticidad del mensaje firmado.
 
-- **Revocar la clave pública**: si se ha revocado una clave pública de DKIM (por ejemplo, en caso de que la clave privada se haya comprometido), se utilizará un valor vacío para la etiqueta "p=", indicando que la clave pública ya no es válida. A continuación, los destinatarios deben indicar un error relativo a cualquier firma DKIM que haga referencia a una clave revocada.
+- **Revocar la clave pública**: si se ha revocado una clave pública de DKIM (por ejemplo, en caso de que la clave privada se haya comprometido), se utilizará un valor vacío para la etiqueta `p=`, indicando que la clave pública ya no es válida. A continuación, los destinatarios deben indicar un error relativo a cualquier firma DKIM que haga referencia a una clave revocada.
 
-- **Tipo de servicio (s=)**: La etiqueta "s=" (Service Type) es opcional y no está disponible por defecto. Permite especificar el tipo o tipos de servicios a los que se aplica el registro DKIM.<br/>
-Los tipos de servicios se definen utilizando una lista de palabras clave separadas por dos puntos ":".<br/>
+- **Tipo de servicio (s=)**: La etiqueta `s=` (Service Type) es opcional y no está disponible por defecto. Permite especificar el tipo o tipos de servicios a los que se aplica el registro DKIM.<br/>
+Los tipos de servicios se definen utilizando una lista de palabras clave separadas por dos puntos `:`.<br/>
 El destinatario debe ignorar este registro si el tipo de servicio adecuado no está listado.<br/>
-La etiqueta "s=" está destinada a restringir el uso de las llaves para otros fines, en caso de que el uso de DKIM se defina para otros servicios en el futuro.<br/>
-Los tipos de servicios actualmente definidos son "\*" (todos los tipos de servicios), "email" (correo electrónico).
+La etiqueta `s=` está destinada a restringir el uso de las llaves para otros fines, en caso de que el uso de DKIM se defina para otros servicios en el futuro.<br/>
+Los tipos de servicios actualmente definidos son `\*` (todos los tipos de servicios), "email" (correo electrónico).
 
 - **Modo de prueba (t=y)**: permite a los titulares del dominio probar la instalación del DKIM sin correr el riesgo de que los mensajes sean rechazados o marcados como spam si la verificación de la firma DKIM no ha podido realizarse.<br/>
-Cuando se utiliza el flag "t=y", el destinatario no debe tratar de forma diferente los mensajes firmados en modo de prueba y los mensajes sin firmar. Sin embargo, el destinatario puede seguir el resultado del modo de prueba para ayudar a los firmantes.
+Cuando se utiliza el flag `t=y`, el destinatario no debe tratar de forma diferente los mensajes firmados en modo de prueba y los mensajes sin firmar. Sin embargo, el destinatario puede seguir el resultado del modo de prueba para ayudar a los firmantes.
 
 - **Subdominios (t=s)**: permite restringir el uso de la firma DKIM únicamente en el dominio (por ejemplo, @mydomain.ovh) o permitir el envío desde el nombre de dominio y sus subdominios (por ejemplo: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.)
 
@@ -1151,7 +1151,7 @@ Le recomendamos que envíe un mensaje de correo electrónico desde una cuenta de
 
 En la cabecera del mensaje de correo electrónico recibido encontrará lo siguiente:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1161,6 +1161,8 @@ Return-Path: <test-dkim@mydomain.ovh>
 Para consultar la cabecera de un mensaje de correo electrónico, consulte nuestra guía [Obtener la cabecera de un email](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers).
 
 ### Casos prácticos <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### ¿Cómo y por qué cambiar su par de claves DKIM? <a name="2selectors"></a>
 
@@ -1197,6 +1199,10 @@ Haga clic en la pestaña que corresponde a su producto.
 </ZoneTabs>
 
 Después de cambiar al nuevo selector, conserve el antiguo durante 7 días antes de eliminarlo y crear uno nuevo.
+
+</Region>
+
+<Region zones={['eu', 'ca']}>
 
 #### ¿Por qué el DKIM no funciona y aparece en rojo en el área de cliente? <a name="reddkim"></a>
 
@@ -1271,6 +1277,10 @@ Estos son los cuatro estados cuyo resultado es el icono DKIM en rojo en el área
   </Tab>
 </Tabs>
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### Desde la API de OVHcloud, ¿cómo entender el estado del DKIM que no funciona? <a name="api-error"></a>
 
 Si utiliza las API de OVHcloud para configurar su DKIM y este no está operativo, consulte la sección "[API - Los diferentes estados del DKIM](#dkim-status)" de esta guía para identificar el estado de sus selectores.
@@ -1297,6 +1307,8 @@ A continuación, encontrará los estados que pueden bloquear el funcionamiento d
     - `toFix`: el selector se ha configurado correctamente en la zona DNS del dominio, pero los valores son incorrectos. Haga clic en [Paso 4 de "Configuración completa de DKIM" para MX Plan y Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Más información <a name="go-further"></a>
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mejorar la seguridad del correo electrónico mediante un registro DKIM
 description: Cómo configurar un registro DKIM en un nombre de dominio y una plataforma de correo electrónico de OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ El registro DKIM (**D**omain**K**eys **I**dentified **M**ail) permite firmar los
 - Haber contratado una de las siguientes soluciones de correo electrónico:
     <Region zones={['eu']}>
     - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](/links/web/hosting), un [hosting gratuito](/links/web/domains-free-hosting) o un MX Plan contratado por separado).
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - MX Plan de OVHcloud (disponible a través de un [plan de hosting web](/links/web/hosting) o un MX Plan contratado por separado).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) o [Private Exchange](/links/web/emails-hosted-exchange).
@@ -65,7 +62,9 @@ Si el dominio está registrado en OVHcloud, puede comprobar si utiliza nuestra c
     - [¿Por qué es necesario configurar los servidores DNS?](#dns-and-dkim)
     - [Ejemplo de un email enviado utilizando DKIM](#example)
     - [¿Qué es un selector DKIM?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Configurar el DKIM automáticamente para una solución de correo electrónico de OVHcloud](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Configurar el DKIM mediante API para una solución de correo electrónico de OVHcloud](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ El destinatario **recipient@otherdomain.ovh** podrá descifrar esta firma con la
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Configurar el DKIM automáticamente para una solución de correo electrónico de OVHcloud <a name="auto-dkim"></a>
 
 La configuración automática del DKIM está disponible para todas nuestras ofertas de correo electrónico:
 
 <Region zones={['eu']}>
 - MX Plan incluida con un [alojamiento web](/links/web/hosting), un [hosting gratuito](/links/web/domains-free-hosting) o adquirida por separado.
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan incluida con un [alojamiento web](/links/web/hosting) o adquirida por separado.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange).
@@ -201,7 +199,7 @@ Si el DKIM no se ha activado cuando ha añadido un nombre de dominio a su plataf
 Haga clic en la pestaña inferior correspondiente a su oferta.
 
 <ZoneTabs>
-  <Tab label="Correo electrónico (MX Plan)">
+  <Tab label="Correo electrónico (MX Plan)" availableIn={['eu']}>
     1. Conéctese a su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>.
     1. Acceda al apartado <code className="action">Web Cloud</code>.
     1. Haga clic en <code className="action">MX Plan</code>.
@@ -282,13 +280,15 @@ Para activar el DKIM, haga clic en la etiqueta rojo `DKIM` y seleccione <code cl
 La activación automática del DKIM dura entre 30 minutos y 24 horas como máximo. Para verificar que su DKIM funciona correctamente, simplemente vaya a la sección de gestión del dominio mencionada en las pestañas anteriores y verifique que el indicador `DKIM` es verde o, para una oferta Zimbra, que la pestaña `DKIM` no muestra más el icono de advertencia.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 La activación automática del DKIM dura entre 30 minutos y 24 horas como máximo. Para verificar que su DKIM funciona correctamente, simplemente vaya a la sección de gestión del dominio mencionada en las pestañas anteriores y verifique que el indicador `DKIM` es verde.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Si la etiqueta `DKIM` es de color rojo, después de las 24 horas, consulte la sección "[¿Por qué el DKIM no funciona y aparece en rojo en el área de cliente?](#reddkim)" de esta guía.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Configurar el DKIM mediante API para una solución de correo electrónico de OVHcloud <a name="internal-dkim"></a>

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Améliorer la sécurité des e-mails via un enregistrement DKIM
 description: Découvrez comment configurer un enregistrement DKIM sur votre nom de domaine et votre plateforme e-mail OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ L’enregistrement DKIM (**D**omain**K**eys **I**dentified **M**ail) permet de s
 - Avoir souscrit à l’une des offres e-mail ci-dessous :
     <Region zones={['eu']}>
     - MX Plan OVHcloud (disponible via une [offre d’hébergement web](/links/web/hosting), un [hébergement gratuit](/links/web/domains-free-hosting) ou une offre MX Plan commandée séparément).
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (disponible via une [offre d’hébergement web](/links/web/hosting) ou une offre MX Plan commandée séparément).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) ou [Private Exchange](/links/web/emails-hosted-exchange).
@@ -65,7 +62,9 @@ Si votre nom de domaine est déposé chez OVHcloud, vous pouvez vérifier si ce 
     - [Pourquoi a-t-on besoin de configurer les serveurs DNS ?](#dns-and-dkim)
     - [Exemple d’un e-mail envoyé en utilisant le DKIM](#example)
     - [Qu’est-ce qu’un sélecteur DKIM ?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Configurer le DKIM automatiquement pour une offre e-mail OVHcloud](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Configurer le DKIM par API pour une offre e-mail OVHcloud](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ Le destinataire **recipient@otherdomain.ovh** pourra déchiffrer cette signature
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Configurer le DKIM automatiquement pour une offre e-mail OVHcloud <a name="auto-dkim"></a>
 
 La configuration automatique du DKIM est accessible pour toutes nos offres e-mail :
 
 <Region zones={['eu']}>
 - MX Plan incluse avec un [hébergement web](/links/web/hosting), un [hébergement gratuit](/links/web/domains-free-hosting) ou commandée séparément.
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan incluse avec un [hébergement web](/links/web/hosting) ou commandée séparément.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange).
@@ -201,7 +199,7 @@ Si le DKIM n’a pas été activé lorsque vous avez ajouté un nom de domaine �
 Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 
 <ZoneTabs>
-  <Tab label="MX Plan">
+  <Tab label="MX Plan" availableIn={['eu']}>
     1. Connectez-vous à votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>.
     1. Rendez-vous dans la partie <code className="action">Web Cloud</code>.
     1. Cliquez sur <code className="action">MX Plan</code>.
@@ -278,13 +276,15 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 L’activation automatique du DKIM dure entre 30 minutes et 24 heures maximum. Pour vérifier que votre DKIM est fonctionnel, il vous suffit de retourner dans la rubrique de gestion du domaine mentionnée dans les onglets ci-dessus et de vérifier que la pastille `DKIM` est verte ou, pour une offre Zimbra, que l’onglet `DKIM` ne présente plus l’icône d’avertissement.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 L’activation automatique du DKIM dure entre 30 minutes et 24 heures maximum. Pour vérifier que votre DKIM est fonctionnel, il vous suffit de retourner dans la rubrique de gestion du domaine mentionnée dans les onglets ci-dessus et de vérifier que la pastille `DKIM` est verte.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Au-delà des 24 heures, si votre pastille `DKIM` est rouge, consultez la rubrique « [Pourquoi le DKIM n’est pas fonctionnel et apparait en rouge dans l’espace client ?](#reddkim) » de ce guide.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Configurer le DKIM par API pour une e-mail OVHcloud <a name="internal-dkim"></a>

--- a/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -19,7 +19,7 @@ L’enregistrement DKIM (**D**omain**K**eys **I**dentified **M**ail) permet de s
 
 ## Prérequis
 
-- Avoir souscrit à l’une des offres e-mail ci-dessous :
+- Avoir souscrit à l’une des offres e-mail ci-dessous :
     <Region zones={['eu']}>
     - MX Plan OVHcloud (disponible via une [offre d’hébergement web](/links/web/hosting), un [hébergement gratuit](/links/web/domains-free-hosting) ou une offre MX Plan commandée séparément).
     </Region>
@@ -91,7 +91,7 @@ Si votre nom de domaine est déposé chez OVHcloud, vous pouvez vérifier si ce 
     - [Pourquoi l’icône DKIM apparait en rouge dans l’espace client ?](#reddkim)
     - [Depuis l’interface API OVHcloud, comment comprendre l’état du DKIM qui ne fonctionne pas ?](#api-error)
 
-### Comment le DKIM fonctionne-t-il ? <a name="how-dkim-work"></a>
+### Comment le DKIM fonctionne-t-il ? <a name="how-dkim-work"></a>
 
 Pour bien comprendre pourquoi le DKIM permet de sécuriser vos échanges d’e-mails, il est nécessaire de comprendre comment il fonctionne. Le DKIM fait appel au « **hachage** » et au « **chiffrement asymétrique** » pour créer une signature sécurisée. La **plateforme e-mail** et la **zone DNS** de votre nom de domaine vont aider à transmettre les informations du DKIM à vos destinataires.
 
@@ -115,7 +115,7 @@ Le **chiffrement**, comme son nom l’indique, a pour but de chiffrer les donné
 
 Dans le chiffrement asymétrique, on utilise une **clé publique** et une **clé privée**. La clé publique est visible et utilisable par tous. La clé privée est uniquement utilisée par le titulaire et n’est pas visible de tous.
 
-Il existe deux utilisations du chiffrement asymétrique :
+Il existe deux utilisations du chiffrement asymétrique :
 
 - **La donnée d’entrée est chiffrée avec la clé publique et déchiffrée par celui qui possède la clé privée**. Par exemple, vous souhaitez qu’un tiers vous transmette des données de manière sécurisée. Vous transmettez votre clé publique sans vous soucier que quelqu’un la récupère, ce tiers chiffrera ses données avec votre clé publique. Les données chiffrées ne pourront être déchiffrées que par le titulaire de la clé privée.
 
@@ -128,7 +128,7 @@ Il existe deux utilisations du chiffrement asymétrique :
 </details>
 
 <details>
-<summary>Comment le hachage et le chiffrement asymétrique sont-ils utilisés pour le DKIM ? <a name="encrypt-and-hash"></a></summary>
+<summary>Comment le hachage et le chiffrement asymétrique sont-ils utilisés pour le DKIM ? <a name="encrypt-and-hash"></a></summary>
 
 Depuis la plateforme e-mail, le DKIM va utiliser le hachage pour créer une signature à partir de certains éléments de [l’en-tête de l’e-mail](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers) et du corps de l’e-mail (contenu de l’e-mail).
 
@@ -137,14 +137,14 @@ La signature est ensuite chiffrée avec la clé privée en utilisant le chiffrem
 </details>
 
 <details>
-<summary>Pourquoi a-t-on besoin de configurer les serveurs DNS ? <a name="dns-and-dkim"></a></summary>
+<summary>Pourquoi a-t-on besoin de configurer les serveurs DNS ? <a name="dns-and-dkim"></a></summary>
 
 Pour que le destinataire puisse vérifier la signature DKIM de l’expéditeur, il aura besoin des paramètres DKIM et surtout de la clé publique pour la déchiffrer. La [zone DNS](/guides/web-cloud/domains/dns-zone-general-information) d’un nom de domaine est publique, c’est pourquoi un enregistrement DNS est ajouté pour transmettre la clé publique et les paramètres DKIM au destinataire.
 
 </details>
 
 <details>
-<summary>Qu’est-ce qu’un sélecteur DKIM ? <a name="selector"></a></summary>
+<summary>Qu’est-ce qu’un sélecteur DKIM ? <a name="selector"></a></summary>
 
 Lorsque vous activez le DKIM, celui-ci fonctionne avec une paire de clé publique / clé privée. Il est possible d’attribuer plusieurs paires de clés à votre nom de domaine, dans le cadre d’une rotation par exemple. En effet, lorsque vous changez de paire de clés, l’ancienne paire doit rester active le temps que l’ensemble des e-mails que vous avez envoyés avec l’ancienne clé ne rencontre pas d’échec dans la vérification du DKIM sur le serveur de réception.
 
@@ -152,7 +152,7 @@ Pour que ce principe de rotation fonctionne, on va utiliser ce qu’on appelle l
 
 **Exemple d’une partie de signature DKIM**
 
-```
+```text
 DKIM-Signature: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -177,7 +177,7 @@ Le destinataire **recipient@otherdomain.ovh** pourra déchiffrer cette signature
 
 ### Configurer le DKIM automatiquement pour une offre e-mail OVHcloud <a name="auto-dkim"></a>
 
-La configuration automatique du DKIM est accessible pour toutes nos offres e-mail :
+La configuration automatique du DKIM est accessible pour toutes nos offres e-mail :
 
 <Region zones={['eu']}>
 - MX Plan incluse avec un [hébergement web](/links/web/hosting), un [hébergement gratuit](/links/web/domains-free-hosting) ou commandée séparément.
@@ -210,11 +210,11 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/emails/general-information/dkim-auto01.png" loading="lazy" />
 
-    Pour activer le DKIM, il vous suffit maintenant de cliquer sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
+    Pour activer le DKIM, cliquez sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
 
-    Dans le cas où votre nom de domaine n’est pas géré dans le même espace client OVHcloud que votre plateforme e-mail ou enregistré hors OVHcloud, vous obtenez la fenêtre ci-dessous :
+    Dans le cas où votre nom de domaine n’est pas géré dans le même espace client OVHcloud que votre plateforme e-mail ou enregistré hors OVHcloud, vous obtenez la fenêtre ci-dessous :
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/emails/general-information/dkim-auto02.png" loading="lazy" />
 
@@ -231,7 +231,7 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto01.png" loading="lazy" />
 
-    Pour activer le DKIM, il vous suffit maintenant de cliquer sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
+    Pour activer le DKIM, cliquez sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
@@ -246,7 +246,7 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto01.png" loading="lazy" />
 
-    Pour activer le DKIM, il vous suffit maintenant de cliquer sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
+    Pour activer le DKIM, cliquez sur la pastille `DKIM` rouge puis sur <code className="action">Activer</code> depuis la fenêtre d’activation qui apparaît.
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto02.png" loading="lazy" />
   </Tab>
@@ -331,7 +331,7 @@ Assurez-vous également que le nom de domaine que vous souhaitez utiliser pour v
 
 #### API - Configuration complète du DKIM <a name="firststep"></a>
 
-Pour configurer le DKIM, rendez-vous sur la <ApiLink>page des API OVHcloud</ApiLink> et connectez-vous :
+Pour configurer le DKIM, rendez-vous sur la <ApiLink>page des API OVHcloud</ApiLink> et connectez-vous :
 
 1. Cliquez sur <code className="action">Authentication</code> en haut à gauche.
 1. Cliquez ensuite sur <code className="action">Login with OVHcloud SSO</code>.
@@ -350,7 +350,7 @@ Dirigez-vous vers la section `/email/domain/` (offres MX Plan et Zimbra), `/emai
 Dirigez-vous vers la section `/email/exchange` (offre Exchange) des API et renseignez « dkim » dans le champ `Filter` pour faire apparaître uniquement les fonctions API relatives au DKIM.
 </Region>
 
-Cliquez sur l’onglet correspondant à votre offre :
+Cliquez sur l’onglet correspondant à votre offre :
 
 <ZoneTabs>
   <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
@@ -367,15 +367,15 @@ Cliquez sur l’onglet correspondant à votre offre :
 <Region zones={['eu']}>
 ##### **Pour MX Plan et Zimbra** <a name="confemail"></a>
 
-Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-dessous :
+Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-dessous :
 
 <Tabs>
   <Tab label="1. Activer le DKIM sur votre nom de domaine">
-    Pour activer le DKIM sur votre nom de domaine, utilisez l’appel API suivant :<br/>
+    Pour activer le DKIM sur votre nom de domaine, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel vous souhaitez activer DKIM.
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel vous souhaitez activer DKIM.
 
     Cliquez sur <code className="action">EXECUTE</code> pour lancer l’activation.<br/>
 
@@ -394,11 +394,11 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
   </Tab>
   <Tab label="2. Vérifier l’état de l’opération DKIM">
     Après avoir lancé le processus d’activation du DKIM, suivez l’état de l’installation pour vous assurer que l’installation se termine ou pour récupérer les enregistrements DNS si votre zone DNS est gérée en dehors de votre espace client OVHcloud.<br/>
-    Pour cela, utilisez l’appel API suivant :<br/>
+    Pour cela, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail.<br/>
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail.<br/>
     <br/>
     Cliquez sur <code className="action">EXECUTE</code> pour visualiser le résultat.<br/>
 
@@ -430,16 +430,16 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
     - si la valeur est `"status": "disabled"`, votre configuration doit être complétée manuellement, passez à l’étape suivante.
   </Tab>
   <Tab label="3. Récupérer l’enregistrement DNS">
-    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
+    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
 
-    - votre service E-mail est lié à un nom de domaine qui est géré dans un autre compte client OVHcloud ;
+    - votre service E-mail est lié à un nom de domaine qui est géré dans un autre compte client OVHcloud ;
     - votre service E-mail est lié à un nom de domaine qui est géré dans un autre bureau d’enregistrement.
 
-    Pour configurer votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **des deux sélecteurs**. Pour cela, utilisez le résultat de l’appel API de l’étape précédente :
+    Pour configurer votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **des deux sélecteurs**. Pour cela, utilisez le résultat de l’appel API de l’étape précédente :
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail.
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail.
 
     Cliquez sur <code className="action">EXECUTE</code> pour visualiser le résultat.
 
@@ -471,7 +471,7 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
     Depuis <ManagerLink to="/">l’espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre service e-mail, dans l’onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
     Ouvrez l’onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> au-dessus du tableau. Dans le formulaire qui s’ouvre, sélectionnez le type `CNAME` et complétez les champs selon les valeurs que vous avez relevées.
 
-    Si on décompose les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
+    Si on décompose les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
 
     - `ovhmo3456789-selector1._domainkey.mydomain.ovh` correspond au sous-domaine de l’enregistrement CNAME. On garde seulement `ovhmo3456789-selector1._domainkey` car le `.mydomain.ovh` est déjà prérempli. <br/>
     - `ovhmo3456789-selector1._domainkey.123403.aj.dkim.mail.ovh.net."` correspond à la cible de l’enregistrement. Il faut bien conserver le point à la fin pour ponctuer la valeur.<br/>
@@ -484,7 +484,7 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
     **Répétez cette opération pour le deuxième sélecteur.**
     :::
 
-    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
+    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
 
     ```console
     ovhmo3456789-selector1._domainkey IN CNAME ovhmo3456789-selector1._domainkey.123403.aj.dkim.mail.ovh.net.
@@ -495,11 +495,11 @@ Suivez les **5 étapes** en cliquant successivement sur chacun des 5 onglets ci-
     :::
   </Tab>
   <Tab label="5. Activation du DKIM">
-    Après la propagation de votre configuration DNS, utilisez à nouveau l’appel API suivant pour activer le DKIM :<br/>
+    Après la propagation de votre configuration DNS, utilisez à nouveau l’appel API suivant pour activer le DKIM :<br/>
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
 
-    - `domain` : saisissez le nom de domaine attaché à votre service e-mail sur lequel vous souhaitez activer DKIM.
+    - `domain` : saisissez le nom de domaine attaché à votre service e-mail sur lequel vous souhaitez activer DKIM.
 
     Cliquez sur <code className="action">EXECUTE</code> pour lancer l’activation.<br/>
 
@@ -546,14 +546,14 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
   <Tab label="1. Liste des sélecteurs">
     Avant de créer un des sélecteurs pour votre nom de domaine, vous devez récupérer le nom qui leur est attribué automatiquement par la plateforme Exchange.<br/>
     <br/>
-    Pour cela, utilisez l’appel API suivant :<br/>
+    Pour cela, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/exchange" method="GET" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkimSelector"} />
     <br/>
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer DKIM. <br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer DKIM. <br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
 
     *Exemple de résultat :*
 
@@ -565,14 +565,14 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
   <Tab label="2. Créer un sélecteur">
     Vous allez maintenant créer un sélecteur, générer sa paire de clés et l’enregistrement DNS associé au nom de domaine.<br/>
     <br/>
-    Pour cela, utilisez l’appel API suivant :<br/>
+    Pour cela, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/exchange" method="POST" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `"selectorName"` : dans l’onglet **EXAMPLE** de la section **REQUEST BODY**, saisissez le nom d’un sélecteur que vous avez relevé à l’étape précédente (exemple: « ovhex123456-selector1 »).
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `"selectorName"` : dans l’onglet **EXAMPLE** de la section **REQUEST BODY**, saisissez le nom d’un sélecteur que vous avez relevé à l’étape précédente (exemple: « ovhex123456-selector1 »).
 
     *Exemple de saisie :*
 
@@ -596,25 +596,25 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     ```console
     status: "todo",
     function: "addExchangeDomainDKIM",
-    id : 107924143,
+    id : 107924143,
     "finishDate": null,
     "todoDate": "2023-05-05T11:32:07+02:00"
     ```
   </Tab>
   <Tab label="3. Récupérer l’enregistrement DNS">
-    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
+    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
 
-    - votre plateforme Exchange est liée à un nom de domaine qui est géré dans un autre compte client OVHcloud ;<br/>
-    - votre plateforme Exchange est liée à un nom de domaine qui est géré dans un autre bureau d’enregistrement ;<br/>
+    - votre plateforme Exchange est liée à un nom de domaine qui est géré dans un autre compte client OVHcloud ;<br/>
+    - votre plateforme Exchange est liée à un nom de domaine qui est géré dans un autre bureau d’enregistrement ;<br/>
 
-    Pour configurez votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **pour chaque sélecteur si vous en avez créé deux**. Pour cela, utilisez l’appel API suivant :
+    Pour configurez votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **pour chaque sélecteur si vous en avez créé deux**. Pour cela, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/exchange" method="GET" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez configurer le DKIM.
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé à l’étape précédente.
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez configurer le DKIM.
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé à l’étape précédente.
 
     *Exemple de résultat :*
 
@@ -640,7 +640,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     Depuis <ManagerLink to="/">l’espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre plateforme Exchange, dans l’onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
     Ouvrez l’onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> au-dessus du tableau. Dans le formulaire qui s’ouvre, sélectionnez le type `CNAME` et complétez les champs selon les valeurs que vous avez relevées.
 
-    Si on prend les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
+    Si on prend les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
 
     - `customerRecord: "ovhex123456-selector1._domainkey.mydomain.ovh"` correspond au sous-domaine de l’enregistrement CNAME. On garde seulement `ovhex123456-selector1._domainkey` car le `.mydomain.ovh` est déjà prérempli. <br/>
     - `targetRecord: "ovhex123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net"` correspond à la cible de l’enregistrement. On y rajoute un point à la fin pour ponctuer la valeur. Cela donne `ovhex123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.`<br/>
@@ -651,7 +651,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
 
     **Répétez cette opération pour le deuxième sélecteur si vous l’avez créé.**<br/>
 
-    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
+    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
 
     ```console
     ovhex123456-selector1._domainkey IN CNAME ovhex123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.
@@ -666,14 +666,14 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     Depuis la section « [API - Les différents états du DKIM](#dkim-status) » de ce guide, vérifiez que la valeur `status:` est bien en `ready` avant de pouvoir activer le DKIM.
     :::
 
-    Pour activer le DKIM, utilisez l’appel API suivant :
+    Pour activer le DKIM, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/exchange" method="POST" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/enable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé.
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé.
 
     *Exemple de résultat :*
 
@@ -703,13 +703,13 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
   <Tab label="1. Liste des sélecteurs">
     Avant de créer un des sélecteurs pour votre nom de domaine, vous devez récupérer le nom qui leur est attribué automatiquement par la plateforme Email Pro.<br/>
     <br/>
-    Pour cela, utilisez l’appel API suivant :<br/>
+    Pour cela, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/pro" method="GET" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim"} />
     <br/>
 
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer DKIM. <br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer DKIM. <br/>
 
     *Exemple de résultat :*
 
@@ -725,13 +725,13 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     Nous vous conseillons de réaliser cette opération à deux reprises pour chacun des sélecteurs précédemment listés. Le deuxième sélecteur vous permettra d’effectuer un changement de paire de clés lorsque cela sera nécessaire. Nous vous invitons à consulter notre cas d’usage « [Comment changer sa paire de clés DKIM](#2selectors) ».
     :::
     <br/>
-    Pour cela, utilisez l’appel API suivant :<br/>
+    Pour cela, utilisez l’appel API suivant :<br/>
 
     <Api version="v1" section="/email/pro" method="POST" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer le DKIM.
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
-    - `"selectorName"` : Dans l’onglet **EXAMPLE** de la section **REQUEST BODY**, saisissez le nom d’un sélecteur que vous avez relevé à l’étape précédente. (exemple: « ovhemp123456-selector1 »).
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer le DKIM.
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `"selectorName"` : Dans l’onglet **EXAMPLE** de la section **REQUEST BODY**, saisissez le nom d’un sélecteur que vous avez relevé à l’étape précédente. (exemple: « ovhemp123456-selector1 »).
 
     *Exemple de saisie :*
 
@@ -754,24 +754,24 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     ```console
     status: "todo",
     function: "addDomainDKIM",
-    id : 107924143,
+    id : 107924143,
     "finishDate": null,
     "todoDate": "2023-05-05T11:32:07+02:00"
     ```
   </Tab>
   <Tab label="3. Récupérer l’enregistrement DNS">
-    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
+    Vous devez configurer manuellement la zone DNS de votre nom de domaine **dans les cas suivants** :
 
-    - votre plateforme Email Pro est liée à un nom de domaine qui est géré dans un autre compte client OVHcloud ;<br/>
-    - votre plateforme Email Pro est liée à un nom de domaine qui est géré dans un autre bureau d’enregistrement ;<br/>
+    - votre plateforme Email Pro est liée à un nom de domaine qui est géré dans un autre compte client OVHcloud ;<br/>
+    - votre plateforme Email Pro est liée à un nom de domaine qui est géré dans un autre bureau d’enregistrement ;<br/>
 
-    Pour configurer votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **pour chaque sélecteur si vous en avez créé deux**. Pour cela, utilisez l’appel API suivant :
+    Pour configurer votre zone DNS, vous devez récupérer les valeurs de l’enregistrement DNS **pour chaque sélecteur si vous en avez créé deux**. Pour cela, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="GET" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ».
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez configurer le DKIM.
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé à l’étape précédente.
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ».
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez configurer le DKIM.
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé à l’étape précédente.
 
     *Exemple de résultat :*
 
@@ -797,7 +797,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     Depuis <ManagerLink to="/">l’espace client OVHcloud</ManagerLink> où est hébergé le nom de domaine de votre plateforme Email Pro, dans l’onglet <code className="action">Web Cloud</code>, cliquez sur <code className="action">Noms de domaine</code> dans la colonne de gauche et sélectionnez le nom de domaine concerné.<br/>
     Ouvrez l’onglet <code className="action">Zone DNS</code> puis cliquez sur <code className="action">Ajouter une entrée</code> au-dessus du tableau. Dans le formulaire qui s’ouvre, sélectionnez le type `CNAME` et complétez les champs selon les valeurs que vous avez relevées.
 
-    Si on prend les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
+    Si on prend les valeurs de l’exemple à l’étape « **3. Récupérer l’enregistrement DNS** » :
 
     - `customerRecord: "ovhemp123456-selector1._domainkey.mydomain.ovh"` correspond au sous-domaine de l’enregistrement CNAME. On garde seulement `ovhemp123456-selector1._domainkey` car le `.mydomain.ovh` est déjà prérempli. <br/>
     - `targetRecord: "ovhemp123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net"` correspond à la cible de l’enregistrement. On y rajoute un point à la fin pour ponctuer la valeur. Cela donne `ovhemp123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.`<br/>
@@ -808,7 +808,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
 
     **Répétez cette opération pour le deuxième sélecteur si vous l’avez créé.**<br/>
 
-    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
+    Si vous configurez votre zone DNS dans une interface tierce hors OVHcloud, votre enregistrement CNAME doit avoir la forme suivante :
 
     ```console
     ovhemp123456-selector1._domainkey IN CNAME ovhemp123456-selector1._domainkey.1500.ab.dkim.mail.ovh.net.
@@ -823,13 +823,13 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
     Depuis la section « [API - Les différents états du DKIM](#dkim-status) » de ce guide, vérifiez que la valeur `status:` est bien en `ready` avant de pouvoir activer le DKIM.
     :::
 
-    Pour activer le DKIM, utilisez l’appel API suivant :
+    Pour activer le DKIM, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="GET" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ».
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer le DKIM.
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé.
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ».
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel vous souhaitez activer le DKIM.
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé.
 
     *Exemple de résultat :*
 
@@ -851,7 +851,7 @@ Suivez les **5 étapes** ci-dessous en cliquant sur chacun des onglets.
 
 #### API - Les différents états du DKIM <a name="dkim-status"></a>
 
-Sélectionnez l’offre e-mail concernée dans les onglets suivants :
+Sélectionnez l’offre e-mail concernée dans les onglets suivants :
 
 <ZoneTabs>
   <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
@@ -859,40 +859,40 @@ Sélectionnez l’offre e-mail concernée dans les onglets suivants :
 
     <Api version="v1" section="/email/domain" method="GET" route={"/email/domain/\\{domain\\}/dkim"} regions={["eu"]} />
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent.
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent.
 
-    Regardez ensuite la valeur `status:` générale dans le résultat :
+    Regardez ensuite la valeur `status:` générale dans le résultat :
 
-    - `disabled` : le DKIM est désactivé, il n’a pas encore été configuré ou il a été désactivé par API. <br/>
-    - `modifying` : la configuration du DKIM est en cours, il est nécessaire de patienter jusqu’à la fin du processus.<br/>
-    - `toConfigure` : la configuration du DKIM est en attente des paramètres DNS du nom de domaine. Vous devez renseigner manuellement les enregistrements DNS dans la zone du nom de domaine. Pour cela, appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).<br/>
-    - `enabled` : le DKIM est configuré et fonctionnel.<br/>
-    - `error` : Le processus d’installation a rencontré une erreur. Nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le nom de domaine concerné.<br/>
+    - `disabled` : le DKIM est désactivé, il n’a pas encore été configuré ou il a été désactivé par API. <br/>
+    - `modifying` : la configuration du DKIM est en cours, il est nécessaire de patienter jusqu’à la fin du processus.<br/>
+    - `toConfigure` : la configuration du DKIM est en attente des paramètres DNS du nom de domaine. Vous devez renseigner manuellement les enregistrements DNS dans la zone du nom de domaine. Pour cela, appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).<br/>
+    - `enabled` : le DKIM est configuré et fonctionnel.<br/>
+    - `error` : Le processus d’installation a rencontré une erreur. Nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le nom de domaine concerné.<br/>
 
     Au niveau des sélecteurs vous avez également 3 états possibles:
 
-    - `set` : le sélecteur est bien configuré et actif.
-    - `toSet` : le sélecteur n’est pas configuré dans la zone DNS du nom de domaine. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
-    - `toFix` : le sélecteur a bien été configuré dans la zone DNS du nom de domaine mais les valeurs sont incorrectes. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
+    - `set` : le sélecteur est bien configuré et actif.
+    - `toSet` : le sélecteur n’est pas configuré dans la zone DNS du nom de domaine. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
+    - `toFix` : le sélecteur a bien été configuré dans la zone DNS du nom de domaine mais les valeurs sont incorrectes. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
     Lors de vos opérations sur le DKIM de votre plateforme Exchange, utilisez l’appel API ci-dessous pour vérifier le statut actuel du DKIM.
 
     <Api version="v1" section="/email/exchange" method="GET" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel le DKIM doit être présent. <br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé. <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel le DKIM doit être présent. <br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé. <br/>
 
-    Regardez ensuite la valeur `status:` dans le résultat :
+    Regardez ensuite la valeur `status:` dans le résultat :
 
-    - `todo` : la tâche a été initialisée, elle va se lancer. <br/>
-    - `WaitingRecord` : les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné.
-    - `ready` : les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. <br/>
-    - `inProduction` : le DKIM est bien configuré et activé, il est donc pleinement opérationnel. <br/>
-    - `disabling` : le DKIM est en cours de désactivation. <br/>
-    - `deleting` : le DKIM est en cours de suppression. <br/>
+    - `todo` : la tâche a été initialisée, elle va se lancer. <br/>
+    - `WaitingRecord` : les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné.
+    - `ready` : les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. <br/>
+    - `inProduction` : le DKIM est bien configuré et activé, il est donc pleinement opérationnel. <br/>
+    - `disabling` : le DKIM est en cours de désactivation. <br/>
+    - `deleting` : le DKIM est en cours de suppression. <br/>
 
     Si vous rencontrez l’erreur suivante lorsque vous lancez l’appel API, cela signifie que le sélecteur n’existe pas ou a été supprimé. Il faudra le créer.
 
@@ -906,18 +906,18 @@ Sélectionnez l’offre e-mail concernée dans les onglets suivants :
 
     <Api version="v1" section="/email/pro" method="GET" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent. <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé. <br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent. <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé. <br/>
 
-    Regardez ensuite la valeur `status:` dans le résultat :
+    Regardez ensuite la valeur `status:` dans le résultat :
 
-    - `todo` : la tâche a été initialisée, elle va se lancer. <br/>
-    - `WaitingRecord` : les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné. <br/>
-    - `ready` : les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. <br/>
-    - `inProduction` : le DKIM est bien configuré et activé, il est donc pleinement opérationnel. <br/>
-    - `disabling` : le DKIM est en cours de désactivation. <br/>
-    - `deleting` : le DKIM est en cours de suppression. <br/>
+    - `todo` : la tâche a été initialisée, elle va se lancer. <br/>
+    - `WaitingRecord` : les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné. <br/>
+    - `ready` : les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. <br/>
+    - `inProduction` : le DKIM est bien configuré et activé, il est donc pleinement opérationnel. <br/>
+    - `disabling` : le DKIM est en cours de désactivation. <br/>
+    - `deleting` : le DKIM est en cours de suppression. <br/>
 
     Si vous rencontrez l’erreur suivante lorsque vous lancez l’appel API, cela signifie que le sélecteur n’existe pas ou a été supprimé. Il faudra le créer.
 
@@ -934,16 +934,16 @@ Sélectionnez l’offre e-mail concernée dans les onglets suivants :
 Le sélecteur DKIM doit être en statut `ready` avant de pouvoir être activé.
 :::
 
-Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
+Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
 
 <ZoneTabs>
   <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
-    Pour activer le DKIM, utilisez l’appel API suivant :
+    Pour activer le DKIM, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/enable"} regions={["eu"]} />
     <br/>
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent. <br/>
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent. <br/>
 
     *Exemple de résultat :*
 
@@ -957,28 +957,28 @@ Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
     ```
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    Pour activer le DKIM sur un sélecteur, utilisez l’appel API suivant :
+    Pour activer le DKIM sur un sélecteur, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/exchange" method="POST" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/enable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.<br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».<br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».<br/>
-    - `selectorName` : saisissez le nom d’un sélecteur existant.<br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange sur lequel vous souhaitez activer le DKIM.<br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».<br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ».<br/>
+    - `selectorName` : saisissez le nom d’un sélecteur existant.<br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
-    Pour activer le DKIM sur un sélecteur, utilisez l’appel API suivant :
+    Pour activer le DKIM sur un sélecteur, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="POST" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/enable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent.<br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous avez créé .<br/>
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent.<br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous avez créé .<br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
   </Tab>
 </ZoneTabs>
 
 :::info
-Lors d’une rotation de sélecteur DKIM, vous pouvez directement activer le deuxième sélecteur que vous avez créé afin de basculer dessus, tout en conservant le premier sélecteur qui restera actif le temps que tous les e-mails délivrés avec celui-ci soient bien analysés par leur destinataire.
+Lors d’une rotation de sélecteur DKIM, vous pouvez directement activer le deuxième sélecteur que vous avez créé pour basculer dessus, tout en conservant le premier sélecteur qui restera actif le temps que tous les e-mails délivrés avec celui-ci soient bien analysés par leur destinataire.
 :::
 
 #### API - Désactiver et supprimer le DKIM <a name="disable-switch"></a>
@@ -989,16 +989,16 @@ Lors d’une rotation de sélecteur DKIM, vous pouvez directement activer le deu
 Le sélecteur DKIM doit être en statut `inProduction` ou `ready` avant de pouvoir être désactivé.
 :::
 
-Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
+Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
 
 <ZoneTabs>
   <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
-    Si vous souhaitez désactiver le DKIM sans supprimer les sélecteurs et leur paire de clés, utilisez l’appel API suivant :
+    Si vous souhaitez désactiver le DKIM sans supprimer les sélecteurs et leur paire de clés, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/domain" method="PUT" route={"/email/domain/\\{domain\\}/dkim/disable"} regions={["eu"]} />
     <br/>
 
-    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent. <br/>
+    - `domain` : saisissez le nom de domaine attaché à votre service E-mail sur lequel le DKIM doit être présent. <br/>
 
     *Exemple de résultat :*
 
@@ -1016,36 +1016,36 @@ Sélectionnez l’offre e-mail concernée parmi les onglets suivants :
 
     <Api version="v1" section="/email/exchange" method="POST" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/disable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez désactiver. <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez désactiver. <br/>
 
-    Si vous souhaitez supprimer le sélecteur DKIM et sa paire de clés, utilisez l’appel API suivant :
+    Si vous souhaitez supprimer le sélecteur DKIM et sa paire de clés, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/exchange" method="DELETE" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « >> private-zz111111-1 ». <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez supprimer. <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « >> private-zz111111-1 ». <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez supprimer. <br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
-    Si vous souhaitez désactiver le DKIM sans supprimer le sélecteur et sa paire de clés, utilisez l’appel API suivant :
+    Si vous souhaitez désactiver le DKIM sans supprimer le sélecteur et sa paire de clés, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="POST" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/disable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro. <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez désactiver. <br/>
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro. <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez désactiver. <br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
 
-    Si vous souhaitez supprimer le sélecteur DKIM et sa paire de clés, utilisez l’appel API suivant :
+    Si vous souhaitez supprimer le sélecteur DKIM et sa paire de clés, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="DELETE" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro. <br/>
-    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez supprimer. <br/>
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro. <br/>
+    - `selectorName` : saisissez le nom du sélecteur que vous souhaitez supprimer. <br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
   </Tab>
 </ZoneTabs>
 
@@ -1057,9 +1057,9 @@ Depuis <ManagerLink to="/">l’espace client OVHcloud</ManagerLink>, cliquez sur
 
 Ouvrez l’onglet <code className="action">Zone DNS</code>, puis cliquez sur <code className="action">Ajouter une entrée</code> au-dessus du tableau. Il existe 3 manières d’ajouter un enregistrement pour paramétrer le DKIM dans votre zone DNS :
 
-- [un enregistrement DKIM](#dkim-record) : configuration permettant de visualiser l’ensemble des paramètres d’un enregistrement DKIM.
-- [un enregistrement TXT](#txt-record) : enregistrement à utiliser lorsque l’ensemble des paramètres DKIM vous ont été fournis.
-- [un enregistrement CNAME](#cname-record) : enregistrement utilisé pour une offre e-mail OVHcloud ou un serveur e-mail Microsoft.
+- [un enregistrement DKIM](#dkim-record) : configuration permettant de visualiser l’ensemble des paramètres d’un enregistrement DKIM.
+- [un enregistrement TXT](#txt-record) : enregistrement à utiliser lorsque l’ensemble des paramètres DKIM vous ont été fournis.
+- [un enregistrement CNAME](#cname-record) : enregistrement utilisé pour une offre e-mail OVHcloud ou un serveur e-mail Microsoft.
 
 #### Enregistrement DKIM <a name="dkim-record"></a>
 
@@ -1077,41 +1077,41 @@ selector-name._domainkey.mydomain.ovh.
 
 - **Clé publique (base64)** : collez la clé publique fournie par votre service e-mail. C’est la clé que les destinataires utilisent pour vérifier votre signature DKIM.
 - **Type de clé** : l’algorithme de signature de la clé — `RSA` (par défaut) ou `ed25519`.
-- **Mode test** : laissez-le sur `Désactivé` en production. Lorsqu’il est activé, les destinataires traitent les messages de test signés en DKIM comme des messages non signés : un échec de vérification n’affecte donc pas la distribution pendant que vous validez votre configuration.
+- **Mode test** : laissez-le sur `Désactivé` en production. Lorsqu’il est activé, les destinataires traitent les messages de test signés en DKIM comme des messages non signés : un échec de vérification n’affecte donc pas la distribution pendant que vous validez votre configuration.
 
 Le cadre **Aperçu de l’enregistrement** affiche l’enregistrement obtenu au fur et à mesure que vous remplissez le formulaire. Si vous avez besoin d’une balise DKIM que le formulaire ne propose pas (par exemple `g=`, `n=` ou `s=`), ajoutez plutôt l’enregistrement sous forme d’[enregistrement TXT](#txt-record), ou utilisez le <code className="action">Mode d'édition avancé</code>.
 
-- **Version (v=)** : sert à indiquer la version du DKIM. Il est recommandé de l’utiliser et sa valeur par défaut est `DKIM1`.<br/>
+- **Version (v=)** : sert à indiquer la version du DKIM. Il est recommandé de l’utiliser et sa valeur par défaut est `DKIM1`.<br/>
 Si spécifié, ce tag doit être placé en premier dans l’enregistrement et doit être égal à « DKIM1 » (sans les guillemets). Les enregistrements qui commencent par un tag « v= » avec une autre valeur doivent être ignorés.
 
-- **Granularité (g=)** : permet de spécifier la partie « local-part » d’une adresse e-mail, c’est-à-dire la partie située avant le « @ ».<br/>
+- **Granularité (g=)** : permet de spécifier la partie « local-part » d’une adresse e-mail, c’est-à-dire la partie située avant le « @ ».<br/>
 Elle permet de spécifier l’adresse e-mail ou les adresses e-mail qui sont autorisées à signer un message électronique avec la clé DKIM du sélecteur.<br/>
-La valeur par défaut de "g=" est "\*", ce qui signifie que toutes les adresses e-mail sont autorisées à utiliser la clé de signature DKIM.<br/>
-En indiquant une valeur spécifique pour "g=", on peut limiter l’utilisation de la clé à une partie locale d’adresse e-mail spécifique ou à une plage d’adresses e-mail spécifiques en utilisant des caractères génériques (par exemple : "\*-group").
+La valeur par défaut de `g=` est `\*`, ce qui signifie que toutes les adresses e-mail sont autorisées à utiliser la clé de signature DKIM.<br/>
+En indiquant une valeur spécifique pour `g=`, on peut limiter l’utilisation de la clé à une partie locale d’adresse e-mail spécifique ou à une plage d’adresses e-mail spécifiques en utilisant des caractères génériques (par exemple : `\*-group`).
 
-- **Algorithme (hash) (h=)** : permet de spécifier les algorithmes de hachage utilisés pour signer les en-têtes d’e-mail. Cette balise permet de définir une liste d’algorithmes de hachage qui seront utilisés pour générer une signature DKIM pour un message donné.
+- **Algorithme (hash) (h=)** : permet de spécifier les algorithmes de hachage utilisés pour signer les en-têtes d’e-mail. Cette balise permet de définir une liste d’algorithmes de hachage qui seront utilisés pour générer une signature DKIM pour un message donné.
 
-- **Type de clé (k=)** : spécifie l’algorithme de signature utilisé pour signer les messages électroniques sortants. Il permet aux destinataires de savoir comment le message a été signé et quelle est la méthode utilisée pour vérifier son authenticité.<br/>
-Les valeurs possibles pour le tag "k=" comprennent "rsa" pour l’algorithme de signature RSA et "ed25519" pour l’algorithme de signature Ed25519. Le choix de l’algorithme dépend de la politique de sécurité de l’expéditeur et de la prise en charge par le destinataire.
+- **Type de clé (k=)** : spécifie l’algorithme de signature utilisé pour signer les messages électroniques sortants. Il permet aux destinataires de savoir comment le message a été signé et quelle est la méthode utilisée pour vérifier son authenticité.<br/>
+Les valeurs possibles pour le tag `k=` comprennent `rsa` pour l’algorithme de signature RSA et `ed25519` pour l’algorithme de signature Ed25519. Le choix de l’algorithme dépend de la politique de sécurité de l’expéditeur et de la prise en charge par le destinataire.
 
-- **Notes (n=)** : sert à inclure des notes d’intérêt pour les administrateurs qui gèrent le système de clés DKIM.<br/>
+- **Notes (n=)** : sert à inclure des notes d’intérêt pour les administrateurs qui gèrent le système de clés DKIM.<br/>
 Ces notes peuvent être utiles pour des raisons de documentation ou pour aider les administrateurs à comprendre ou à gérer le fonctionnement de DKIM. Les notes incluses dans n= ne sont pas interprétées par les programmes et n’affectent pas le fonctionnement du DKIM.
 
-- **Clé publique (base64) (p=)** : utilisée pour renseigner les données de clé publique DKIM, qui sont encodées en base64.<br/>
+- **Clé publique (base64) (p=)** : utilisée pour renseigner les données de clé publique DKIM, qui sont encodées en base64.<br/>
 Ce tag est obligatoire dans la signature DKIM et permet aux destinataires de la signature de récupérer la clé publique nécessaire pour vérifier l’authenticité du message signé.
 
-- **Révoquer la clé publique** : si une clé publique DKIM a été révoquée (par exemple en cas de compromission de la clé privée), une valeur vide doit être utilisée pour le tag "p=", indiquant que cette clé publique n’est plus valide. Les destinataires doivent alors retourner une erreur pour toute signature DKIM faisant référence à une clé révoquée.
+- **Révoquer la clé publique** : si une clé publique DKIM a été révoquée (par exemple en cas de compromission de la clé privée), une valeur vide doit être utilisée pour le tag `p=`, indiquant que cette clé publique n’est plus valide. Les destinataires doivent alors retourner une erreur pour toute signature DKIM faisant référence à une clé révoquée.
 
-- **Type de service (s=)**: La balise "s=" (Service Type) est optionnelle et n’est pas présente par défaut. Elle permet de spécifier le ou les types de services au(x)quel(s) cet enregistrement DKIM s’applique.<br/>
-Les types de services sont définis en utilisant une liste de mots-clés séparés par des deux-points ":".<br/>
+- **Type de service (s=)**: La balise `s=` (Service Type) est optionnelle et n’est pas présente par défaut. Elle permet de spécifier le ou les types de services au(x)quel(s) cet enregistrement DKIM s’applique.<br/>
+Les types de services sont définis en utilisant une liste de mots-clés séparés par des deux-points `:`.<br/>
 Le destinataire doit ignorer cet enregistrement si le type de service approprié n’est pas répertorié.<br/>
-La balise "s=" est destinée à restreindre l’utilisation des clés pour d’autres fins, dans le cas où l’utilisation du DKIM serait définie pour d’autres services à l’avenir.<br/>
+La balise `s=` est destinée à restreindre l’utilisation des clés pour d’autres fins, dans le cas où l’utilisation du DKIM serait définie pour d’autres services à l’avenir.<br/>
 Les types de services actuellement définis sont « \* » (tous les types de services), « email » (courrier électronique).
 
-- **Mode test (t=y)** : permet aux titulaires du nom de domaine de tester la mise en place du DKIM sans risquer de voir les messages rejetés ou marqués comme spam si la vérification de signature DKIM échoue.<br/>
-Lorsque le flag "t=y" est utilisé, le destinataire ne doit pas traiter différemment les messages signés en mode de test et les messages non signés. Cependant, le destinataire peut suivre le résultat du mode de test pour aider les signataires.
+- **Mode test (t=y)** : permet aux titulaires du nom de domaine de tester la mise en place du DKIM sans risquer de voir les messages rejetés ou marqués comme spam si la vérification de signature DKIM échoue.<br/>
+Lorsque le flag `t=y` est utilisé, le destinataire ne doit pas traiter différemment les messages signés en mode de test et les messages non signés. Cependant, le destinataire peut suivre le résultat du mode de test pour aider les signataires.
 
-- **Sous-domaines (t=s)** : permet de restreindre l’utilisation de la signature DKIM au nom de domaine uniquement (par exemple : @mydomain.ovh) ou de permettre l’envoi depuis le nom de domaine et ses sous-domaines (par exemple : @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.).
+- **Sous-domaines (t=s)** : permet de restreindre l’utilisation de la signature DKIM au nom de domaine uniquement (par exemple : @mydomain.ovh) ou de permettre l’envoi depuis le nom de domaine et ses sous-domaines (par exemple : @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.).
 
 #### Enregistrement TXT <a name="txt-record"></a>
 
@@ -1123,13 +1123,13 @@ Pour bien comprendre la composition de l’enregistrement DKIM, consultez la par
 
 **Exemple d’un enregistrement DKIM**
 
-- sous-domaine :
+- sous-domaine :
 
 ```console
 selector-name._domainkey.mydomain.ovh.
 ```
 
-- cible :
+- cible :
 
 ```console
 v=DKIM1;t=s;p= MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA77VDAIfyhjtoF0DIE5V7 rev1EKk4L0nxdBpD5O/jPrM4KP0kukeuB6IMpVplkkq52MSDeRcjoO50h0DmwZOr RUkyGjQwOnAh0VhY3fqkuwBYftEX7vWo8C2E1ylzimABkwPpSL62jZ1DheoXcil9 1M35wWBKtlYdXVedKjCQKOEnwTo+0hdNe38rU9NMgq6nbTIMjDntvxoVI+yF3kcx q/VpAY8BIYbcAXkVFvUyfUBABnnKpf0SfblsfcLW0Koy/FRxPDFOvnjNxXeOxMFR UI6K6PaW2WvtbJG2v+gHLY5M4tB0+/FNJU9emZfkPOk3DmRhZ8ENi7+oZa2ivUDj OQIDAQAB
@@ -1145,9 +1145,9 @@ Il s’agit précisément du type d’enregistrement utilisé pour activer le DK
 
 Nous vous conseillons d’envoyer un e-mail depuis un compte de votre plateforme Exchange vers une adresse e-mail qui vérifie la signature DKIM lors de la réception.
 
-Voici ce que vous pourrez trouver dans l’en-tête de l’e-mail reçu :
+Voici ce que vous pourrez trouver dans l’en-tête de l’e-mail reçu :
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1158,13 +1158,15 @@ Pour récupérer l’en-tête d’un e-mail, consulter notre guide « [Récupér
 
 ### Cas d’usages <a name="usecases"></a>
 
-#### Comment et pourquoi changer la paire de clés DKIM sur mon offre ? <a name="2selectors"></a>
+<Region zones={['eu', 'ca']}>
+
+#### Comment et pourquoi changer la paire de clés DKIM sur mon offre ? <a name="2selectors"></a>
 
 :::warning
 Cette question concerne uniquement les offres Exchange et Email Pro.
 :::
 
-Lorsque vous activez pour la première fois le DKIM sur votre service e-mail, il est possible de créer 2 sélecteurs qui contiennent chacun une paire de clés. Le deuxième sélecteur sert de successeur à celui qui est en cours d’utilisation.
+Lorsque vous activez pour la première fois le DKIM sur votre service e-mail, vous pouvez créer 2 sélecteurs qui contiennent chacun une paire de clés. Le deuxième sélecteur sert de successeur à celui qui est en cours d’utilisation.
 
 Pour éviter les tentatives de déchiffrement de la clé DKIM, il est conseillé de changer régulièrement de paire de clés. Pour cela, assurez-vous d’avoir bien configuré vos 2 sélecteurs en vérifiant que le premier est en status `inProduction`et le second en status `ready`. Vous pouvez vérifier cet état en vous référant à la section « [API - Les différents états du DKIM](#dkim-status) ».
 
@@ -1172,29 +1174,33 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre.
 
 <ZoneTabs>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    Pour basculer sur le deuxième sélecteur, utilisez l’appel API suivant :
+    Pour basculer sur le deuxième sélecteur, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/exchange" method="POST" route={"/email/exchange/\\{organizationName\\}/service/\\{exchangeService\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/enable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
-    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
-    - `selectorName` : saisissez le nom du sélecteur sur lequel vous souhaitez basculer. <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Exchange. <br/>
+    - `exchangeService` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `organizationName` : saisissez le nom de votre plateforme Exchange se présentant sous la forme « hosted-zz111111-1 » ou « private-zz111111-1 ». <br/>
+    - `selectorName` : saisissez le nom du sélecteur sur lequel vous souhaitez basculer. <br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
-    Pour basculer sur le deuxième sélecteur, utilisez l’appel API suivant :
+    Pour basculer sur le deuxième sélecteur, utilisez l’appel API suivant :
 
     <Api version="v1" section="/email/pro" method="POST" route={"/email/pro/\\{service\\}/domain/\\{domainName\\}/dkim/\\{selectorName\\}/enable"} />
 
-    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent.<br/>
-    - `selectorName` : saisissez le nom du sélecteur sur lequel vous souhaitez basculer. <br/>
-    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
+    - `domainName` : saisissez le nom de domaine attaché à votre plateforme Email Pro sur lequel le DKIM doit être présent.<br/>
+    - `selectorName` : saisissez le nom du sélecteur sur lequel vous souhaitez basculer. <br/>
+    - `service` : saisissez le nom de votre plateforme Email Pro se présentant sous la forme « emailpro-zz111111-1 ». <br/>
   </Tab>
 </ZoneTabs>
 
 Après avoir basculé sur le nouveau sélecteur, conservez l’ancien durant 7 jours avant de le supprimer et d’en créer un nouveau.
 
-#### Pourquoi le DKIM n’est pas fonctionnel et apparait en rouge dans l’espace client ? <a name="reddkim"></a>
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
+#### Pourquoi le DKIM n’est pas fonctionnel et apparait en rouge dans l’espace client ? <a name="reddkim"></a>
 
 :::warning
 Cette question concerne uniquement les offres Exchange et Email Pro.
@@ -1229,13 +1235,13 @@ Cliquez sur l’onglet ci-dessous correspondant à votre offre, pour constater l
   </Tab>
 </ZoneTabs>
 
-Voici les 4 états ayant pour résultat l’icône DKIM en rouge dans votre espace client, Cliquez sur l’onglet correspondant à votre code erreur :
+Voici les 4 états ayant pour résultat l’icône DKIM en rouge dans votre espace client, Cliquez sur l’onglet correspondant à votre code erreur :
 
 <Tabs>
   <Tab label="501">
     « **Only one dkim selector has been initialized** »<br/><br/>
     Seul un sélecteur DKIM est présent dans votre configuration. Pour nous permettre la bascule vers une nouvelle clé lorsque cela est nécessaire, il est demandé de configurer les 2 sélecteurs fournis par le service.<br/><br/>
-    Pour corriger cette erreur :
+    Pour corriger cette erreur :
 
     - Vérifiez l’état des sélecteurs DKIM pour identifier celui qui doit être configuré. Pour cela, aidez-vous de la partie « [API - Les différents états du DKIM](#dkim-status) » de ce guide.
     - Une fois que vous avez identifié le sélecteur à configurer, suivez les étapes de la partie « [API - Configuration complète du DKIM](#firststep) » sur ce guide, selon votre offre (Exchange ou Email Pro), en l’appliquant uniquement au sélecteur concerné.
@@ -1248,7 +1254,7 @@ Voici les 4 états ayant pour résultat l’icône DKIM en rouge dans votre espa
   <Tab label="503">
     « **CNAME record is wrong** »<br/><br/>
     La valeur de l’enregistrement CNAME nécessaire à la configuration du DKIM n’a pas été saisie correctement. Vous devez configurer correctement la zone DNS du nom de domaine attaché.
-    Pour configurer votre zone DNS, récupérez les valeurs de l’enregistrement CNAME qui s’affiche :
+    Pour configurer votre zone DNS, récupérez les valeurs de l’enregistrement CNAME qui s’affiche :
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-503.png" loading="lazy" />
 
@@ -1258,7 +1264,7 @@ Voici les 4 états ayant pour résultat l’icône DKIM en rouge dans votre espa
   <Tab label="504">
     « **One CNAME record is missing** »<br/><br/>
     La valeur de l’enregistrement CNAME nécessaire à la configuration du DKIM est manquante. Vous devez configurer la zone DNS du nom de domaine attaché.
-    Pour configurer votre zone DNS, récupérez les valeurs de l’enregistrement CNAME qui s’affiche :
+    Pour configurer votre zone DNS, récupérez les valeurs de l’enregistrement CNAME qui s’affiche :
 
     <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-503.png" loading="lazy" />
 
@@ -1267,7 +1273,11 @@ Voici les 4 états ayant pour résultat l’icône DKIM en rouge dans votre espa
   </Tab>
 </Tabs>
 
-#### Depuis l’interface API OVHcloud, comment comprendre l’état du DKIM qui ne fonctionne pas ? <a name="api-error"></a>
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
+#### Depuis l’interface API OVHcloud, comment comprendre l’état du DKIM qui ne fonctionne pas ? <a name="api-error"></a>
 
 Si vous utilisez les API OVHcloud pour configurer votre DKIM et que celui-ci n’est pas fonctionnel aidez-vous de la rubrique « [API - Les différents états du DKIM](#dkim-status) » de ce guide pour identifier l’état de vos sélecteurs.
 
@@ -1275,24 +1285,26 @@ Retrouvez ci-dessous les états qui peuvent bloquer le fonctionnement de votre D
 
 <ZoneTabs>
   <Tab label="Exchange et Email Pro" availableIn={['eu']}>
-    - `WaitingRecord` : Les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné. Selon vote offre, suivez **l’étape 5** dans la section « [API - Configuration complète du DKIM](#firststep) » pour configurer correctement la zone DNS du nom de domaine concerné.
-    - `ready` : Les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. Il vous suffira d’activer le sélecteur en vous appuyant sur la section « [API - Activer ou changer un sélecteur DKIM](#enable-switch) ».
-    - `deleting` : Le DKIM est en cours de suppression. Après suppression, il vous faudra suivre la section « [API - Configuration complète du DKIM](#firststep) ».
-    - `disabling` : Le DKIM est en cours de désactivation. Après cette opération, vous pourrez activer le sélecteur en vous appuyant sur la section « [API - Activer ou changer un sélecteur DKIM](#enable-switch) ».
-    - `todo` : La tâche a été initialisée, elle doit se lancer. Au-delà de 24 heures, si votre sélecteur est toujours dans cet état, nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le numéro du sélecteur concerné.
+    - `WaitingRecord` : Les enregistrements DNS sont en attente de configuration ou en cours de validation dans la zone DNS du nom de domaine. Une vérification automatique régulière est faite pour constater si l’enregistrement DNS est présent et correctement renseigné. Selon vote offre, suivez **l’étape 5** dans la section « [API - Configuration complète du DKIM](#firststep) » pour configurer correctement la zone DNS du nom de domaine concerné.
+    - `ready` : Les enregistrements DNS sont présents dans la zone. Le DKIM peut maintenant être activé. Il vous suffira d’activer le sélecteur en vous appuyant sur la section « [API - Activer ou changer un sélecteur DKIM](#enable-switch) ».
+    - `deleting` : Le DKIM est en cours de suppression. Après suppression, il vous faudra suivre la section « [API - Configuration complète du DKIM](#firststep) ».
+    - `disabling` : Le DKIM est en cours de désactivation. Après cette opération, vous pourrez activer le sélecteur en vous appuyant sur la section « [API - Activer ou changer un sélecteur DKIM](#enable-switch) ».
+    - `todo` : La tâche a été initialisée, elle doit se lancer. Au-delà de 24 heures, si votre sélecteur est toujours dans cet état, nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le numéro du sélecteur concerné.
   </Tab>
   <Tab label="MX Plan et Zimbra" availableIn={['eu']}>
-    - `disabled` : Le DKIM est désactivé, il n’a pas encore été configuré ou il a été désactivé par API. <br/>
-    - `modifying` : La configuration du DKIM est en cours, il est nécessaire de patienter jusqu’à la fin du processus.<br/>
-    - `toConfigure` : La configuration du DKIM est en attente des paramètres DNS du nom de domaine. Vous devez renseigner manuellement les enregistrements DNS dans la zone du nom de domaine. Pour cela; appuyez-vous sur l’étape « [Configuration complète du DKIM](#confemail) » de ce guide. <br/>
-    - `error` : Le processus d’installation a rencontré une erreur. Nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le nom de domaine concerné.
+    - `disabled` : Le DKIM est désactivé, il n’a pas encore été configuré ou il a été désactivé par API. <br/>
+    - `modifying` : La configuration du DKIM est en cours, il est nécessaire de patienter jusqu’à la fin du processus.<br/>
+    - `toConfigure` : La configuration du DKIM est en attente des paramètres DNS du nom de domaine. Vous devez renseigner manuellement les enregistrements DNS dans la zone du nom de domaine. Pour cela; appuyez-vous sur l’étape « [Configuration complète du DKIM](#confemail) » de ce guide. <br/>
+    - `error` : Le processus d’installation a rencontré une erreur. Nous vous invitons à ouvrir un [ticket auprès du support](/links/support-contact) en précisant le nom de domaine concerné.
 
     Au niveau des sélecteurs vous avez également 2 états relatifs à une erreur:
 
-    - `toSet` : Le sélecteur n’est pas configuré dans la zone DNS du nom de domaine. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
-    - `toFix` : Le sélecteur a bien été configuré dans la zone DNS du nom de domaine mais les valeurs sont incorrectes. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
+    - `toSet` : Le sélecteur n’est pas configuré dans la zone DNS du nom de domaine. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
+    - `toFix` : Le sélecteur a bien été configuré dans la zone DNS du nom de domaine mais les valeurs sont incorrectes. Appuyez-vous sur [l’étape 4 de « la configuration complète du DKIM » pour MX Plan et Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Aller plus loin
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -152,7 +152,7 @@ Perché questo principio di rotazione funzioni, utilizzeremo quello che chiamiam
 
 **Esempio di una parte della firma DKIM**
 
-```
+```text
 DKIM-Firma: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -1083,17 +1083,17 @@ selector-name._domainkey.mydomain.ovh.
 Il riquadro **Panoramica del record** mostra il record risultante man mano che compili il modulo. Se hai bisogno di un tag DKIM che il modulo non espone (ad esempio `g=`, `n=` o `s=`), aggiungi il record come [record TXT](#txt-record) oppure utilizza la <code className="action">Modalità di modifica avanzata</code>.
 
 - **Versione (v=)**: serve a indicare la versione del DKIM. Si raccomanda di utilizzarla e il suo valore predefinito è `DKIM1`.<br/>
-Se specificato, questo tag deve essere inserito per primo nel record e deve essere uguale a "DKIM1" (senza virgolette). I record che iniziano con un tag "v=" con un altro valore devono essere ignorati.
+Se specificato, questo tag deve essere inserito per primo nel record e deve essere uguale a "DKIM1" (senza virgolette). I record che iniziano con un tag `v=` con un altro valore devono essere ignorati.
 
 - **Granularità (g=)**: permette di specificare la parte "locale-partenza" di un indirizzo email, cioè quella situata anteriormente a "@".<br/>
 In questo modo è possibile specificare l'indirizzo email o gli indirizzi autorizzati a firmare un messaggio elettronico con la chiave DKIM del selettore.<br/>
-Il valore predefinito di "g=" è "\*", il che significa che tutti gli indirizzi email sono autorizzati ad utilizzare la chiave di firma DKIM.<br/>
-Indicando un valore specifico per "g=", l'utilizzo della chiave può essere limitato a una parte locale di indirizzo email specifico o a una gamma di indirizzi email specifici utilizzando caratteri generici (ad esempio: "\*-group").
+Il valore predefinito di `g=` è `\*`, il che significa che tutti gli indirizzi email sono autorizzati ad utilizzare la chiave di firma DKIM.<br/>
+Indicando un valore specifico per `g=`, l'utilizzo della chiave può essere limitato a una parte locale di indirizzo email specifico o a una gamma di indirizzi email specifici utilizzando caratteri generici (ad esempio: `\*-group`).
 
 - **Algoritmo (hash=)**: permette di specificare gli algoritmi di hash utilizzati per firmare le intestazioni di email. Questo tag permette di definire una lista di algoritmi di hash che saranno utilizzati per generare una firma DKIM per un messaggio specifico.
 
 - **Tipo di chiave (k=)**: specifica l'algoritmo di firma utilizzato per firmare i messaggi elettronici uscenti. Il messaggio è stato firmato e il metodo utilizzato per verificarne l'autenticità.<br/>
-I possibili valori per il tag "k=" includono "rsa" per l'algoritmo di firma RSA e "ed25519" per l'algoritmo di firma Ed25519. La scelta dell'algoritmo dipende dalla politica di sicurezza del mittente e dalla presa in carico da parte del destinatario.
+I possibili valori per il tag `k=` includono `rsa` per l'algoritmo di firma RSA e `ed25519` per l'algoritmo di firma Ed25519. La scelta dell'algoritmo dipende dalla politica di sicurezza del mittente e dalla presa in carico da parte del destinatario.
 
 - **Note (n=)**: Serve a includere note di interesse per gli amministratori che gestiscono il sistema di chiavi DKIM.<br/>
 Queste note possono essere utili per ragioni di documentazione o per aiutare gli amministratori a comprendere o gestire il funzionamento di DKIM. Le note incluse in n= non sono interpretate dai programmi e non incidono sul funzionamento del DKIM.
@@ -1101,16 +1101,16 @@ Queste note possono essere utili per ragioni di documentazione o per aiutare gli
 - **Chiave pubblica (base64) (p=)**: utilizzato per inserire i dati della chiave pubblica DKIM, codificati in base64.<br/>
 Questo tag è obbligatorio nella firma DKIM e permette ai destinatari della firma di recuperare la chiave pubblica necessaria per verificare l'autenticità del messaggio firmato.
 
-- **Rimuovi la chiave pubblica**: se una chiave pubblica DKIM è stata rimossa (ad esempio in caso di manomissione della chiave privata), si deve utilizzare un valore vuoto per il tag "p=", indicando che la chiave pubblica non è più valida. I destinatari devono restituire un errore per ogni firma DKIM che faccia riferimento a una chiave revocata.
+- **Rimuovi la chiave pubblica**: se una chiave pubblica DKIM è stata rimossa (ad esempio in caso di manomissione della chiave privata), si deve utilizzare un valore vuoto per il tag `p=`, indicando che la chiave pubblica non è più valida. I destinatari devono restituire un errore per ogni firma DKIM che faccia riferimento a una chiave revocata.
 
-- **Tipo di servizio (s=)**: Il tag "s=" (Service Type) è facoltativo e non è presente di default. Permette di specificare il tipo o i tipi di servizi ai quali si applica questo record DKIM.<br/>
-I tipi di servizi sono definiti utilizzando un elenco di parole chiave separate da due punti ":".<br/>
+- **Tipo di servizio (s=)**: Il tag `s=` (Service Type) è facoltativo e non è presente di default. Permette di specificare il tipo o i tipi di servizi ai quali si applica questo record DKIM.<br/>
+I tipi di servizi sono definiti utilizzando un elenco di parole chiave separate da due punti `:`.<br/>
 Il destinatario deve ignorare tale registrazione se il tipo di servizio adeguato non è registrato.<br/>
-Il tag "s=" è destinato a limitare l'uso delle chiavi per altri scopi, nel caso in cui l'utilizzo del DKIM sia definito per altri servizi in futuro.<br/>
-I tipi di servizi attualmente definiti sono "\*" (tutti i tipi di servizi), "email" (email).
+Il tag `s=` è destinato a limitare l'uso delle chiavi per altri scopi, nel caso in cui l'utilizzo del DKIM sia definito per altri servizi in futuro.<br/>
+I tipi di servizi attualmente definiti sono `\*` (tutti i tipi di servizi), "email" (email).
 
 - **Modalità test (t=y)**: permette ai intestatari del dominio di testare l'installazione del DKIM senza rischiare di vedere i messaggi respinti o contrassegnati come spam se la verifica della firma DKIM fallisce.<br/>
-Quando si usa il flag "t=y", il destinatario non deve trattare diversamente i messaggi firmati in modalità di test e i messaggi non firmati. Tuttavia, il destinatario può seguire l'esito del test per aiutare i firmatari.
+Quando si usa il flag `t=y`, il destinatario non deve trattare diversamente i messaggi firmati in modalità di test e i messaggi non firmati. Tuttavia, il destinatario può seguire l'esito del test per aiutare i firmatari.
 
 - **Sottodomini (t=s)**: permette di limitare l'utilizzo della firma DKIM esclusivamente a nome di dominio (ad esempio: @mydomain.ovh) o di permettere l'invio dal dominio e dai suoi sottodomini (ad esempio: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc).
 
@@ -1148,7 +1148,7 @@ Ti consigliamo di inviare un'email da un account della tua piattaforma Exchange 
 
 Ecco cosa si trova nell'intestazione dell'email ricevuta:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1158,6 +1158,8 @@ Return-Path: <test-dkim@mydomain.ovh>
 Per recuperare l'intestazione di un'email, consulta la guida [Recuperare l'intestazione di un'email](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers).
 
 ### Casi d'uso <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### Come e perché cambiare la sua coppia di chiavi DKIM? <a name="2selectors"></a>
 
@@ -1194,6 +1196,10 @@ Clicca sulla scheda qui sotto corrispondente alla tua offerta.
 </ZoneTabs>
 
 Dopo aver effettuato il passaggio al nuovo selettore, conservare il vecchio per 7 giorni prima di eliminarlo e crearne uno nuovo.
+
+</Region>
+
+<Region zones={['eu', 'ca']}>
 
 #### Perché il DKIM non funziona e appare in rosso nello Spazio Cliente? <a name="reddkim"></a>
 
@@ -1268,6 +1274,10 @@ Ecco i 4 stati che hanno come risultato l'icona DKIM in rosso nel tuo Spazio Cli
   </Tab>
 </Tabs>
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### Dall'interfaccia API OVHcloud, come capire lo stato del DKIM che non funziona? <a name="api-error"></a>
 
 Se utilizzi le API OVHcloud per configurare il tuo DKIM e questo non funziona, consulta la sezione "[API - I diversi stati del DKIM](#dkim-status)" di questa guida per identificare lo stato dei tuoi selettori.
@@ -1294,6 +1304,8 @@ Di seguito sono riportati gli stati che possono bloccare il funzionamento della 
     - `toFix`: il selettore è stato configurato correttamente nella zona DNS del nome di dominio ma i valori sono errati. Clicca su [Step 4 della "Configurazione completa di DKIM" per MX Plan e Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Per saperne di più
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migliora la sicurezza delle email con un record DKIM
 description: Come configurare un record DKIM sul tuo nome di dominio e sulla tua piattaforma email OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ Il record DKIM (**D**omain**K**eys **I**dentified **M**ail) permette di firmare 
 - Aver sottoscritto una delle soluzioni email disponibili:
     <Region zones={['eu']}>
     - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web](/links/web/hosting), un [hosting gratuito](/links/web/domains-free-hosting) o una soluzione MX Plan ordinata separatamente.
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud. È disponibile tramite una [offerta di hosting Web](/links/web/hosting) o una soluzione MX Plan ordinata separatamente.
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) o [Private Exchange](/links/web/emails-hosted-exchange).
@@ -65,7 +62,9 @@ Se il tuo dominio è registrato presso OVHcloud, verifica che utilizzi la config
     - [Perché è necessario configurare i server DNS?](#dns-and-dkim)
     - [Esempio di un'email inviata utilizzando il DKIM](#example)
     - [Cos'è un selettore DKIM?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Configurare automaticamente il DKIM per un'offerta email OVHcloud](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Configurare il DKIM tramite API per un'offerta email OVHcloud](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ Il destinatario **recipient@otherdomain.ovh** potrà decifrare questa firma con 
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Configurare il DKIM automaticamente per un servizio di posta Exchange o Email Pro OVHcloud <a name="auto-dkim"></a>
 
 La configurazione automatica del DKIM è disponibile per tutte le nostre offerte email:
 
 <Region zones={['eu']}>
 - MX Plan inclusa con un [hosting Web](/links/web/hosting), un [hosting gratuito](/links/web/domains-free-hosting) o ordinata separatamente.
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan inclusa con un [hosting Web](/links/web/hosting) o ordinata separatamente.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange).
@@ -201,7 +199,7 @@ Se il DKIM non è stato attivato quando avete aggiunto un nome a dominio alla vo
 Clicca sulla scheda qui sotto corrispondente alla tua offerta.
 
 <ZoneTabs>
-  <Tab label="Email (MX Plan)">
+  <Tab label="Email (MX Plan)" availableIn={['eu']}>
     1. Accedi allo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>.
     1. Accedi alla sezione <code className="action">Web Cloud</code>.
     1. Clicca su <code className="action">MX Plan</code>.
@@ -279,13 +277,15 @@ Clicca sulla scheda qui sotto corrispondente alla tua offerta.
 L'attivazione automatica del DKIM richiede tra i 30 minuti e un massimo di 24 ore. Per verificare che il tuo DKIM funzioni correttamente, torna alla sezione di gestione del dominio indicata nelle schede precedenti e controlla che il badge `DKIM` sia verde oppure, per un'offerta Zimbra, che la scheda `DKIM` non mostri più l'icona di avviso.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 L'attivazione automatica del DKIM richiede tra i 30 minuti e un massimo di 24 ore. Per verificare che il tuo DKIM funzioni correttamente, torna alla sezione di gestione del dominio indicata nelle schede precedenti e controlla che il badge `DKIM` sia verde.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Dopo le 24 ore, se la tua casellina `DKIM` è rossa, consulta la sezione "[Perché il DKIM non funziona e appare in rosso nello Spazio Cliente?](#reddkim)" di questa guida.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Configurare il DKIM tramite API per un'email OVHcloud <a name="internal-dkim"></a>

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -153,7 +153,7 @@ Aby zasada rotacji działała, użyjemy tzw. **selektorów DKIM**. Wybieracz DKI
 
 **Przykład części podpisu DKIM**
 
-```
+```text
 DKIM-Podpis: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -239,7 +239,7 @@ Kliknij na zakładkę poniżej odpowiadającą Twojej ofercie.
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
     1. Przejdź do sekcji <code className="action">Web Cloud</code>.
-    1. Kliknij <code className="action">Email Pro</code>.
+    1. Kliknij <code className="action">E-mail Pro</code>.
     1. Wybierz odpowiednią platformę.
     1. Na koniec przejdź do zakładki <code className="action">Przypisane domeny</code>.
 
@@ -317,7 +317,7 @@ Kliknij kartę poniżej odnoszącą się do Twojej oferty.
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
     1. Przejdź do sekcji <code className="action">Web Cloud</code>.
-    1. Kliknij <code className="action">Email Pro</code>.
+    1. Kliknij <code className="action">E-mail Pro</code>.
     1. Wybierz odpowiednią platformę.
 
     Domyślnie nazwa Twojej platformy odpowiada jej nazwie lub będzie widoczna pod przypisaną jej nazwą (patrz obrazek poniżej).
@@ -1083,17 +1083,17 @@ selector-name._domainkey.mydomain.ovh.
 Pole **Podgląd nagrania** wyświetla wynikowy rekord w miarę wypełniania formularza. Jeśli potrzebujesz tagu DKIM, którego formularz nie udostępnia (na przykład `g=`, `n=` lub `s=`), dodaj rekord jako [rekord TXT](#txt-record) lub użyj opcji <code className="action">Tryb zaawansowanego edytowania</code>.
 
 - **Wersja (v=)**: służy do wskazania wersji DKIM. Zaleca się jego użycie, a jego domyślną wartością jest `DKIM`.<br/>
-Jeśli tak, tag ten musi być umieszczony jako pierwszy w rekordzie i musi być równy "DKIM1" (bez cudzysłów). Zapisy, które zaczynają się od tagu "v=" z inną wartością, muszą zostać zignorowane.
+Jeśli tak, tag ten musi być umieszczony jako pierwszy w rekordzie i musi być równy "DKIM1" (bez cudzysłów). Zapisy, które zaczynają się od tagu `v=` z inną wartością, muszą zostać zignorowane.
 
 - **Granulat (g =)**: pozwala określić część "local-part" konta e-mail, czyli część przed "@".<br/>
 Umożliwia ona określenie adresu e-mail lub adresów e-mail, które są uprawnione do podpisywania wiadomości e-mail za pomocą klucza DKIM selektora.<br/>
-Domyślną wartością "g=" jest "\*", co oznacza, że wszystkie adresy e-mail są uprawnione do korzystania z klucza podpisu DKIM.<br/>
-Wskazując określoną wartość dla "g=", można ograniczyć stosowanie klucza do określonej lokalnej części adresu e-mail lub określonego zakresu adresów e-mail, używając znaków ogólnych (np.: "\*-group").
+Domyślną wartością `g=` jest `\*`, co oznacza, że wszystkie adresy e-mail są uprawnione do korzystania z klucza podpisu DKIM.<br/>
+Wskazując określoną wartość dla `g=`, można ograniczyć stosowanie klucza do określonej lokalnej części adresu e-mail lub określonego zakresu adresów e-mail, używając znaków ogólnych (np.: `\*-group`).
 
 - **Algorytm (hash) (h=)**: pozwala określić algorytmy hakowania używane do podpisywania nagłówków wiadomości. Ten znacznik pozwala na zdefiniowanie listy algorytmów haszujących, które będą używane do generowania podpisu DKIM dla danej wiadomości.
 
 - **Typ klucza (k=)**: określa algorytm podpisu używany do podpisywania wychodzących wiadomości elektronicznych. Umożliwia on odbiorcom sprawdzenie, w jaki sposób wiadomość została podpisana i w jaki sposób została ona zweryfikowana.<br/>
-Wartości możliwe dla tagu "k=" obejmują "rsa" dla algorytmu podpisu RSA i "ed25519" dla algorytmu podpisu Ed25519. Wybór algorytmu zależy od polityki bezpieczeństwa nadawcy i od tego, czy odbiorca go przyjmie.
+Wartości możliwe dla tagu `k=` obejmują `rsa` dla algorytmu podpisu RSA i `ed25519` dla algorytmu podpisu Ed25519. Wybór algorytmu zależy od polityki bezpieczeństwa nadawcy i od tego, czy odbiorca go przyjmie.
 
 - **Uwagi (n=)**: Ma na celu uwzględnienie ocen odsetek dla administratorów zarządzających systemem kluczy DKIM.<br/>
 Noty te mogą być przydatne z powodów dokumentacyjnych lub pomóc administratorom zrozumieć lub zarządzać działaniem DKIM. Uwagi zawarte w n= nie są interpretowane przez programy i nie mają wpływu na funkcjonowanie DKIM.
@@ -1101,16 +1101,16 @@ Noty te mogą być przydatne z powodów dokumentacyjnych lub pomóc administrato
 - **Klucz publiczny (base64) (p=)**: używany do wprowadzania danych klucza publicznego DKIM, które są zakodowane w bazie64.<br/>
 Tag ten jest obowiązkowy w podpisze DKIM i umożliwia adresatom podpisu pobranie klucza publicznego niezbędnego do weryfikacji autentyczności podpisanej wiadomości.
 
-- **Odwołaj klucz publiczny**: jeżeli klucz publiczny DKIM został odwołany (np. w przypadku ataku na klucz prywatny), do tagu "p=" należy użyć wartości pustej wskazującej, że ten klucz publiczny przestał być ważny. Adresaci muszą wówczas zwrócić błąd w przypadku każdego podpisu DKIM odnoszącego się do klucza cofniętego.
+- **Odwołaj klucz publiczny**: jeżeli klucz publiczny DKIM został odwołany (np. w przypadku ataku na klucz prywatny), do tagu `p=` należy użyć wartości pustej wskazującej, że ten klucz publiczny przestał być ważny. Adresaci muszą wówczas zwrócić błąd w przypadku każdego podpisu DKIM odnoszącego się do klucza cofniętego.
 
-- **Typ usługi (s=)**: Tagi "s=" (Service Type) są opcjonalne i nie są domyślnie wyświetlane. Pozwala on określić rodzaj usługi lub rodzaje usług, do których ma zastosowanie ten wpis DKIM.<br/>
-Rodzaje usług definiuje się za pomocą listy słów kluczowych oddzielonych dwoma punktami ":".<br/>
+- **Typ usługi (s=)**: Tagi `s=` (Service Type) są opcjonalne i nie są domyślnie wyświetlane. Pozwala on określić rodzaj usługi lub rodzaje usług, do których ma zastosowanie ten wpis DKIM.<br/>
+Rodzaje usług definiuje się za pomocą listy słów kluczowych oddzielonych dwoma punktami `:`.<br/>
 Odbiorca musi zignorować tę rejestrację, jeśli nie został określony odpowiedni rodzaj usługi.<br/>
-Znacznik "s=" ma na celu ograniczenie wykorzystania kluczy do innych celów, w przypadku gdy wykorzystanie DKIM byłoby określone dla innych usług w przyszłości.<br/>
-Typami usług obecnie zdefiniowanymi są: "\*" (wszystkie rodzaje usług), "e-mail" (e-mail).
+Znacznik `s=` ma na celu ograniczenie wykorzystania kluczy do innych celów, w przypadku gdy wykorzystanie DKIM byłoby określone dla innych usług w przyszłości.<br/>
+Typami usług obecnie zdefiniowanymi są: `\*` (wszystkie rodzaje usług), "e-mail" (e-mail).
 
 - **Tryb testowy (t=y)**: umożliwia abonentom domeny przetestowanie wdrożenia DKIM bez ryzyka, że wiadomości odrzucone lub oznaczone jako spam zostaną wykryte w przypadku niepowodzenia weryfikacji podpisu DKIM.<br/>
-W przypadku gdy stosowany jest flag "t=y", odbiorca nie może przetwarzać w inny sposób podpisanych wiadomości w trybie testowym i niepodpisanych komunikatów. Odbiorca może jednak śledzić wynik testu, aby pomóc sygnatariuszom.
+W przypadku gdy stosowany jest flag `t=y`, odbiorca nie może przetwarzać w inny sposób podpisanych wiadomości w trybie testowym i niepodpisanych komunikatów. Odbiorca może jednak śledzić wynik testu, aby pomóc sygnatariuszom.
 
 - **Subdomeny (t=s)**: pozwala na ograniczenie używania podpisu DKIM wyłącznie w nazwie domeny (np.: @mydomain.ovh) lub zezwolić na wysyłkę z nazwy domeny i jej subdomen (na przykład: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.)
 
@@ -1148,7 +1148,7 @@ Zalecamy wysłanie e-maila z konta w Twojej platformie Exchange na adres e-mail,
 
 Oto co możesz znaleźć w nagłówku otrzymanego e-maila:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1157,7 +1157,9 @@ Return-Path: <test-dkim@mydomain.ovh>
 
 Aby pobrać nagłówek wiadomości e-mail, zapoznaj się z naszym przewodnikiem "[Pobierz nagłówek wiadomości](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers)".
 
-## Przykłady zastosowania <a name="usecases"></a>
+### Przykłady zastosowania <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### Jak i dlaczego warto zmienić parę kluczy DKIM? <a name="2selectors"></a>
 
@@ -1195,7 +1197,11 @@ Kliknij na zakładkę odnoszącą się do Twojej oferty.
 
 Po przełączeniu na nowy selektor zachowaj stary przez 7 dni przed usunięciem i utworzeniem nowego.
 
-### Dlaczego DKIM nie działa i jest wyświetlany na czerwono w Panelu klienta? <a name="reddkim"></a>
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
+#### Dlaczego DKIM nie działa i jest wyświetlany na czerwono w Panelu klienta? <a name="reddkim"></a>
 
 :::warning
 To pytanie dotyczy tylko ofert Exchange i E-mail Pro.
@@ -1220,7 +1226,7 @@ Kliknij na poniższą zakładkę odnoszącą się do Twojej oferty, aby sprawdzi
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
     1. Przejdź do sekcji <code className="action">Web Cloud</code>.
-    1. Kliknij <code className="action">Email Pro</code>.
+    1. Kliknij <code className="action">E-mail Pro</code>.
     1. Wybierz odpowiednią platformę.
     1. Na koniec przejdź do zakładki <code className="action">Przypisane domeny</code>.
 
@@ -1268,7 +1274,11 @@ Oto cztery statusy, po których w Panelu klienta wyświetli się czerwona ikona 
   </Tab>
 </Tabs>
 
-### Z poziomu interfejsu API OVHcloud, jak zrozumieć stan DKIM, który nie działa? <a name="api-error"></a>
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
+#### Z poziomu interfejsu API OVHcloud, jak zrozumieć stan DKIM, który nie działa? <a name="api-error"></a>
 
 Jeśli do konfiguracji DKIM używasz API OVHcloud, a DKIM nie działa, zapoznaj się z rubryką "[API - Różne stany DKIM](#dkim-status)" niniejszego przewodnika, aby sprawdzić stan selektorów.
 
@@ -1294,6 +1304,8 @@ Poniżej znajdziesz statusy, które mogą blokować działanie DKIM i odpowiedni
     - `toFix`: selektor został skonfigurowany w strefie DNS domeny, ale wartości są nieprawidłowe. Skorzystaj z [etapu 4 "pełnej konfiguracji DKIM" dla MX Plan i Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Sprawdź również
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Poprawa bezpieczeństwa e-maili dzięki rejestracji DKIM
 description: Dowiedz się, jak skonfigurować rekord DKIM w Twojej nazwy domeny i platformie e-mail OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -23,9 +23,6 @@ Wpis DKIM (**D**omain**K**eys **I**dentified **M**ail) pozwala na podpisanie e-m
 - Zamówienie jednej z poniższych ofert e-mail:
     <Region zones={['eu']}>
     - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](/links/web/hosting), [hosting darmowy](/links/web/domains-free-hosting) lub w ramach oferty MX Plan zamówionej oddzielnie).
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (dostępny w ramach [oferty hostingu](/links/web/hosting) lub w ramach oferty MX Plan zamówionej oddzielnie).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) lub [Private Exchange](/links/web/emails-hosted-exchange).
@@ -66,7 +63,9 @@ Jeśli Twoja domena jest zarejestrowana w OVHcloud, możesz sprawdzić, czy uży
     - [Dlaczego trzeba skonfigurować serwery DNS?](#dns-and-dkim)
     - [Przykład e-maila wysłanego z wykorzystaniem DKIM](#example)
     - [Co to jest selekcja DKIM?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Automatyczna konfiguracja DKIM dla oferty e-mail OVHcloud](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Konfiguracja DKIM przez API dla oferty e-mail OVHcloud](#internal-dkim)
 </Region>
@@ -175,15 +174,14 @@ Odbiorca **recipient@otherdomain.ovh** będzie mógł odszyfrować ten podpis kl
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Automatyczna konfiguracja DKIM dla oferty e-mail OVHcloud <a name="auto-dkim"></a>
 
 Automatyczna konfiguracja DKIM jest dostępna dla wszystkich naszych ofert e-mail:
 
 <Region zones={['eu']}>
 - MX Plan wchodzący w skład [hostingu](/links/web/hosting), [hostingu darmowego](/links/web/domains-free-hosting) lub zamówiony osobno.
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan wchodzący w skład [hostingu](/links/web/hosting) lub zamówiony osobno.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange).
@@ -202,7 +200,7 @@ Jeśli DKIM nie został włączony podczas dodawania domeny do Twojej platformy 
 Kliknij na zakładkę poniżej odpowiadającą Twojej ofercie.
 
 <ZoneTabs>
-  <Tab label="MX Plan">
+  <Tab label="MX Plan" availableIn={['eu']}>
     1. Zaloguj się do <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>.
     1. Przejdź do sekcji <code className="action">Web Cloud</code>.
     1. Kliknij <code className="action">MX Plan</code>.
@@ -279,13 +277,15 @@ Kliknij na zakładkę poniżej odpowiadającą Twojej ofercie.
 Automatyczna aktywacja DKIM trwa od 30 minut do maksymalnie 24 godzin. Aby sprawdzić, czy Twój DKIM działa poprawnie, wróć do sekcji zarządzania domeną, jak w powyższych zakładkach, i sprawdź, czy guzik `DKIM` jest zielony, lub, w przypadku oferty Zimbra, czy zakładka `DKIM` nie zawiera już ikony ostrzeżenia.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 Automatyczna aktywacja DKIM trwa od 30 minut do maksymalnie 24 godzin. Aby sprawdzić, czy Twój DKIM działa poprawnie, wróć do sekcji zarządzania domeną, jak w powyższych zakładkach, i sprawdź, czy guzik `DKIM` jest zielony.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Po upływie 24 godzin, jeśli Twój przycisk `DKIM` jest czerwony, zapoznaj się z rubryką ["Dlaczego DKIM nie działa i wyświetla się w Panelu klienta na czerwono?"](#reddkim) niniejszego przewodnika.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Konfiguracja DKIM przez API dla oferty e-mail OVHcloud <a name="internal-dkim"></a>

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -152,7 +152,7 @@ Para que este princípio de rotação funcione, vamos utilizar o que chamamos os
 
 **Exemplo de uma parte de assinatura DKIM**
 
-```
+```text
 DKIM-Signature: v=1; a=rsa-sha256; d=mydomain.ovh; s=ovhex123456-selector1; c=relaxed/relaxed; t=1681877341;
 ```
 
@@ -238,7 +238,7 @@ Clique no separador seguinte da sua oferta.
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Aceda à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
     1. Aceda à secção <code className="action">Web Cloud</code>.
-    1. Clique em <code className="action">Email Pro</code>.
+    1. Clique em <code className="action">E-mail Pro</code>.
     1. Selecione a plataforma em causa.
     1. Por fim, aceda ao separador <code className="action">Domínios associados</code>.
 
@@ -316,7 +316,7 @@ Clique no separador abaixo correspondente à sua oferta.
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Aceda à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
     1. Aceda à secção <code className="action">Web Cloud</code>.
-    1. Clique em <code className="action">Email Pro</code>.
+    1. Clique em <code className="action">E-mail Pro</code>.
     1. Selecione a plataforma em causa.
 
     Por predefinição, o nome da plataforma corresponde à sua referência ou esta será visível sob o nome que lhe atribuiu (ver imagem abaixo).
@@ -1082,17 +1082,17 @@ selector-name._domainkey.mydomain.ovh.
 O quadro **Vista geral do registo** mostra o registo resultante à medida que preenche o formulário. Se precisar de uma tag DKIM que o formulário não apresenta (por exemplo `g=`, `n=` ou `s=`), adicione o registo como um [registo TXT](#txt-record) ou utilize o <code className="action">Modo de edição avançado</code>.
 
 - **Versão (v=)**: serve para indicar a versão do DKIM. Recomenda-se a sua utilização e o seu valor predefinido é `DKIM1`.<br/>
-Se especificado, esta etiqueta deve ser colocada em primeiro lugar no registo e deve ser igual a "DKIM1" (sem as aspas). Os registos que comecem com uma tag "v=" com outro valor devem ser ignorados.
+Se especificado, esta etiqueta deve ser colocada em primeiro lugar no registo e deve ser igual a "DKIM1" (sem as aspas). Os registos que comecem com uma tag `v=` com outro valor devem ser ignorados.
 
 - **Granularidade (g=)**: permite especificar a parte "local-part" de um endereço de e-mail, ou seja, a parte situada antes de "@".<br/>
 Permite especificar o endereço de e-mail ou os endereços de e-mail que estão autorizados a assinar uma mensagem eletrónica com a chave DKIM do seletor.<br/>
-O valor predefinido de "g=" é "\*", o que significa que todos os endereços de e-mail estão autorizados a utilizar a chave de assinatura DKIM.<br/>
-Ao indicar um valor específico para "g=", pode limitar-se a utilização da chave a uma parte local de um endereço de e-mail específico ou a um intervalo de endereços de e-mail específicos, utilizando caracteres genéricos (por exemplo: "\*-group").
+O valor predefinido de `g=` é `\*`, o que significa que todos os endereços de e-mail estão autorizados a utilizar a chave de assinatura DKIM.<br/>
+Ao indicar um valor específico para `g=`, pode limitar-se a utilização da chave a uma parte local de um endereço de e-mail específico ou a um intervalo de endereços de e-mail específicos, utilizando caracteres genéricos (por exemplo: `\*-group`).
 
 - **Algoritmo (hash) (h=)**: permite especificar os algoritmos de triagem utilizados para assinar os cabeçalhos de e-mail. Esta baliza permite definir uma lista de algoritmos de picadura que serão utilizados para gerar uma assinatura DKIM para uma determinada mensagem.
 
 - **Tipo de chave (k=)**: especificar o algoritmo de assinatura utilizado para assinar as mensagens eletrónicas saídas. Permite aos destinatários saber como a mensagem foi assinada e qual o método utilizado para verificar a sua autenticidade.<br/>
-Os valores possíveis para a tag "k=" incluem "rsa" para o algoritmo de assinatura RSA e "ed25519" para o algoritmo de assinatura Ed25519. A escolha do algoritmo depende da política de segurança do remetente e da tomada a cargo pelo destinatário.
+Os valores possíveis para a tag `k=` incluem `rsa` para o algoritmo de assinatura RSA e `ed25519` para o algoritmo de assinatura Ed25519. A escolha do algoritmo depende da política de segurança do remetente e da tomada a cargo pelo destinatário.
 
 - **Notas (n=)**: serve para incluir notas de interesse para os administradores que gerem o sistema de chaves DKIM.<br/>
 Estas notas podem ser úteis por razões de documentação ou para ajudar os administradores a compreender ou a gerir o funcionamento da DKIM. As notas incluídas em n= não são interpretadas pelos programas nem afetam o funcionamento do DKIM.
@@ -1100,16 +1100,16 @@ Estas notas podem ser úteis por razões de documentação ou para ajudar os adm
 - **Chave pública (base64) (p=)**: utilizada para introduzir os dados de chave pública DKIM, que são codificados na base64.<br/>
 Esta etiqueta é obrigatória na assinatura DKIM e permite aos destinatários da assinatura recuperar a chave pública necessária para verificar a autenticidade da mensagem assinada.
 
-- **Revogar a chave pública**: se uma chave pública DKIM tiver sido revogada (por exemplo, em caso de comprometimento da chave privada), deve ser utilizado um valor vazio para a etiqueta "p=", indicando que esta chave pública deixou de ser válida. Os destinatários devem, então, enviar um erro para qualquer assinatura DKIM que faça referência a uma chave revogada.
+- **Revogar a chave pública**: se uma chave pública DKIM tiver sido revogada (por exemplo, em caso de comprometimento da chave privada), deve ser utilizado um valor vazio para a etiqueta `p=`, indicando que esta chave pública deixou de ser válida. Os destinatários devem, então, enviar um erro para qualquer assinatura DKIM que faça referência a uma chave revogada.
 
-- **Tipo de serviço (s=)**: A localização "s=" (Service Type) é opcional e não está presente por predefinição. Permite especificar o(s) tipo(s) de serviços aos quais se aplica este registo DKIM.<br/>
-Os tipos de serviços são definidos utilizando uma lista de palavras-chave separadas por dois pontos ":".<br/>
+- **Tipo de serviço (s=)**: A localização `s=` (Service Type) é opcional e não está presente por predefinição. Permite especificar o(s) tipo(s) de serviços aos quais se aplica este registo DKIM.<br/>
+Os tipos de serviços são definidos utilizando uma lista de palavras-chave separadas por dois pontos `:`.<br/>
 O destinatário deve ignorar este registo se o tipo de serviço adequado não estiver registado.<br/>
-A baliza "s=" destina-se a restringir a utilização das chaves para outros fins, no caso de a utilização do DKIM ser definida para outros serviços no futuro.<br/>
-Os tipos de serviços atualmente definidos são "\*" (todos os tipos de serviços), "e-mail" (correio eletrónico).
+A baliza `s=` destina-se a restringir a utilização das chaves para outros fins, no caso de a utilização do DKIM ser definida para outros serviços no futuro.<br/>
+Os tipos de serviços atualmente definidos são `\*` (todos os tipos de serviços), "e-mail" (correio eletrónico).
 
-- **Modo de teste (t=y)**: permite aos titulares do domínio testar a implementação do DKIM sem correr o risco de ver as mensagens rejeitadas ou marcadas como SPAM se a verificação de assinatura DKIM falhar.<br/>
-Quando se utiliza a flag "t=y", o destinatário não deve tratar de forma diferente as mensagens assinadas em modo de teste e as mensagens não assinadas. No entanto, o destinatário pode seguir o resultado do método de teste para ajudar os signatários.
+- **Modo de teste (t=y)**: permite aos titulares do domínio testar a implementação do DKIM sem correr o risco de ver as mensagens rejeitadas ou marcadas como spam se a verificação de assinatura DKIM falhar.<br/>
+Quando se utiliza a flag `t=y`, o destinatário não deve tratar de forma diferente as mensagens assinadas em modo de teste e as mensagens não assinadas. No entanto, o destinatário pode seguir o resultado do método de teste para ajudar os signatários.
 
 - **Subdomínios (t=s)**: permite restringir a utilização da assinatura DKIM apenas ao nome de domínio (por exemplo: @mydomain.ovh) ou permitir o envio a partir do nome de domínio e dos seus subdomínios (por exemplo: @mydomain.ovh, @test.mydomain.ovh, @other.mydomain.ovh, etc.).
 
@@ -1147,7 +1147,7 @@ Aconselhamos que envie um e-mail a partir de uma conta da sua plataforma Exchang
 
 Pode consultar o cabeçalho do e-mail recebido:
 
-```
+```text
 ARC-Authentication-Results: i=1; mx.example.com;
        dkim=pass header.i=@mydomain.ovh header.s=ovhex123456-selector1 header.b=KUdGjiMs;
        spf=pass (example.com: domain of test-dkim@mydomain.ovh designates 54.36.141.6 as permitted sender) smtp.mailfrom=test-dkim@mydomain.ovh
@@ -1157,6 +1157,8 @@ Return-Path: <test-dkim@mydomain.ovh>
 Para obter o cabeçalho de um e-mail, consulte o nosso manual "[Obter o cabeçalho de um e-mail](/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/diagnostic-headers)".
 
 ### Casos de utilização <a name="usecases"></a>
+
+<Region zones={['eu', 'ca']}>
 
 #### Como e porquê alterar o par de chaves DKIM? <a name="2selectors"></a>
 
@@ -1194,6 +1196,10 @@ Clique no separador seguinte da sua oferta.
 
 Depois de passar para o novo seletor, mantenha o antigo durante 7 dias antes de o eliminar e de criar um novo.
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### Porque é que o DKIM não está funcional e aparece a vermelho na Área de Cliente? <a name="reddkim"></a>
 
 :::warning
@@ -1219,7 +1225,7 @@ Clique no separador abaixo correspondente à sua oferta para verificar o estado 
   <Tab label="E-mail Pro" availableIn={['eu']}>
     1. Aceda à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
     1. Aceda à secção <code className="action">Web Cloud</code>.
-    1. Clique em <code className="action">Email Pro</code>.
+    1. Clique em <code className="action">E-mail Pro</code>.
     1. Selecione a plataforma em causa.
     1. Por fim, aceda ao separador <code className="action">Domínios associados</code>.
 
@@ -1267,6 +1273,10 @@ Eis os 4 estados que têm por resultado o ícone DKIM a vermelho na sua Área de
   </Tab>
 </Tabs>
 
+</Region>
+
+<Region zones={['eu', 'ca']}>
+
 #### A partir da interface API OVHcloud, como compreender o estado do DKIM que não funciona? <a name="api-error"></a>
 
 Se utilizar as API da OVHcloud para configurar o seu DKIM e este não estiver funcional, consulte a secção "[API - Os diferentes estados do DKIM](#dkim-status)" deste guia para identificar o estado dos seus seletores.
@@ -1293,6 +1303,8 @@ Abaixo irá encontrar os estados que podem bloquear o funcionamento do seu DKIM 
     - `toFix`: o seletor foi corretamente configurado na zona DNS do domínio, mas os valores estão incorretos. Pressione [etapa 4 "configuração completa do DKIM" para MX Plan e Zimbra](#confemail).
   </Tab>
 </ZoneTabs>
+
+</Region>
 
 ## Saiba mais
 

--- a/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-dkim.mdx
@@ -1,7 +1,7 @@
 ---
 title: Melhorar a segurança dos e-mails através do registo DKIM
 description: Saiba como configurar um registo DKIM no seu nome de domínio e na sua plataforma de e-mail OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -22,9 +22,6 @@ O registo DKIM (**D**omain**K**eys **I**dentified **M**ail) permite assinar os e
 - Ter adquirido uma das ofertas de correio eletrónico abaixo:
     <Region zones={['eu']}>
     - MX Plan OVHcloud (disponível através de uma [oferta de alojamento web](/links/web/hosting), um [alojamento gratuito](/links/web/domains-free-hosting) ou uma oferta MX Plan encomendada separadamente).
-    </Region>
-    <Region zones={['ca', 'apac']}>
-    - MX Plan OVHcloud (disponível através de uma [oferta de alojamento web](/links/web/hosting) ou uma oferta MX Plan encomendada separadamente).
     </Region>
     <Region zones={['eu', 'ca']}>
     - [Exchange](/links/web/emails-hosted-exchange) ou [Private Exchange](/links/web/emails-hosted-exchange).
@@ -65,7 +62,9 @@ Se o seu nome de domínio estiver registado na OVHcloud, pode verificar se este 
     - [Porque é que precisamos de configurar os servidores DNS?](#dns-and-dkim)
     - [Exemplo de um e-mail enviado utilizando o DKIM](#example)
     - [O que é um seletor DKIM?](#selector)
+<Region zones={['eu', 'ca']}>
 - [Configurar o DKIM automaticamente para uma oferta de correio eletrónico OVHcloud](#auto-dkim)
+</Region>
 <Region zones={['eu', 'ca']}>
 - [Configurar o DKIM através da API para uma oferta de correio eletrónico OVHcloud](#internal-dkim)
 </Region>
@@ -174,15 +173,14 @@ O destinatário **recipient@otherdomain.ovh** poderá decifrar esta assinatura c
 
 </details>
 
+<Region zones={['eu', 'ca']}>
+
 ### Configurar o DKIM automaticamente para uma oferta de correio eletrónico OVHcloud <a name="auto-dkim"></a>
 
 A configuração automática do DKIM está disponível para todas as nossas ofertas de correio eletrónico:
 
 <Region zones={['eu']}>
 - MX Plan incluída com um [alojamento web](/links/web/hosting), um [alojamento gratuito](/links/web/domains-free-hosting) ou adquirida separadamente.
-</Region>
-<Region zones={['ca', 'apac']}>
-- MX Plan incluída com um [alojamento web](/links/web/hosting) ou adquirida separadamente.
 </Region>
 <Region zones={['eu', 'ca']}>
 - [Exchange](/links/web/emails-exchange).
@@ -201,7 +199,7 @@ Se o DKIM não foi ativado quando adicionou um nome de domínio à sua plataform
 Clique no separador seguinte da sua oferta.
 
 <ZoneTabs>
-  <Tab label="MX Plan">
+  <Tab label="MX Plan" availableIn={['eu']}>
     1. Aceda à <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>.
     1. Aceda à secção <code className="action">Web Cloud</code>.
     1. Clique em <code className="action">MX Plan</code>.
@@ -278,13 +276,15 @@ Clique no separador seguinte da sua oferta.
 A ativação automática do DKIM dura entre 30 minutos e 24 horas no máximo. Para verificar que o seu DKIM está funcional, basta voltar à rubrica de gestão do domínio mencionada nos separadores acima e verificar que o botão `DKIM` está verde ou, para uma oferta Zimbra, que o separador `DKIM` não apresenta mais o ícone de aviso.
 </Region>
 
-<Region zones={['ca', 'apac']}>
+<Region zones={['ca']}>
 A ativação automática do DKIM dura entre 30 minutos e 24 horas no máximo. Para verificar que o seu DKIM está funcional, basta voltar à rubrica de gestão do domínio mencionada nos separadores acima e verificar que o botão `DKIM` está verde.
 </Region>
 
 <img className="thumbnail" alt="email" src="/images/assets/screens/control-panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dkim-auto03.png" loading="lazy" />
 
 Se a etiqueta `DKIM` for vermelha após 24 horas, consulte a secção "[Porque é que o DKIM não está funcional e aparece a vermelho na Área de Cliente?](#reddkim)" deste guia.
+
+</Region>
 
 <Region zones={['eu', 'ca']}>
 ### Configurar o DKIM através da API para uma oferta de correio eletrónico OVHcloud <a name="internal-dkim"></a>


### PR DESCRIPTION
Customer feedback (onegate, 2026-04-21 ): the guide offers automatic DKIM configuration for **MX Plan in Canada**, where it does not exist.

## Root cause

DKIM for MX Plan is served **only** by the `/email/domain` API. That API is Europe-only.

| Source | Europe | Canada |
|---|---|---|
| `/email/domain` — carries `/dkim`, `/dkim/enable`, `/dkim/disable` | 77 endpoints | **0 — the API does not exist** |
| `/email/mxplan` | 27 endpoints, **no DKIM** | 27 endpoints, **no DKIM** |
| `email.mxplan.Domain` model | no DKIM field | no DKIM field |

The customer is right: automatic DKIM for MX Plan is unavailable outside Europe.

> [!NOTE]
> The `emailpro` Manager module does have a `dkim-autoconfig`, which looks like a contradiction at first glance. It serves Email Pro, not MX Plan.

## What was wrong

- The **MX Plan tab had no zone gating at all** — it rendered in all three zones, while Exchange, Email Pro and Zimbra were already gated.
- Two bullets **explicitly claimed MX Plan eligibility in CA/APAC**: one in the requirements, one in the offer list.
- Found while fixing the above: once MX Plan is gated, **APAC has no eligible OVHcloud offer left** — Exchange, Email Pro and Zimbra are already excluded there. APAC readers would have seen a heading, an intro sentence and an empty tab container, since `ZoneTabs` renders its wrapper even with no applicable tab.

## What this PR does

Applied to the **7 locales**:

- the MX Plan tab of the automatic configuration section is now **Europe only**;
- both CA/APAC bullets claiming MX Plan eligibility are **removed**;
- the **whole automatic configuration section, and its table-of-contents entry**, are restricted to Europe and Canada — matching the API section, which was already gated that way;
- the activation-delay paragraph now targets **Canada only**.

## Result per zone

| Zone | Sections | Offers listed | Automatic DKIM section |
|---|---|---|---|
| **Europe** | 11 | MX Plan, Exchange, Email Pro, Zimbra | shown, unchanged |
| **Canada** | 11 | Exchange | shown, Exchange only |
| **APAC** | 9 | non-OVHcloud solution | **hidden** |

APAC readers keep what actually applies to them: manual DKIM configuration for a non-OVHcloud email solution, the DKIM tests and the use cases.

## Validation

- `content:lint` passes
- `build:fr` passes, no dead link
- rendered output **simulated for each of the three zones**
- `<Region>` tag balance unchanged (25/25 per locale, 23/23 in German) and file length identical — only the gating moved

<details>
<summary><b>Out of scope — four pre-existing mentions still visible outside their zone</b></summary>

In the use-cases section, three `Exchange and Email Pro solutions` callouts and one cross-reference to the API section remain visible in CA/APAC. That cross-reference is a **dead link in APAC**, where the API section is hidden.

The API section was already gated `['eu', 'ca']` before this PR, so these are **not regressions introduced here**. Happy to fix them in this branch or in a separate ticket — your call.

</details>
