### PR TITLE
docs: document deleted DNS zone recovery email in dns-zone-history

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: Versionsverlauf einer DNS-Zone verwalten
 description: Erfahren Sie, wie Sie Backups Ihrer DNS-Zone einsehen, vergleichen, herunterladen und wiederherstellen
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ Die DNS-Verwaltung wird durch den Versionsverlauf Ihrer DNS-Zonen vereinfacht.
 ## In der praktischen Anwendung
 
 :::info
+**Einschränkungen der Backups**
+
 Die Backups Ihrer DNS-Zone unterliegen folgenden Einschränkungen:
 
 - Es werden maximal 200 Backups für eine DNS-Zone aufbewahrt.
 - Sobald ein Backup älter als 31 Tage ist, wird es automatisch gelöscht, mit Ausnahme der **5 jüngsten Backups**.
+
+**Wenn Ihre DNS-Zone gelöscht wurde**
+
+Wenn eine DNS-Zone aus Ihrem OVHcloud Kundencenter gelöscht wird (manuelle Löschung, Ablauf des Dienstes oder ein anderer Grund), wird zum Zeitpunkt der Löschung eine E-Mail an den **Administratorkontakt** des Dienstes gesendet. Der Betreff lautet `[aa00000-ovh] [OVH-DNS] Löschung Ihrer DNS-Zone domain.tld` und die E-Mail enthält einen Link, über den Sie den Inhalt Ihrer früheren DNS-Zone abrufen können.
+
+Dieser Link ist nur **30 Tage** ab dem Versand der E-Mail gültig. Nach Ablauf dieser Frist ist die Konfiguration der gelöschten DNS-Zone unwiederbringlich verloren.
+
+Falls Sie diese E-Mail nicht in Ihrem Postfach finden, können Sie sie in Ihrem OVHcloud Kundencenter im Bereich <code className="action">Meine Kommunikation</code> einsehen, in dem alle an Ihre Kontakt-E-Mail-Adresse gesendeten Nachrichten zusammengefasst sind. Weitere Informationen finden Sie in unserer Anleitung "[Verwalten von Benachrichtigungen in Ihrem OVHcloud Kundencenter](/guides/account-and-service-management/account-information/manage-messages)".
+
+Um den Administratorkontakt eines Dienstes zu überprüfen oder zu ändern, lesen Sie unsere Anleitung "[Die Kontakte Ihrer Dienste verwalten](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 

--- a/docs/en/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Managing a DNS zone's history"
 description: Find out how to view, compare, download and restore your DNS zone backups
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ DNS management is now made easier thanks to the history of your DNS zones.
 ## Instructions
 
 :::info
+**Backup limits**
+
 Your DNS zone backups are subject to the following limitations:
 
 - We keep a maximum of 200 backups for the same DNS zone.
 - Once a backup is more than 31 days old, it is automatically deleted, with the exception of the **5 most recent backups** made.
+
+**If your DNS zone has been deleted**
+
+When a DNS zone is deleted from your OVHcloud Control Panel (manual deletion, service expiry or any other reason), an email is sent to the service's **administrator contact** at the time of deletion. Its subject line reads `[aa00000-ovh] [OVH-DNS] Deletion of your DNS Zone domain.tld` and contains a link to retrieve the contents of your former DNS zone.
+
+This link is only valid for **30 days** from the date the email was sent. After this period, the configuration of the deleted DNS zone is permanently lost.
+
+If you cannot find this email in your mailbox, you can view it in your OVHcloud Control Panel, in the <code className="action">My messages</code> section, which contains all the messages sent to your contact email address. For more information, consult our guide "[How to manage messages in your OVHcloud Control Panel](/guides/account-and-service-management/account-information/manage-messages)".
+
+To check or change the administrator contact of a service, consult our guide "[Managing contacts for your services](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 

--- a/docs/es/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gestionar el historial de una zona DNS
 description: Descubra cómo consultar, comparar, descargar y restaurar las copias de seguridad de la zona DNS
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ La gestión de los DNS se simplifica gracias al historial de las zonas DNS.
 ## Procedimiento
 
 :::info
+**Límites de las copias de seguridad**
+
 Las copias de seguridad de su zona DNS están sujetas a las siguientes limitaciones:
 
 - Conservamos un máximo de 200 copias de seguridad para una misma zona DNS.
 - Cuando una copia de seguridad tiene más de 31 días, se elimina automáticamente, a excepción de las **5 copias de seguridad más recientes** realizadas.
