### PR TITLE
AI Guide Wrong French Translation in feedback part

### DIFF
--- a/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
+++ b/docs/fr/guides/public-cloud/ai-machine-learning/ai-training-submit-job.mdx
@@ -163,6 +163,6 @@ Si vous avez besoin d'une formation ou d'une assistance technique pour la mise e
 
 ## Nous voulons vos retours !
 
-N’hésitez pas à nous faire part de vos questions, retours et suggestions concernant AI Notebooks :
+N’hésitez pas à nous faire part de vos questions, retours et suggestions pour améliorer le service :
 
-- Dans le canal #ai-notebooks du [serveur Discord OVHcloud](https://discord.gg/ovhcloud), où vous pouvez échanger avec la communauté et les équipes OVHcloud.
+- Sur le [serveur Discord OVHcloud](https://discord.gg/ovhcloud)


### PR DESCRIPTION
The FR Translation of an AI Training guide was mentioning "AI Notebooks" Discord channel on its feedback part.

English versions of this tutorial do not present the problem as they just mention the Discord, without mentioning a channel.

Not sure why. Anyway, here is a fix.