### PR TITLE
docs: clarify subdomain DNS zone scope in domain-create-subdomains

### DIFF
--- a/docs/de/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/de/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erstellung einer Subdomain
 description: Erfahren Sie hier, wie Sie eine Subdomain bei OVHcloud erstellen und nutzen
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,6 +15,12 @@ Zum Beispiel ist *www.ovhcloud.com* eine Subdomain des Domainnamens *ovhcloud.co
 
 Sie können für einen Domainnamen eine unbegrenzte Anzahl an Subdomains erstellen.
   
+:::tip
+Diese Anleitung erklärt, wie Sie eine Subdomain erstellen, indem Sie ihre DNS-Einträge zur aktiven DNS-Zone des Domainnamens hinzufügen, von dem sie abhängt. Dies ist der häufigste Fall.
+
+Wenn Ihre Subdomain über eine **eigene DNS-Zone** verfügen soll, die von der des übergeordneten Domainnamens getrennt ist, konsultieren Sie direkt unsere Anleitung "[OVHcloud DNS-Zone für Subdomain erstellen](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Diese Anleitung erklärt Besonderheiten von Subdomains und wie Sie Subdomains bei OVHcloud erstellen.**
 
 ## Voraussetzungen

--- a/docs/en/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/en/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to create a subdomain
 description: Find out how to define a subdomain and how to create one at OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -18,6 +18,12 @@ For example, *www.ovhcloud.com* is a subdomain of the domain name *ovhcloud.com*
 
 You can create an infinite number of subdomains from a single domain name.
   
+:::tip
+This guide explains how to create a subdomain by adding its DNS records to the active DNS zone of the domain name it depends on. This is the most common case.
+
+If you want your subdomain to have its **own DNS zone**, separate from that of the domain name it depends on, please refer directly to our guide on "[Create an OVHcloud DNS zone for a subdomain](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Find out more about subdomains and how to create one with OVHcloud.**
 
 ## Requirements

--- a/docs/es/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/es/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: ¿Cómo crear un subdominio?
 description: Descubra cómo crear un subdominio en OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,6 +15,12 @@ Por ejemplo, *www.ovhcloud.com* es un subdominio del nombre de dominio *ovhcloud
 
 Puede crear infinidad de subdominios a partir de un único nombre de dominio.
   
+:::tip
+Esta guía explica cómo crear un subdominio añadiendo sus registros DNS en la zona DNS activa del nombre de dominio del que depende. Es el caso más habitual.
+
+Si desea que su subdominio disponga de su **propia zona DNS**, distinta de la del nombre de dominio del que depende, consulte directamente nuestra guía "[Crear una zona DNS de OVHcloud para un subdominio](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Descubra los subdominios y cómo crearlos en OVHcloud.**
 
 ## Requisitos

--- a/docs/fr/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/fr/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comment créer un sous-domaine ?
 description: "Découvrez la définition d’un sous-domaine et comment en créer chez OVHcloud"
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -14,6 +14,12 @@ Au cours de l’utilisation de votre nom de domaine, vous serez amenés à crée
 Par exemple, *www.ovhcloud.com* est un sous-domaine du nom de domaine *ovhcloud.com*.
 
 Vous pouvez créer une infinité de sous-domaines à partir d’un seul nom de domaine.
+
+:::tip
+Ce guide explique comment créer un sous-domaine en ajoutant ses enregistrements DNS dans la zone DNS active du nom de domaine dont il dépend. C’est le cas le plus courant.
+
+Si vous souhaitez que votre sous-domaine dispose de sa **propre zone DNS**, distincte de celle du nom de domaine dont il dépend, consultez directement notre guide « [Créer une zone DNS OVHcloud pour un sous-domaine](/guides/web-cloud/domains/dns-zone-create-subdomain) ».
+:::
 
 **Découvrez les sous-domaines et comment en créer chez OVHcloud.**
 

--- a/docs/it/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/it/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: Come creare un sottodominio?
 description: Questa guida ti mostra la definizione di un sottodominio e come crearlo in OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,6 +15,12 @@ Ad esempio, *www.ovhcloud.com* è un sottodominio del dominio *ovhcloud.com*.
 
 È possibile creare un'infinità di sottodomini a partire da un solo dominio.
   
+:::tip
+Questa guida ti mostra come creare un sottodominio aggiungendo i suoi record DNS nella zona DNS attiva del nome di dominio a cui appartiene. È il caso più frequente.
+
+Se desideri che il tuo sottodominio disponga di una **propria zona DNS**, distinta da quella del nome di dominio a cui appartiene, consulta direttamente la nostra guida "[Creare una zona DNS OVHcloud per un sottodominio](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Questa guida ti mostra i sottodomini e come crearli in OVHcloud.**
 
 ## Prerequisiti

--- a/docs/pl/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/pl/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: Jak utworzyć subdomenę?
 description: Dowiedz się, jak zdefiniować subdomenę i jak ją utworzyć w OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,6 +15,12 @@ Na przykład *www.ovhcloud.com* jest subdomeną nazwy domeny *ovhcloud.com*.
 
 Możesz utworzyć nieskończoną liczbę subdomen na podstawie jednej nazwy domeny.
   
+:::tip
+Ten przewodnik wyjaśnia, jak utworzyć subdomenę, dodając jej rekordy DNS do aktywnej strefy DNS nazwy domeny, do której należy. Jest to najczęstszy przypadek.
+
+Jeśli chcesz, aby Twoja subdomena miała **własną strefę DNS**, odrębną od strefy nazwy domeny, do której należy, skorzystaj bezpośrednio z przewodnika "[Tworzenie strefy DNS OVHcloud dla poddomeny](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Poznaj subdomeny i dowiedz się, jak je utworzyć w OVHcloud.**
 
 ## Wymagania początkowe

--- a/docs/pt/guides/web-cloud/domains/domain-create-subdomains.mdx
+++ b/docs/pt/guides/web-cloud/domains/domain-create-subdomains.mdx
@@ -1,7 +1,7 @@
 ---
 title: Como criar um subdomínio?
 description: Saiba a definição de um subdomínio e como criá-lo na OVHcloud
-lastUpdated: 2026-02-10
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -15,6 +15,12 @@ Por exemplo, *www.ovhcloud.com* é um subdomínio do nome de domínio *ovhcloud.
 
 Pode criar infinitos subdomínios a partir de um único nome de domínio.
   
+:::tip
+Este guia explica como criar um subdomínio, adicionando os seus registos DNS na zona DNS ativa do nome de domínio do qual depende. Trata-se do caso mais frequente.
+
+Se quiser que o seu subdomínio disponha de uma **zona DNS própria**, distinta da do nome de domínio do qual depende, consulte diretamente o guia "[Criar uma zona DNS OVHcloud para um subdomínio](/guides/web-cloud/domains/dns-zone-create-subdomain)".
+:::
+
 **Saiba os subdomínios e como os criar na OVHcloud.**
 
 ## Requisitos


### PR DESCRIPTION
Add a tip in the Objective section pointing readers who need a dedicated DNS zone for their subdomain to dns-zone-create-subdomain. The two guides sit in different sidebar sections, so the distinction was easy to miss.

Applied to all 7 locales.