+
+**Si su zona DNS ha sido eliminada**
+
+Cuando una zona DNS se elimina de su área de cliente de OVHcloud (eliminación manual, expiración del servicio u otro motivo), en el momento de la eliminación se envía un correo electrónico al **contacto administrador** del servicio. Su asunto tiene el formato `[aa00000-ovh] [OVH-DNS] Eliminación de su zona DNS domain.tld` y contiene un enlace que permite recuperar el contenido de su antigua zona DNS.
+
+Este enlace solo es válido durante **30 días** a partir del envío del correo electrónico. Transcurrido este plazo, la configuración de la zona DNS eliminada se pierde definitivamente.
+
+Si no encuentra este correo electrónico en su bandeja de entrada, puede consultarlo desde su área de cliente de OVHcloud, en el apartado <code className="action">Mis mensajes</code>, que reúne todos los mensajes enviados a su dirección de correo electrónico de contacto. Para más información, consulte nuestra guía "[Gestionar las comunicaciones relacionadas con los servicios de OVHcloud](/guides/account-and-service-management/account-information/manage-messages)".
+
+Para comprobar o modificar el contacto administrador de un servicio, consulte nuestra guía "[Gestionar los contactos de los servicios](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 

--- a/docs/fr/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Gérer l’historique d’une zone DNS"
 description: Découvrez comment consulter, comparer, télécharger et restaurer vos sauvegardes de zone DNS
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ Désormais, la gestion des DNS est facilitée grâce à l’historique de vos zo
 ## En pratique
 
 :::info
+**Limites des sauvegardes**
+
 Les sauvegardes de votre zone DNS sont soumises aux limitations suivantes :
 
 - Nous conservons au maximum 200 sauvegardes pour une même zone DNS.
 - Dès qu’une sauvegarde a plus de 31 jours, celle-ci est automatiquement supprimée, à l’exception des **5 sauvegardes les plus récentes** effectuées.
+
+**Si votre zone DNS a été supprimée**
+
+Lorsqu’une zone DNS est supprimée de votre espace client OVHcloud (suppression manuelle, expiration du service ou autre raison), un e-mail est envoyé au **contact administrateur** du service au moment de la suppression. Son objet est de la forme `[aa00000-ovh] [OVH-DNS] Suppression de votre Zone DNS domain.tld` et il contient un lien permettant de récupérer le contenu de votre ancienne zone DNS.
+
+Ce lien n’est valable que **30 jours** à compter de l’envoi de l’e-mail. Passé ce délai, la configuration de la zone DNS supprimée est définitivement perdue.
+
+Si vous ne retrouvez pas cet e-mail dans votre messagerie, vous pouvez le consulter depuis votre espace client OVHcloud, dans la rubrique <code className="action">Mes communications</code>, qui regroupe l’ensemble des messages envoyés à votre adresse e-mail de contact. Pour plus d’informations, consultez notre guide « [Gérer les communications liées aux services OVHcloud](/guides/account-and-service-management/account-information/manage-messages) ».
+
+Pour vérifier ou modifier le contact administrateur d’un service, consultez notre guide « [Gérer les contacts de vos services](/guides/account-and-service-management/account-information/managing-contacts) ».
 
 :::
 

--- a/docs/it/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gestire la cronologia di una zona DNS
 description: Scopri come consultare, confrontare, scaricare e ripristinare i backup della zona DNS
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ La gestione dei DNS è semplificata grazie alla cronologia delle zone DNS.
 ## Procedura
 
 :::info
+**Limiti dei backup**
+
 I backup della zona DNS sono soggetti alle seguenti limitazioni:
 
 - Conserviamo al massimo 200 backup per la stessa zona DNS.
 - Quando un backup ha più di 31 giorni, viene automaticamente eliminato, ad eccezione dei **5 backup più recenti** effettuati.
+
+**Se la tua zona DNS è stata eliminata**
+
+Quando una zona DNS viene eliminata dal tuo Spazio Cliente OVHcloud (eliminazione manuale, scadenza del servizio o altro motivo), al momento dell'eliminazione viene inviata un'email al **contatto amministratore** del servizio. L'oggetto è del tipo `[aa00000-ovh] [OVH-DNS] Eliminazione della tua zona DNS domain.tld` e contiene un link che permette di recuperare il contenuto della tua vecchia zona DNS.
+
+Questo link è valido solo **30 giorni** dall'invio dell'email. Trascorso questo periodo, la configurazione della zona DNS eliminata è definitivamente persa.
+
+Se non trovi questa email nella tua casella di posta, puoi consultarla dal tuo Spazio Cliente OVHcloud, nella sezione <code className="action">Le mie comunicazioni</code>, che raccoglie tutti i messaggi inviati al tuo indirizzo email di contatto. Per maggiori informazioni, consulta la nostra guida "[Gestire le comunicazioni relative ai servizi OVHcloud](/guides/account-and-service-management/account-information/manage-messages)".
+
+Per verificare o modificare il contatto amministratore di un servizio, consulta la nostra guida "[Gestire i contatti dei servizi OVHcloud](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 

--- a/docs/pl/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zarządzanie historią strefy DNS
 description: Dowiedz się, jak sprawdzać, porównywać, pobierać i przywracać kopie zapasowe strefy DNS
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ Zarządzanie DNS jest teraz łatwiejsze dzięki historii Twoich stref DNS.
 ## W praktyce
 
 :::info
