### PR TITLE
fix(docs): describe AI & ML screenshots in alt text, repair go-operator callout

### DIFF
--- a/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/de/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,15 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 If this kind of errors occurs:
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-access-data.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-access-data.mdx
@@ -41,7 +41,7 @@ You can read the [Getting started](/guides/public-cloud/ai-machine-learning/ai-c
 
 You should get a page like this, showing your dataset in the file explorer:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-17-how-to-cli-data-notebooks/jupyterlab_with_dataset.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab file browser showing the datasets folder mounted in the notebook alongside the Launcher tab" src="/images/public-cloud/ai-machine-learning/cli-17-how-to-cli-data-notebooks/jupyterlab_with_dataset.png" loading="lazy" />
 
 You will not be able to modify the dataset from this notebook because you loaded it with read-only permissions.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-install-client.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-install-client.mdx
@@ -80,7 +80,7 @@ You have the choice between two methods to log in:
 -   terminal: you can authenticate yourself from within the terminal.
 -   browser: you will reach an authentication page similar to this:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-10-howto-install-cli/00_oauth2_login.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Login page with the User Name and Password fields and the Connect button" src="/images/public-cloud/ai-machine-learning/cli-10-howto-install-cli/00_oauth2_login.png" loading="lazy" />
 
 Use the credentials of your **AI Training** user to log in.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook.mdx
@@ -265,7 +265,7 @@ Status:
 
 Now that the notebook is in the `RUNNING` state, a https address is defined in the `Url` field. This `URL` corresponds to your JupyterLab server. Pasting this `URL` in your browser displays the following screen:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-11-howto-run-notebook-cli/jupyterlab_home_page.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab Launcher home page offering Notebook Console and Other sections with Python 3 Terminal and Text File tiles" src="/images/public-cloud/ai-machine-learning/cli-11-howto-run-notebook-cli/jupyterlab_home_page.png" loading="lazy" />
 
 You can now start writing code in your notebook. Since we used the PyTorch framework in our example, we will be able to use it without having to install anything ourselves.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-sharing-notebooks.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-cli-sharing-notebooks.mdx
@@ -188,12 +188,12 @@ Wait a few seconds for the notebook to be in the `RUNNING` state.
 The `Url` field corresponds to the address to paste in your browser to access the notebook.
 If you're already logged in with your browser, then it will display the notebook. Otherwise, you will get a page like this:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_page.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Login page showing an unauthorized error above the User Name and Password fields with a Login with token link" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_page.png" loading="lazy" />
 
 You can try in a private navigation window to get the login page and test the token.
 Clicking on `Login with token` leads to this page:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_token_page.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Login page in token mode showing an unauthorized error above the Token field with a Login with user/password link" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_token_page.png" loading="lazy" />
 
 Paste the token we created earlier into the text box and click on `Connect`. You should now see your notebook.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-data.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-data.mdx
@@ -29,7 +29,7 @@ There are two ways to manage your data:
 2.  At the job start, the volume is attached inside the wanted directory. Data is then available inside the job as long as the `RUNNING` phase lasts.
 3.  After the job stop, data is synchronized back **from** the underlying filesystem volume **into** the **OVHcloud Object Storage**. This synchronization is done during the `FINALIZING` phase.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_job.svg" loading="lazy" />
+<img className="thumbnail" alt="Diagram of the job data phases showing data synchronization from OBJECT STORE to VOLUME while INITIALIZING then filesystem interactions between VOLUME and JOB while RUNNING then synchronization back to OBJECT STORE while FINALIZING" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_job.svg" loading="lazy" />
 
 ### AI Notebooks
 
@@ -39,7 +39,7 @@ There are two ways to manage your data:
 
 This applies to your internal [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) and remote object storage volumes.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_notebook.svg" loading="lazy" />
+<img className="thumbnail" alt="Diagram of the notebook data phases showing data synchronization from OBJECT STORE to VOLUME while STARTING then filesystem interactions between VOLUME and NOTEBOOK while RUNNING then synchronization back to OBJECT STORE while STOPPING" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_notebook.svg" loading="lazy" />
 
 ## Capabilities
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-apps-deployments.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-apps-deployments.mdx
@@ -205,7 +205,7 @@ You can also modify the scaling strategy after the app has been created using th
   <Tab label="Using the Control Panel (UI)">
     To modify scaling strategies through the UI, navigate to your application details page by clicking on its name in the AI Deploy section. On this page, you will find general information about your application, including a **Resources** section.
     
-    ![image](/images/public-cloud/ai-machine-learning/deploy-guide-04-scaling-strategies/update-autoscaling-1.png)
+    <img className="thumbnail" alt="Dashboard of the my-app AI Deploy app with the Resources panel highlighted showing Automatic scaling with minimum replicas 1 maximum replicas 5 metric monitored CPU and trigger threshold 75%" src="/images/public-cloud/ai-machine-learning/deploy-guide-04-scaling-strategies/update-autoscaling-1.png" loading="lazy" />
     
     In this window, click the <code className="action">Edit</code> button to access scaling configuration options. This will open an **Update application scaling** window where you can:
     - Switch between auto scaling and static scaling

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-apps.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-apps.mdx
@@ -47,7 +47,7 @@ Only the `RUNNING` and `SCALING` time of the app **is billed**. For more informa
 - `DELETING`: The app is being removed.
 - `DELETED`: The app is fully deleted.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-09-concepts-apps/apps_concept.svg" loading="lazy" />
+<img className="thumbnail" alt="State diagram of an AI Deploy app with transitions between QUEUED INITIALIZING SCALING RUNNING STOPPING STOPPED DELETING FAILED ERROR and DELETE" src="/images/public-cloud/ai-machine-learning/deploy-guide-09-concepts-apps/apps_concept.svg" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-billing.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-billing.mdx
@@ -37,7 +37,7 @@ During its lifetime, the app will go through the following status:
 - `DELETING`: The app is being removed. When it is deleted, you will no longer see it, it will no longer exist.
 - `DELETED`: The app is fully deleted.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Timeline of the AI Deploy app lifecycle from Launch through Queued Initializing Scaling Running Standby Stopping and Stopped to Delete with CPU/GPU not billed outside the Running phase and remote data billed at Object Storage pricing" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.lifecycle.png" loading="lazy" />
 
 ## Billing principles
 
@@ -61,7 +61,7 @@ We **do not provide** a pay-per-call pricing so far.
 
 Here is a detailed graph that illustrates every step that is billed or not during the AI Deploy workflow:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.billing.png" loading="lazy" />
+<img className="thumbnail" alt="Timeline of the AI Deploy app lifecycle from Launch to Delete annotated under each phase with what happens and what is billed including compute resources allocated per replica during Running and ephemeral data lost once Stopped" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.billing.png" loading="lazy" />
 
 ### Compute resources details
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-custom-image.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-custom-image.mdx
@@ -44,7 +44,7 @@ Inside your Docker image, you are free to install almost anything and everything
 
 AI Deploy accepts images from **public** or **private** repositories. In short, we can summarize AI deploy with the following schema:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/ai_deploy_concept.png" loading="lazy" />
+<img className="thumbnail" alt="Three-step diagram containerize your AI models or web app with frameworks such as Flask FastAPI Streamlit TensorFlow gradio and PyTorch then push the Docker image to a public or private registry then deploy in a few seconds with AI Deploy offering an HTTP endpoint CPU and GPU nodes high availability easy scaling secure authentication Object Storage access and monitoring" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/ai_deploy_concept.png" loading="lazy" />
 
 ## Guidelines to follow
 
@@ -309,7 +309,7 @@ docker push my-registry.ai.cloud.ovh.net/custom-image:latest
 
 If you want to know the exact commands to push on the shared registry, please consult the <code className="action">Details</code> button of the **Shared Docker Registry** section in the **Home** panel of AI Training.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/shared_registry_details.png" loading="lazy" />
+<img className="thumbnail" alt="AI Training Home tab Information panel listing Shared Docker Registry and OVHcloud AI Training command line interface each with a Details button" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/shared_registry_details.png" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-flask-image.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-flask-image.mdx
@@ -185,7 +185,7 @@ Consider adding the `--unsecure-http` attribute if you want your application to 
 
 Once the app is running you can access your Flask application directly from the app's URL.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-02-flask/flask-app.png" loading="lazy" />
+<img className="thumbnail" alt="Browser page displaying the text Web App with Python Flask using AI Training" src="/images/public-cloud/ai-machine-learning/deploy-tuto-02-flask/flask-app.png" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-streamlit-image.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-streamlit-image.mdx
@@ -193,7 +193,7 @@ Consider adding the `--unsecure-http` attribute if you want your application to 
 
 Once the AI Deploy app is running you can access your Streamlit application directly from the app's URL.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-01-streamlit/streamlit.png" loading="lazy" />
+<img className="thumbnail" alt="Streamlit app titled My first app showing a four-row table with first column and second column values and a line chart of three series a b and c" src="/images/public-cloud/ai-machine-learning/deploy-tuto-01-streamlit/streamlit.png" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-getting-started.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-getting-started.mdx
@@ -308,7 +308,7 @@ You have the flexibility to keep your AI Deploy app running for an indefinite pe
   <Tab label="Using the Control Panel (UI)">
     Click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then select the <code className="action">AI Deploy</code> section. Locate the specific AI Deploy app you want to stop. Click the <code className="action">...</code> button and stop your AI Deploy application by selecting <code className="action">Stop</code> from the context menu.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-02-getting-started/step-11-stop-app.png" loading="lazy" />
+    <img className="thumbnail" alt="AI Deploy page in the OVHcloud Control Panel with the my-model-api app In service and the Stop entry highlighted in its actions menu" src="/images/public-cloud/ai-machine-learning/deploy-guide-02-getting-started/step-11-stop-app.png" loading="lazy" />
 
 Once stopped, your AI Deploy app will free up the previously allocated compute resources. Your endpoint is kept and if you restart your AI Deploy app, the same endpoint can be reused seamlessly.
     Also, when you stop your app, you no longer book compute resources which means you don't have expenses for this part. Only expenses for attached storage may occur.

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-load-test-app.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-load-test-app.mdx
@@ -185,7 +185,7 @@ Once your `locustfile.py` is ready, open the Locust web interface on `[http://yo
 
 The web interface should look as below:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust.png" loading="lazy" />
+<img className="thumbnail" alt="Locust web interface Start new load test form with the Number of users Spawn rate and Host fields and the Start swarming button with status READY" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust.png" loading="lazy" />
 
 ### Run your load tests
 
@@ -201,11 +201,11 @@ Launch the test.
 
 At the end of the load test, you will see this quick summary: 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/result_locust.png" loading="lazy" />
+<img className="thumbnail" alt="Locust Statistics tab showing the POST /spam_detection_path row with 128060 requests 53 fails a median of 260 ms an average of 442 ms a maximum of 7477 ms and 805.7 requests per second with 0% failures" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/result_locust.png" loading="lazy" />
 
 If we want to get more details about our test, we can see the graphs provided by Locust in the `charts` tab. Here is what we can see:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust_graphs.png" loading="lazy" />
+<img className="thumbnail" alt="Locust Charts tab showing Total Requests per Second climbing in steps to about 800 with no failures and Response Times rising to about 2500 ms at the 95th percentile while the median stays low" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust_graphs.png" loading="lazy" />
 
 We deployed this API from 1 to 5 replicas, with 1 CPU for each of them, completed with auto-scaling. We can see that our API has been a bit overloaded. Indeed, with the graphics or with the quick summary, we can see some failures. These failures are due to server errors. We may suppose that we reached some hardware limits at some point, for example before scaling to a greater amount of replicas.
 
@@ -226,24 +226,24 @@ This dashboard is provided for free in AI Deploy, for each deployed application.
 
 You can select the deployed app at the top of this Grafana dashboard, as shown below: 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/general_dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana App Monitoring dashboard with the app selector at the top and Resource usage panels for GPU Usage GPU Memory Usage CPU Usage Memory Usage Network Usage Ephemeral storage usage Volumes Total Size Volumes Total File Count and an HTTP section" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/general_dashboard.png" loading="lazy" />
 
 With this dashboard, you can see the percentage of CPU used in real time, the HTTP latency of your API, the autoscaling of the app, network bandwidth and more. 
 Vertical blue bars show scaling events.
 
 Here is the result for the CPU load, overall (all replicas combined): 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/cpu_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana Resource usage panels during the load test with CPU Usage peaking near 60% then falling back and Memory Usage Network Usage and Ephemeral storage usage panels alongside with vertical blue bars marking scaling events" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/cpu_spam.png" loading="lazy" />
 
 We can see that our app has scaled a few times and hasn't reach maximum capacity usage, thanks to autoscaling. Let's now take a look at the latency of our application:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/latency_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana Volumes and HTTP panels with HTTP Call Latency at the 95th percentile plateauing around 750 ms then peaking above 1.5 s and HTTP Call Count rising to about 280 calls before dropping back to zero" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/latency_spam.png" loading="lazy" />
 
 Here we see that the latency has increased gradually, since we have a spawn rate of two new users per second. API latency was stable with approximately 750ms then peaked to 1.5s. 
 
 Again, interpretation will depend on your needs. Do we need to provide more CPU because the latency is too high? This question will vary depending on your customers need. For an anti-spam, adding 1 second is quite big for a company receiving thousands of mails per day, not so disturbing if it's a dozen per day. Let's now take a look at the scaling of our application:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/scaling_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana Auto-scaling panels showing Running replicas rising from 1 to 4 against a maximum of 5 a Usage target of 75% and per-replica CPU Usage and Memory Usage curves for replicas 9nwqj d2dwf dtz8c and zd2ln" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/scaling_spam.png" loading="lazy" />
 
 We can see that the threshold has been capped at 75% for the autoscaling and this has been respected. On the 5 replicas provided to the application, 4 have been used. 
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-openai-whisper.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-openai-whisper.mdx
@@ -101,7 +101,7 @@ You can create your Object Storage bucket using either the UI (OVHcloud Control 
     
     Then, select the <code className="action">Object Storage</code> section (in the Storage category) and create a new object container by clicking <code className="action">Storage</code> > <code className="action">Object Storage</code> > <code className="action">Create an object container</code>.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-17-streamlit-whisper/new-object-container.png" loading="lazy" />
+    <img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/deploy-tuto-17-streamlit-whisper/new-object-container.png" loading="lazy" />
 
 You can create the bucket that will store your Whisper model. Select the container *type* and the *datastore_alias* that match your needs, and name it as you wish. *`GRA` alias and `whisper-model` name will be used in this tutorial.*
   </Tab>

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -25,7 +25,7 @@ This tutorial's objectives are:
 
 Here is a schema to explain how it works:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/diagramme.png" loading="lazy" />
+<img className="thumbnail" alt="Diagram of the exchange between the user the Flask app running with AI Deploy on port 5000 and the Rasa model running with AI Deploy on port 5005 numbered say hello then request response for hello then send response hello you then write hello you" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/diagramme.png" loading="lazy" />
 
 ## Requirements
 
@@ -262,7 +262,7 @@ That's it! On the URL of this app, you can speak to your chatbot. Try to have a 
 
 Here is an example of a discussion with the chatbot:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/result.jpg" loading="lazy" />
+<img className="thumbnail" alt="Two chatbot conversation windows where the assistant greets the user then asks about their housing and transport and finally summarizes the entered values as appartment rer on site" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/result.jpg" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-tokens.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-tokens.mdx
@@ -75,7 +75,7 @@ If your app is already deployed, you can still add or update labels at any time 
   <Tab label="Using the Control Panel (UI)">
     Navigate to the **AI Deploy** section where all your apps are listed. **Click the name of your app** to open its details page. Locate the **Labels** section. Enter the key-value pair and click <code className="action">+</code> to add the label to your app.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-03-tokens/03-app-add-label-existing-app.png" loading="lazy" />
+    <img className="thumbnail" alt="Dashboard of the hello-world-clear-cronin app with the Labels panel highlighted showing the key team the value ml-engineering and an existing group = A label" src="/images/public-cloud/ai-machine-learning/deploy-guide-03-tokens/03-app-add-label-existing-app.png" loading="lazy" />
 
 After saving, the added label will be visible in the **Labels** section of the app details. 
   </Tab>

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-update-custom-docker-image.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-update-custom-docker-image.mdx
@@ -10,7 +10,7 @@ In order to be launched, our AI Deploy application **has to be containerised**, 
 
 While our app is running, it is likely that we will have to **update our Docker image** to correct or bring new features. That is why we will understand in this tutorial **how to make our app use the updated version of our Docker image**. 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/update_docker_img_deploy.svg" loading="lazy" />
+<img className="thumbnail" alt="Diagram of using an updated Docker image in a deployed app showing tag and push to the image registry then ovhai app set-image to update the image then stop and restart the app so AI Deploy pulls the updated image" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/update_docker_img_deploy.svg" loading="lazy" />
 
 ## Requirements
 
@@ -74,7 +74,7 @@ However, if we **stop and restart** the app, the image used will be the one indi
 
 This stop & restart operation can be performed from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> (UI) by clicking the `...` button, next to your app, as shown on the screenshot below:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/stop_start_app_control-panel.png" loading="lazy" />
+<img className="thumbnail" alt="AI Deploy Apps tab listing deployed apps with the actions menu open on the running speech_to_text_app-compassionate app showing Details Generate a token Start Stop and Delete" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/stop_start_app_control-panel.png" loading="lazy" />
 
 Execute it from the `ovhai` CLI with the following commands:
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-web-service-yolov5.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-deploy-web-service-yolov5.mdx
@@ -29,7 +29,7 @@ For more information on how to train YOLOv5 on a custom dataset, refer to the fo
 
 First, the tree structure of your folder should be as follows.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-04-flask-yolov5/tree_yolov5_web_service.png" loading="lazy" />
+<img className="thumbnail" alt="Terminal tree output of the web service project listing Dockerfile app.py requirements.txt a models_train folder with yolov5m_100epochs.pt and yolov5s_100epochs.pt a static folder with bandeau.png and style.css and a templates folder with index.html" src="/images/public-cloud/ai-machine-learning/deploy-tuto-04-flask-yolov5/tree_yolov5_web_service.png" loading="lazy" />
 
 -   You have to create the folder named `models_train` and this is where you can store the weights generated after your trainings. You are free to put as many weight files as you want in the `models_train` folder.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-function-calling-langchain4j.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-function-calling-langchain4j.mdx
@@ -22,7 +22,7 @@ To do this, we will use **[LangChain4j](https://github.com/langchain4j/langchain
 
 Combined with OVHcloud **[AI Endpoints](https://www.ovhcloud.com/en-gb/public-cloud/ai-endpoints/)** which offers both LLM and embedding models, it becomes easy to create advanced, production-ready assistants.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-14-function-calling-langchain4j/painter.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration of a humanoid robot painting on a canvas mounted on a wooden easel in an artist studio" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-14-function-calling-langchain4j/painter.png" loading="lazy" />
 
 ## Definition
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -17,7 +17,7 @@ In this article, we will explore how to create a Model Context Protocol (MCP) se
 
 Combined with OVHcloud **[AI Endpoints](https://www.ovhcloud.com/en-gb/public-cloud/ai-endpoints/)** which offers both LLM and embedding models, it becomes easy to create advanced, production-ready assistants.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-15-mcp-langchain4j/robot.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration of a white humanoid robot leaning over a desk to look at an open laptop" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-15-mcp-langchain4j/robot.png" loading="lazy" />
 
 ## Definition
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-sentiment-analyzer.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-sentiment-analyzer.mdx
@@ -170,7 +170,7 @@ curl -X POST http://localhost:8080/sentiment -d "I feel great today!"
 
 You should receive an emoji (or label) representing the sentiment of the text:
 
-![image](/images/guides/public-cloud/ai-machine-learning/endpoints-tuto-04-sentiment-analyzer/sentiment-analysis.png)
+<img className="thumbnail" alt="API client sending a POST request to localhost:8080/sentiment with the plain body I'm angry and receiving a 200 OK response in 80 ms whose preview is an angry face emoji" src="/images/guides/public-cloud/ai-machine-learning/endpoints-tuto-04-sentiment-analyzer/sentiment-analysis.png" loading="lazy" />
 
 ## Conclusion
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-structured-output-langchain4j.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-endpoints-structured-output-langchain4j.mdx
@@ -17,7 +17,7 @@ To do this, we will use **[LangChain4j](https://github.com/langchain4j/langchain
 
 Combined with OVHcloud **[AI Endpoints](https://www.ovhcloud.com/en-gb/public-cloud/ai-endpoints/)** which offers both LLM and embedding models, it becomes easy to create advanced, production-ready assistants.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-13-structured-output-langchain4j/parrot.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration of a laptop on a desk displaying a photo of a colourful parrot next to a black coffee cup" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-13-structured-output-langchain4j/parrot.png" loading="lazy" />
 
 ## Definition
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-manage-registries.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-manage-registries.mdx
@@ -54,11 +54,11 @@ This is why it can be interesting to add and manage other registries. We can eit
 
 Click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then go to the `AI Training` section, which is located under `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="AI & MACHINE LEARNING section of the Control Panel menu listing AI Dashboard AI Notebooks AI Training AI Deploy and AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 By clicking the <code className="action">Private Docker Registry</code> button, you should be able to see and manage (add, delete) your different private registries.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/registries_overview.png" loading="lazy" />
+<img className="thumbnail" alt="AI Training Private Docker Registry tab listing two registries ID_01 pointing to index.docker.io and ID_02 pointing to xyz.gra.container-registry.ovh.net both in the GRA region with an Add button" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/registries_overview.png" loading="lazy" />
 
 Note that the `shared registry` will not appear here. This one is displayed in the **Home** panel of AI Training.
 
@@ -131,10 +131,10 @@ To finish setting up your private Harbor registry, you will need to **create a p
 #### Get your OVHcloud Managed Private Registry API URL
 
 In order to add this registry to AI Tools, you will need to retrieve its URL. To do this, go to the Managed Private Registry section on the OVHcloud Public Cloud Manager, and in the "more options" button (...) at the right, click on `Harbor API`:
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-1.png" loading="lazy" />
+<img className="thumbnail" alt="Managed Private Registry page listing the my-registry registry on Harbor version 2.0.1 with the actions menu open and Harbor API highlighted" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-1.png" loading="lazy" />
 
 Then, copy the URL of the Harbor API, which is the URL of your private registry:
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-2.png" loading="lazy" />
+<img className="thumbnail" alt="Private registry API dialog showing the URL for your private registry API field filled with an address ending in gra7.container-registry.ovh.net and a copy icon" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-2.png" loading="lazy" />
 
 #### Add the Harbor registry
 
@@ -146,7 +146,7 @@ During this step, you will be asked your user's credentials (user ID and passwor
   <Tab label="Using the Control Panel (UI)">
     To add your private registry via UI, click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then go to the `AI Dashboard` section which is located under `AI & Machine Learning`.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+    <img className="thumbnail" alt="AI & MACHINE LEARNING section of the Control Panel menu listing AI Dashboard AI Notebooks AI Training AI Deploy and AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 By default, you will be redirected to the <code className="action">Dashboard</code> panel. To add a custom registry URL, click the <code className="action">Docker Registries</code> button. Once there, click the <code className="action">+ Add</code> button to add your private Docker registry.
     
@@ -238,7 +238,7 @@ During this step, you will be asked your Docker credentials.
 
 Click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then go to the `AI Dashboard` section which is located under `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="AI & MACHINE LEARNING section of the Control Panel menu listing AI Dashboard AI Notebooks AI Training AI Deploy and AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 By default, you will be redirected to the <code className="action">Dashboard</code> panel. To add a custom registry URL, click the <code className="action">Docker Registries</code> button. Once there, click the <code className="action">+ Add</code> button to add your private Docker registry.
 
@@ -291,7 +291,7 @@ You will be asked your GitHub credentials.
   <Tab label="Using the Control Panel (UI)">
     Click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then go to the `AI Dashboard` section which is located under `AI & Machine Learning`.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+    <img className="thumbnail" alt="AI & MACHINE LEARNING section of the Control Panel menu listing AI Dashboard AI Notebooks AI Training AI Deploy and AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 By default, you will be redirected to the <code className="action">Dashboard</code> panel. To add a custom registry URL, click the <code className="action">Docker Registries</code> button. Once there, click the <code className="action">+ Add</code> button to add your private Docker registry.
     

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-billing.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-billing.mdx
@@ -30,7 +30,7 @@ During its lifetime, the notebook will go through the following statuses:
 - `ERROR`: The notebook ended due to a backend error. You may reach our support.
 - `DELETING`: The notebook is being removed. When it is deleted, you will no longer see it, and it will no longer exist. Its internal [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) data will not be deleted automatically after notebook deletion. If you are sure you want to delete it, you can find and delete it in the `notebooks_workspace` container of your Object Storage, under the notebook ID directory.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai_notebooks_lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Timeline of the AI Notebook lifecycle from Launch through Starting Running Stopping and Stopped to Delete annotated with the auto-save of the workspace the expiration time reached branch and what happens at each phase" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai_notebooks_lifecycle.png" loading="lazy" />
 
 ## Billing principles
 
@@ -45,7 +45,7 @@ AI Notebooks is a **pay-per-use solution**. You only pay for the **resources** c
 
 Here is a detailed graph that illustrates every step that is billed or not during the AI Notebook workflow:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai.notebooks.billing.png" loading="lazy" />
+<img className="thumbnail" alt="Timeline of the AI Notebook lifecycle from Launch to Delete with CPU/GPU billed only during Running remote data billed at Object Storage pricing and the workspace billed once Stopped when the notebook is older than 30 days or the workspace exceeds 10G" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai.notebooks.billing.png" loading="lazy" />
 
 ### Compute resources details
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-concept.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-concept.mdx
@@ -48,7 +48,7 @@ Only the `RUNNING` time of the notebook **is billed**. For more information abou
 - `ERROR`: The notebook ended due to a backend error. You may reach our support.
 - `DELETING`: The notebook is being removed. When it is deleted, you will no longer see it, and it will no longer exist. Its internal [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) data will not be deleted automatically after the notebook is deleted. If you are sure you want to delete it, you can find and delete it in the `notebooks_workspace` container of your Object Storage, under the notebook ID directory.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-concepts-notebooks/notebooks_concept.svg" loading="lazy" />
+<img className="thumbnail" alt="State diagram of an AI Notebook with transitions between STARTING RUNNING STOPPING STOPPED TIMEOUT DELETING FAILED ERROR and DELETE" src="/images/public-cloud/ai-machine-learning/notebook-guide-concepts-notebooks/notebooks_concept.svg" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-hugging-face-sentiment-analysis.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-hugging-face-sentiment-analysis.mdx
@@ -69,7 +69,7 @@ Beforehand, if you want to store your data (Tweets) in an **object container**, 
 
 If you want to upload it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the Object Storage section and create a new object container by clicking <code className="action">Object Storage</code> > <code className="action">Create an object container</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-05-hugging-face-sentiment-analysis/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-05-hugging-face-sentiment-analysis/new-object-container.png" loading="lazy" />
 
 If you want to run it with the CLI, just follow [this guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). You have to choose the region, the name of your container and the path where your data is located and use the following command:
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui.mdx
@@ -20,7 +20,7 @@ First, you need to push some data to the `Object Storage` before accessing it fr
 
 You can access to the `Object Storage` section of your Public Cloud project on the OVHcloud Control Panel.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-storage.png" loading="lazy" />
+<img className="thumbnail" alt="Object Storage page in the OVHcloud Control Panel" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-storage.png" loading="lazy" />
 
 :::info
 You can upload different types of data: datasets, code, notebooks, connection weights, text or csv files, etc.
@@ -42,7 +42,7 @@ If you choose an S3* compatible Object Storage solution, please note that they a
 
 If you want to know more about the different storage solutions, refer to this page.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-solution.png" loading="lazy" />
+<img className="thumbnail" alt="Step 1 of object container creation selecting the Standard Swift solution" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-solution.png" loading="lazy" />
 
 ### 2- Select a region
 
@@ -52,7 +52,7 @@ To optimize the download and upload times, we advise you to store your data in t
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-region.png" loading="lazy" />
+<img className="thumbnail" alt="Step 2 selecting the Gravelines GRA region" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-region.png" loading="lazy" />
 
 ### 3- Select a type of container
 
@@ -64,15 +64,15 @@ Choose the type of your data according to what you want to do.
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-type.png" loading="lazy" />
+<img className="thumbnail" alt="Step 3 selecting the Private container type" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-type.png" loading="lazy" />
 
 ### 4- Name your container
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-name.png" loading="lazy" />
+<img className="thumbnail" alt="Step 4 naming the container my-dataset" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-name.png" loading="lazy" />
 
 You have created your container to host your dataset.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-container-created.png" loading="lazy" />
+<img className="thumbnail" alt="Container list confirming that my-dataset has been added" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-container-created.png" loading="lazy" />
 
 You are now ready to load your data!
 
@@ -80,11 +80,11 @@ You are now ready to load your data!
 
 In order to upload your dataset into your object container `my-dataset`, you have to go on `Add objects` and select your local `my-dataset.zip` file.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-add-objects-to-container.png" loading="lazy" />
+<img className="thumbnail" alt="Empty my-dataset container showing its URL and the Add objects button" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-add-objects-to-container.png" loading="lazy" />
 
 You will now see your `my-dataset.zip` file displayed in your object container.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-zip-file-uploaded.png" loading="lazy" />
+<img className="thumbnail" alt="my-dataset container after importing dataset.zip" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-zip-file-uploaded.png" loading="lazy" />
 
 :::info
 You can also create a new empty `my-weights` container in which you can save your **connection weights** (or your **validated model**) at the end of your training.
@@ -103,7 +103,7 @@ You are now ready to launch a notebook with your data!
 
 To launch an AI notebook, access the **AI Notebooks** section of your Public Cloud project in the OVHcloud Control Panel.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-ai-notebooks.png" loading="lazy" />
+<img className="thumbnail" alt="AI Notebooks landing page in the OVHcloud Control Panel" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-ai-notebooks.png" loading="lazy" />
 
 For the *first 4 steps* of the notebook creation, please refer to this [tutorial](/guides/public-cloud/ai-machine-learning/ai-notebooks-definition).
 
@@ -111,7 +111,7 @@ For the *first 4 steps* of the notebook creation, please refer to this [tutorial
 
 You can choose between *2 datacenters* for the storage of your notebook: `GRA` or `BHS`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-localisation.png" loading="lazy" />
+<img className="thumbnail" alt="Step 5 selecting the Gravelines GRA datacenter location" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-localisation.png" loading="lazy" />
 
 ### Attach container or a Git repository
 
@@ -127,7 +127,7 @@ As mentioned before, S3 compatible buckets are not yet compatible with our AI pr
 
 You can load the container `my-dataset` in the `/workspace/dataset` directory, with `Read-only` permission.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-ro.png" loading="lazy" />
+<img className="thumbnail" alt="Attaching the my-dataset container to /workspace/dataset with read-only permission" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-ro.png" loading="lazy" />
 
 You will not be able to modify the dataset from this notebook because you loaded it with `Read-only` permission.
 
@@ -140,7 +140,7 @@ Similarly to the `Read-only` mode, you can load data with `Read-write` permissio
 
 Once you have some data that you want to save from the notebook to Object Storage (connection weights in this example), you can simply write it to the `/workspace/weights` folder.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-weights-rw.png" loading="lazy" />
+<img className="thumbnail" alt="Attaching the my-weights container to /workspace/weights with read and write permission" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-weights-rw.png" loading="lazy" />
 
 This folder will be uploaded to your Object Storage when you stop your notebook.
 
@@ -153,7 +153,7 @@ To be able to edit and make changes easily, use the Read-write permission.
 
 The command is as follows:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-git-repo-rw.png" loading="lazy" />
+<img className="thumbnail" alt="Attaching a public Git repository to /workspace/git-hub-repository with read and write permission" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-git-repo-rw.png" loading="lazy" />
 
 :::warning
 To make your command valid, don't forget to add a `.git` at the end of the GitHub repository URL.
@@ -167,7 +167,7 @@ When loading large files from the `Object Storage`, it can take some time to dow
 
 To do so, you can check `Cache`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-cache.png" loading="lazy" />
+<img className="thumbnail" alt="Attaching the my-dataset container read-only with the Cache option enabled" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-cache.png" loading="lazy" />
 
 Cached volumes will be deleted at least 72 hours after the last notebook using it has stopped.
 Note that the cache is shared with all users in your project. The main consequence you need to be careful about
@@ -177,13 +177,13 @@ is the fact that if someone else modifies the data in your cached volume, you wi
 
 Your notebook is now ready to be launched with your data!
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-attached-data.png" loading="lazy" />
+<img className="thumbnail" alt="Step 7 showing two Object Storage containers and one Git repository attached to the notebook" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-attached-data.png" loading="lazy" />
 
 You can read the [Getting started](/guides/public-cloud/ai-machine-learning/ai-notebooks-definition) page to know how to find this URL.
 
 As soon as you access your notebook, you will see your different folders containing your data.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-containers.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab launcher showing the dataset git-hub-repository and weights folders" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-containers.png" loading="lazy" />
 
 ## Feedback
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-marine-mammal-sounds-classification.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-marine-mammal-sounds-classification.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 The purpose of this tutorial is to show how it is possible to train a model in order to classify sounds. To do this, we take as an example a dataset of **marine mammals sounds**.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/marine-mammals-categories.png" loading="lazy" />
+<img className="thumbnail" alt="Grid of twelve labelled marine mammal illustrations including Atlantic Spotted Dolphin Bearded Seal Bottlenose Dolphin Bowhead Whale Clymene Dolphin Common Dolphin False Killer Whale and Harp Seal" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/marine-mammals-categories.png" loading="lazy" />
 
 ## Requirements
 
@@ -34,7 +34,7 @@ The purpose of this tutorial is to show how it is possible to train a model in o
 
 If you want to upload it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the Object Storage section and [create a new object container](/guides/storage-and-backup/object-storage/pcs-create-container) by clicking <code className="action">Object Storage</code> > <code className="action">Create an object container</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/new-object-container.png" loading="lazy" />
 
 :::info
 In the OVHcloud Control Panel, you can upload files but not folders. For instance, you can upload a .zip file to optimize the bandwidth, then unzip it later when accessing it through your JupyterLab.

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-spam-classifier.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-spam-classifier.mdx
@@ -10,7 +10,7 @@ This tutorial will show you how to build a simple spam classifier with **OVHclou
 
 At the end of this tutorial, you will have learnt the principal methods to build your own **spam classifier**.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-09-spam-classifier/spam-classifier.png" loading="lazy" />
+<img className="thumbnail" alt="Hand-drawn diagram of an incoming message envelope classified either as ham on the left or as spam on the right" src="/images/public-cloud/ai-machine-learning/notebook-tuto-09-spam-classifier/spam-classifier.png" loading="lazy" />
 
 :::info
 We will be able to create this model with the dataset named **SMSSPamCollection**. Find it on the SMS Spam Collection Dataset [link](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection).

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-speech-to-text-recognition.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-speech-to-text-recognition.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2022-09-01
 
 The purpose of this tutorial is to show you how it is possible to **convert speech into text** and **generate transcripts** thanks to AI Notebooks.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-08-speech-to-text/speech-to-text.jpeg" loading="lazy" />
+<img className="thumbnail" alt="Hand-drawn diagram of a speaking person feeding an AI model that outputs a text document" src="/images/public-cloud/ai-machine-learning/notebook-tuto-08-speech-to-text/speech-to-text.jpeg" loading="lazy" />
 
 In **Natural Language Processing** (NLP), speech-to-text is a Deep Learning task that enables machines to understand and read human language. There are many applications: transcription, summaries, diarization, subtitle generation, ...
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-tensorboard-embedded.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-tensorboard-embedded.mdx
@@ -12,7 +12,7 @@ TensorBoard is a tool made by TensorFlow, for providing the measurements and vis
 
 TensorBoard provides a visual interface :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/overview_interface_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="TensorBoard SCALARS tab showing the accuracy and loss charts for the test and train runs with the smoothing slider set to 0.6" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/overview_interface_tensorboard.png" loading="lazy" />
 
 The tutorial presents a simple example of launching **TensorBoard** in a notebook.
 
@@ -54,7 +54,7 @@ All source code for this tutorial can be found [here](https://github.com/ovh/ai-
 
 The example notebook is based on the Fashion MNIST dataset.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/image_overview_jupyter_notebook_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab with the notebook_tutorial_tensorboard tab open showing the heading TUTORIAL TensorBoard integration in notebooks and a grid of Fashion MNIST clothing images" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/image_overview_jupyter_notebook_tensorboard.png" loading="lazy" />
 
 Then access the example notebook via the following path:
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-transfer-learning-resnet.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-transfer-learning-resnet.mdx
@@ -36,7 +36,7 @@ The **ResNet** model architecture allows the training error to be reduced with a
 
 Residual neural networks ignore some connections and make double or triple layer jumps that contain non-linearities (ReLU).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-07-transfer-learning-resnet50-image-classification/resnet.png" loading="lazy" />
+<img className="thumbnail" alt="Diagram of a residual block where the input x passes through two weight layers separated by a relu then is added back to the identity shortcut before a final relu" src="/images/public-cloud/ai-machine-learning/notebook-tuto-07-transfer-learning-resnet50-image-classification/resnet.png" loading="lazy" />
 
 With this method, performance is generally improved.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-tuto-rock-paper-scissors.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-tuto-rock-paper-scissors.mdx
@@ -43,7 +43,7 @@ To learn more about the license of this dataset, please follow this [link](https
 
 If you want to create it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the Object Storage section and create a new object container by clicking `Object Storage` > `Create an object container`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-15-rock-paper-scissors/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-15-rock-paper-scissors/new-object-container.png" loading="lazy" />
 
 If you want to run it with the CLI, just follow this [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). You have to choose the region, the name of your container and the path where your data is located and use the following commands.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-weights-biases.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-weights-biases.mdx
@@ -10,7 +10,7 @@ The purpose of this tutorial is to show how it is possible to use **Weights & Bi
 
 Weight and Biases allow you to track your machine learning experiments, version your datasets and manage your models easily, like shown below :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/overview_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases workspace comparing seven training runs with charts for Test error rate loss acc val_loss val_acc and epoch" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/overview_wandb.png" loading="lazy" />
 
 This tutorial presents two examples of using Weights & Biases. In the first notebook we will use TensorFlow and in the second a PyTorch docker image.
 
@@ -62,15 +62,15 @@ The aim of this tutorial is to show how it is possible, thanks to Weights & Bias
 
 For example, you can display the accuracy and loss curves for your valid and train data. These metrics will be displayed for each epoch of each training.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/valid_train_metrics_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases workspace with a Valid data section showing val_loss and val_acc and a Train data section showing loss and acc for the seven training runs" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/valid_train_metrics_mnist_wandb.png" loading="lazy" />
 
 You can then compare your trainings using the **Parallel coordinates** graph type:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/parallel_coordinates_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases Parallel coordinates chart linking the loss learning_rate and epochs axes to the resulting acc value with a colour scale from 0.984 to 1.000" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/parallel_coordinates_mnist_wandb.png" loading="lazy" />
 
 You can also compare the **Test error rates**:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/test_error_rate_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases Test error rate bar chart comparing the runs training_1 to training_7 with values between about 1.2 and 1.9" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/test_error_rate_mnist_wandb.png" loading="lazy" />
 
 A preview of this notebook can be found on [GitHub](https://github.com/ovh/ai-training-examples/tree/main/notebooks/computer-vision/image-classification/tensorflow/weights-and-biases).
 
@@ -82,15 +82,15 @@ The notebook using PyTorch and Weights & Biases is based on YOLOv5 and the COCO 
 
 The aim of this tutorial is to show how Weights & Biases can be used with the YOLOv5 real-time object detection framework. In order to achieve this, the YOLOv5 s, m, l and x models performance will be compared on the COCO dataset for the same number of epochs.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/loss_train_valid_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases workspace with a train section showing obj_loss cls_loss and box_loss and a val section showing the same three losses for the four runs yolov5x_results yolov5l_results yolov5m_results and yolov5s_results" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/loss_train_valid_yolov5_wandb.png" loading="lazy" />
 
 Another possibility with Weights & Biases is to display the use of your computing resources:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/system_utilization_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases System section showing GPU Power Usage in watts and percent GPU Memory Allocated GPU Time Spent Accessing Memory GPU Temp and GPU Utilization over time for the four YOLOv5 runs" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/system_utilization_yolov5_wandb.png" loading="lazy" />
 
 You can also create your report with your curves and images and share it with your team!
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/report_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Weights and Biases report titled YOLOv5 model comparaison with an Images row showing the same photo annotated by each of the four runs and a Results row showing their PR_curve.png precision recall curves" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/report_yolov5_wandb.png" loading="lazy" />
 
 A preview of this notebook can be found on [GitHub](https://github.com/ovh/ai-training-examples/tree/main/notebooks/computer-vision/object-detection/miniconda/weights-and-biases).
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace.mdx
@@ -35,7 +35,7 @@ This workspace is saved as long as your notebook is in `STOPPED` state.
 
 Here is a graph summarizing your notebook's workspace and ephemeral storage usage during its various states:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-workspace/ai-notebooks_workspace.svg" loading="lazy" />
+<img className="thumbnail" alt="Diagram summarizing how the persistent workspace directory and the ephemeral data directory are used across the notebook states" src="/images/public-cloud/ai-machine-learning/notebook-guide-workspace/ai-notebooks_workspace.svg" loading="lazy" />
 
 
 ### Deleting workspace files

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov5-example.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov5-example.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 The purpose of this tutorial is to show how it is possible to train YOLOv5 to recognize objects. YOLOv5 is an object detection algorithm. Although closely related to image classification, object detection performs image classification on a more precise scale. Object detection locates and categories features in images.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/image-yolov5.png" loading="lazy" />
+<img className="thumbnail" alt="Street photo annotated by YOLOv5 with bounding boxes labelled person at confidences from 0.56 to 0.86 bicycle 0.74 and dog 0.82 overlaid with the text You Only Look Once" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/image-yolov5.png" loading="lazy" />
 
 It is based on the YOLOv5 open source repository by [Ultralytics](https://github.com/ultralytics/yolov5).
 
@@ -35,7 +35,7 @@ It is based on the YOLOv5 open source repository by [Ultralytics](https://github
 
 If you want to upload it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the Object Storage section and create a new object container by clicking <code className="action">Object Storage</code> > <code className="action">Create an object container</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/new-object-container.png" loading="lazy" />
 
 If you want to run it with the CLI, just follow this [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). You have to choose the region, the name of your container and the path where your data is located and use the following command:
 
@@ -80,7 +80,7 @@ In this tutorial, you need 2 object containers.
 - the **first object container** contains your dataset (labelled and separated) and your `data.yaml` file.
 - the **second object container** is empty. It is intended to save your model weights (for a future inference for example).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/notebook-attach-data.png" loading="lazy" />
+<img className="thumbnail" alt="Step 7 Attach a Git container or repository with the dataset - GRA container mounted read-only on /workspace/data the weights - GRA container mounted read and write on /workspace/models_train and the ai-training-examples Git repository mounted on /workspace/examples" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/notebook-attach-data.png" loading="lazy" />
 
 Once the repository has been cloned, find the YOLOv5 notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `object-detection` > `miniconda` > `notebook_object_detection_yolov5.ipynb`.
 
@@ -103,7 +103,7 @@ You can then reach your notebook’s URL once it is running.
 
 You should have this overview:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/overview-notebook.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab showing the notebook_object_detection notebook opened on the heading TUTORIAL Train YOLOv5 on custom dataset with its introduction and requirements sections" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/overview-notebook.png" loading="lazy" />
 
 ### Experimenting YOLOv5 notebook
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov7-sign-language.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov7-sign-language.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 The purpose of this tutorial is to show how it is possible to train YOLOv7 to recognize **American Sign Language letters**. YOLOv7 is an object detection algorithm. Although closely related to image classification, object detection performs image classification on a more precise scale. Object detection locates and categorizes features in images.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/overview-notebook.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab showing the notebook_yolov7_asl_recognition notebook opened on the heading TUTORIAL Train YOLOv7 for American Sign Language recognition with a diagram of a model a camera and a detected hand sign" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/overview-notebook.png" loading="lazy" />
 
 It is based on the YOLOv7 open source [repository](https://github.com/WongKinYiu/yolov7).
 
@@ -45,7 +45,7 @@ To learn more about the license of this dataset, please follow this [link](https
 
 If you want to create it from the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, go to the Object Storage section and create a new object container by clicking `Object Storage` > `Create an object container`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Create an object container page with step 1 Select a region open on the All locations tab offering Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK and Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/new-object-container.png" loading="lazy" />
 
 If you want to run it with the CLI, just follow this [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). You have to choose the region, the name of your container and the path where your data is located and use the following commands.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-solutions-remote-connect.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-solutions-remote-connect.mdx
@@ -63,27 +63,27 @@ Here is how to add your SSH key to your AI Solution if you are using the <Manage
     
     From there, click on the <code className="action">+ Create a notebook</code> or <code className="action">+ Launch a job</code> button to configure and create your AI Solution.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-1.png" loading="lazy" />
+    <img className="thumbnail" alt="AI Training page in the OVHcloud Control Panel with the Launch a job button highlighted" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-1.png" loading="lazy" />
 
 Fill in the various details required until you find the <code className="action">Advanced configuration</code> section. Open it.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-2.png" loading="lazy" />
+    <img className="thumbnail" alt="Collapsed Advanced configuration section of the job creation form" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-2.png" loading="lazy" />
 
 From there you will find a `SSH Public Keys` sub-section where you can add and configure new SSH keys by clicking on the <code className="action">+ Configure an SSH Key</code> button:
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-3.png" loading="lazy" />
+    <img className="thumbnail" alt="SSH Public Keys section showing no key configured and the Configure an SSH key button" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-3.png" loading="lazy" />
 
 This will open a window where you can put the content of your public key file (e.g., `id_ed25519.pub`):
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-4.png" loading="lazy" />
+    <img className="thumbnail" alt="Configure a new SSH key dialog with the key name and public key filled in" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-4.png" loading="lazy" />
 
 Click on <code className="action">Confirm</code>. Once your key is added, you can select it from your SSH Keys list:
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-5.png" loading="lazy" />
+    <img className="thumbnail" alt="SSH key dropdown listing the id_ed25519 and SSH_key_VM keys" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-5.png" loading="lazy" />
 
 Once selected, make sure to click on the <code className="action">+</code> to confirm the addition of your key. You should see the following message: `1 of 10 SSH key configured`.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-6.png" loading="lazy" />
+    <img className="thumbnail" alt="SSH Public Keys section showing 1 of 10 SSH keys configured" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-6.png" loading="lazy" />
   </Tab>
   <Tab label="Using ovhai CLI">
     To follow this part, make sure you have installed the [ovhai CLI](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) on your computer or on an instance.
@@ -132,11 +132,11 @@ ovh@job-36ed1f18-626b-42f7-b15f-0ed844e65d20:~$
 
 In Visual Studio Code, click on the <code className="action">Remote Explorer</code> icon.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-1.png" loading="lazy" />
+<img className="thumbnail" alt="VS Code activity bar with the Remote Explorer icon selected" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-1.png" loading="lazy" />
 
 From there, click the gear icon on the SSH feature to access the SSH configuration file for VSCode, typically located at `~/.ssh/config`, and open it.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-2.png" loading="lazy" />
+<img className="thumbnail" alt="VS Code Remote Explorer opening the SSH config file selection prompt" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-2.png" loading="lazy" />
 
 Add the following section for your new host:
 
@@ -149,25 +149,25 @@ IdentityFile C:\Path\To\id_ed25519 # Path to your private key file (not .pub)
 
 Save the `config` file. Then refresh remotes by clicking on this icon:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-3.png" loading="lazy" />
+<img className="thumbnail" alt="Refresh button of the VS Code SSH remotes list" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-3.png" loading="lazy" />
 
 Your resource should now appear in the SSH menu on the left. Connect to it by clicking the arrow next to your resource. VSCode will restart to connect to your remote resource:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-4.png" loading="lazy" />
+<img className="thumbnail" alt="SSH remotes list showing my_ai_training_job with the Connect in New Window action" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-4.png" loading="lazy" />
 
 If the connection is well established, you should see this message in the bottom-left corner of VSCode:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-5.png" loading="lazy" />
+<img className="thumbnail" alt="VS Code status bar confirming the SSH connection to my_ai_training_job" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-5.png" loading="lazy" />
 
 ### Develop and Run Your Code
 
 Once connected, you can start developing and running your code in the default `/workspace` folder, by clicking on the <code className="action">Open folder</code> blue button, and select `/workspace`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-6.png" loading="lazy" />
+<img className="thumbnail" alt="Open Folder prompt listing the contents of the remote workspace directory" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-6.png" loading="lazy" />
 
 You can also open a terminal and run commands from it. Enjoy!
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-7.png" loading="lazy" />
+<img className="thumbnail" alt="VS Code terminal running nvidia-smi on the remote job showing an NVIDIA H100 PCIe GPU" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-7.png" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-solutions-resources.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-solutions-resources.mdx
@@ -45,11 +45,11 @@ To fetch your AI Tool monitoring URL, you can use either the CLI or the Control 
     
     From there, you will access a table listing your instances, where you can find the one you need and its general information. To view your instance details, click either the instance name or the <code className="action">...</code> button and then <code className="action">Manage</code>.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/00_access_tool_details.png" loading="lazy" />
+    <img className="thumbnail" alt="AI Training page with the AI Notebooks AI Training and AI Deploy menu entries highlighted and the actions menu of the ai-training-demo job open on Manage" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/00_access_tool_details.png" loading="lazy" />
 
 From there, you can click on the <code className="action">Grafana Dashboard</code> button, under <code className="action">Usage monitoring</code>, to access your monitoring Grafana UI.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/01_access_grafana_ui.png" loading="lazy" />
+    <img className="thumbnail" alt="Dashboard of the ai-training-demo job with the Grafana dashboard link highlighted under Usage monitoring in the Access panel" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/01_access_grafana_ui.png" loading="lazy" />
   </Tab>
   <Tab label="Using ovhai CLI">
     To follow this part, make sure you have installed the [ovhai CLI](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) on your computer or on an instance.
@@ -164,7 +164,7 @@ For AI Notebooks and AI Training, the following features are available:
 - **Volumes Total Size**: Total size of volumes attached to your notebook or job.
 - **Volumes Total File Count**: Total number of files in attached volumes.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/02_resource_dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="Grafana resource dashboard with the GPU Usage GPU Memory Usage CPU Usage Memory Usage Network Usage and Ephemeral storage usage panels showing two bursts of GPU activity" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/02_resource_dashboard.png" loading="lazy" />
 
 #### AI Deploy Applications
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image.mdx
@@ -353,7 +353,7 @@ For example, if we want to push a first version of our built image named `cnn_im
 
 If you want to know the exact commands to push on your shared registry, please consult the <code className="action">Details</code> button of the **Shared Docker Registry** section, in the **Home** panel of AI Training.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-02-build-custom-image/shared_registry_details.png" loading="lazy" />
+<img className="thumbnail" alt="AI Training Home tab Information panel listing Shared Docker Registry and OVHcloud AI Training command line interface each with a Details button" src="/images/public-cloud/ai-machine-learning/training-tuto-02-build-custom-image/shared_registry_details.png" loading="lazy" />
 
 ## Dockerfile examples
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-jobs.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-jobs.mdx
@@ -47,7 +47,7 @@ Only the `RUNNING` time of the job **is billed**. For more information about job
 - `FAILED`: The job ended with an error, e.g. the process in the job finished with a non 0 exit code, Docker image could not be pulled, etc.
 - `ERROR`: The job ended due to a backend error.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-03-concepts-jobs/status-diagram.svg" loading="lazy" />
+<img className="thumbnail" alt="State diagram of an AI Training job with transitions between QUEUED INITIALIZING PENDING RUNNING FINALIZING TIMEOUT DONE FAILED INTERRUPTING INTERRUPTED and ERROR" src="/images/public-cloud/ai-machine-learning/training-guide-03-concepts-jobs/status-diagram.svg" loading="lazy" />
 
 ## Go further
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-models-comparaison-wandb.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-models-comparaison-wandb.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2025-06-27
 
 The purpose of this tutorial is to compare two methods by running two jobs in parallel in order to classify audios. To see which model is better in terms of accuracy, resource consumption and training time, we will use the [Weights & Biases](https://wandb.ai/site) tool.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/models-comparaison-overview.png" loading="lazy" />
+<img className="thumbnail" alt="Models comparaison parallel coordinates chart linking the accuracy val_accuracy loss val_loss Relative Time and best_epoch axes to the resulting best_val_loss for two runs" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/models-comparaison-overview.png" loading="lazy" />
 
 ### Use case
 
@@ -81,7 +81,7 @@ You will follow different steps to process your data and train your two models.
 
 The tutorial is as follows:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/instructions-overview.jpeg" loading="lazy" />
+<img className="thumbnail" alt="Hand-drawn diagram of two approaches where audio files are turned either into a CSV file fed to an ANN or into spectrograms fed to a CNN with both results sent to Weights and Biases" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/instructions-overview.jpeg" loading="lazy" />
 
 Here we will mainly discuss how to write the data processing and models training codes, the `requirements.txt` and `packages.txt` files and the `Dockerfile`. If you want to see the whole code, please refer to the [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/jobs/weights-and-biases/audio-classification-models-comparaison).
 
@@ -153,7 +153,7 @@ Refer to the comments of the [code](https://github.com/ovh/ai-training-examples/
 
 *The head of the `csv` file:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/csv-file-overview.png" loading="lazy" />
+<img className="thumbnail" alt="First five rows of the extracted features dataframe with the filename length chroma_stft rms spectral_centroid spectral_bandwidth tempo and mfcc columns totalling 28 columns" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/csv-file-overview.png" loading="lazy" />
 
 #### Audio to spectrogram with image generation
 
@@ -163,7 +163,7 @@ Refer to the comments of the [code](https://github.com/ovh/ai-training-examples/
 
 *A sample spectrogram:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/spectrogram-example.png" loading="lazy" />
+<img className="thumbnail" alt="Mel spectrogram of an audio sample where energy is shown as bright orange and yellow bands on a dark background" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/spectrogram-example.png" loading="lazy" />
 
 Once the processing of the data is complete, the AI models must be built.
 
@@ -482,25 +482,25 @@ Now, you can access the Weights & Biases panel. You will be able to check the ac
 
 *Accuracy:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/accuracy.png" loading="lazy" />
+<img className="thumbnail" alt="accuracy chart where the image-classification-spectrogramms run rises above 0.9 while the audio-classification-features run climbs more slowly to about 0.9" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/accuracy.png" loading="lazy" />
 
 *Loss:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/loss.png" loading="lazy" />
+<img className="thumbnail" alt="loss chart where the image-classification-spectrogramms run falls quickly below 0.2 while the audio-classification-features run decreases gradually to about 0.3" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/loss.png" loading="lazy" />
 
 - **Validation data:**
 
 *Accuracy:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-accuracy.png" loading="lazy" />
+<img className="thumbnail" alt="val_accuracy chart where the image-classification-spectrogramms run plateaus above 0.9 while the audio-classification-features run plateaus around 0.7" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-accuracy.png" loading="lazy" />
 
 *Loss:*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-loss.png" loading="lazy" />
+<img className="thumbnail" alt="val_loss chart where the image-classification-spectrogramms run drops below 0.2 while the audio-classification-features run stays around 1 and rises slightly at the end" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-loss.png" loading="lazy" />
 
 You can then observe which model is better in terms of speed, accuracy or resource consumption...
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/gpu-power-usage.png" loading="lazy" />
+<img className="thumbnail" alt="GPU Power Usage chart in watts where the image-classification-spectrogramms run stays near 38.7 W for almost three hours while the audio-classification-features run appears only as a brief spike near 36.6 W" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/gpu-power-usage.png" loading="lazy" />
 
 In this case, we see that the **model classifying the spectrograms** is better in terms of accuracy and loss on the validation set.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
@@ -46,7 +46,7 @@ Currently, the following configurations are available :
 -   **MXNet** : An OVHcloud preset image containing JupyterLab notebook, Visual Studio Code IDE and `mxnet` libraries
 -   **Fast.ai** : An OVHcloud preset image containing JupyterLab notebook, Visual Studio Code IDE and `fast.ai` libraries
 -   **autogluon** : An OVHcloud preset image containing JupyterLab notebook, Visual Studio Code IDE and `AutoGluon` + `mxnet` libraries
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/01_submit_image.png" loading="lazy" />
+    <img className="thumbnail" alt="Step 2 Enter the Docker image offering the MXNet Fast.ai Pytorch Tensorflow 2 and Hugging Face Transformers presets each bundled with JupyterLab and VSCode with Tensorflow 2 selected and a Custom image field below" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/01_submit_image.png" loading="lazy" />
 
 Once your image is chosen, click <code className="action">Next</code>.
 
@@ -64,7 +64,7 @@ If you want to be able to save your notebook files on your object storage, we st
 
 Once your job is `In progress`, in the job description panel, you should see the `Access` link. Click on it and you will be redirected on your job URL.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/02_http_access_url.png" loading="lazy" />
+<img className="thumbnail" alt="Job detail panels showing Job information for ai-training-tensorflow-acid-alvarez in the GRA region a Container panel with the ovhcom/ai-training-tensorflow:2.3.0 image In progress and an HTTP access link and a Resources panel with 1 GPU" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/02_http_access_url.png" loading="lazy" />
 
 ### Step 5 - Login as an AI Training user
 
@@ -78,17 +78,17 @@ If you have not created a user for AI Training yet, you can follow the instructi
 
 Fill the fields and click <code className="action">Login</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/03_login_form.png" loading="lazy" />
+<img className="thumbnail" alt="OVHcloud Login form with the User Name and Password fields and the Connect button" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/03_login_form.png" loading="lazy" />
 
 ### Step 6 - Use your notebook
 
 In most provided preset image,s you can choose which editor you prefer between JupyterLab and VisualStudio code.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/04_jupyter_vs_vscode.png" loading="lazy" />
+<img className="thumbnail" alt="Choice between the Jupyter Lab button and the Visual Studio Code button" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/04_jupyter_vs_vscode.png" loading="lazy" />
 
 Just select the one that you want to use, and you will be redirected to the corresponding one.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/05_jupyter.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab with the Launcher tab open offering Notebook and Console tiles for Python 3 and an index.html file in the file browser" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/05_jupyter.png" loading="lazy" />
 
 By default, the home directory of your job is located under `/workspace`. It means that you will have **read** and **write** access to that directory as well as your **read** and **write** mounted volumes.
 
@@ -103,7 +103,7 @@ For installing specific libraries that require privileged access, you will have 
 :::info
 If you open a **console** tab in your notebook and type `nvidia-smi`, you will see the available GPUs that you can use on your notebook.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/09_nvidia_smi.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab terminal showing the TensorFlow banner then the nvidia-smi output reporting driver version 450.51.05 CUDA version 11.0 and one Tesla V100S GPU using 25W of 250W and no running processes" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/09_nvidia_smi.png" loading="lazy" />
 
 :::
 
@@ -114,15 +114,15 @@ Once you are done working with your notebook don't forget to stop it.
 
 You can do it by selecting <code className="action">Stop</code> in the action menu.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/06_stop_notebook.png" loading="lazy" />
+<img className="thumbnail" alt="Actions panel containing a single Stop entry" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/06_stop_notebook.png" loading="lazy" />
 
 Then <code className="action">confirm</code> your choice.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/07_confirm_stop.png" loading="lazy" />
+<img className="thumbnail" alt="Stop the job confirmation dialog listing the job ID region Docker image user admin status In progress and creation date with Cancel and Confirm stop buttons" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/07_confirm_stop.png" loading="lazy" />
 
 After some time your job should go into an `Interrupted` state meaning that the job has been stopped.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/08_interrupted.png" loading="lazy" />
+<img className="thumbnail" alt="Status field showing the Interrupted badge" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/08_interrupted.png" loading="lazy" />
 
 :::info
 Before going into the `Interrupted` state, your job may run through the `Finalizing` state. During this phase, all data inside `read & write volumes` are saved inside their linked containers in your object storage.

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
@@ -30,7 +30,7 @@ This guide covers the initialisation of **AI Training** and the submission of [*
 
 Click <ManagerLink to="/#/pci/projects">this link</ManagerLink> to access your Public Cloud project, then go to the <code className="action">AI Training</code> section, located under `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/00_training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="AI and Machine Learning section of the OVHcloud Control Panel menu with AI Training selected" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/00_training_menu.png" loading="lazy" />
 
 ### Step 2 - Starting a job submission
 
@@ -48,9 +48,9 @@ Each **job** is executed in an OVHcloud region. Each region has its own **AI Tra
 
 Select the desired region and click <code className="action">Next</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/02_name_job.png" loading="lazy" />
+<img className="thumbnail" alt="Launch a job form with the Job name field filled in as example-job" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/02_name_job.png" loading="lazy" />
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/03_submit_region.png" loading="lazy" />
+<img className="thumbnail" alt="Location step with the Gravelines GRA region selected" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/03_submit_region.png" loading="lazy" />
 
 ### Step 4 - Specifying the amount of resources
 
@@ -60,7 +60,7 @@ The max amount of GPUs or CPUs you can select for your **job** is region-depende
 
 Once the amount of resources is set you can see a preview of the billing rate. Click <code className="action">Next</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/04_submit_resources.png" loading="lazy" />
+<img className="thumbnail" alt="Resources table listing the available CPU and GPU flavors with their hourly prices" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/04_submit_resources.png" loading="lazy" />
 
 ### Step 5 - Providing a Docker image
 
@@ -76,7 +76,7 @@ Preset images cannot cover all your needs so you can specify your own image if n
 
 This includes public images (e.g. Dockerhub), images within the shared registry or images in your added private registry. For more information, see how to [add a private registry](/guides/public-cloud/ai-machine-learning/ai-manage-registries).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/05_submit_image.png" loading="lazy" />
+<img className="thumbnail" alt="Docker Image step on the Custom image tab with a registry image path field" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/05_submit_image.png" loading="lazy" />
 
 ### Step 6 - Privacy Settings
 
@@ -88,7 +88,7 @@ Next, select your privacy settings.
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/06_job_privacy_settings.png" loading="lazy" />
+<img className="thumbnail" alt="Privacy step with Public access selected" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/06_job_privacy_settings.png" loading="lazy" />
 
 ### Step 7 - Job lifecycle
 
@@ -101,7 +101,7 @@ This also allows us to address host-located incidents, e.g. when a single GPU fa
 
 By default, your job will automatically shut down after 7 consecutive days of being in `RUNNING` status. Rest assured that all your settings and data will be preserved. You have the option to enable Automatic Restart, which will automatically restart your job back on every 7 days, ensuring minimal disruption to your workflow. Alternatively, you can also contact [our support](https://help.ovhcloud.com/csm?id=csm_get_help) to extend this automatic restart period from 7 to 28 days.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/07_job_lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Expiry step showing the Automatic restart toggle and its tooltip" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/07_job_lifecycle.png" loading="lazy" />
 
 ### Step 8 - Advanced configuration
 
@@ -115,7 +115,7 @@ If you want to learn more about configuring containers and Git repositories in t
 
 Finally, **SSH public keys** allow you to access your job remotely.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/08_job_advanced_config.png" loading="lazy" />
+<img className="thumbnail" alt="Expanded Advanced configuration section showing Docker commands volumes and SSH keys" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/08_job_advanced_config.png" loading="lazy" />
 
 ### Step 9 - Submitting your job
 
@@ -127,13 +127,13 @@ Click <code className="action">Order</code> to confirm and launch the creation o
 
 When your job is created, it will appear on your AI Training tab:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/10_ai_training_panel.png" loading="lazy" />
+<img className="thumbnail" alt="AI Training job list showing example-job in progress" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/10_ai_training_panel.png" loading="lazy" />
 
 ### Step 10 - Consulting your job
 
 From this list you can access your job details either by clicking on its name or by clicking on <code className="action">...</code> and selecting `Manage`. The details include several components, like the job resources, statuses, billing, logs and access url. This URL is of the form `https://<JOB-ID>.job.<REGION>.ai.cloud.ovh.net/`. Moreover, you can access any available port by adding it to the job URL this way: `https://<JOB-ID>-<PORT>.job.<REGION>.ai.cloud.ovh.net/`. You can check the list of available ports in the [capabilities](/guides/public-cloud/ai-machine-learning/ai-training-capabilities).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/11_job_details.png" loading="lazy" />
+<img className="thumbnail" alt="Job dashboard showing access lifecycle timeline resources and the ovhai CLI command" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/11_job_details.png" loading="lazy" />
 
 You can also check your job logs by clicking the <code className="action">Logs</code> button.
 
@@ -143,17 +143,17 @@ If you are done using your job, if your model converged prematurely or if you ju
 
 From the list of **jobs** you can list the available actions at the far right of each entry and interrupt the job by clicking <code className="action">Stop</code>. Alternatively, from the **job** details you can also interrupt the **job** from the list of actions by clicking the <code className="action">🔴</code> stop button.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/12_job_stop.png" loading="lazy" />
+<img className="thumbnail" alt="Job header with the stop button highlighted" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/12_job_stop.png" loading="lazy" />
 
 After that, if you no longer need your job, you can delete it. To do so, just click on the <code className="action">...</code> button, and then select <code className="action">Delete</code> action.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/13_job_delete.png" loading="lazy" />
+<img className="thumbnail" alt="Job list with the actions menu open and Delete highlighted" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/13_job_delete.png" loading="lazy" />
 
 ### Step 12 - Cloning your job
 
 You can also click the <code className="action">🔄</code> restart button to clone the job with the same configuration. This will launch a new job identical to the original (e.g., `example-job`), allowing you to rerun your workflow without re‑configuring the job.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/14_job_clone.png" loading="lazy" />
+<img className="thumbnail" alt="Job header with the clone button highlighted" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/14_job_clone.png" loading="lazy" />
 
 ## Go further
 The **AI Training** service is mainly supposed to be used through the **`ovhai` CLI**. The OVHcloud Control Panel only offers a subset of the features and is meant to help you get started before using the CLI. Discover how to [install the OVHcloud AI CLI](/guides/public-cloud/ai-machine-learning/ai-cli-install-client).

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-training-tensorboard-inside-job.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-training-tensorboard-inside-job.mdx
@@ -12,7 +12,7 @@ TensorBoard is a tool made by TensorFlow, for providing the measurements and vis
 
 TensorBoard provides a visual interface:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-05-tensorboard/overview_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="TensorBoard SCALARS tab showing the accuracy and loss charts for the test and train runs with the smoothing slider set to 0.6" src="/images/public-cloud/ai-machine-learning/training-tuto-05-tensorboard/overview_tensorboard.png" loading="lazy" />
 
 The tutorial presents a simple example of launching **TensorBoard** in a job.
 

--- a/docs/en/guides/public-cloud/ai-machine-learning/ai-users.mdx
+++ b/docs/en/guides/public-cloud/ai-machine-learning/ai-users.mdx
@@ -37,7 +37,7 @@ In addition to the AI Training role, we strongly recommend adding the **ObjectSt
 
 To apply these roles, click on the <code className="action">Project Management</code> category in the left-hand vertical menu to access the <code className="action">Users & Roles</code> section:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/03_users_menu.png" loading="lazy" />
+<img className="thumbnail" alt="Project Management menu with Users & Roles selected above Quota and Localisation SSH Keys Billing Control Credit and Vouchers Contacts and Rights and Project settings" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/03_users_menu.png" loading="lazy" />
 
 On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
@@ -45,7 +45,7 @@ On this page, you can either **create a new user** for your Public Cloud project
 
 Click on <code className="action">+ Add user</code>, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**):
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/04_users_roles.png" loading="lazy" />
+<img className="thumbnail" alt="Edit roles dialog with the AI Training Operator and ObjectStore operator checkboxes ticked among the available roles and Cancel and Confirm buttons" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/04_users_roles.png" loading="lazy" />
 
 This will generate a password that will allow you to authenticate to your existing AI Notebooks, AI Training jobs, AI Deploy apps and to the `ovhai` CLI to launch new ones.
 
@@ -60,7 +60,7 @@ This will generate a password that will allow you to authenticate to your existi
 
 To edit an existing user, simply click the <code className="action">...</code> button next to the user, and select `Edit roles` to modify its existing roles:
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/05_edit_user_roles.png" loading="lazy" />
+<img className="thumbnail" alt="Users & Roles page listing an admin user and the my-first-user user holding the AI Training Operator and ObjectStore operator roles with the actions menu open and Edit roles highlighted" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/05_edit_user_roles.png" loading="lazy" />
 
 ## Go further
 - You can check the [OVHcloud documentation on how to submit a job](/guides/public-cloud/ai-machine-learning/ai-training-submit-job).

--- a/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/en/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -803,16 +803,17 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 ```
 
 :::info
-If this kind of errors occurs:
-:::
+If this kind of error occurs:
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 

--- a/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/es/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,15 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 If this kind of errors occurs:
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-access-data.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-access-data.mdx
@@ -41,7 +41,7 @@ Vous pouvez consulter la page [Démarrer](/guides/public-cloud/ai-machine-learni
 
 Vous devriez obtenir une page comme celle-ci, montrant votre dataset dans l'explorateur de fichiers :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-17-how-to-cli-data-notebooks/jupyterlab_with_dataset.png" loading="lazy" />
+<img className="thumbnail" alt="Navigateur de fichiers JupyterLab affichant le dossier datasets monté dans le notebook à côté de l'onglet Launcher" src="/images/public-cloud/ai-machine-learning/cli-17-how-to-cli-data-notebooks/jupyterlab_with_dataset.png" loading="lazy" />
 
 Vous ne pourrez pas modifier le dataset depuis ce notebook car vous l'avez chargé avec des permissions en lecture seule.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-install-client.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-install-client.mdx
@@ -80,7 +80,7 @@ Vous avez le choix entre deux méthodes de connexion :
 -   terminal : vous pouvez vous authentifier directement depuis le terminal.
 -   navigateur : vous accédez à une page d’authentification semblable à celle-ci :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-10-howto-install-cli/00_oauth2_login.png" loading="lazy" />
+<img className="thumbnail" alt="Page de connexion OVHcloud avec les champs User Name et Password et le bouton Connect" src="/images/public-cloud/ai-machine-learning/cli-10-howto-install-cli/00_oauth2_login.png" loading="lazy" />
 
 Utilisez les identifiants de votre utilisateur **AI Training** pour vous connecter.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-run-notebook.mdx
@@ -265,7 +265,7 @@ Status:
 
 Maintenant que le notebook est dans l'état `RUNNING`, une adresse https est définie dans le champ `Url`. Cette `URL` correspond à votre serveur JupyterLab. En collant cette `URL` dans votre navigateur, l'écran suivant s'affiche :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-11-howto-run-notebook-cli/jupyterlab_home_page.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil du Launcher JupyterLab proposant les sections Notebook Console et Other avec les tuiles Python 3 Terminal et Text File" src="/images/public-cloud/ai-machine-learning/cli-11-howto-run-notebook-cli/jupyterlab_home_page.png" loading="lazy" />
 
 Vous pouvez maintenant commencer à écrire du code dans votre notebook. Comme nous avons utilisé le framework PyTorch dans notre exemple, nous pourrons l'utiliser sans avoir besoin d'installer quoi que ce soit nous-mêmes.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-sharing-notebooks.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-cli-sharing-notebooks.mdx
@@ -188,12 +188,12 @@ Attendez quelques secondes que le notebook atteigne l'état `RUNNING`.
 Le champ `Url` correspond à l'adresse à coller dans votre navigateur pour accéder au notebook.
 Si vous êtes déjà connecté avec votre navigateur, il affichera alors le notebook. Sinon, vous obtiendrez une page comme celle-ci :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_page.png" loading="lazy" />
+<img className="thumbnail" alt="Page de connexion OVHcloud affichant une erreur unauthorized au-dessus des champs User Name et Password avec un lien Login with token" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_page.png" loading="lazy" />
 
 Vous pouvez essayer dans une fenêtre de navigation privée pour obtenir la page de connexion et tester le token.
 Cliquer sur `Login with token` amène à cette page :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_token_page.png" loading="lazy" />
+<img className="thumbnail" alt="Page de connexion OVHcloud en mode token affichant une erreur unauthorized au-dessus du champ Token avec un lien Login with user/password" src="/images/public-cloud/ai-machine-learning/cli-14-howto-cli-sharing/ovh_login_token_page.png" loading="lazy" />
 
 Collez le token que nous avons créé précédemment dans le champ de texte et cliquez sur `Connect`. Vous devriez maintenant voir votre notebook.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-data.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-data.mdx
@@ -29,7 +29,7 @@ Les **jobs AI Training** et les **AI Notebooks** peuvent lire et écrire des don
 2.  Au démarrage du job, le volume est attaché dans le répertoire souhaité. Les données sont ensuite disponibles dans le job tant que dure la phase `RUNNING`.
 3.  Après l'arrêt du job, les données sont resynchronisées **depuis** le volume de système de fichiers sous-jacent **vers** l'**OVHcloud Object Storage**. Cette synchronisation a lieu pendant la phase `FINALIZING`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_job.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma des phases de données d'un job montrant la synchronisation depuis OBJECT STORE vers VOLUME pendant INITIALIZING puis les interactions du système de fichiers entre VOLUME et JOB pendant RUNNING puis la synchronisation de retour vers OBJECT STORE pendant FINALIZING" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_job.svg" loading="lazy" />
 
 ### AI Notebooks
 
@@ -39,7 +39,7 @@ Les **jobs AI Training** et les **AI Notebooks** peuvent lire et écrire des don
 
 Cela s'applique à votre [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) interne ainsi qu'aux volumes d'object storage distants.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_notebook.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma des phases de données d'un notebook montrant la synchronisation depuis OBJECT STORE vers VOLUME pendant STARTING puis les interactions du système de fichiers entre VOLUME et NOTEBOOK pendant RUNNING puis la synchronisation de retour vers OBJECT STORE pendant STOPPING" src="/images/public-cloud/ai-machine-learning/gi-02-concepts-data/data_phases_notebook.svg" loading="lazy" />
 
 ## Capacités
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-apps-deployments.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-apps-deployments.mdx
@@ -205,7 +205,7 @@ Vous pouvez également modifier la stratégie de scaling une fois l’app créé
   <Tab label="Depuis l'espace client (UI)">
     Pour modifier les stratégies de scaling depuis l’interface, accédez à la page de détails de votre application en cliquant sur son nom dans la section AI Deploy. Sur cette page, vous trouverez des informations générales sur votre application, dont une section **Resources**.
 
-    ![image](/images/public-cloud/ai-machine-learning/deploy-guide-04-scaling-strategies/update-autoscaling-1.png)
+    <img className="thumbnail" alt="Tableau de bord de l'application AI Deploy my-app avec le panneau Resources mis en évidence affichant Automatic scaling avec minimum replicas 1 maximum replicas 5 metric monitored CPU et trigger threshold 75%" src="/images/public-cloud/ai-machine-learning/deploy-guide-04-scaling-strategies/update-autoscaling-1.png" loading="lazy" />
 
     Dans cette fenêtre, cliquez sur le bouton <code className="action">Modifier</code> pour accéder aux options de configuration du scaling. Cela ouvrira une fenêtre **Update application scaling** dans laquelle vous pouvez :
     - Basculer entre l’autoscaling et le scaling statique

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-apps.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-apps.mdx
@@ -47,7 +47,7 @@ Seul le temps `RUNNING` et `SCALING` de l’app **est facturé**. Pour plus d’
 - `DELETING` : l’app est en cours de suppression.
 - `DELETED` : l’app est entièrement supprimée.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-09-concepts-apps/apps_concept.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma d'états d'une application AI Deploy avec les transitions entre QUEUED INITIALIZING SCALING RUNNING STOPPING STOPPED DELETING FAILED ERROR et DELETE" src="/images/public-cloud/ai-machine-learning/deploy-guide-09-concepts-apps/apps_concept.svg" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-billing.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-billing.mdx
@@ -37,7 +37,7 @@ Au cours de son cycle de vie, l’app passera par les statuts suivants :
 - `DELETING` : l’app est en cours de suppression. Une fois supprimée, vous ne la verrez plus, elle n’existera plus.
 - `DELETED` : l’app est entièrement supprimée.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Chronologie du cycle de vie d'une application AI Deploy depuis Launch jusqu'à Delete en passant par Queued Initializing Scaling Running Standby Stopping et Stopped avec le CPU/GPU non facturé en dehors de la phase Running et les données distantes facturées au tarif Object Storage" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.lifecycle.png" loading="lazy" />
 
 ## Principes de facturation
 
@@ -61,7 +61,7 @@ Les ressources **optionnelles**, non incluses avec AI Deploy, sont :
 
 Voici un graphique détaillé illustrant chaque étape facturée ou non pendant le workflow AI Deploy :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.billing.png" loading="lazy" />
+<img className="thumbnail" alt="Chronologie du cycle de vie d'une application AI Deploy de Launch à Delete annotée sous chaque phase avec ce qui se passe et ce qui est facturé notamment les ressources de calcul allouées par réplique pendant Running et les données éphémères perdues une fois Stopped" src="/images/public-cloud/ai-machine-learning/deploy-guide-06-billing-concept/ai.deploy.billing.png" loading="lazy" />
 
 ### Détails des ressources de calcul
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-custom-image.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-custom-image.mdx
@@ -44,7 +44,7 @@ Les images Docker que vous construisez peuvent être déployées en local, avec 
 
 AI Deploy accepte les images provenant de dépôts **publics** ou **privés**. En résumé, voici comment fonctionne AI Deploy :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/ai_deploy_concept.png" loading="lazy" />
+<img className="thumbnail" alt="Schéma en trois étapes conteneurisez vos modèles d'IA ou votre application web avec des frameworks comme Flask FastAPI Streamlit TensorFlow gradio et PyTorch puis poussez l'image Docker vers un registre public ou privé puis déployez en quelques secondes avec AI Deploy qui offre un endpoint HTTP des nœuds CPU et GPU la haute disponibilité une mise à l'échelle simple une authentification sécurisée l'accès à l'Object Storage et la supervision" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/ai_deploy_concept.png" loading="lazy" />
 
 ## Recommandations à suivre
 
@@ -309,7 +309,7 @@ docker push my-registry.ai.cloud.ovh.net/custom-image:latest
 
 Si vous souhaitez connaître les commandes exactes pour envoyer sur le registre partagé, veuillez consulter le bouton <code className="action">Détails</code> de la section **Shared Docker Registry** dans le panneau **Home** d’AI Training.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/shared_registry_details.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Home d'AI Training avec le panneau Information listant Shared Docker Registry et OVHcloud AI Training command line interface chacun avec un bouton Details" src="/images/public-cloud/ai-machine-learning/deploy-tuto-12-build-custom-image/shared_registry_details.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-flask-image.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-flask-image.mdx
@@ -185,7 +185,7 @@ Pensez à ajouter l’attribut `--unsecure-http` si vous souhaitez que votre app
 
 Une fois l’app en cours d’exécution, vous pouvez accéder à votre application Flask directement depuis l’URL de l’app.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-02-flask/flask-app.png" loading="lazy" />
+<img className="thumbnail" alt="Page de navigateur affichant le texte Web App with Python Flask using AI Training" src="/images/public-cloud/ai-machine-learning/deploy-tuto-02-flask/flask-app.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-streamlit-image.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-build-use-streamlit-image.mdx
@@ -193,7 +193,7 @@ Pensez à ajouter l’attribut `--unsecure-http` si vous souhaitez que votre app
 
 Une fois l’app AI Deploy en cours d’exécution, vous pouvez accéder à votre application Streamlit directement depuis l’URL de l’app.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-01-streamlit/streamlit.png" loading="lazy" />
+<img className="thumbnail" alt="Application Streamlit intitulée My first app affichant un tableau de quatre lignes avec les colonnes first column et second column et un graphique en courbes de trois séries a b et c" src="/images/public-cloud/ai-machine-learning/deploy-tuto-01-streamlit/streamlit.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-getting-started.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-getting-started.mdx
@@ -308,7 +308,7 @@ Vous avez la flexibilité de laisser votre app AI Deploy s’exécuter indéfini
   <Tab label="Depuis l'espace client (UI)">
     Cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis sélectionnez la section <code className="action">AI Deploy</code>. Repérez l’app AI Deploy que vous souhaitez arrêter. Cliquez sur le bouton <code className="action">...</code> et arrêtez votre application AI Deploy en sélectionnant <code className="action">Arrêter</code> dans le menu contextuel.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-02-getting-started/step-11-stop-app.png" loading="lazy" />
+    <img className="thumbnail" alt="Page AI Deploy dans l'espace client OVHcloud avec l'application my-model-api In service et l'entrée Stop mise en évidence dans son menu d'actions" src="/images/public-cloud/ai-machine-learning/deploy-guide-02-getting-started/step-11-stop-app.png" loading="lazy" />
 
 Une fois arrêtée, votre app AI Deploy libérera les ressources de calcul précédemment allouées. Votre endpoint est conservé, et si vous redémarrez votre app AI Deploy, le même endpoint pourra être réutilisé sans problème.
     Par ailleurs, lorsque vous arrêtez votre app, vous ne réservez plus de ressources de calcul, ce qui signifie que vous n’avez plus de dépenses pour cette partie. Seules des dépenses liées au stockage attaché peuvent subsister.

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-load-test-app.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-load-test-app.mdx
@@ -185,7 +185,7 @@ Une fois votre `locustfile.py` prêt, ouvrez l’interface web de Locust sur `[h
 
 L’interface web devrait ressembler à ceci :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust.png" loading="lazy" />
+<img className="thumbnail" alt="Interface web de Locust avec le formulaire Start new load test comprenant les champs Number of users Spawn rate et Host et le bouton Start swarming avec le statut READY" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust.png" loading="lazy" />
 
 ### Lancer vos tests de charge
 
@@ -201,11 +201,11 @@ Lancez le test.
 
 À la fin du test de charge, vous verrez ce résumé rapide :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/result_locust.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Statistics de Locust affichant la ligne POST /spam_detection_path avec 128060 requêtes 53 échecs une médiane de 260 ms une moyenne de 442 ms un maximum de 7477 ms et 805.7 requêtes par seconde avec 0% d'échecs" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/result_locust.png" loading="lazy" />
 
 Si nous souhaitons obtenir plus de détails sur notre test, nous pouvons consulter les graphiques fournis par Locust dans l’onglet `charts`. Voici ce que l’on peut observer :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust_graphs.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Charts de Locust affichant Total Requests per Second qui augmente par paliers jusqu'à environ 800 sans échec et Response Times qui monte à environ 2500 ms au 95e centile alors que la médiane reste basse" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/locust_graphs.png" loading="lazy" />
 
 Nous avons déployé cette API de 1 à 5 réplicas, avec 1 CPU pour chacun, complété par l’autoscaling. On peut voir que notre API a été légèrement surchargée. En effet, sur les graphiques comme dans le résumé rapide, on observe quelques échecs. Ces échecs sont dus à des erreurs serveur. On peut supposer que nous avons atteint certaines limites matérielles à un moment donné, par exemple avant de monter en charge vers un plus grand nombre de réplicas.
 
@@ -226,24 +226,24 @@ Ce dashboard est fourni gratuitement dans AI Deploy, pour chaque application dé
 
 Vous pouvez sélectionner l’app déployée en haut de ce dashboard Grafana, comme illustré ci-dessous :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/general_dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord Grafana App Monitoring avec le sélecteur d'application en haut et les panneaux Resource usage pour GPU Usage GPU Memory Usage CPU Usage Memory Usage Network Usage Ephemeral storage usage Volumes Total Size Volumes Total File Count et une section HTTP" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/general_dashboard.png" loading="lazy" />
 
 Avec ce dashboard, vous pouvez voir le pourcentage de CPU utilisé en temps réel, la latence HTTP de votre API, l’autoscaling de l’app, la bande passante réseau et bien plus encore.
 Les barres verticales bleues indiquent les événements de scaling.
 
 Voici le résultat pour la charge CPU, globalement (tous réplicas confondus) :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/cpu_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Panneaux Grafana Resource usage pendant le test de charge avec CPU Usage culminant près de 60% puis redescendant et les panneaux Memory Usage Network Usage et Ephemeral storage usage à côté avec des barres bleues verticales marquant les événements de scaling" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/cpu_spam.png" loading="lazy" />
 
 On constate que notre app a scalé à plusieurs reprises et n’a pas atteint sa capacité maximale, grâce à l’autoscaling. Regardons maintenant la latence de notre application :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/latency_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Panneaux Grafana Volumes et HTTP avec HTTP Call Latency au 95e centile se stabilisant autour de 750 ms puis culminant au-delà de 1.5 s et HTTP Call Count montant à environ 280 appels avant de retomber à zéro" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/latency_spam.png" loading="lazy" />
 
 On voit ici que la latence a augmenté progressivement, puisque nous avons un taux d’apparition de deux nouveaux utilisateurs par seconde. La latence de l’API était stable autour de 750 ms, puis a atteint un pic à 1,5 s.
 
 Là encore, l’interprétation dépendra de vos besoins. Devons-nous fournir plus de CPU parce que la latence est trop élevée ? Cette question variera selon les besoins de vos clients. Pour un anti-spam, ajouter 1 seconde est considérable pour une entreprise recevant des milliers d’e-mails par jour, mais peu gênant s’il s’agit d’une douzaine par jour. Regardons maintenant le scaling de notre application :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/scaling_spam.png" loading="lazy" />
+<img className="thumbnail" alt="Panneaux Grafana Auto-scaling montrant Running replicas passant de 1 à 4 pour un maximum de 5 un Usage target de 75% et les courbes CPU Usage et Memory Usage par réplique pour les répliques 9nwqj d2dwf dtz8c et zd2ln" src="/images/public-cloud/ai-machine-learning/deploy-tuto-10-locust/scaling_spam.png" loading="lazy" />
 
 On constate que le seuil a été plafonné à 75 % pour l’autoscaling, et que celui-ci a été respecté. Sur les 5 réplicas fournis à l’application, 4 ont été utilisés.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-openai-whisper.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-openai-whisper.mdx
@@ -101,7 +101,7 @@ Vous pouvez créer votre conteneur Object Storage soit via l’interface (espace
 
     Sélectionnez ensuite la section <code className="action">Object Storage</code> (dans la catégorie Storage) et créez un nouveau conteneur d’objets en cliquant sur <code className="action">Stockage</code> > <code className="action">Object Storage</code> > <code className="action">Créer un conteneur d'objets</code>.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-17-streamlit-whisper/new-object-container.png" loading="lazy" />
+    <img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/deploy-tuto-17-streamlit-whisper/new-object-container.png" loading="lazy" />
 
 Vous pouvez créer le conteneur qui stockera votre modèle Whisper. Sélectionnez le *type* de conteneur et le *datastore_alias* correspondant à vos besoins, et nommez-le comme vous le souhaitez. *L’alias `GRA` et le nom `whisper-model` seront utilisés dans ce tutoriel.*
   </Tab>

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-rasa-chatbot.mdx
@@ -25,7 +25,7 @@ Les objectifs de ce tutoriel sont les suivants :
 
 Voici un schéma expliquant le fonctionnement :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/diagramme.png" loading="lazy" />
+<img className="thumbnail" alt="Schéma de l'échange entre l'utilisateur l'application Flask exécutée avec AI Deploy sur le port 5000 et le modèle Rasa exécuté avec AI Deploy sur le port 5005 numéroté say hello puis request response for hello puis send response hello you puis write hello you" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/diagramme.png" loading="lazy" />
 
 ## Prérequis
 
@@ -262,7 +262,7 @@ Voilà ! Sur l’URL de cette app, vous pouvez discuter avec votre chatbot. Essa
 
 Voici un exemple de discussion avec le chatbot :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/result.jpg" loading="lazy" />
+<img className="thumbnail" alt="Deux fenêtres de conversation avec le chatbot où l'assistant salue l'utilisateur puis l'interroge sur son logement et son transport et récapitule enfin les valeurs saisies appartment rer on site" src="/images/public-cloud/ai-machine-learning/deploy-tuto-11-rasa-chatbot-flask/result.jpg" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-tokens.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-tokens.mdx
@@ -75,7 +75,7 @@ Si votre app est déjà déployée, vous pouvez toujours ajouter ou mettre à jo
   <Tab label="Depuis l'espace client (UI)">
     Accédez à la section **AI Deploy** où toutes vos apps sont listées. **Cliquez sur le nom de votre app** pour ouvrir sa page de détails. Repérez la section **Labels**. Saisissez la paire clé-valeur et cliquez sur <code className="action">+</code> pour ajouter le label à votre app.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-03-tokens/03-app-add-label-existing-app.png" loading="lazy" />
+    <img className="thumbnail" alt="Tableau de bord de l'application hello-world-clear-cronin avec le panneau Labels mis en évidence affichant la clé team la valeur ml-engineering et un label group = A existant" src="/images/public-cloud/ai-machine-learning/deploy-guide-03-tokens/03-app-add-label-existing-app.png" loading="lazy" />
 
 Après l’enregistrement, le label ajouté sera visible dans la section **Labels** des détails de l’app. 
   </Tab>

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-update-custom-docker-image.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-update-custom-docker-image.mdx
@@ -10,7 +10,7 @@ Pour être lancée, notre application AI Deploy **doit être conteneurisée**, �
 
 Pendant que notre app est en cours d'exécution, il est probable que nous devions **mettre à jour notre image Docker** pour corriger des problèmes ou apporter de nouvelles fonctionnalités. C'est pourquoi nous allons voir dans ce tutoriel **comment faire en sorte que notre app utilise la version mise à jour de notre image Docker**.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/update_docker_img_deploy.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma de l'utilisation d'une image Docker mise à jour dans une application déployée montrant le tag et le push vers le registre d'images puis ovhai app set-image pour mettre à jour l'image puis l'arrêt et le redémarrage de l'application pour qu'AI Deploy récupère l'image mise à jour" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/update_docker_img_deploy.svg" loading="lazy" />
 
 ## Prérequis
 
@@ -74,7 +74,7 @@ Cependant, si nous **arrêtons et redémarrons** l'app, l'image utilisée sera c
 
 Cette opération d'arrêt et de redémarrage peut être effectuée depuis le <ManagerLink to="/">espace client OVHcloud</ManagerLink> (UI) en cliquant sur le bouton `...` à côté de votre app, comme illustré sur la capture d'écran ci-dessous :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/stop_start_app_control-panel.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Apps d'AI Deploy listant les applications déployées avec le menu d'actions ouvert sur l'application speech_to_text_app-compassionate en cours d'exécution affichant Details Generate a token Start Stop et Delete" src="/images/public-cloud/ai-machine-learning/deploy-guide-08-update-custom-docker-image/stop_start_app_control-panel.png" loading="lazy" />
 
 Exécutez-la depuis la CLI `ovhai` avec les commandes suivantes :
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-web-service-yolov5.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-deploy-web-service-yolov5.mdx
@@ -29,7 +29,7 @@ Pour plus d'informations sur la façon d'entraîner YOLOv5 sur un jeu de donnée
 
 Tout d'abord, l'arborescence de votre dossier doit être la suivante.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/deploy-tuto-04-flask-yolov5/tree_yolov5_web_service.png" loading="lazy" />
+<img className="thumbnail" alt="Sortie de la commande tree du projet de service web listant Dockerfile app.py requirements.txt un dossier models_train avec yolov5m_100epochs.pt et yolov5s_100epochs.pt un dossier static avec bandeau.png et style.css et un dossier templates avec index.html" src="/images/public-cloud/ai-machine-learning/deploy-tuto-04-flask-yolov5/tree_yolov5_web_service.png" loading="lazy" />
 
 -   Vous devez créer le dossier nommé `models_train`, c'est là que vous pourrez stocker les poids générés après vos entraînements. Vous êtes libre de placer autant de fichiers de poids que vous le souhaitez dans le dossier `models_train`.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-function-calling-langchain4j.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-function-calling-langchain4j.mdx
@@ -22,7 +22,7 @@ Pour cela, nous allons utiliser **[LangChain4j](https://github.com/langchain4j/l
 
 Associé aux **[AI Endpoints](/links/public-cloud/ai-endpoints)** d’OVHcloud, qui proposent à la fois des modèles LLM et des modèles d’embedding, il devient facile de créer des assistants avancés et prêts pour la production.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-14-function-calling-langchain4j/painter.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration d'un robot humanoïde peignant sur une toile posée sur un chevalet en bois dans un atelier d'artiste" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-14-function-calling-langchain4j/painter.png" loading="lazy" />
 
 ## Définition
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-mcp-langchain4j.mdx
@@ -17,7 +17,7 @@ Dans cet article, nous allons explorer comment créer un serveur et un client Mo
 
 Associé à OVHcloud **[AI Endpoints](/links/public-cloud/ai-endpoints)**, qui propose à la fois des modèles LLM et des modèles d'embedding, il devient facile de créer des assistants avancés, prêts pour la production.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-15-mcp-langchain4j/robot.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration d'un robot humanoïde blanc penché sur un bureau pour regarder un ordinateur portable ouvert" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-15-mcp-langchain4j/robot.png" loading="lazy" />
 
 ## Définition
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-sentiment-analyzer.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-sentiment-analyzer.mdx
@@ -170,7 +170,7 @@ curl -X POST http://localhost:8080/sentiment -d "I feel great today!"
 
 Vous devriez recevoir un emoji (ou un label) représentant le sentiment du texte :
 
-![image](/images/guides/public-cloud/ai-machine-learning/endpoints-tuto-04-sentiment-analyzer/sentiment-analysis.png)
+<img className="thumbnail" alt="Client API envoyant une requête POST vers localhost:8080/sentiment avec le corps en texte brut I'm angry et recevant une réponse 200 OK en 80 ms dont l'aperçu est un émoji de visage en colère" src="/images/guides/public-cloud/ai-machine-learning/endpoints-tuto-04-sentiment-analyzer/sentiment-analysis.png" loading="lazy" />
 
 ## Conclusion
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-structured-output-langchain4j.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-endpoints-structured-output-langchain4j.mdx
@@ -17,7 +17,7 @@ Pour cela, nous allons utiliser **[LangChain4j](https://github.com/langchain4j/l
 
 Associé à OVHcloud **[AI Endpoints](/links/public-cloud/ai-endpoints)**, qui propose à la fois des modèles LLM et des modèles d'embedding, il devient facile de créer des assistants avancés, prêts pour la production.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-13-structured-output-langchain4j/parrot.png" loading="lazy" />
+<img className="thumbnail" alt="Illustration d'un ordinateur portable sur un bureau affichant la photo d'un perroquet coloré à côté d'un gobelet de café noir" src="/images/public-cloud/ai-machine-learning/endpoints-tuto-13-structured-output-langchain4j/parrot.png" loading="lazy" />
 
 ## Définition
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-manage-registries.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-manage-registries.mdx
@@ -54,11 +54,11 @@ C'est pourquoi il peut être intéressant d'ajouter et de gérer d'autres regist
 
 Cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis rendez-vous dans la section `AI Training`, située sous `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="Section AI & MACHINE LEARNING du menu de l'espace client listant AI Dashboard AI Notebooks AI Training AI Deploy et AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 En cliquant sur le bouton <code className="action">Registres Docker Privés</code>, vous devriez pouvoir voir et gérer (ajouter, supprimer) vos différents registres privés.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/registries_overview.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Private Docker Registry d'AI Training listant deux registres ID_01 pointant vers index.docker.io et ID_02 pointant vers xyz.gra.container-registry.ovh.net tous deux dans la région GRA avec un bouton Add" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/registries_overview.png" loading="lazy" />
 
 Notez que le `registre partagé` n'apparaîtra pas ici. Celui-ci est affiché dans le panneau **Home** d'AI Training.
 
@@ -131,10 +131,10 @@ Pour terminer la configuration de votre registre Harbor privé, vous devrez **cr
 #### Récupérer l'URL de l'API de votre OVHcloud Managed Private Registry
 
 Afin d'ajouter ce registre aux AI Tools, vous devrez récupérer son URL. Pour cela, rendez-vous dans la section Managed Private Registry de l'OVHcloud Public Cloud Manager, et dans le bouton « plus d'options » (...) à droite, cliquez sur `Harbor API` :
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-1.png" loading="lazy" />
+<img className="thumbnail" alt="Page Managed Private Registry listant le registre my-registry en version Harbor 2.0.1 avec le menu d'actions ouvert et Harbor API mis en évidence" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-1.png" loading="lazy" />
 
 Copiez ensuite l'URL de l'API Harbor, qui est l'URL de votre registre privé :
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-2.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre Private registry API affichant le champ URL for your private registry API renseigné avec une adresse terminant par gra7.container-registry.ovh.net et une icône de copie" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/get-private-registry-api-url-2.png" loading="lazy" />
 
 #### Ajouter le registre Harbor
 
@@ -146,7 +146,7 @@ Au cours de cette étape, il vous sera demandé les identifiants de votre utilis
   <Tab label="Depuis l'espace client (UI)">
     Pour ajouter votre registre privé via l'interface, cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis rendez-vous dans la section `AI Dashboard`, située sous `AI & Machine Learning`.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+    <img className="thumbnail" alt="Section AI & MACHINE LEARNING du menu de l'espace client listant AI Dashboard AI Notebooks AI Training AI Deploy et AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 Par défaut, vous serez redirigé vers le panneau <code className="action">Dashboard</code>. Pour ajouter une URL de registre personnalisée, cliquez sur le bouton <code className="action">Registres Docker</code>. Une fois là, cliquez sur le bouton <code className="action">+ Ajouter</code> pour ajouter votre registre Docker privé.
 
@@ -238,7 +238,7 @@ Au cours de cette étape, il vous sera demandé vos identifiants Docker.
 
 Cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis rendez-vous dans la section `AI Dashboard`, située sous `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="Section AI & MACHINE LEARNING du menu de l'espace client listant AI Dashboard AI Notebooks AI Training AI Deploy et AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 Par défaut, vous serez redirigé vers le panneau <code className="action">Dashboard</code>. Pour ajouter une URL de registre personnalisée, cliquez sur le bouton <code className="action">Registres Docker</code>. Une fois là, cliquez sur le bouton <code className="action">+ Ajouter</code> pour ajouter votre registre Docker privé.
 
@@ -291,7 +291,7 @@ Vos identifiants GitHub vous seront demandés.
   <Tab label="Depuis l'espace client (UI)">
     Cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis rendez-vous dans la section `AI Dashboard`, située sous `AI & Machine Learning`.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
+    <img className="thumbnail" alt="Section AI & MACHINE LEARNING du menu de l'espace client listant AI Dashboard AI Notebooks AI Training AI Deploy et AI Endpoints" src="/images/public-cloud/ai-machine-learning/gi-07-manage-registry/training_menu.png" loading="lazy" />
 
 Par défaut, vous serez redirigé vers le panneau <code className="action">Dashboard</code>. Pour ajouter une URL de registre personnalisée, cliquez sur le bouton <code className="action">Registres Docker</code>. Une fois là, cliquez sur le bouton <code className="action">+ Ajouter</code> pour ajouter votre registre Docker privé.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-billing.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-billing.mdx
@@ -30,7 +30,7 @@ Au cours de sa vie, le notebook passera par les statuts suivants :
 - `ERROR` : le notebook s'est arrêté en raison d'une erreur backend. Vous pouvez contacter notre support.
 - `DELETING` : le notebook est en cours de suppression. Une fois supprimé, vous ne le verrez plus, et il n'existera plus. Ses données internes du dossier [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) ne seront pas supprimées automatiquement après la suppression du notebook. Si vous êtes sûr(e) de vouloir les supprimer, vous pouvez les retrouver et les supprimer dans le conteneur `notebooks_workspace` de votre Object Storage, sous le répertoire de l'ID du notebook.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai_notebooks_lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Chronologie du cycle de vie d'un AI Notebook depuis Launch jusqu'à Delete en passant par Starting Running Stopping et Stopped annotée avec la sauvegarde automatique du workspace la branche expiration time reached et ce qui se passe à chaque phase" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai_notebooks_lifecycle.png" loading="lazy" />
 
 ## Principes de facturation
 
@@ -45,7 +45,7 @@ AI Notebooks est une **solution facturée à l'usage**. Vous ne payez que pour l
 
 Voici un graphique détaillé illustrant chaque étape facturée ou non pendant le déroulement d'un AI Notebook :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai.notebooks.billing.png" loading="lazy" />
+<img className="thumbnail" alt="Chronologie du cycle de vie d'un AI Notebook de Launch à Delete avec le CPU/GPU facturé uniquement pendant Running les données distantes facturées au tarif Object Storage et le workspace facturé une fois Stopped si le notebook a plus de 30 jours ou si le workspace dépasse 10G" src="/images/public-cloud/ai-machine-learning/notebook-guide-billing-concept/ai.notebooks.billing.png" loading="lazy" />
 
 ### Détails des ressources de calcul
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-concept.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-concept.mdx
@@ -48,7 +48,7 @@ Seul le temps passé à l'état `RUNNING` du notebook **est facturé**. Pour plu
 - `ERROR` : le notebook s'est terminé en raison d'une erreur backend. Vous pouvez contacter notre support.
 - `DELETING` : le notebook est en cours de suppression. Une fois supprimé, vous ne le verrez plus et il n'existera plus. Ses données internes dans [/workspace](/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace) ne seront pas supprimées automatiquement après la suppression du notebook. Si vous êtes certain de vouloir les supprimer, vous pouvez les trouver et les supprimer dans le conteneur `notebooks_workspace` de votre Object Storage, sous le répertoire de l'ID du notebook.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-concepts-notebooks/notebooks_concept.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma d'états d'un AI Notebook avec les transitions entre STARTING RUNNING STOPPING STOPPED TIMEOUT DELETING FAILED ERROR et DELETE" src="/images/public-cloud/ai-machine-learning/notebook-guide-concepts-notebooks/notebooks_concept.svg" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-hugging-face-sentiment-analysis.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-hugging-face-sentiment-analysis.mdx
@@ -69,7 +69,7 @@ Au préalable, si vous souhaitez stocker vos données (Tweets) dans un **contene
 
 Si vous souhaitez l'envoyer depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, allez dans la section Object Storage et créez un nouveau conteneur d'objets en cliquant sur <code className="action">Object Storage</code> > <code className="action">Créer un conteneur d'objets</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-05-hugging-face-sentiment-analysis/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-05-hugging-face-sentiment-analysis/new-object-container.png" loading="lazy" />
 
 Si vous souhaitez le faire avec la CLI, suivez simplement [ce guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). Vous devez choisir la région, le nom de votre conteneur et le chemin où se trouvent vos données, puis utiliser la commande suivante :
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-manage-data-ui.mdx
@@ -20,7 +20,7 @@ Vous devez d'abord envoyer des données vers l'`Object Storage` avant d'y accéd
 
 Vous pouvez accéder à la section `Object Storage` de votre projet Public Cloud depuis l'espace client OVHcloud.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-storage.png" loading="lazy" />
+<img className="thumbnail" alt="Page Object Storage dans l'espace client OVHcloud" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-storage.png" loading="lazy" />
 
 :::info
 Vous pouvez envoyer différents types de données : jeux de données, code, notebooks, poids de connexion, fichiers texte ou csv, etc.
@@ -42,7 +42,7 @@ Si vous choisissez une solution Object Storage compatible S3*, notez qu'elles ne
 
 Si vous souhaitez en savoir plus sur les différentes solutions de stockage, référez-vous à cette page.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-solution.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 1 de la création du conteneur objet sélection de la solution Standard Swift" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-solution.png" loading="lazy" />
 
 ### 2- Sélectionnez une région
 
@@ -52,7 +52,7 @@ Pour optimiser les temps de téléchargement et d'envoi, nous vous conseillons d
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-region.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 2 sélection de la région Gravelines GRA" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-region.png" loading="lazy" />
 
 ### 3- Sélectionnez un type de conteneur
 
@@ -64,15 +64,15 @@ Choisissez le type de vos données en fonction de ce que vous souhaitez faire.
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-type.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 3 sélection du type de conteneur Private" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-type.png" loading="lazy" />
 
 ### 4- Nommez votre conteneur
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-name.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 4 nom du conteneur my-dataset" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-container-name.png" loading="lazy" />
 
 Vous avez créé votre conteneur pour héberger votre jeu de données.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-container-created.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des conteneurs confirmant l'ajout de my-dataset" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-object-container-created.png" loading="lazy" />
 
 Vous êtes maintenant prêt(e) à charger vos données !
 
@@ -80,11 +80,11 @@ Vous êtes maintenant prêt(e) à charger vos données !
 
 Afin d'envoyer votre jeu de données dans votre conteneur d'objets `my-dataset`, vous devez aller sur `Ajouter des objets` et sélectionner votre fichier local `my-dataset.zip`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-add-objects-to-container.png" loading="lazy" />
+<img className="thumbnail" alt="Conteneur my-dataset vide affichant son URL et le bouton Add objects" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-add-objects-to-container.png" loading="lazy" />
 
 Vous verrez maintenant votre fichier `my-dataset.zip` affiché dans votre conteneur d'objets.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-zip-file-uploaded.png" loading="lazy" />
+<img className="thumbnail" alt="Conteneur my-dataset après l'import de dataset.zip" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-zip-file-uploaded.png" loading="lazy" />
 
 :::info
 Vous pouvez également créer un nouveau conteneur vide `my-weights` dans lequel vous pourrez sauvegarder vos **poids de connexion** (ou votre **modèle validé**) à la fin de votre entraînement.
@@ -103,7 +103,7 @@ Vous êtes maintenant prêt(e) à lancer un notebook avec vos données !
 
 Pour lancer un AI notebook, accédez à la section **AI Notebooks** de votre projet Public Cloud dans l'espace client OVHcloud.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-ai-notebooks.png" loading="lazy" />
+<img className="thumbnail" alt="Page d'accueil AI Notebooks dans l'espace client OVHcloud" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-ai-notebooks.png" loading="lazy" />
 
 Pour les *4 premières étapes* de la création du notebook, veuillez vous référer à ce [tutoriel](/guides/public-cloud/ai-machine-learning/ai-notebooks-definition).
 
@@ -111,7 +111,7 @@ Pour les *4 premières étapes* de la création du notebook, veuillez vous réf�
 
 Vous pouvez choisir entre *2 datacenters* pour le stockage de votre notebook : `GRA` ou `BHS`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-localisation.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 5 sélection du datacenter Gravelines GRA" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-localisation.png" loading="lazy" />
 
 ### Attachez un conteneur ou un dépôt Git
 
@@ -127,7 +127,7 @@ Comme mentionné précédemment, les buckets compatibles S3 ne sont pas encore c
 
 Vous pouvez charger le conteneur `my-dataset` dans le répertoire `/workspace/dataset`, avec la permission `Read-only`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-ro.png" loading="lazy" />
+<img className="thumbnail" alt="Attachement du conteneur my-dataset sur /workspace/dataset en lecture seule" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-ro.png" loading="lazy" />
 
 Vous ne pourrez pas modifier le jeu de données depuis ce notebook car vous l'avez chargé avec la permission `Read-only`.
 
@@ -140,7 +140,7 @@ Comme pour le mode `Read-only`, vous pouvez charger des données avec la permiss
 
 Une fois que vous disposez de données que vous souhaitez sauvegarder du notebook vers l'Object Storage (des poids de connexion dans cet exemple), il vous suffit de les écrire dans le dossier `/workspace/weights`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-weights-rw.png" loading="lazy" />
+<img className="thumbnail" alt="Attachement du conteneur my-weights sur /workspace/weights en lecture et écriture" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-weights-rw.png" loading="lazy" />
 
 Ce dossier sera envoyé vers votre Object Storage lorsque vous arrêterez votre notebook.
 
@@ -153,7 +153,7 @@ Pour pouvoir les modifier facilement, utilisez la permission Read-write.
 
 La commande est la suivante :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-git-repo-rw.png" loading="lazy" />
+<img className="thumbnail" alt="Attachement d'un dépôt Git public sur /workspace/git-hub-repository en lecture et écriture" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-git-repo-rw.png" loading="lazy" />
 
 :::warning
 Pour que votre commande soit valide, n'oubliez pas d'ajouter `.git` à la fin de l'URL du dépôt GitHub.
@@ -167,7 +167,7 @@ Lors du chargement de fichiers volumineux depuis l'`Object Storage`, le téléch
 
 Pour cela, vous pouvez cocher `Cache`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-cache.png" loading="lazy" />
+<img className="thumbnail" alt="Attachement du conteneur my-dataset en lecture seule avec l'option Cache activée" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-dataset-cache.png" loading="lazy" />
 
 Les volumes en cache seront supprimés au moins 72 heures après l'arrêt du dernier notebook les utilisant.
 Notez que le cache est partagé entre tous les utilisateurs de votre projet. La principale conséquence à laquelle vous devez faire attention
@@ -177,13 +177,13 @@ est que si une autre personne modifie les données de votre volume en cache, vou
 
 Votre notebook est maintenant prêt à être lancé avec vos données !
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-attached-data.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 7 montrant deux conteneurs Object Storage et un dépôt Git attachés au notebook" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-attached-data.png" loading="lazy" />
 
 Vous pouvez consulter la page [Bien démarrer](/guides/public-cloud/ai-machine-learning/ai-notebooks-definition) pour savoir comment retrouver cette URL.
 
 Dès que vous accédez à votre notebook, vous verrez vos différents dossiers contenant vos données.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-containers.png" loading="lazy" />
+<img className="thumbnail" alt="Lanceur JupyterLab affichant les dossiers dataset git-hub-repository et weights" src="/images/public-cloud/ai-machine-learning/notebook-guide-data-ui/ui-notebook-containers.png" loading="lazy" />
 
 ## Nous voulons vos retours !
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-marine-mammal-sounds-classification.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-marine-mammal-sounds-classification.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 L'objectif de ce tutoriel est de montrer comment il est possible d'entraîner un modèle afin de classifier des sons. Pour cela, nous prenons comme exemple un dataset de **sons de mammifères marins**.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/marine-mammals-categories.png" loading="lazy" />
+<img className="thumbnail" alt="Grille de douze illustrations de mammifères marins légendées comprenant Atlantic Spotted Dolphin Bearded Seal Bottlenose Dolphin Bowhead Whale Clymene Dolphin Common Dolphin False Killer Whale et Harp Seal" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/marine-mammals-categories.png" loading="lazy" />
 
 ## Prérequis
 
@@ -34,7 +34,7 @@ L'objectif de ce tutoriel est de montrer comment il est possible d'entraîner un
 
 Si vous souhaitez l'envoyer depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section Object Storage et [créez un nouveau conteneur d'objets](/guides/storage-and-backup/object-storage/pcs-create-container) en cliquant sur <code className="action">Object Storage</code> > <code className="action">Créer un conteneur d'objets</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-06-marine-mammal-sounds-classification/new-object-container.png" loading="lazy" />
 
 :::info
 Dans l'espace client OVHcloud, vous pouvez envoyer des fichiers mais pas des dossiers. Par exemple, vous pouvez envoyer un fichier .zip pour optimiser la bande passante, puis le décompresser ultérieurement en y accédant depuis votre JupyterLab.

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-spam-classifier.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-spam-classifier.mdx
@@ -10,7 +10,7 @@ Ce tutoriel vous montrera comment construire un classificateur de spam simple av
 
 À la fin de ce tutoriel, vous aurez appris les principales méthodes pour construire votre propre **classificateur de spam**.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-09-spam-classifier/spam-classifier.png" loading="lazy" />
+<img className="thumbnail" alt="Schéma dessiné à la main d'une enveloppe de message entrant classée soit comme ham à gauche soit comme spam à droite" src="/images/public-cloud/ai-machine-learning/notebook-tuto-09-spam-classifier/spam-classifier.png" loading="lazy" />
 
 :::info
 Nous pourrons créer ce modèle avec le dataset nommé **SMSSPamCollection**. Retrouvez-le sur le [lien](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection) du SMS Spam Collection Dataset.

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-speech-to-text-recognition.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-speech-to-text-recognition.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2022-09-01
 
 L'objectif de ce tutoriel est de vous montrer comment il est possible de **convertir de la parole en texte** et de **générer des transcriptions** grâce aux AI Notebooks.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-08-speech-to-text/speech-to-text.jpeg" loading="lazy" />
+<img className="thumbnail" alt="Schéma dessiné à la main d'une personne qui parle alimentant un modèle d'IA qui produit un document texte" src="/images/public-cloud/ai-machine-learning/notebook-tuto-08-speech-to-text/speech-to-text.jpeg" loading="lazy" />
 
 En **Natural Language Processing** (NLP), le speech-to-text est une tâche de Deep Learning qui permet aux machines de comprendre et de lire le langage humain. Les applications sont nombreuses : transcription, résumés, diarisation, génération de sous-titres, ...
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-tensorboard-embedded.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-tensorboard-embedded.mdx
@@ -12,7 +12,7 @@ TensorBoard est un outil créé par TensorFlow, qui fournit les mesures et visua
 
 TensorBoard fournit une interface visuelle :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/overview_interface_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet SCALARS de TensorBoard affichant les graphiques accuracy et loss pour les runs test et train avec le curseur de lissage réglé sur 0.6" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/overview_interface_tensorboard.png" loading="lazy" />
 
 Le tutoriel présente un exemple simple de lancement de **TensorBoard** dans un notebook.
 
@@ -54,7 +54,7 @@ L'ensemble du code source de ce tutoriel se trouve [ici](https://github.com/ovh/
 
 Le notebook d'exemple est basé sur le dataset Fashion MNIST.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/image_overview_jupyter_notebook_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab avec l'onglet notebook_tutorial_tensorboard ouvert affichant le titre TUTORIAL TensorBoard integration in notebooks et une grille d'images de vêtements du jeu de données Fashion MNIST" src="/images/public-cloud/ai-machine-learning/notebook-tuto-02-tensorboard/image_overview_jupyter_notebook_tensorboard.png" loading="lazy" />
 
 Accédez ensuite au notebook d'exemple via le chemin suivant :
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-transfer-learning-resnet.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-transfer-learning-resnet.mdx
@@ -36,7 +36,7 @@ L'architecture du modèle **ResNet** permet de réduire l'erreur d'entraînement
 
 Les réseaux de neurones résiduels ignorent certaines connexions et effectuent des sauts de deux ou trois couches contenant des non-linéarités (ReLU).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-07-transfer-learning-resnet50-image-classification/resnet.png" loading="lazy" />
+<img className="thumbnail" alt="Schéma d'un bloc résiduel où l'entrée x traverse deux couches de poids séparées par un relu puis est additionnée au raccourci identité avant un relu final" src="/images/public-cloud/ai-machine-learning/notebook-tuto-07-transfer-learning-resnet50-image-classification/resnet.png" loading="lazy" />
 
 Avec cette méthode, la performance est généralement améliorée.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-tuto-rock-paper-scissors.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-tuto-rock-paper-scissors.mdx
@@ -43,7 +43,7 @@ Pour en savoir plus sur la licence de ce dataset, veuillez suivre ce [lien](http
 
 Si vous souhaitez le créer depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section Object Storage et créez un nouveau conteneur d'objets en cliquant sur `Object Storage` > `Créer un conteneur d'objets`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-15-rock-paper-scissors/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-15-rock-paper-scissors/new-object-container.png" loading="lazy" />
 
 Si vous souhaitez l'exécuter avec la CLI, suivez simplement ce [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). Vous devez choisir la région, le nom de votre conteneur et le chemin où se trouvent vos données, puis utiliser les commandes suivantes.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-weights-biases.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-weights-biases.mdx
@@ -10,7 +10,7 @@ L'objectif de ce tutoriel est de montrer comment il est possible d'utiliser **We
 
 Weights & Biases vous permet de suivre vos expérimentations de machine learning, de versionner vos datasets et de gérer facilement vos modèles, comme illustré ci-dessous :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/overview_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Espace de travail Weights and Biases comparant sept runs d'entraînement avec les graphiques Test error rate loss acc val_loss val_acc et epoch" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/overview_wandb.png" loading="lazy" />
 
 Ce tutoriel présente deux exemples d'utilisation de Weights & Biases. Dans le premier notebook, nous utiliserons TensorFlow et dans le second, une image Docker PyTorch.
 
@@ -62,15 +62,15 @@ L'objectif de ce tutoriel est de montrer comment il est possible, grâce à Weig
 
 Par exemple, vous pouvez afficher les courbes d'accuracy et de loss pour vos données de validation et d'entraînement. Ces métriques seront affichées pour chaque epoch de chaque entraînement.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/valid_train_metrics_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Espace de travail Weights and Biases avec une section Valid data affichant val_loss et val_acc et une section Train data affichant loss et acc pour les sept runs d'entraînement" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/valid_train_metrics_mnist_wandb.png" loading="lazy" />
 
 Vous pouvez ensuite comparer vos entraînements à l'aide du type de graphique **Parallel coordinates** :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/parallel_coordinates_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique Parallel coordinates de Weights and Biases reliant les axes loss learning_rate et epochs à la valeur acc obtenue avec une échelle de couleurs allant de 0.984 à 1.000" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/parallel_coordinates_mnist_wandb.png" loading="lazy" />
 
 Vous pouvez également comparer les **Test error rates** :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/test_error_rate_mnist_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Diagramme en barres Test error rate de Weights and Biases comparant les runs training_1 à training_7 avec des valeurs comprises entre environ 1.2 et 1.9" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/test_error_rate_mnist_wandb.png" loading="lazy" />
 
 Un aperçu de ce notebook est disponible sur [GitHub](https://github.com/ovh/ai-training-examples/tree/main/notebooks/computer-vision/image-classification/tensorflow/weights-and-biases).
 
@@ -82,15 +82,15 @@ Le notebook utilisant PyTorch et Weights & Biases est basé sur YOLOv5 et le dat
 
 L'objectif de ce tutoriel est de montrer comment Weights & Biases peut être utilisé avec le framework de détection d'objets en temps réel YOLOv5. Pour cela, les performances des modèles YOLOv5 s, m, l et x seront comparées sur le dataset COCO pour le même nombre d'epochs.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/loss_train_valid_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Espace de travail Weights and Biases avec une section train affichant obj_loss cls_loss et box_loss et une section val affichant les trois mêmes pertes pour les quatre runs yolov5x_results yolov5l_results yolov5m_results et yolov5s_results" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/loss_train_valid_yolov5_wandb.png" loading="lazy" />
 
 Une autre possibilité offerte par Weights & Biases est d'afficher l'utilisation de vos ressources de calcul :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/system_utilization_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Section System de Weights and Biases affichant GPU Power Usage en watts et en pourcentage GPU Memory Allocated GPU Time Spent Accessing Memory GPU Temp et GPU Utilization au fil du temps pour les quatre runs YOLOv5" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/system_utilization_yolov5_wandb.png" loading="lazy" />
 
 Vous pouvez également créer votre rapport avec vos courbes et vos images, et le partager avec votre équipe !
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/report_yolov5_wandb.png" loading="lazy" />
+<img className="thumbnail" alt="Rapport Weights and Biases intitulé YOLOv5 model comparaison avec une ligne Images montrant la même photo annotée par chacun des quatre runs et une ligne Results montrant leurs courbes précision rappel PR_curve.png" src="/images/public-cloud/ai-machine-learning/notebook-tuto-03-weight-biases/report_yolov5_wandb.png" loading="lazy" />
 
 Un aperçu de ce notebook est disponible sur [GitHub](https://github.com/ovh/ai-training-examples/tree/main/notebooks/computer-vision/object-detection/miniconda/weights-and-biases).
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-workspace.mdx
@@ -35,7 +35,7 @@ Ce workspace est sauvegardé tant que votre notebook est à l'état `STOPPED`.
 
 Voici un graphique résumant l'utilisation du workspace et du stockage éphémère de votre notebook au cours de ses différents états :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-guide-workspace/ai-notebooks_workspace.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma résumant l'utilisation du répertoire workspace persistant et du répertoire data éphémère au fil des états du notebook" src="/images/public-cloud/ai-machine-learning/notebook-guide-workspace/ai-notebooks_workspace.svg" loading="lazy" />
 
 
 ### Supprimer des fichiers du workspace

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov5-example.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov5-example.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 L'objectif de ce tutoriel est de montrer comment il est possible d'entraîner YOLOv5 à reconnaître des objets. YOLOv5 est un algorithme de détection d'objets. Bien qu'étroitement lié à la classification d'images, la détection d'objets effectue une classification d'images à une échelle plus précise. La détection d'objets localise et catégorise les éléments dans les images.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/image-yolov5.png" loading="lazy" />
+<img className="thumbnail" alt="Photo de rue annotée par YOLOv5 avec des cadres de détection étiquetés person avec des scores de confiance de 0.56 à 0.86 bicycle 0.74 et dog 0.82 surmontée du texte You Only Look Once" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/image-yolov5.png" loading="lazy" />
 
 Il repose sur le repository open source de YOLOv5 développé par [Ultralytics](https://github.com/ultralytics/yolov5).
 
@@ -35,7 +35,7 @@ Il repose sur le repository open source de YOLOv5 développé par [Ultralytics](
 
 Si vous souhaitez l'envoyer depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section Object Storage et créez un nouveau conteneur d'objets en cliquant sur <code className="action">Object Storage</code> > <code className="action">Créer un conteneur d'objets</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/new-object-container.png" loading="lazy" />
 
 Si vous souhaitez l'exécuter avec la CLI, suivez simplement ce [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). Vous devez choisir la région, le nom de votre conteneur et le chemin où se trouvent vos données, puis utiliser la commande suivante :
 
@@ -80,7 +80,7 @@ Dans ce tutoriel, vous avez besoin de 2 conteneurs d'objets.
 - le **premier conteneur d'objets** contient votre dataset (étiqueté et séparé) ainsi que votre fichier `data.yaml`.
 - le **second conteneur d'objets** est vide. Il est destiné à sauvegarder les poids de votre modèle (pour une future inférence par exemple).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/notebook-attach-data.png" loading="lazy" />
+<img className="thumbnail" alt="Étape 7 Attach a Git container or repository avec le conteneur dataset - GRA monté en lecture seule sur /workspace/data le conteneur weights - GRA monté en lecture et écriture sur /workspace/models_train et le dépôt Git ai-training-examples monté sur /workspace/examples" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/notebook-attach-data.png" loading="lazy" />
 
 Une fois le dépôt cloné, trouvez le notebook YOLOv5 en suivant ce chemin : `ai-training-examples` > `notebooks` > `computer-vision` > `object-detection` > `miniconda` > `notebook_object_detection_yolov5.ipynb`.
 
@@ -103,7 +103,7 @@ Vous pourrez ensuite accéder à l'URL de votre notebook une fois qu'il est en c
 
 Vous devriez obtenir cet aperçu :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/overview-notebook.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab affichant le notebook notebook_object_detection ouvert sur le titre TUTORIAL Train YOLOv5 on custom dataset avec ses sections introduction et prérequis" src="/images/public-cloud/ai-machine-learning/notebook-tuto-04-yolov5/overview-notebook.png" loading="lazy" />
 
 ### Expérimenter avec le notebook YOLOv5
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov7-sign-language.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-notebooks-yolov7-sign-language.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2023-05-11
 
 L'objectif de ce tutoriel est de montrer comment il est possible d'entraîner YOLOv7 à reconnaître **les lettres de l'American Sign Language**. YOLOv7 est un algorithme de détection d'objets. Bien qu'étroitement lié à la classification d'images, la détection d'objets effectue une classification d'images à une échelle plus précise. La détection d'objets localise et catégorise les éléments dans les images.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/overview-notebook.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab affichant le notebook notebook_yolov7_asl_recognition ouvert sur le titre TUTORIAL Train YOLOv7 for American Sign Language recognition avec un schéma d'un modèle d'une caméra et d'un signe de la main détecté" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/overview-notebook.png" loading="lazy" />
 
 Il repose sur le [repository](https://github.com/WongKinYiu/yolov7) open source de YOLOv7.
 
@@ -45,7 +45,7 @@ Pour en savoir plus sur la licence de ce dataset, veuillez suivre ce [lien](http
 
 Si vous souhaitez le créer depuis l'<ManagerLink to="/">espace client OVHcloud</ManagerLink>, rendez-vous dans la section Object Storage et créez un nouveau conteneur d'objets en cliquant sur `Object Storage` > `Créer un conteneur d'objets`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/new-object-container.png" loading="lazy" />
+<img className="thumbnail" alt="Page Create an object container avec l'étape 1 Select a region ouverte sur l'onglet All locations proposant Beauharnois BHS Frankfurt DE Gravelines GRA Strasbourg SBG London UK et Warsaw WAW" src="/images/public-cloud/ai-machine-learning/notebook-tuto-11-yolov7/new-object-container.png" loading="lazy" />
 
 Si vous souhaitez l'exécuter avec la CLI, suivez simplement ce [guide](/guides/public-cloud/ai-machine-learning/ai-cli-access-data). Vous devez choisir la région, le nom de votre conteneur et le chemin où se trouvent vos données, puis utiliser les commandes suivantes.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-solutions-remote-connect.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-solutions-remote-connect.mdx
@@ -63,27 +63,27 @@ Voici comment ajouter votre clé SSH à votre solution AI si vous utilisez l'<Ma
     
     À partir de là, cliquez sur le bouton <code className="action">+ Créer un notebook</code> ou <code className="action">+ Lancer un job</code> pour configurer et créer votre solution AI.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-1.png" loading="lazy" />
+    <img className="thumbnail" alt="Page AI Training dans l'espace client OVHcloud avec le bouton Launch a job mis en évidence" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-1.png" loading="lazy" />
 
 Remplissez les différents champs requis jusqu'à trouver la section <code className="action">Configuration avancée</code>. Ouvrez-la.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-2.png" loading="lazy" />
+    <img className="thumbnail" alt="Section Advanced configuration repliée du formulaire de création du job" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-2.png" loading="lazy" />
 
 À partir de là, vous trouverez une sous-section `SSH Public Keys` où vous pouvez ajouter et configurer de nouvelles clés SSH en cliquant sur le bouton <code className="action">+ Configurer une clé SSH</code> :
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-3.png" loading="lazy" />
+    <img className="thumbnail" alt="Section SSH Public Keys sans clé configurée et bouton Configure an SSH key" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-3.png" loading="lazy" />
 
 Cela ouvrira une fenêtre où vous pouvez coller le contenu de votre fichier de clé publique (par exemple, `id_ed25519.pub`) :
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-4.png" loading="lazy" />
+    <img className="thumbnail" alt="Fenêtre Configure a new SSH key avec le nom et la clé publique renseignés" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-4.png" loading="lazy" />
 
 Cliquez sur <code className="action">Confirmer</code>. Une fois votre clé ajoutée, vous pouvez la sélectionner dans votre liste de clés SSH :
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-5.png" loading="lazy" />
+    <img className="thumbnail" alt="Liste déroulante des clés SSH affichant id_ed25519 et SSH_key_VM" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-5.png" loading="lazy" />
 
 Une fois sélectionnée, veillez à cliquer sur <code className="action">+</code> pour confirmer l'ajout de votre clé. Vous devriez voir le message suivant : `1 of 10 SSH key configured`.
     
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-6.png" loading="lazy" />
+    <img className="thumbnail" alt="Section SSH Public Keys indiquant 1 clé SSH configurée sur 10" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/manager-6.png" loading="lazy" />
   </Tab>
   <Tab label="Depuis la CLI ovhai">
     Pour suivre cette partie, assurez-vous d'avoir installé la [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) sur votre ordinateur ou sur une instance.
@@ -132,11 +132,11 @@ ovh@job-36ed1f18-626b-42f7-b15f-0ed844e65d20:~$
 
 Dans Visual Studio Code, cliquez sur l'icône <code className="action">Remote Explorer</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-1.png" loading="lazy" />
+<img className="thumbnail" alt="Barre d'activité de VS Code avec l'icône Remote Explorer sélectionnée" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-1.png" loading="lazy" />
 
 À partir de là, cliquez sur l'icône en forme d'engrenage de la fonctionnalité SSH pour accéder au fichier de configuration SSH de VSCode, généralement situé à `~/.ssh/config`, et ouvrez-le.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-2.png" loading="lazy" />
+<img className="thumbnail" alt="Remote Explorer de VS Code ouvrant la sélection du fichier de configuration SSH" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-2.png" loading="lazy" />
 
 Ajoutez la section suivante pour votre nouvel hôte :
 
@@ -149,25 +149,25 @@ IdentityFile C:\Path\To\id_ed25519 # Path to your private key file (not .pub)
 
 Enregistrez le fichier `config`. Puis actualisez les ressources distantes en cliquant sur cette icône :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-3.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton Refresh de la liste des hôtes SSH de VS Code" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-3.png" loading="lazy" />
 
 Votre ressource devrait maintenant apparaître dans le menu SSH à gauche. Connectez-vous à celle-ci en cliquant sur la flèche à côté de votre ressource. VSCode redémarrera pour se connecter à votre ressource distante :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-4.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des hôtes SSH affichant my_ai_training_job avec l'action Connect in New Window" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-4.png" loading="lazy" />
 
 Si la connexion est bien établie, vous devriez voir ce message dans le coin inférieur gauche de VSCode :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-5.png" loading="lazy" />
+<img className="thumbnail" alt="Barre d'état de VS Code confirmant la connexion SSH à my_ai_training_job" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-5.png" loading="lazy" />
 
 ### Développer et exécuter votre code
 
 Une fois connecté, vous pouvez commencer à développer et exécuter votre code dans le dossier par défaut `/workspace`, en cliquant sur le bouton bleu <code className="action">Open folder</code>, et en sélectionnant `/workspace`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-6.png" loading="lazy" />
+<img className="thumbnail" alt="Invite Open Folder listant le contenu du répertoire workspace distant" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-6.png" loading="lazy" />
 
 Vous pouvez également ouvrir un terminal et y exécuter des commandes. Profitez-en !
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-7.png" loading="lazy" />
+<img className="thumbnail" alt="Terminal VS Code exécutant nvidia-smi sur le job distant et affichant un GPU NVIDIA H100 PCIe" src="/images/public-cloud/ai-machine-learning/gi-03-remote-connection/vscode-7.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-solutions-resources.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-solutions-resources.mdx
@@ -45,11 +45,11 @@ Pour récupérer l'URL de monitoring de votre AI Tool, vous pouvez utiliser soit
 
     Vous accédez alors à un tableau listant vos instances, où vous pouvez trouver celle dont vous avez besoin et ses informations générales. Pour afficher les détails de votre instance, cliquez soit sur le nom de l'instance, soit sur le bouton <code className="action">...</code>, puis sur <code className="action">Gérer</code>.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/00_access_tool_details.png" loading="lazy" />
+    <img className="thumbnail" alt="Page AI Training avec les entrées de menu AI Notebooks AI Training et AI Deploy mises en évidence et le menu d'actions du job ai-training-demo ouvert sur Manage" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/00_access_tool_details.png" loading="lazy" />
 
 Depuis cet écran, vous pouvez cliquer sur le bouton <code className="action">Grafana Dashboard</code>, sous <code className="action">Usage monitoring</code>, pour accéder à votre interface de monitoring Grafana.
 
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/01_access_grafana_ui.png" loading="lazy" />
+    <img className="thumbnail" alt="Tableau de bord du job ai-training-demo avec le lien Grafana dashboard mis en évidence sous Usage monitoring dans le panneau Access" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/01_access_grafana_ui.png" loading="lazy" />
   </Tab>
   <Tab label="Depuis la CLI ovhai">
     Pour suivre cette partie, assurez-vous d'avoir installé la [CLI ovhai](/guides/public-cloud/ai-machine-learning/ai-cli-install-client) sur votre ordinateur ou sur une instance.
@@ -164,7 +164,7 @@ Pour AI Notebooks et AI Training, les fonctionnalités suivantes sont disponible
 - **Volumes Total Size** : taille totale des volumes attachés à votre notebook ou job.
 - **Volumes Total File Count** : nombre total de fichiers dans les volumes attachés.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/02_resource_dashboard.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord Grafana des ressources avec les panneaux GPU Usage GPU Memory Usage CPU Usage Memory Usage Network Usage et Ephemeral storage usage montrant deux pics d'activité GPU" src="/images/public-cloud/ai-machine-learning/gi-11-concepts-resources/02_resource_dashboard.png" loading="lazy" />
 
 #### Applications AI Deploy
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-build-use-custom-image.mdx
@@ -353,7 +353,7 @@ Par exemple, si nous souhaitons envoyer une première version de notre image con
 
 Si vous souhaitez connaître les commandes exactes pour envoyer vers votre registre partagé, consultez le bouton <code className="action">Détails</code> de la section **Shared Docker Registry**, dans le panneau **Home** d'AI Training.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-02-build-custom-image/shared_registry_details.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet Home d'AI Training avec le panneau Information listant Shared Docker Registry et OVHcloud AI Training command line interface chacun avec un bouton Details" src="/images/public-cloud/ai-machine-learning/training-tuto-02-build-custom-image/shared_registry_details.png" loading="lazy" />
 
 ## Exemples de Dockerfile
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-jobs.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-jobs.mdx
@@ -47,7 +47,7 @@ Seul le temps `RUNNING` du job **est facturé**. Pour plus d’informations sur 
 - `FAILED` : le job s’est terminé avec une erreur, par exemple le processus du job s’est terminé avec un code de sortie différent de 0, l’image Docker n’a pas pu être récupérée, etc.
 - `ERROR` : le job s’est terminé en raison d’une erreur du backend.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-03-concepts-jobs/status-diagram.svg" loading="lazy" />
+<img className="thumbnail" alt="Schéma d'états d'un job AI Training avec les transitions entre QUEUED INITIALIZING PENDING RUNNING FINALIZING TIMEOUT DONE FAILED INTERRUPTING INTERRUPTED et ERROR" src="/images/public-cloud/ai-machine-learning/training-guide-03-concepts-jobs/status-diagram.svg" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-models-comparaison-wandb.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-models-comparaison-wandb.mdx
@@ -8,7 +8,7 @@ lastUpdated: 2025-06-27
 
 L'objectif de ce tutoriel est de comparer deux méthodes en exécutant deux jobs en parallèle afin de classifier des audios. Pour voir quel modèle est le plus performant en termes de précision, de consommation de ressources et de temps d'entraînement, nous utiliserons l'outil [Weights & Biases](https://wandb.ai/site).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/models-comparaison-overview.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique en coordonnées parallèles Models comparaison reliant les axes accuracy val_accuracy loss val_loss Relative Time et best_epoch au best_val_loss obtenu pour deux runs" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/models-comparaison-overview.png" loading="lazy" />
 
 ### Cas d'usage
 
@@ -81,7 +81,7 @@ Vous allez suivre différentes étapes pour traiter vos données et entraîner v
 
 Le tutoriel se déroule comme suit :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/instructions-overview.jpeg" loading="lazy" />
+<img className="thumbnail" alt="Schéma dessiné à la main de deux approches où les fichiers audio sont convertis soit en un fichier CSV fourni à un ANN soit en spectrogrammes fournis à un CNN les deux résultats étant envoyés vers Weights and Biases" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/instructions-overview.jpeg" loading="lazy" />
 
 Nous allons principalement voir comment écrire le code de traitement des données et d'entraînement des modèles, les fichiers `requirements.txt` et `packages.txt`, ainsi que le `Dockerfile`. Si vous souhaitez consulter le code complet, reportez-vous au [dépôt GitHub](https://github.com/ovh/ai-training-examples/tree/main/jobs/weights-and-biases/audio-classification-models-comparaison).
 
@@ -153,7 +153,7 @@ Reportez-vous aux commentaires du [code](https://github.com/ovh/ai-training-exam
 
 *L'en-tête du fichier `csv` :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/csv-file-overview.png" loading="lazy" />
+<img className="thumbnail" alt="Cinq premières lignes du dataframe de caractéristiques extraites avec les colonnes filename length chroma_stft rms spectral_centroid spectral_bandwidth tempo et mfcc pour un total de 28 colonnes" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/csv-file-overview.png" loading="lazy" />
 
 #### Audio vers spectrogramme avec génération d'image
 
@@ -163,7 +163,7 @@ Reportez-vous aux commentaires du [code](https://github.com/ovh/ai-training-exam
 
 *Un exemple de spectrogramme :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/spectrogram-example.png" loading="lazy" />
+<img className="thumbnail" alt="Spectrogramme de Mel d'un échantillon audio où l'énergie apparaît sous forme de bandes orange et jaune vif sur un fond sombre" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/spectrogram-example.png" loading="lazy" />
 
 Une fois le traitement des données terminé, les modèles d'IA doivent être construits.
 
@@ -482,25 +482,25 @@ Vous pouvez maintenant accéder au panneau Weights & Biases. Vous pourrez consul
 
 *Précision :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/accuracy.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique accuracy où le run image-classification-spectrogramms dépasse 0.9 tandis que le run audio-classification-features monte plus lentement jusqu'à environ 0.9" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/accuracy.png" loading="lazy" />
 
 *Perte :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/loss.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique loss où le run image-classification-spectrogramms descend rapidement sous 0.2 tandis que le run audio-classification-features décroît progressivement jusqu'à environ 0.3" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/loss.png" loading="lazy" />
 
 - **Données de validation :**
 
 *Précision :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-accuracy.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique val_accuracy où le run image-classification-spectrogramms se stabilise au-dessus de 0.9 tandis que le run audio-classification-features se stabilise autour de 0.7" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-accuracy.png" loading="lazy" />
 
 *Perte :*
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-loss.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique val_loss où le run image-classification-spectrogramms descend sous 0.2 tandis que le run audio-classification-features reste autour de 1 et remonte légèrement à la fin" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/val-loss.png" loading="lazy" />
 
 Vous pouvez ensuite observer quel modèle est le meilleur en termes de vitesse, de précision ou de consommation de ressources...
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/gpu-power-usage.png" loading="lazy" />
+<img className="thumbnail" alt="Graphique GPU Power Usage en watts où le run image-classification-spectrogramms reste proche de 38.7 W pendant près de trois heures tandis que le run audio-classification-features n'apparaît que sous forme d'un bref pic près de 36.6 W" src="/images/public-cloud/ai-machine-learning/training-tuto-06-models-comparaison-weights-and-biases/gpu-power-usage.png" loading="lazy" />
 
 Dans ce cas, nous constatons que le **modèle classifiant les spectrogrammes** est meilleur en termes de précision et de perte sur le jeu de validation.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-start-use-notebooks.mdx
@@ -46,7 +46,7 @@ Les configurations suivantes sont actuellement disponibles :
 -   **MXNet** : une image préconfigurée OVHcloud contenant le notebook JupyterLab, l'IDE Visual Studio Code et les bibliothèques `mxnet`
 -   **Fast.ai** : une image préconfigurée OVHcloud contenant le notebook JupyterLab, l'IDE Visual Studio Code et les bibliothèques `fast.ai`
 -   **autogluon** : une image préconfigurée OVHcloud contenant le notebook JupyterLab, l'IDE Visual Studio Code et les bibliothèques `AutoGluon` + `mxnet`
-    <img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/01_submit_image.png" loading="lazy" />
+    <img className="thumbnail" alt="Étape 2 Enter the Docker image proposant les préréglages MXNet Fast.ai Pytorch Tensorflow 2 et Hugging Face Transformers chacun fourni avec JupyterLab et VSCode avec Tensorflow 2 sélectionné et un champ Custom image en dessous" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/01_submit_image.png" loading="lazy" />
 
 Une fois votre image choisie, cliquez sur <code className="action">Suivant</code>.
 
@@ -64,7 +64,7 @@ Si vous souhaitez pouvoir sauvegarder les fichiers de votre notebook sur votre O
 
 Une fois votre job `In progress`, dans le panneau de description du job, vous devriez voir le lien `Access`. Cliquez dessus et vous serez redirigé vers l'URL de votre job.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/02_http_access_url.png" loading="lazy" />
+<img className="thumbnail" alt="Panneaux de détail du job affichant Job information pour ai-training-tensorflow-acid-alvarez dans la région GRA un panneau Container avec l'image ovhcom/ai-training-tensorflow:2.3.0 In progress et un lien HTTP access et un panneau Resources avec 1 GPU" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/02_http_access_url.png" loading="lazy" />
 
 ### Étape 5 - Se connecter en tant qu'utilisateur AI Training
 
@@ -78,17 +78,17 @@ Si vous n'avez pas encore créé d'utilisateur pour AI Training, vous pouvez sui
 
 Remplissez les champs et cliquez sur <code className="action">Login</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/03_login_form.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire de connexion OVHcloud avec les champs User Name et Password et le bouton Connect" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/03_login_form.png" loading="lazy" />
 
 ### Étape 6 - Utiliser votre notebook
 
 Dans la plupart des images préconfigurées fournies, vous pouvez choisir l'éditeur que vous préférez entre JupyterLab et VisualStudio Code.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/04_jupyter_vs_vscode.png" loading="lazy" />
+<img className="thumbnail" alt="Choix entre le bouton Jupyter Lab et le bouton Visual Studio Code" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/04_jupyter_vs_vscode.png" loading="lazy" />
 
 Sélectionnez simplement celui que vous souhaitez utiliser, et vous serez redirigé vers celui-ci.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/05_jupyter.png" loading="lazy" />
+<img className="thumbnail" alt="JupyterLab avec l'onglet Launcher ouvert proposant les tuiles Notebook et Console pour Python 3 et un fichier index.html dans le navigateur de fichiers" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/05_jupyter.png" loading="lazy" />
 
 Par défaut, le répertoire personnel de votre job se trouve sous `/workspace`. Cela signifie que vous disposerez d'un accès en **lecture** et en **écriture** à ce répertoire, ainsi qu'à vos volumes montés en **lecture** et en **écriture**.
 
@@ -103,7 +103,7 @@ Pour installer des bibliothèques spécifiques nécessitant un accès privilégi
 :::info
 Si vous ouvrez un onglet **console** dans votre notebook et tapez `nvidia-smi`, vous verrez les GPU disponibles que vous pouvez utiliser sur votre notebook.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/09_nvidia_smi.png" loading="lazy" />
+<img className="thumbnail" alt="Terminal JupyterLab affichant la bannière TensorFlow puis la sortie de nvidia-smi indiquant la version de pilote 450.51.05 la version CUDA 11.0 et un GPU Tesla V100S consommant 25W sur 250W sans processus en cours" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/09_nvidia_smi.png" loading="lazy" />
 
 :::
 
@@ -114,15 +114,15 @@ Une fois que vous avez terminé de travailler avec votre notebook, n'oubliez pas
 
 Vous pouvez le faire en sélectionnant <code className="action">Arrêter</code> dans le menu d'actions.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/06_stop_notebook.png" loading="lazy" />
+<img className="thumbnail" alt="Panneau Actions contenant une seule entrée Stop" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/06_stop_notebook.png" loading="lazy" />
 
 Puis <code className="action">confirmez</code> votre choix.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/07_confirm_stop.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre de confirmation Stop the job listant l'ID du job la région l'image Docker l'utilisateur admin le statut In progress et la date de création avec les boutons Cancel et Confirm stop" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/07_confirm_stop.png" loading="lazy" />
 
 Après un certain temps, votre job devrait passer à l'état `Interrupted`, signifiant que le job a été arrêté.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/08_interrupted.png" loading="lazy" />
+<img className="thumbnail" alt="Champ Status affichant le badge Interrupted" src="/images/public-cloud/ai-machine-learning/training-guide-06-howto-notebooks/08_interrupted.png" loading="lazy" />
 
 :::info
 Avant de passer à l'état `Interrupted`, votre job peut traverser l'état `Finalizing`. Durant cette phase, toutes les données présentes dans les `read & write volumes` sont sauvegardées dans les conteneurs associés de votre Object Storage.

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
@@ -30,7 +30,7 @@ Ce guide couvre l'initialisation d'**AI Training** et la soumission de [**jobs**
 
 Cliquez sur <ManagerLink to="/#/pci/projects">ce lien</ManagerLink> pour accéder à votre projet Public Cloud, puis rendez-vous dans la section <code className="action">AI Training</code>, située sous `AI & Machine Learning`.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/00_training_menu.png" loading="lazy" />
+<img className="thumbnail" alt="Section AI and Machine Learning du menu de l'espace client OVHcloud avec AI Training sélectionné" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/00_training_menu.png" loading="lazy" />
 
 ### Étape 2 - Démarrer la soumission d'un job
 
@@ -48,9 +48,9 @@ Chaque **job** est exécuté dans une région OVHcloud. Chaque région dispose d
 
 Sélectionnez la région souhaitée et cliquez sur <code className="action">Suivant</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/02_name_job.png" loading="lazy" />
+<img className="thumbnail" alt="Formulaire Launch a job avec le champ Job name renseigné avec example-job" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/02_name_job.png" loading="lazy" />
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/03_submit_region.png" loading="lazy" />
+<img className="thumbnail" alt="Étape Location avec la région Gravelines GRA sélectionnée" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/03_submit_region.png" loading="lazy" />
 
 ### Étape 4 - Spécifier la quantité de ressources
 
@@ -60,7 +60,7 @@ La quantité maximale de GPUs ou de CPUs que vous pouvez sélectionner pour votr
 
 Une fois la quantité de ressources définie, vous pouvez voir un aperçu du tarif de facturation. Cliquez sur <code className="action">Suivant</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/04_submit_resources.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau Resources listant les flavors CPU et GPU disponibles avec leur tarif horaire" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/04_submit_resources.png" loading="lazy" />
 
 ### Étape 5 - Fournir une image Docker
 
@@ -76,7 +76,7 @@ Les images préconfigurées ne peuvent pas couvrir tous vos besoins, vous pouvez
 
 Cela inclut les images publiques (par exemple Dockerhub), les images du registre partagé ou les images de votre registre privé ajouté. Pour plus d'informations, découvrez comment [ajouter un registre privé](/guides/public-cloud/ai-machine-learning/ai-manage-registries).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/05_submit_image.png" loading="lazy" />
+<img className="thumbnail" alt="Étape Docker Image sur l'onglet Custom image avec le champ du chemin de l'image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/05_submit_image.png" loading="lazy" />
 
 ### Étape 6 - Paramètres de confidentialité
 
@@ -88,7 +88,7 @@ L'*accès public* exposera vos données et votre code à quiconque obtient le li
 :::
 
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/06_job_privacy_settings.png" loading="lazy" />
+<img className="thumbnail" alt="Étape Privacy avec Public access sélectionné" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/06_job_privacy_settings.png" loading="lazy" />
 
 ### Étape 7 - Cycle de vie du job
 
@@ -101,7 +101,7 @@ Cela nous permet également de traiter les incidents localisés sur un hôte, pa
 
 Par défaut, votre job s'arrêtera automatiquement après 7 jours consécutifs au statut `RUNNING`. Soyez assuré que tous vos paramètres et données seront préservés. Vous avez la possibilité d'activer le redémarrage automatique, qui relancera automatiquement votre job tous les 7 jours, garantissant une interruption minimale de votre workflow. Vous pouvez également contacter [notre support](https://help.ovhcloud.com/csm?id=csm_get_help) pour étendre cette période de redémarrage automatique de 7 à 28 jours.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/07_job_lifecycle.png" loading="lazy" />
+<img className="thumbnail" alt="Étape Expiry affichant l'interrupteur Automatic restart et son infobulle" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/07_job_lifecycle.png" loading="lazy" />
 
 ### Étape 8 - Configuration avancée
 
@@ -115,7 +115,7 @@ Si vous souhaitez en savoir plus sur la configuration des conteneurs et des dép
 
 Enfin, les **clés publiques SSH** vous permettent d'accéder à votre job à distance.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/08_job_advanced_config.png" loading="lazy" />
+<img className="thumbnail" alt="Section Advanced configuration dépliée affichant les commandes Docker les volumes et les clés SSH" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/08_job_advanced_config.png" loading="lazy" />
 
 ### Étape 9 - Soumettre votre job
 
@@ -127,13 +127,13 @@ Cliquez sur <code className="action">Commander</code> pour confirmer et lancer l
 
 Une fois votre job créé, il apparaîtra dans votre onglet AI Training :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/10_ai_training_panel.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des jobs AI Training affichant example-job en cours" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/10_ai_training_panel.png" loading="lazy" />
 
 ### Étape 10 - Consulter votre job
 
 Depuis cette liste, vous pouvez accéder aux détails de votre job en cliquant sur son nom ou en cliquant sur <code className="action">...</code> puis en sélectionnant `Manage`. Les détails incluent plusieurs éléments, comme les ressources du job, les statuts, la facturation, les logs et l'URL d'accès. Cette URL est de la forme `https://<JOB-ID>.job.<REGION>.ai.cloud.ovh.net/`. De plus, vous pouvez accéder à n'importe quel port disponible en l'ajoutant à l'URL du job de cette façon : `https://<JOB-ID>-<PORT>.job.<REGION>.ai.cloud.ovh.net/`. Vous pouvez consulter la liste des ports disponibles dans les [capacités](/guides/public-cloud/ai-machine-learning/ai-training-capabilities).
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/11_job_details.png" loading="lazy" />
+<img className="thumbnail" alt="Tableau de bord du job affichant l'accès la chronologie du cycle de vie les ressources et la commande ovhai" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/11_job_details.png" loading="lazy" />
 
 Vous pouvez également consulter les logs de votre job en cliquant sur le bouton <code className="action">Logs</code>.
 
@@ -143,17 +143,17 @@ Si vous avez terminé d'utiliser votre job, si votre modèle a convergé prémat
 
 Depuis la liste des **jobs**, vous pouvez consulter les actions disponibles tout à droite de chaque entrée et interrompre le job en cliquant sur <code className="action">Arrêter</code>. Vous pouvez également interrompre le **job** depuis ses détails, dans la liste des actions, en cliquant sur le bouton d'arrêt <code className="action">🔴</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/12_job_stop.png" loading="lazy" />
+<img className="thumbnail" alt="En-tête du job avec le bouton d'arrêt mis en évidence" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/12_job_stop.png" loading="lazy" />
 
 Ensuite, si vous n'avez plus besoin de votre job, vous pouvez le supprimer. Pour cela, cliquez simplement sur le bouton <code className="action">...</code>, puis sélectionnez l'action <code className="action">Supprimer</code>.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/13_job_delete.png" loading="lazy" />
+<img className="thumbnail" alt="Liste des jobs avec le menu d'actions ouvert et Delete mis en évidence" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/13_job_delete.png" loading="lazy" />
 
 ### Étape 12 - Cloner votre job
 
 Vous pouvez également cliquer sur le bouton de redémarrage <code className="action">🔄</code> pour cloner le job avec la même configuration. Cela lancera un nouveau job identique à l'original (par exemple, `example-job`), vous permettant de relancer votre workflow sans avoir à reconfigurer le job.
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/14_job_clone.png" loading="lazy" />
+<img className="thumbnail" alt="En-tête du job avec le bouton de clonage mis en évidence" src="/images/public-cloud/ai-machine-learning/training-guide-02-howto-submit-job/14_job_clone.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-tensorboard-inside-job.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-tensorboard-inside-job.mdx
@@ -12,7 +12,7 @@ TensorBoard est un outil créé par TensorFlow, pour fournir les mesures et visu
 
 TensorBoard fournit une interface visuelle :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/training-tuto-05-tensorboard/overview_tensorboard.png" loading="lazy" />
+<img className="thumbnail" alt="Onglet SCALARS de TensorBoard affichant les graphiques accuracy et loss pour les runs test et train avec le curseur de lissage réglé sur 0.6" src="/images/public-cloud/ai-machine-learning/training-tuto-05-tensorboard/overview_tensorboard.png" loading="lazy" />
 
 Ce tutoriel présente un exemple simple de lancement de **TensorBoard** dans un job.
 

--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-users.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-users.mdx
@@ -37,7 +37,7 @@ En plus du rôle AI Training, nous recommandons fortement d'ajouter le rôle **O
 
 Pour appliquer ces rôles, cliquez sur la catégorie <code className="action">Project Management</code> dans le menu vertical de gauche pour accéder à la section <code className="action">Utilisateurs & Rôles</code> :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/03_users_menu.png" loading="lazy" />
+<img className="thumbnail" alt="Menu Project Management avec Users & Roles sélectionné au-dessus de Quota and Localisation SSH Keys Billing Control Credit and Vouchers Contacts and Rights et Project settings" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/03_users_menu.png" loading="lazy" />
 
 Sur cette page, vous pouvez soit **créer un nouvel utilisateur** pour votre Public Cloud project, soit **modifier les rôles d'un utilisateur existant**.
 
@@ -45,7 +45,7 @@ Sur cette page, vous pouvez soit **créer un nouvel utilisateur** pour votre Pub
 
 Cliquez sur <code className="action">+ Ajouter un utilisateur</code>, indiquez un nom comme description de l'utilisateur, et **attribuez les rôles nécessaires** pour utiliser les AI Solutions avec l'Object Storage (**AI Training Operator** ou **AI Training Reader**, selon le niveau d'accès que vous souhaitez accorder, et **ObjectStore Operator**) :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/04_users_roles.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre Edit roles avec les cases AI Training Operator et ObjectStore operator cochées parmi les rôles disponibles et les boutons Cancel et Confirm" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/04_users_roles.png" loading="lazy" />
 
 Cela générera un mot de passe qui vous permettra de vous authentifier auprès de vos AI Notebooks, jobs AI Training, apps AI Deploy existants et de la CLI `ovhai` pour en lancer de nouveaux.
 
@@ -60,7 +60,7 @@ Cela générera un mot de passe qui vous permettra de vous authentifier auprès 
 
 Pour modifier un utilisateur existant, cliquez simplement sur le bouton <code className="action">...</code> à côté de l'utilisateur, et sélectionnez `Edit roles` pour modifier ses rôles existants :
 
-<img className="thumbnail" alt="image" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/05_edit_user_roles.png" loading="lazy" />
+<img className="thumbnail" alt="Page Users & Roles listant un utilisateur admin et l'utilisateur my-first-user possédant les rôles AI Training Operator et ObjectStore operator avec le menu d'actions ouvert et Edit roles mis en évidence" src="/images/public-cloud/ai-machine-learning/gi-01-manage-users/05_edit_user_roles.png" loading="lazy" />
 
 ## Aller plus loin
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/automatically-label-taint-node-pool.mdx
@@ -486,7 +486,6 @@ avec les informations suivantes :
     }
   }
 ```
->
 
 ### Suppression
 

--- a/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/fr/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,16 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 Si ce type d'erreur survient :
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 Vous avez certainement oublié de changer le nom du dépôt lors de la phase d'init de ce tutoriel.
 Pour corriger cela, vous devez modifier l'instruction d'import dans le fichier `./controllers/ovhnginx_controller.go`, en remplaçant le dépôt GitHub `ovhcloud-devrel` dans `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` par votre propre dépôt GitHub.
->
+:::
 
 ### Tester l'opérateur en « mode dev »
 

--- a/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/it/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,15 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 If this kind of errors occurs:
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 

--- a/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/pl/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,15 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 If this kind of errors occurs:
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 

--- a/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
+++ b/docs/pt/guides/public-cloud/containers-orchestration/managed-kubernetes/deploy-go-operator.mdx
@@ -804,15 +804,16 @@ func (r *OvhNginxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 :::info
 If this kind of errors occurs:
-:::
 
 ```bash
 controllers/ovhnginx_controller.go:22:4: no required module provides package github.com/ovhcloud-devrel/nginx-go-operator/api/v1; to add it:
     go get github.com/ovhcloud-devrel/nginx-go-operator/api/v1
 Error: not all generators ran successfully
 ```
+
 You certainly forgot to change the repository name during the init phase of this tutorial.
 To fix it, you have to change the import statement in the `./controllers/ovhnginx_controller.go` file, replace `ovhcloud-devrel` GitHub repository in `tutorialsv1 "github.com/ovhcloud-devrel/nginx-go-operator/api/v1"` with your own GitHub repository.
+:::
 
 ### Test the operator in "dev mode"
 


### PR DESCRIPTION
## Context

Images across the AI & Machine Learning family used the literal placeholders
`alt="image"` or `alt="Alt text"`, which tell a screen-reader user nothing. This
PR replaces them with descriptions naming the real UI labels and values, and
folds in two mechanical structural defects that pre-date this work.

## Alt text (86 files)

- **46 guides / 133 unique images** covered across the family — 3 guides landed
  in an earlier commit on this branch, 43 in this round.
- Done in **EN and FR**, which are real translated files in this family. The
  other five locales are symlinks to EN and inherit the change automatically.
- Alts describe what each screenshot actually shows, naming the real UI labels
  and values rather than paraphrasing the surrounding prose, so each one stands
  alone. House convention followed: no sentence punctuation (only 0.7% of the
  repo's ~17k alts use any); French keeps its accents and apostrophes.
- Two markdown images were converted to the JSX `<img>` form already used
  everywhere else in the family. **No `src` value changed.**
- `ai-notebooks-create-rasa-chatbot.mdx` and `ai-training-train-rasa-chatbot.mdx`
  are deliberately untouched — PR #659 owns them and has already fixed their
  placeholders.

## Structural fixes (8 files)

**Truncated `:::info` callout in `deploy-go-operator.mdx`** — the `:::` closer
sat directly after the introductory line, so the callout rendered containing only
*"If this kind of error occurs"* while the error output and the two-sentence fix
explanation fell outside it as plain body text. The closer now sits past the
content it introduces, in all 7 locales. Also corrects the EN grammar
("kind of **errors** occurs" → "kind of **error** occurs").

**Two stray `>` lines** rendering as empty blockquotes, in
`deploy-go-operator.mdx` and `automatically-label-taint-node-pool.mdx`. Both were
FR-only — the other six locales had already been fixed. Each was verified in
context before removal: a lone `>` inside a multi-line blockquote is legitimate,
and neither of these was (both sat alone between a closing code fence and a blank
line, with no adjacent `>` lines).

## Verification

- **0** placeholders left of the original 272; EN/FR `alt="` counts match on every guide
- **0** `src` values changed — verified by diffing the added vs removed `src` sets
- **0** markdown `![...](...)` image lines added; **0** U+00A0 introduced
- Directives and code fences balanced in all 7 locales of both edited guides
- `pnpm build:en` and `pnpm build:fr` green; the repaired callout was confirmed in
  the **built HTML** for both locales (code block and fix sentence now inside the
  callout), with no empty blockquote remaining
- No prose, headings, frontmatter, or `lastUpdated` values altered
