### PR TITLE
feat(i18n): translate the Pulumi backend state guide to FR + fix stale Pulumi links

### DIFF
--- a/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/de/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 

--- a/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/en/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 

--- a/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/es/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 

--- a/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/fr/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -1,25 +1,25 @@
 ---
-title: Using OVHcloud Object Storage as Pulumi Backend to store your Pulumi state
-description: Find out how to use an Object Storage bucket as a Pulumi Backend to store your Pulumi state
+title: Utiliser l'Object Storage OVHcloud comme backend Pulumi pour stocker votre état Pulumi
+description: Découvrez comment utiliser un bucket Object Storage comme backend Pulumi pour stocker votre état Pulumi
 lastUpdated: 2024-05-06
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
 
 
-## Objective
+## Objectif
 
-It is possible to store Pulumi state on a remote data store/backend like an AWS S3 bucket, a Google Cloud Storage (GCS), etc., but did you know that you can also store your Pulumi states on an OVHcloud Object Storage container (bucket)?
+Il est possible de stocker un état Pulumi sur un espace de stockage/backend distant, comme un bucket AWS S3, un Google Cloud Storage (GCS), etc., mais saviez-vous que vous pouvez également stocker vos états Pulumi dans un conteneur (bucket) Object Storage OVHcloud ?
 
-In this tutorial you will:
+Dans ce tutoriel, vous allez :
 
-- create an OVHcloud Object Storage container
-- log in to Pulumi and initialise your Pulumi backend
+- créer un conteneur Object Storage OVHcloud
+- vous connecter à Pulumi et initialiser votre backend Pulumi
 