+**Ograniczenia kopii zapasowych**
+
 Kopie zapasowe Twojej strefy DNS podlegają następującym ograniczeniom:
 
 - Przechowujemy maksymalnie 200 kopii zapasowych dla jednej strefy DNS.
 - Gdy kopia zapasowa ma więcej niż 31 dni, jest automatycznie usuwana, z wyjątkiem **5 najnowszych kopii zapasowych**.
+
+**Jeśli Twoja strefa DNS została usunięta**
+
+Gdy strefa DNS zostanie usunięta z Panelu klienta OVHcloud (usunięcie ręczne, wygaśnięcie usługi lub inny powód), w momencie usunięcia na **kontakt administracyjny** usługi wysyłana jest wiadomość e-mail. Jej temat ma postać `[aa00000-ovh] [OVH-DNS] Usunięcie Twojej strefy DNS domain.tld`, a sama wiadomość zawiera link umożliwiający odzyskanie treści poprzedniej strefy DNS.
+
+Link ten jest ważny tylko **30 dni** od daty wysłania wiadomości. Po upływie tego terminu konfiguracja usuniętej strefy DNS zostaje bezpowrotnie utracona.
+
+Jeśli nie możesz znaleźć tej wiadomości w swojej skrzynce pocztowej, możesz ją wyświetlić w Panelu klienta OVHcloud, w sekcji <code className="action">Połączenia</code>, która zawiera wszystkie wiadomości wysłane na Twój kontaktowy adres e-mail. Więcej informacji znajdziesz w naszym przewodniku "[Zarządzanie komunikacją dotyczącą usług OVHcloud](/guides/account-and-service-management/account-information/manage-messages)".
+
+Aby sprawdzić lub zmienić kontakt administracyjny usługi, zapoznaj się z naszym przewodnikiem "[Zarządzanie kontaktami swoich usług](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 

--- a/docs/pt/guides/web-cloud/domains/dns-zone-history.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-zone-history.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gerir o histórico de uma zona DNS
 description: Saiba como consultar, comparar, descarregar e restaurar os backups da zona DNS
-lastUpdated: 2026-07-30
+lastUpdated: 2026-08-26
 availableIn: [eu, ca, apac]
 ---
 
@@ -39,10 +39,22 @@ A gestão dos DNS é facilitada graças ao histórico das zonas DNS.
 ## Instruções
 
 :::info
+**Limites dos backups**
+
 Os backups da sua zona DNS estão sujeitos às seguintes limitações:
 
 - Conservamos no máximo 200 backups para a mesma zona DNS.
 - Quando um backup tem mais de 31 dias, é automaticamente eliminado, à exceção dos **5 backups mais recentes** efetuados.
+
+**Se a sua zona DNS foi eliminada**
+
+Quando uma zona DNS é eliminada da sua Área de Cliente OVHcloud (eliminação manual, expiração do serviço ou outro motivo), é enviado um e-mail para o **contacto administrador** do serviço no momento da eliminação. O respetivo assunto tem o formato `[aa00000-ovh] [OVH-DNS] Eliminação da sua zona DNS domain.tld` e contém um link que permite recuperar o conteúdo da sua antiga zona DNS.
+
+Este link só é válido durante **30 dias** a contar do envio do e-mail. Decorrido esse prazo, a configuração da zona DNS eliminada é definitivamente perdida.
+
+Se não encontrar este e-mail na sua caixa de correio, pode consultá-lo na sua Área de Cliente OVHcloud, na secção <code className="action">As minhas comunicações</code>, que reúne todas as mensagens enviadas para o seu endereço de e-mail de contacto. Para mais informações, consulte o nosso guia "[Gerir comunicações relacionadas com os serviços da OVHcloud](/guides/account-and-service-management/account-information/manage-messages)".
+
+Para verificar ou alterar o contacto administrador de um serviço, consulte o nosso guia "[Como gerir os contactos (gestores) dos serviços OVHcloud](/guides/account-and-service-management/account-information/managing-contacts)".
 
 :::
 


### PR DESCRIPTION
This change completes the "Managing the history of a DNS zone" guide to cover the case of a deleted DNS zone, which was so far missing from the documentation. The `:::info` block at the top of the "Instructions" section is reorganised into two parts introduced by sub-headings — the existing backup limits on one side, the recovery procedure on the other — rather than adding a second callout below the first one. The new part explains that an email containing a recovery link is sent to the service's administrator contact at the time of deletion, whatever the cause (manual deletion, service expiry or any other reason), gives the subject line of that email so that customers can find it in their mailbox, and warns that the link is only valid for 30 days, after which the zone configuration is permanently lost. It finally points to the "How to manage messages in your OVHcloud Control Panel" guide — the Control Panel section where the email remains available — and to "Managing contacts for your services", to check which administrator contact receives this notification. All 7 locales are updated: UI labels were verified against the Manager's `Messages_{lang}.json` files, the titles of the linked guides are read from each locale's frontmatter, and the 7 files remain structurally identical.
