### PR TITLE
fix(account): clarify e-invoicing FAQ and shorten SIRET guide title

### DIFF
--- a/docs/fr/guides/account-and-service-management/account-information/faq-account-management.mdx
+++ b/docs/fr/guides/account-and-service-management/account-information/faq-account-management.mdx
@@ -224,7 +224,7 @@ Rendez-vous sur la page <ManagerLink to="/#/account/useraccount/infos">Mon profi
 
 Le champ **N° SIRET** n'est pas directement modifiable : il se renseigne via l'assistant de recherche. Cliquez sur <code className="action">Mettre à jour mes informations d'entreprise</code>, saisissez votre numéro de SIRET dans le champ qui apparaît, puis enregistrez.
 
-La procédure complète est détaillée dans notre guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+La procédure complète est détaillée dans notre guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 :::tip
 **Où trouver mon numéro SIRET ?**

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -155,7 +155,7 @@ Ces motifs signalent que les données d'identification de votre entreprise sont 
 
 Renseigner votre numéro de SIRET déclenche une mise à jour automatique des coordonnées de votre société, dont votre taux de TVA, à partir du catalogue gouvernemental des déclarations de société. L'assistant recherche également l'**adresse de réception de vos factures électroniques** auprès de la plateforme agréée.
 
-La procédure complète est décrite dans le guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+La procédure complète est décrite dans le guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 :::info
 Le code `DEST_ERR` correspond au cas d'une facture adressée à la mauvaise entité, notamment lorsque plusieurs sociétés appartiennent à un même groupe. Vérifiez que le SIRET et l'adresse de réception enregistrés dans votre espace client correspondent bien à l'entité qui doit recevoir la facture.
@@ -206,7 +206,7 @@ Si le **numéro de commande (PO)** est absent ou incorrect sur votre facture, re
 
 Ce motif signale qu'une mention obligatoire est absente de la facture. La réforme impose en effet de nouvelles mentions, parmi lesquelles le **numéro SIREN du client** et l'**adresse complète de livraison** lorsqu'elle diffère de l'adresse de facturation.
 
-Ces mentions étant renseignées à partir des données de votre espace client, vérifiez que celles-ci sont complètes et à jour en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+Ces mentions étant renseignées à partir des données de votre espace client, vérifiez que celles-ci sont complètes et à jour en vous aidant du guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 Si vos données sont correctes, la correction relève de nos équipes : le refus déclenche l'envoi automatique des éléments nécessaires à la régularisation.
 
@@ -254,7 +254,7 @@ Un avoir est un document comptable qui permet de corriger ou d'annuler tout ou p
 
 [FAQ sur la facturation électronique OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing)
 