-## Requirements
+## Prérequis
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
-- [Pulumi CLI](https://www.pulumi.com/docs/install/) installed
+- Une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- L'[interface de ligne de commande Pulumi](https://www.pulumi.com/docs/install/) installée
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---
@@ -32,91 +32,91 @@ In this tutorial you will:
 ---
 {/* CP-NAV-END:publiccloud-projects */}
 
-**Before you begin**
+**Avant de commencer**
 
-- You should have installed Pulumi CLI, on your machine. You can install it by following the [detailed installation instructions](https://www.pulumi.com/docs/install/).
+- Vous devez avoir installé l'interface de ligne de commande Pulumi sur votre machine. Vous pouvez l'installer en suivant les [instructions d'installation détaillées](https://www.pulumi.com/docs/install/).
 
 **Pulumi**
 
 <img className="thumbnail" alt="Pulumi" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi.jpg" loading="lazy" />
 
-[Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
-Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
+[Pulumi](https://www.pulumi.com/) est un outil d'Infrastructure as Code (IaC) qui vous permet de construire vos infrastructures avec un langage de programmation, en Golang par exemple.
+Les utilisateurs définissent l'état souhaité dans des programmes Pulumi et Pulumi crée les ressources correspondantes.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi propose une interface de ligne de commande (CLI) intuitive pour provisionner, mettre à jour ou supprimer votre infrastructure. Si vous êtes familier des CLI Docker Compose et Terraform, vous adopterez également l'[interface de ligne de commande Pulumi](https://www.pulumi.com/docs/iac/cli/).
 
-At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
+Chez OVHcloud, nous avons créé un [provider Pulumi](https://www.pulumi.com/registry/packages/ovh/) que vous pouvez utiliser pour interagir avec les ressources OVHcloud et les gérer.
 
-**Pulumi states and backend**
+**États et backend Pulumi**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stocke des métadonnées sur votre infrastructure afin de pouvoir gérer vos ressources cloud, par exemple vos ressources OVHcloud. Ces métadonnées sont appelées `state` (état) et prennent généralement la forme de fichiers JSON. Chaque [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) possède son propre état, et c'est grâce à cet état que Pulumi sait quand et comment créer, lire, supprimer ou mettre à jour des ressources cloud.
 
-A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
+Un état Pulumi est mis à jour lorsque vous exécutez les commandes `pulumi login`, `pulumi up` ou `pulumi destroy`.
 
-By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+Par défaut, les fichiers d'état sont stockés dans le cloud Pulumi, mais vous pouvez également les stocker en local.
+Vous pouvez stocker l'état à distance dans un [backend autogéré](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
-<img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
+<img className="thumbnail" alt="Schéma de l'état Pulumi" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 
-For example, you can store your Pulumi state on an OVHcloud High Performance Object Storage container.
+Vous pouvez par exemple stocker votre état Pulumi dans un conteneur Object Storage High Performance d'OVHcloud.
 
-There are several ways of doing this: using the `pulumi login` command or configuring a `backend` in your `Pulumi.yaml` file.
+Il existe plusieurs manières de procéder : en utilisant la commande `pulumi login` ou en configurant un `backend` dans votre fichier `Pulumi.yaml`.
 
-A state is composed of several files inside a `.pulumi` folder:
+Un état est composé de plusieurs fichiers contenus dans un dossier `.pulumi` :
 
-- `meta.yaml`: This is the metadata file. It does not hold information about the stacks but rather information about the backend itself.
-- `stacks/`: Active state files for each stack (e.g. `dev.json`).
-- `locks/`: Optional lock files for each stack if the stack is currently being operated on by a Pulumi operation (e.g. `dev/$lock.json`).
-- `history/`: History for each stack (e.g. `dev/dev-$timestamp.history.json` where $timestamp records the time the history file was created).
+- `meta.yaml` : il s'agit du fichier de métadonnées. Il ne contient pas d'informations sur les stacks, mais sur le backend lui-même.
+- `stacks/` : les fichiers d'état actifs de chaque stack (par exemple `dev.json`).
+- `locks/` : les fichiers de verrouillage facultatifs de chaque stack, si une opération Pulumi est en cours sur celle-ci (par exemple `dev/$lock.json`).
+- `history/` : l'historique de chaque stack (par exemple `dev/dev-$timestamp.history.json`, où $timestamp enregistre la date et l'heure de création du fichier d'historique).
 
-## Instructions
+## En pratique
 
-### Creating an Object Storage container/bucket
+### Création d'un conteneur/bucket Object Storage
 
-First, you need to have an Object Storage container. If you don't already have one, please consult the guide [Creating an Object Storage container](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage).
+Vous devez tout d'abord disposer d'un conteneur Object Storage. Si vous n'en possédez pas encore, consultez le guide [Créer un conteneur Object Storage](/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage).
 
-For this guide, our Object Storage container has the following characteristics:
+Pour ce guide, notre conteneur Object Storage possède les caractéristiques suivantes :
 
-- a `Object Storage - High Performance class`
-- located in the `GRA` region
-- with a newly created user
-- named `pulumi`
+- une classe `Object Storage - High Performance`
+- situé dans la région `GRA`
+- avec un utilisateur nouvellement créé
+- nommé `pulumi`
 
-<img className="thumbnail" alt="OVHcloud Object Storage" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/object-storage.png" loading="lazy" />
+<img className="thumbnail" alt="Object Storage OVHcloud" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/object-storage.png" loading="lazy" />
 
 :::info
-Save the Object Storage credentials, you will use the `Object Storage access key` and the `Object Storage secret key` in the coming `export` commands.
+Conservez les identifiants de votre Object Storage : vous utiliserez la `clé d'accès Object Storage` et la `clé secrète Object Storage` dans les commandes `export` à venir.
 
 :::
 
 
-Click on <code className="action">pulumi</code> to access the bucket and to display its information, including the useful `Endpoint`.
+Cliquez sur <code className="action">pulumi</code> pour accéder au bucket et afficher ses informations, dont l'`Endpoint`, qui vous sera utile.
 
-<img className="thumbnail" alt="OVHcloud Object Storage pulumi bucket" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-bucket.png" loading="lazy" />
+<img className="thumbnail" alt="Bucket pulumi de l'Object Storage OVHcloud" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-bucket.png" loading="lazy" />
 
-Export your Object Storage credentials in environment variables:
+Exportez les identifiants de votre Object Storage dans des variables d'environnement :
 
 ```bash
 export AWS_ACCESS_KEY_ID=<S3 access key>
 export AWS_SECRET_ACCESS_KEY=<S3 secret key>
 ```
 
-### Set-up Pulumi backend and login
+### Configuration du backend Pulumi et connexion
 
-There are several ways to define the backend for storing a Pulumi report in a remote backend.
-Follow the one you prefer.
+Il existe plusieurs manières de définir le backend permettant de stocker un rapport Pulumi dans un backend distant.
+Suivez celle que vous préférez.
 
 <Tabs>
-  <Tab label="Pulumi login with backend URL">
-    Execute the `pulumi login` command and pass in parameter directly the S3 backend URL:
+  <Tab label="Connexion à Pulumi avec l'URL du backend">
+    Exécutez la commande `pulumi login` et passez directement en paramètre l'URL du backend S3 :
     ```bash
     $ pulumi login 's3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra'
     
     Logged in to ovh-tuto-27gm21h6v46 as gitpod (s3://pulumi?endpoint=s3.gra.perf.cloud.ovh.net&region=gra)
     ```
   </Tab>
-  <Tab label="Backend configuration in the Pulumi.yaml file">
-    Or if you don't want to type the URL every time, you can define a backend property in the `Pulumi.yaml` config file as below:
+  <Tab label="Configuration du backend dans le fichier Pulumi.yaml">
+    Ou, si vous ne souhaitez pas saisir l'URL à chaque fois, vous pouvez définir une propriété `backend` dans le fichier de configuration `Pulumi.yaml`, comme ci-dessous :
     
     ```bash
     ...
@@ -125,7 +125,7 @@ Follow the one you prefer.
     ...
     ```
     
-    Then you can simply run the `pulumi login` command to log in and store/retrieve the state:
+    Vous pouvez ensuite simplement exécuter la commande `pulumi login` pour vous connecter et stocker/récupérer l'état :
     
     ```bash
     $ pulumi login
@@ -136,15 +136,15 @@ Follow the one you prefer.
 </Tabs>
 
 
-As you can see, in both solutions, we defined all the needed parameters to access to the existing OVHcloud S3 bucket:
+Comme vous pouvez le constater, dans les deux solutions, nous avons défini tous les paramètres nécessaires pour accéder au bucket Object Storage OVHcloud existant :
 
 - endpoint=s3.gra.perf.cloud.ovh.net
-- region=gra (or the region of your OVHcloud Object Storage bucket)
+- region=gra (ou la région de votre bucket Object Storage OVHcloud)
 
-Now you can code your Pulumi program and after running the `pulumi up` command, your Pulumi state file will be stored in an OVHcloud Object Storage container.
+Vous pouvez maintenant coder votre programme Pulumi. Après l'exécution de la commande `pulumi up`, votre fichier d'état Pulumi sera stocké dans un conteneur Object Storage OVHcloud.
 
-<img className="thumbnail" alt="OVHcloud pulumi bucket with state files" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-bucket-with-state-files.png" loading="lazy" />
+<img className="thumbnail" alt="Bucket pulumi OVHcloud contenant les fichiers d'état" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-bucket-with-state-files.png" loading="lazy" />
 
-## Go further
+## Aller plus loin
 
-Join our [community of users](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/it/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 

--- a/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pl/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 

--- a/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
+++ b/docs/pt/guides/public-cloud/compute/use-object-storage-pulumi-backend-state.mdx
@@ -43,18 +43,18 @@ In this tutorial you will:
 [Pulumi](https://www.pulumi.com/) is an Infrastructure as Code (IasC) tool that allows you to build your infrastructures with a programming language, in Golang for example.
 Users define the desired state in Pulumi programs and Pulumi creates the desired resources.
 
-Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/cli/) too.
+Pulumi offers an intuitive command line interface (CLI), to provision, update or delete your infrastructure. If you are familiar with Docker Compose CLI and Terraform CLI, you will adopt [Pulumi CLI](https://www.pulumi.com/docs/iac/cli/) too.
 
 At OVHcloud we created a [Pulumi provider](https://www.pulumi.com/registry/packages/ovh/) that you can use to interact with and manage OVHcloud resources.
 
 **Pulumi states and backend**
 
-Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/concepts/stack/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
+Pulumi stores metadata about your infrastructure so that it can manage your cloud resources, for example your OVHcloud resources. This metadata is called `state` and is typically JSON files. Each [stack](https://www.pulumi.com/docs/iac/concepts/stacks/) has its own state, and state is how Pulumi knows when and how to create, read, delete, or update cloud resources.
 
 A Pulumi state is updated when you run the `pulumi login`, `pulumi up` or `pulumi destroy` commands.
 
 By default, status files are stored in the Pulumi cloud, and you can also store them locally.
-You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/concepts/state/#using-a-self-managed-backend).
+You can store the state remotely in a [self-managed backend](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/).
 
 <img className="thumbnail" alt="Pulumi state schema" src="/images/public-cloud/compute/use-object-storage-pulumi-backend-state/pulumi-state-schema.png" loading="lazy" />
 


### PR DESCRIPTION
Last untranslated guide of the FR mass-translation round. The FR file had
localised frontmatter but an English body.

**FR translation** (`cb4d568ee`) — canonical headings (Objectif / Prérequis /
En pratique / Aller plus loin), CP-NAV block reused verbatim from the sibling
compute guides, `Public Cloud` button verified against `Messages_fr_FR.json`,
`lastUpdated` preserved. Structural parity with EN: headings, code fences,
images, tabs and bullets all match.

**Stale Pulumi links** (`e99f63226`, all 7 locales) — Pulumi reorganised its
docs; three links only resolved via redirect and one anchor was dead:

- `/docs/cli/` → `/docs/iac/cli/`
- `/docs/concepts/stack/` → `/docs/iac/concepts/stacks/`
- `/docs/concepts/state/#using-a-self-managed-backend` →
  `/docs/iac/operations/stack-management/using-a-diy-backend/`

The self-managed-backend anchor no longer exists, so readers were landing at
the page top. That section was split onto a dedicated page which still carries
the `.pulumi` layout detail (`meta.yaml`, `stacks/`, `locks/`, `history/`) the
guide's own bullet list mirrors — checked against the May 2024 snapshot. All
three targets now return 200 with no redirect.

All 7 files compile. Diff in the 6 non-FR locales is URL-only (3 lines each).

Note: `de/es/it/pl/pt` still have English bodies for this guide — pre-existing,
not touched here.