-[Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
+[Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
 
 [Corriger une erreur de coordonnées bancaires](/guides/account-and-service-management/managing-billing-payments-and-services/correct-bank-details-error)
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur la facturation électronique OVHcloud
 description: Retrouvez les questions les plus fréquemment posées sur la réforme de la facturation électronique et la réception de vos factures OVHcloud
-lastUpdated: 2026-07-31
+lastUpdated: 2026-08-27
 ---
 
 <Banner kind="siret-fr" />
@@ -92,7 +92,7 @@ Pour savoir comment y accéder, consultez le guide « [Gérer mes factures OVHc
 
 Une facture est générée uniquement lorsque votre commande est **finalisée**. Nous vous invitons à vérifier le statut de vos commandes depuis votre espace client en vous aidant du guide « [Gérer mes commandes OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders) ».
 
-Si votre commande est bien finalisée mais que la facture n'est toujours pas disponible, vérifiez que les informations de votre compte, notamment votre **numéro SIRET**, sont à jour. Des informations incorrectes peuvent empêcher l'association de votre compte avec votre plateforme de facturation électronique. Pour les vérifier ou les mettre à jour, consultez le guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+Si votre commande est bien finalisée mais que la facture n'est toujours pas disponible, vérifiez que les informations de votre compte, notamment votre **numéro SIRET**, sont à jour. Des informations incorrectes peuvent empêcher l'association de votre compte avec votre plateforme de facturation électronique. Pour les vérifier ou les mettre à jour, consultez le guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 Enfin, vérifiez les communications qui vous ont été adressées. Lorsque la plateforme refuse le dépôt d'une facture, nos équipes en sont informées et vous adressent un e-mail confirmant que la correction de la facture est prise en charge en vue d'un nouveau dépôt. Nous vous invitons alors à patienter 48 heures.
 
@@ -138,19 +138,19 @@ Vous pouvez également suivre l'état de vos factures et de vos paiements direct
 
 Si votre facture n'a pas pu être transmise, cela est généralement dû à des informations de routage incorrectes (SIRET, plateforme de réception ou identifiant).
 
-Nous vous invitons à vérifier ces informations auprès de votre plateforme de réception ou de votre client. Une fois les informations corrigées, la facture pourra être retransmise ou régularisée.
+Vous pouvez vérifier et mettre à jour les informations de votre compte client en vous aidant du guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
-Vous pouvez également vérifier et mettre à jour les informations de votre compte client en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+La modification de ces informations permettra de mettre à jour uniquement les prochaines factures.
 
 </details>
 
 <details>
 
-<summary>Que faire si ma facture a été envoyée à la mauvaise entité ?</summary>
+<summary>Que faire si ma facture a été envoyée à la mauvaise entreprise ?</summary>
 
 La facture étant générée à partir des informations renseignées dans votre espace client au moment de son émission, sa réédition avec des informations différentes n'est pas possible.
 
-Nous vous invitons à vérifier et, si nécessaire, à mettre à jour vos informations de compte en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+Nous vous invitons à vérifier et, si nécessaire, à mettre à jour vos informations de compte en vous aidant du guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 </details>
 
@@ -166,7 +166,7 @@ En cas de changement de plateforme de réception, assurez-vous que vos nouvelles
 
 <summary>Comment mettre à jour mes informations de facturation ?</summary>
 
-Nous vous invitons à mettre à jour vos informations de compte en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+Nous vous invitons à mettre à jour vos informations de compte en vous aidant du guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 Toutefois, si des informations de type adresse, nom de société ou pays doivent évoluer, notre système se base sur les informations déclarées auprès de l'INPI. Vous devez donc déclarer ce changement avant de pouvoir mettre à jour vos données dans votre espace client. Pour cela, connectez-vous au [Guichet unique de l'INPI](https://procedures.inpi.fr/), qui centralise désormais les formalités des entreprises.
 
@@ -190,7 +190,7 @@ Mettez d'abord à jour les données de votre entreprise auprès de l'INPI :
 
 Le délai de mise à jour est généralement de quelques jours ouvrés, mais il peut varier selon les dossiers.
 
-Une fois le nouveau KBIS édité, mettez à jour vos informations dans votre espace client OVHcloud en vous aidant du guide « [Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
+Une fois le nouveau KBIS édité, mettez à jour vos informations dans votre espace client OVHcloud en vous aidant du guide « [Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate) ».
 
 </details>
 
@@ -334,7 +334,7 @@ L'émission d'un avoir n'est pas automatique : elle intervient uniquement aprè
 
 [Gérer mes factures OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management)
 
-[Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
+[Renseigner votre numéro de SIRET](/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate)
 
 [Notion de Numéro de commande ou Purchase Order (PO)](/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order)
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -1,6 +1,6 @@
 ---
-title: Renseigner votre numéro de SIRET et mettre à jour votre taux de TVA
-description: Découvrez comment renseigner votre numéro de SIRET pour mettre à jour le taux de TVA de votre compte de facturation OVHcloud
+title: Renseigner votre numéro de SIRET
+description: Découvrez comment renseigner votre numéro de SIRET, mettre à jour le taux de TVA et corriger l'adresse de facturation de votre compte OVHcloud
 lastUpdated: 2026-08-24
 ---
 


### PR DESCRIPTION
Remove the claim that a corrected invoice can be re-sent or regularised: updating the account details only applies to future invoices.

Shorten the SIRET guide title so the rendered <title>, which appends " - OVHcloud Documentation", fits within the SERP limit, and widen its description to cover SIRET, VAT rate and billing address. Align the ten in-body link labels pointing at that guide with its new title.