### PR TITLE
SK-2723 - WEB - Email - Fix and harmonise the MX Plan generation tabs

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -241,7 +241,7 @@ Geben Sie im Formular `Weiterleitung erstellen` Folgendes ein:
     :::
 
   </Tab>
-  <Tab label="Zimbra MX Plan">
+  <Tab label="MX Plan Zimbra">
     Standardmäßig befinden Sie sich im Tab <code className="action">Allgemeine Informationen</code> Ihres MX Plan. Klicken Sie auf den Tab <code className="action">Weiterleitungen</code>.
     
     Die Tabelle der bereits aktiven Weiterleitungen wird angezeigt. Rechts klicken Sie auf den Button <code className="action">Weiterleitung hinzufügen</code>.
@@ -424,7 +424,7 @@ Wählen Sie unten den Tab für die E-Mail-Technologie, die von Ihrem MX Plan Die
     
        <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-redirect-delete01.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra MX Plan">
+  <Tab label="MX Plan Zimbra">
     - Standardmäßig befinden Sie sich im Tab <code className="action">Allgemeine Informationen</code> Ihres MX Plan.
     - Klicken Sie auf den Tab <code className="action">Weiterleitungen</code>.
     - Klicken Sie auf <code className="action">...</code> rechts neben der betreffenden Weiterleitung und dann auf <code className="action">Weiterleitung löschen</code>.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail Alias und Weiterleitung verwenden
 description: Erfahren Sie hier, wie Sie E-Mail Aliase und Weiterleitungen verwalten
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Wählen Sie in Ihrem MX Plan Dienst die betreffende Domain aus.
 In unserem Beispiel ist dies eine **Weiterleitung mit lokaler Kopie** (siehe [Schema 2](#diagram) am Anfang dieser Anleitung). Wenn dies Ihren Bedürfnissen entspricht, folgen Sie den nachstehenden Schritten, indem Sie auf den Tab für die Webmail-Technologie klicken, die von Ihrem MX Plan verwendet wird:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Standardmäßig befinden Sie sich im Tab <code className="action">Allgemeine Informationen</code> Ihres MX Plan. Klicken Sie auf den Tab <code className="action">E-Mails</code> und dann rechts auf den Button <code className="action">Verwaltung der Weiterleitungen</code>.
     
     <img className="thumbnail" alt="E-Mails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail Alias und Weiterleitung verwenden
 description: Erfahren Sie hier, wie Sie E-Mail Aliase und Weiterleitungen verwalten
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -126,21 +126,21 @@ Rufen Sie Ihre E-Mails online und ohne Installation über das Webmail [Outlook W
 Folgen Sie den passenden Anweisungen für Ihren E-Mail-Dienst:
 
 <ZoneTabs>
-  <Tab label="MX Plan E-Mail (Legacy)">
-    Wenn Sie den Typ Ihres MX Plan Angebots nicht kennen, lesen Sie den Abschnitt zur [Identifikation Ihres MX Plans](#whichmxplan).<br/>
-
-Klicken Sie auf <code className="action">MX Plan</code> und wählen Sie den Namen des betreffenden Dienstes aus. Gehen Sie zum Tab <code className="action">E-Mails</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt. <br/>
-
-Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Passwort ändern</code>.<br/><br/>
-    <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="MX Plan E-Mail (neue Version)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Wenn Sie den Typ Ihres MX Plan Angebots nicht kennen, lesen Sie den Abschnitt zur [Identifikation Ihres MX Plans](#whichmxplan).<br/>
 
 Klicken Sie auf <code className="action">MX Plan</code> und wählen Sie den Namen des betreffenden Dienstes aus. Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt. <br/>
 
 Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Wenn Sie den Typ Ihres MX Plan Angebots nicht kennen, lesen Sie den Abschnitt zur [Identifikation Ihres MX Plans](#whichmxplan).<br/>
+
+Klicken Sie auf <code className="action">MX Plan</code> und wählen Sie den Namen des betreffenden Dienstes aus. Gehen Sie zum Tab <code className="action">E-Mails</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt. <br/>
+
+Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Passwort ändern</code>.<br/><br/>
+    <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="E-Mail Pro" availableIn={['eu']}>
     Klicken Sie auf <code className="action">E-Mail Pro</code> und wählen Sie den Dienstnamen aus. Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt.<br/>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Passwort eines E-Mail-Accounts ändern
 description: Erfahren Sie hier, wie Sie das Passwort eines OVHcloud E-Mail-Accounts ändern
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -137,19 +137,19 @@ Klicken Sie auf den Button <code className="action">...</code> und dann auf <cod
   <Tab label="MX Plan E-Mail (neue Version)">
     Wenn Sie den Typ Ihres MX Plan Angebots nicht kennen, lesen Sie den Abschnitt zur [Identifikation Ihres MX Plans](#whichmxplan).<br/>
 
-Klicken Sie auf <code className="action">MX Plan</code> und wählen Sie den Namen des betreffenden Dienstes aus. Gehen Sie zum Tab <code className="action">E-Mails</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt. <br/>
+Klicken Sie auf <code className="action">MX Plan</code> und wählen Sie den Namen des betreffenden Dienstes aus. Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt. <br/>
 
 Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="E-Mail Pro" availableIn={['eu']}>
-    Klicken Sie auf <code className="action">E-Mail Pro</code> und wählen Sie den Dienstnamen aus. Gehen Sie zum Tab <code className="action">E-Mail Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt.<br/>
+    Klicken Sie auf <code className="action">E-Mail Pro</code> und wählen Sie den Dienstnamen aus. Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt.<br/>
 
 Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-emailpro01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    Klicken Sie auf <code className="action">Microsoft</code>, dann <code className="action">Exchange</code> und wählen Sie den Dienstnamen aus. Gehen Sie zum Tab <code className="action">E-Mail Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt.<br/>
+    Klicken Sie auf <code className="action">Microsoft</code>, dann <code className="action">Exchange</code> und wählen Sie den Dienstnamen aus. Gehen Sie zum Tab <code className="action">E-Mail-Accounts</code>. In diesem Fenster werden die bestehenden E-Mail-Accounts angezeigt.<br/>
 
 Klicken Sie auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.<br/><br/>
     <img className="thumbnail" alt="E-Mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-exchange01.png" loading="lazy" /><br/>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Adresse wegen Spam gesperrt: Was tun?"
 description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Wählen Sie in den folgenden Tabs die betroffene E-Mail-Lösung aus:
 
     <img className="thumbnail" alt="Spalte Status auf Spam im Tab E-Mail-Accounts für MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Dieser Tab gilt für alle Adressen, die die Technologie **Zimbra** verwenden: **MX Plan - Zimbra**, **Zimbra Starter** und **Zimbra Pro**. Der Entsperrvorgang ist für diese drei Lösungen identisch.
-
-    Wenn die Sperrung greift, wird **kein Support-Ticket automatisch erzeugt**, und die Adresse ist nicht mehr zugänglich (sowohl das Zimbra-Webmail als auch der E-Mail-Versand sind deaktiviert).
-
-    Um die Adresse entsperren zu lassen:
-
-    1. Führen Sie die in [Schritt 1](#step1) beschriebenen Prüfungen anhand der Elemente durch, auf die Sie zugreifen können (Geräte der Nutzer, Drittanbieter-Software, Weiterleitungen, die über einen anderen Zugang sichtbar sind).
-    2. **Erstellen Sie manuell ein Support-Ticket** über Ihr OVHcloud Kundencenter.
-    3. Geben Sie im Ticket Folgendes an:
-        - die von der Sperrung betroffene E-Mail-Adresse;
-        - den zugehörigen Dienst (MX Plan, Zimbra Starter oder Zimbra Pro) sowie dessen Kennung;
-        - die bereits durchgeführten Abhilfemaßnahmen (Virenscans, Entfernung nicht legitimer Absender, Hinzufügen des SPAM/DCE-Filters usw.).
-
-    Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Wenn die Sperrung eine MX Plan E-Mail-Adresse mit dem Webmail **Roundcube** betrifft, wird kein Support-Ticket erzeugt.
 
@@ -243,6 +227,22 @@ Wählen Sie in den folgenden Tabs die betroffene E-Mail-Lösung aus:
 
     Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Dieser Tab gilt für alle Adressen, die die Technologie **Zimbra** verwenden: **MX Plan - Zimbra**, **Zimbra Starter** und **Zimbra Pro**. Der Entsperrvorgang ist für diese drei Lösungen identisch.
+
+    Wenn die Sperrung greift, wird **kein Support-Ticket automatisch erzeugt**, und die Adresse ist nicht mehr zugänglich (sowohl das Zimbra-Webmail als auch der E-Mail-Versand sind deaktiviert).
+
+    Um die Adresse entsperren zu lassen:
+
+    1. Führen Sie die in [Schritt 1](#step1) beschriebenen Prüfungen anhand der Elemente durch, auf die Sie zugreifen können (Geräte der Nutzer, Drittanbieter-Software, Weiterleitungen, die über einen anderen Zugang sichtbar sind).
+    2. **Erstellen Sie manuell ein Support-Ticket** über Ihr OVHcloud Kundencenter.
+    3. Geben Sie im Ticket Folgendes an:
+        - die von der Sperrung betroffene E-Mail-Adresse;
+        - den zugehörigen Dienst (MX Plan, Zimbra Starter oder Zimbra Pro) sowie dessen Kennung;
+        - die bereits durchgeführten Abhilfemaßnahmen (Virenscans, Entfernung nicht legitimer Absender, Hinzufügen des SPAM/DCE-Filters usw.).
+
+    Sobald das Ticket vom Support bearbeitet wurde, wird die Adresse entsperrt. [Schritt 3](#step3) ist in diesem Fall nicht anwendbar.
   </Tab>
 </ZoneTabs>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: "E-Mail-Adresse wegen Spam gesperrt: Was tun?"
-description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren."
+description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-Mail-Adresse wegen Spam gesperrt: Was tun?"
 description: "Eine wegen Spam gesperrte E-Mail-Adresse entsperren: Ursache der verdächtigen Aktivität identifizieren, beheben und den OVHcloud Support kontaktieren"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using email aliases and redirections
 description: Find out how to manage aliases and email redirections
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -203,7 +203,7 @@ From your MX Plan service, in the <code className="action">General Information</
 
 ### Creating a redirection <a name="redirect"></a>
 
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
+#### Via the OVHcloud Control Panel <a name="redirect-manager"></a>
 
 Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
 
@@ -492,7 +492,7 @@ To add an alias to your email account, follow the steps described by clicking on
 
 <Tabs>
   <Tab label="Step 1">
-    In the table that appears, you will find an `Alias` column.
+    The table has an `Alias` column.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/email-alias012.png" loading="lazy" />
   </Tab>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using email aliases and redirections
 description: Find out how to manage aliases and email redirections
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ From your MX Plan service, select the domain concerned.
 In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below by clicking on the tab corresponding to the webmail technology used by your MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     By default, you are in the <code className="action">General information</code> tab of your MX Plan. Click on the <code className="action">Emails</code> tab, then on the right-hand side on the <code className="action">Manage redirections</code> button.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -128,21 +128,21 @@ Access your email online, without installation, via the [Outlook Web App (OWA)](
 Follow the instructions for your solution:
 
 <ZoneTabs>
-  <Tab label="MX Plan email (legacy version)">
-    If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
-
-Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Emails</code> tab. The window that appears will display all email accounts. <br/>
-
-Click the <code className="action">...</code> button, then click <code className="action">Change password</code>.<br/><br/>
-    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="MX Plan email (new version)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
 
 Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts. <br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Edit</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
+
+Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Emails</code> tab. The window that appears will display all email accounts. <br/>
+
+Click the <code className="action">...</code> button, then click <code className="action">Change password</code>.<br/><br/>
+    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     Click <code className="action">Email Pro</code>, then choose the name of the service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts.<br/>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Changing the password of an email account
 description: Find out how to change the password for an OVHcloud email account
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -139,7 +139,7 @@ Click the <code className="action">...</code> button, then click <code className
   <Tab label="MX Plan email (new version)">
     If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
 
-Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Emails</code> tab. The window that appears will display all email accounts. <br/>
+Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts. <br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Edit</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -19,7 +19,7 @@ import { Panel } from '@components/Panel';
 
 You can access your OVHcloud email accounts using the password associated with them. There are 2 ways you can modify it, depending on your email plan:
 
-- From Webmail
+- From webmail
 - Via the OVHcloud Control Panel
 
 **This guide explains how to change the password for an OVHcloud email account.**
@@ -131,7 +131,7 @@ Follow the instructions for your solution:
   <Tab label="MX Plan (Zimbra / OWA)">
     If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
 
-Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts. <br/>
+Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Email accounts</code> tab. The tab lists all your email accounts. <br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Edit</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
@@ -139,19 +139,19 @@ Click the <code className="action">...</code> button, then click <code className
   <Tab label="MX Plan (Roundcube)">
     If you do not know which type of MX Plan solution you have, please read the section [Identify your MX Plan solution](#whichmxplan).<br/>
 
-Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Emails</code> tab. The window that appears will display all email accounts. <br/>
+Click <code className="action">MX Plan</code>, then choose the name of the MX Plan service concerned. Go to the <code className="action">Emails</code> tab. The tab lists all your email accounts. <br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Change password</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
-    Click <code className="action">Email Pro</code>, then choose the name of the service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts.<br/>
+    Click <code className="action">Email Pro</code>, then choose the name of the service concerned. Go to the <code className="action">Email accounts</code> tab. The tab lists all your email accounts.<br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Edit</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-emailpro01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    Click <code className="action">Microsoft</code>, then <code className="action">Exchange</code> and choose the name of the service concerned. Go to the <code className="action">Email accounts</code> tab. The window that appears will display all email accounts.<br/>
+    Click <code className="action">Microsoft</code>, then <code className="action">Exchange</code> and choose the name of the service concerned. Go to the <code className="action">Email accounts</code> tab. The tab lists all your email accounts.<br/>
 
 Click the <code className="action">...</code> button, then click <code className="action">Edit</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-exchange01.png" loading="lazy" /><br/>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: What to do if your email address is blocked for spam
-description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support."
+description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
@@ -62,7 +62,7 @@ When your email address is blocked for spam, this means that suspicious activity
 
 ## Instructions <a name="instructions"></a>
 
-Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution in order to follow the correct unblocking process.
+Before continuing, if the block concerns an MX Plan email address, identify the email technology used by your solution to follow the correct unblocking process.
 
 <Region zones={['eu']}>
 
@@ -109,7 +109,7 @@ When suspicious activity is detected on outgoing emails, the address concerned i
 - The anti-spam server, which scans emails as they are sent, has found that one or more elements of the email are considered suspicious and may constitute spam.
 - The sending frequency and the number of recipients are too high and contribute to the activity being considered as spamming. To carry out mass mailings, you need to use a mailing list service rather than a standard email address.
 
-The precise reasons for a block cannot be disclosed, in order to prevent any attempt to bypass the spam detection system. To test the content of an email, you can use a tool external to OVHcloud such as [Mailtester](https://www.mail-tester.com/).
+The precise reasons for a block cannot be disclosed, to prevent any attempt to bypass the spam detection system. To test the content of an email, you can use a tool external to OVHcloud such as [Mailtester](https://www.mail-tester.com/).
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: What to do if your email address is blocked for spam
 description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Select the email solution concerned in the following tabs:
     
     <img className="thumbnail" alt="Status column Spam in the Email accounts tab for MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    This tab applies to all addresses using the **Zimbra** technology: **MX Plan - Zimbra**, **Zimbra Starter** and **Zimbra Pro**. The unblocking process is identical for these three solutions.
-
-    When the block is applied, **no support ticket is generated automatically** and the address is no longer accessible (Zimbra webmail and email sending are both disabled).
-
-    To get the address unblocked:
-
-    1. Carry out the checks described in [step 1](#step1), based on the elements you can access (user devices, third-party software, redirections visible from another access).
-    2. **Manually create a support ticket** from your OVHcloud Control Panel.
-    3. In the ticket, specify:
-        - The email address affected by the block;
-        - The associated service (MX Plan, Zimbra Starter or Zimbra Pro) and its identifier;
-        - The corrective actions already taken (antivirus scans, removal of non-legitimate senders, addition of the SPAM/DCE filter, etc.).
-
-    Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     If the block concerns an MX Plan email address with **Roundcube** webmail, no support ticket is generated.
 
@@ -243,6 +227,22 @@ Select the email solution concerned in the following tabs:
 
     Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    This tab applies to all addresses using the **Zimbra** technology: **MX Plan - Zimbra**, **Zimbra Starter** and **Zimbra Pro**. The unblocking process is identical for these three solutions.
+
+    When the block is applied, **no support ticket is generated automatically** and the address is no longer accessible (Zimbra webmail and email sending are both disabled).
+
+    To get the address unblocked:
+
+    1. Carry out the checks described in [step 1](#step1), based on the elements you can access (user devices, third-party software, redirections visible from another access).
+    2. **Manually create a support ticket** from your OVHcloud Control Panel.
+    3. In the ticket, specify:
+        - The email address affected by the block;
+        - The associated service (MX Plan, Zimbra Starter or Zimbra Pro) and its identifier;
+        - The corrective actions already taken (antivirus scans, removal of non-legitimate senders, addition of the SPAM/DCE filter, etc.).
+
+    Once the ticket has been processed by support, the address is unblocked. [Step 3](#step3) does not apply in this case.
   </Tab>
 </ZoneTabs>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: What to do if your email address is blocked for spam
 description: "Unblock an email address blocked for spam: identify the cause of the suspicious activity, fix it and contact OVHcloud support"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar los alias y redirecciones de correo
 description: Cómo gestionar los alias y redirecciones de correo
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar los alias y redirecciones de correo
 description: Cómo gestionar los alias y redirecciones de correo
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Desde su servicio MX Plan, seleccione el dominio en cuestión.
 En nuestro ejemplo, se trata de una **redirección con copia local** (consulte el [esquema 2](#diagram) al principio de esta guía). Si lo necesita, siga los pasos que se indican a continuación en la pestaña correspondiente a la tecnología webmail utilizada por su MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Por defecto, se encuentra en la pestaña <code className="action">Información general</code> de su MX Plan. Haga clic en la pestaña <code className="action">Correo electrónico</code> y seleccione el botón <code className="action">Gestionar las redirecciones</code> en el lado derecho.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cambiar la contraseña de una dirección de correo
 description: Cómo cambiar la contraseña de una dirección de correo de OVHcloud
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -138,7 +138,7 @@ Haga clic en el botón <code className="action">...</code> y seleccione <code cl
   <Tab label="Emails MX Plan (nueva versión)">
     Si no conoce el tipo de producto MX Plan que posee, consulte el apartado [Identifique su producto MX Plan](#whichmxplan).<br/>
 
-Haga clic en <code className="action">MX Plan</code> y seleccione el servicio MX Plan correspondiente. Abra la pestaña <code className="action">Correo electrónico</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes. <br/>
+Haga clic en <code className="action">MX Plan</code> y seleccione el servicio MX Plan correspondiente. Abra la pestaña <code className="action">Cuentas de correo</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes. <br/>
 
 Haga clic en el botón <code className="action">...</code> y seleccione <code className="action">Editar</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -127,21 +127,21 @@ Consulte su correo en línea, sin instalación, mediante el webmail [Outlook Web
 Siga las indicaciones de su solución:
 
 <ZoneTabs>
-  <Tab label="MXplan (versión histórica)">
-    Si no conoce el tipo de producto MX Plan que posee, consulte el apartado [Identifique su producto MX Plan](#whichmxplan).<br/>
-
-Haga clic en <code className="action">MX Plan</code> y seleccione el servicio MX Plan correspondiente. Abra la pestaña <code className="action">Correo electrónico</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes. <br/>
-
-Haga clic en el botón <code className="action">...</code> y seleccione <code className="action">Cambiar la contraseña</code>.<br/><br/>
-    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="Emails MX Plan (nueva versión)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Si no conoce el tipo de producto MX Plan que posee, consulte el apartado [Identifique su producto MX Plan](#whichmxplan).<br/>
 
 Haga clic en <code className="action">MX Plan</code> y seleccione el servicio MX Plan correspondiente. Abra la pestaña <code className="action">Cuentas de correo</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes. <br/>
 
 Haga clic en el botón <code className="action">...</code> y seleccione <code className="action">Editar</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Si no conoce el tipo de producto MX Plan que posee, consulte el apartado [Identifique su producto MX Plan](#whichmxplan).<br/>
+
+Haga clic en <code className="action">MX Plan</code> y seleccione el servicio MX Plan correspondiente. Abra la pestaña <code className="action">Correo electrónico</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes. <br/>
+
+Haga clic en el botón <code className="action">...</code> y seleccione <code className="action">Cambiar la contraseña</code>.<br/><br/>
+    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     Haga clic en <code className="action">Email Pro</code> y seleccione el nombre de la plataforma correspondiente. Abra la pestaña <code className="action">Cuentas de correo</code>. Se abrirá una ventana en la que se mostrarán las cuentas de correo existentes.<br/>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Correo electrónico bloqueado por spam: ¿qué hacer?"
 description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Correo electrónico bloqueado por spam: ¿qué hacer?"
 description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Seleccione el plan de correo electrónico correspondiente en las siguientes pest
     
     <img className="thumbnail" alt="Columna estado Spam en la pestaña Cuentas de correo MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Esta pestaña se aplica a todas las direcciones que utilizan la tecnología **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** y **Zimbra Pro**. El proceso de desbloqueo es idéntico para estos tres planes.
-
-    En el momento del bloqueo, **no se genera ningún tique de asistencia automáticamente** y la dirección deja de ser accesible (webmail Zimbra y envío desactivados).
-
-    Para desbloquear la dirección:
-
-    1. Realice las comprobaciones descritas en la [etapa 1](#step1), a partir de los elementos accesibles (equipos de usuario, programas de terceros, redirecciones visibles desde otro acceso).
-    2. **Cree manualmente un tique de asistencia** desde su área de cliente de OVHcloud.
-    3. En el tique, indique:
-        - La dirección de correo electrónico afectada por el bloqueo.
-        - El servicio asociado (MX Plan, Zimbra Starter o Zimbra Pro) y su identificador.
-        - Las acciones correctivas ya emprendidas (análisis antivirus, eliminación de remitentes no legítimos, adición del filtro SPAM/DCE, etc.).
-
-    Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Si el bloqueo afecta a una dirección de correo electrónico MX Plan con el webmail **Roundcube**, no se genera ningún tique de asistencia.
 
@@ -243,6 +227,22 @@ Seleccione el plan de correo electrónico correspondiente en las siguientes pest
 
     Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Esta pestaña se aplica a todas las direcciones que utilizan la tecnología **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** y **Zimbra Pro**. El proceso de desbloqueo es idéntico para estos tres planes.
+
+    En el momento del bloqueo, **no se genera ningún tique de asistencia automáticamente** y la dirección deja de ser accesible (webmail Zimbra y envío desactivados).
+
+    Para desbloquear la dirección:
+
+    1. Realice las comprobaciones descritas en la [etapa 1](#step1), a partir de los elementos accesibles (equipos de usuario, programas de terceros, redirecciones visibles desde otro acceso).
+    2. **Cree manualmente un tique de asistencia** desde su área de cliente de OVHcloud.
+    3. En el tique, indique:
+        - La dirección de correo electrónico afectada por el bloqueo.
+        - El servicio asociado (MX Plan, Zimbra Starter o Zimbra Pro) y su identificador.
+        - Las acciones correctivas ya emprendidas (análisis antivirus, eliminación de remitentes no legítimos, adición del filtro SPAM/DCE, etc.).
+
+    Una vez que el soporte tramite el tique, la dirección se desbloqueará. La [etapa 3](#step3) no se aplica en este caso.
   </Tab>
 </ZoneTabs>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Correo electrónico bloqueado por spam: ¿qué hacer?"
-description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud."
+description: "Desbloquee una dirección de correo bloqueada por spam: identifique la causa de la actividad sospechosa, corríjala y contacte con el soporte OVHcloud"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -23,26 +23,26 @@ Retrouvez dans ce guide différentes informations et aides concernant la configu
 
 <details>
 
-<summary>Qu'est-ce qu'une redirection e-mail ?</summary>
+<summary>Qu'est-ce qu'une redirection e-mail ?</summary>
 
 
 Une redirection permet de modifier le trajet initial d'un e-mail vers une ou plusieurs autres adresses e-mail.
 
-Par exemple : vous souhaitez qu'à la réception d'un e-mail sur **contact@mydomain.ovh**, celui-ci soit également renvoyé vers **john.smith@otherdomain.ovh**. Une redirection permet de transmettre automatiquement un e-mail destiné à **contact@mydomain.ovh** vers **john.smith@otherdomain.ovh**.
+Par exemple : vous souhaitez qu'à la réception d'un e-mail sur **contact@mydomain.ovh**, celui-ci soit également renvoyé vers **john.smith@otherdomain.ovh**. Une redirection permet de transmettre automatiquement un e-mail destiné à **contact@mydomain.ovh** vers **john.smith@otherdomain.ovh**.
 
 </details>
 
 
 <details>
 
-<summary>Qu'est-ce qu'un alias e-mail ?</summary>
+<summary>Qu'est-ce qu'un alias e-mail ?</summary>
 
 
 Contrairement à la redirection, l'adresse e-mail associée à l'alias n'est pas une adresse que l'on consulte, il s'agit d'un « masque ».
 
 Créer un alias pour votre adresse e-mail vous permet de communiquer une adresse « masque » à vos contacts, sans avoir à communiquer votre adresse e-mail personnelle à l'expéditeur. Une adresse e-mail peut avoir plusieurs alias.
 
-Par exemple : votre adresse e-mail est **john.smith@mydomain.ovh** et votre alias **information@mydomain.ovh**. Vous pouvez alors communiquer à vos contacts l'adresse **information@mydomain.ovh** et recevoir vos e-mails sur **john.smith@mydomain.ovh**, sans que l'expéditeur ait connaissance de **john.smith@mydomain.ovh**.
+Par exemple : votre adresse e-mail est **john.smith@mydomain.ovh** et votre alias **information@mydomain.ovh**. Vous pouvez alors communiquer à vos contacts l'adresse **information@mydomain.ovh** et recevoir vos e-mails sur **john.smith@mydomain.ovh**, sans que l'expéditeur ait connaissance de **john.smith@mydomain.ovh**.
 
 </details>
 
@@ -54,9 +54,9 @@ Par exemple : votre adresse e-mail est **john.smith@mydomain.ovh** et votre alia
 
 Cliquez sur les onglets suivants pour des explications illustrées sur le fonctionnement des alias et redirections.
 
-- `From` : Désigne l'adresse de l'expéditeur.
-- `To` : Désigne l'adresse du destinataire.
-- `Redirect to` : Désigne l'adresse e-mail de redirection qui a été configurée.
+- `From` : Désigne l'adresse de l'expéditeur.
+- `To` : Désigne l'adresse du destinataire.
+- `Redirect to` : Désigne l'adresse e-mail de redirection qui a été configurée.
 
 <Tabs>
   <Tab label="1. La redirection simple">
@@ -89,7 +89,7 @@ Il est possible de configurer une redirection vers plusieurs adresses e-mail. Ce
 
 ## Prérequis
 
-- Disposer d’une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
+- Disposer d’une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
@@ -142,24 +142,24 @@ Il est possible de configurer une redirection vers plusieurs adresses e-mail. Ce
 
 ## En pratique
 
-Ce guide concerne l'ensemble de nos offres e-mail. En fonction de l'offre, la gestion des alias et des redirections peut se faire depuis l'espace client OVHcloud ou depuis le webmail. Pour plus de clarté, nous mentionnons les types d'offres e-mail concernées dans chaque chapitre de ce guide. Voici les différents types d'offres e-mail OVHcloud :
+Ce guide concerne l'ensemble de nos offres e-mail. En fonction de l'offre, la gestion des alias et des redirections peut se faire depuis l'espace client OVHcloud ou depuis le webmail. Pour plus de clarté, nous mentionnons les types d'offres e-mail concernées dans chaque chapitre de ce guide. Voici les différents types d'offres e-mail OVHcloud :
 
- - **MX Plan Roundcube** : Correspond à l'offre MX Plan utilisant le webmail Roundcube.
- - **MX Plan Zimbra** : Correspond à l'offre MX Plan utilisant le webmail Zimbra. 
- - **MX Plan OWA** : Correspond à l'offre MX Plan utilisant le webmail Outlook Web App (OWA). 
+ - **MX Plan Roundcube** : Correspond à l'offre MX Plan utilisant le webmail Roundcube.
+ - **MX Plan Zimbra** : Correspond à l'offre MX Plan utilisant le webmail Zimbra. 
+ - **MX Plan OWA** : Correspond à l'offre MX Plan utilisant le webmail Outlook Web App (OWA). 
  <Region zones={['eu', 'ca']}>
- - **Exchange** : S'applique aux offres **Hosted**, **Private** et **Dedicated** Exchange utilisant le webmail Outlook Web App (OWA).
+ - **Exchange** : S'applique aux offres **Hosted**, **Private** et **Dedicated** Exchange utilisant le webmail Outlook Web App (OWA).
  </Region>
  <Region zones={['eu']}>
- - **Email Pro** : Offre E-mail basée sur Exchange utilisant le webmail Outlook Web App (OWA).
+ - **Email Pro** : Offre E-mail basée sur Exchange utilisant le webmail Outlook Web App (OWA).
  </Region>
  <Region zones={['eu']}>
- - **Zimbra** : Offre dédiée utilisant le webmail Zimbra.
+ - **Zimbra** : Offre dédiée utilisant le webmail Zimbra.
  </Region>
- - **Redirect** : Cette offre gratuite est automatiquement disponible si vous disposez d'un nom de domaine dans votre espace client sans offre e-mail attachée. Elle permet de créer des redirections e-mail.
+ - **Redirect** : Cette offre gratuite est automatiquement disponible si vous disposez d'un nom de domaine dans votre espace client sans offre e-mail attachée. Elle permet de créer des redirections e-mail.
 
 :::info
-La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l'identifier depuis votre espace client, suivez ce cheminement :
+La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l'identifier depuis votre espace client, suivez ce cheminement :
 
 Depuis votre service MX Plan, dans l'onglet <code className="action">Informations Générales</code>, relevez la technologie utilisée sous la mention **Webmail** dans l'encadré `Abonnement`.
 
@@ -211,7 +211,7 @@ Actuellement, seules les offres **MX plan** et **Redirect** disposent d'une inte
 
 Depuis votre service MX Plan, sélectionnez le domaine concerné.
 
-Dans notre exemple, il s'agit d'une **redirection avec copie locale** (voir le [schéma 2](#diagram) au début de ce guide). Si cela correspond à votre besoin, suivez les étapes ci-dessous en cliquant sur l'onglet correspondant à la technologie webmail utilisée par votre MX Plan :
+Dans notre exemple, il s'agit d'une **redirection avec copie locale** (voir le [schéma 2](#diagram) au début de ce guide). Si cela correspond à votre besoin, suivez les étapes ci-dessous en cliquant sur l'onglet correspondant à la technologie webmail utilisée par votre MX Plan :
 
 <Tabs>
   <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
@@ -223,13 +223,13 @@ Le tableau des redirections déjà actives s'affiche. À droite, cliquez sur le 
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-2.png" loading="lazy" />
 
-Dans le formulaire `Créer une redirection`, complétez les éléments suivants :
+Dans le formulaire `Créer une redirection`, complétez les éléments suivants :
     
-    - **De l'adresse** : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.
-    - **Vers l'adresse** : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.
-    - **Choisissez un mode de copie** : Choisissez si vous souhaitez :
-         - **Conserver une copie du mail chez OVHcloud** : Recevoir l'e-mail sur votre adresse principale ainsi que l'adresse de redirection (voir le [schéma 2](#diagram) au début de ce guide).
-         - **Ne pas conserver de copie du mail** : Renvoyer directement vers l'adresse de redirection sans que l'adresse principale ne le reçoive (voir le [schéma 1](#diagram) au début de ce guide).
+    - **De l'adresse** : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.
+    - **Vers l'adresse** : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.
+    - **Choisissez un mode de copie** : Choisissez si vous souhaitez :
+         - **Conserver une copie du mail chez OVHcloud** : Recevoir l'e-mail sur votre adresse principale ainsi que l'adresse de redirection (voir le [schéma 2](#diagram) au début de ce guide).
+         - **Ne pas conserver de copie du mail** : Renvoyer directement vers l'adresse de redirection sans que l'adresse principale ne le reçoive (voir le [schéma 1](#diagram) au début de ce guide).
     
     Cliquez ensuite sur <code className="action">Valider</code> pour confirmer l'ajout de cette redirection.
     
@@ -248,13 +248,13 @@ Dans le formulaire `Créer une redirection`, complétez les éléments suivants 
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-zimbra-1.png" loading="lazy" />
 
-Dans le formulaire `Créer une redirection`, complétez les éléments suivants :
+Dans le formulaire `Créer une redirection`, complétez les éléments suivants :
     
-    - **De l'adresse** : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.
-    - **Vers l'adresse** : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.
-    - **Choisissez un mode de copie** : Choisissez si vous souhaitez :
-         - **Conserver une copie du mail chez OVHcloud** : Recevoir l'e-mail sur votre adresse principale ainsi que l'adresse de redirection (voir le [schéma 2](#diagram) au début de ce guide).
-         - **Ne pas conserver de copie du mail** : Renvoyer directement vers l'adresse de redirection sans que l'adresse principale ne le reçoive (voir le [schéma 1](#diagram) au début de ce guide).
+    - **De l'adresse** : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.
+    - **Vers l'adresse** : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.
+    - **Choisissez un mode de copie** : Choisissez si vous souhaitez :
+         - **Conserver une copie du mail chez OVHcloud** : Recevoir l'e-mail sur votre adresse principale ainsi que l'adresse de redirection (voir le [schéma 2](#diagram) au début de ce guide).
+         - **Ne pas conserver de copie du mail** : Renvoyer directement vers l'adresse de redirection sans que l'adresse principale ne le reçoive (voir le [schéma 1](#diagram) au début de ce guide).
     
     Cliquez ensuite sur <code className="action">Valider</code> pour confirmer l'ajout de cette redirection.
     
@@ -280,7 +280,7 @@ La création d'une redirection se fait par le biais de règles de boîte de réc
 ##### Outlook Web App (OWA) <a name="redirect-webmail-owa"></a>
 
 :::tip
-Ce chapitre concerne les offres suivantes :
+Ce chapitre concerne les offres suivantes :
 
 - **MX Plan OWA**.
 <Region zones={['eu', 'ca']}>
@@ -305,7 +305,7 @@ Outlook Web App est une interface utilisée pour notre offre **Exchange** et une
 Outlook Web App est une interface utilisée pour une partie des comptes **MX Plan**.
 </Region>
 
-Parcourez les onglets ci-dessous pour mettre en place votre redirection via Outlook Web App :
+Parcourez les onglets ci-dessous pour mettre en place votre redirection via Outlook Web App :
 
 <Tabs>
   <Tab label="Étape 1">
@@ -326,16 +326,16 @@ Cette fenêtre permet de gérer vos redirections mais également d'appliquer des
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/emails-all-03.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 4">
-    Dans la fenêtre qui s'affiche, complétez les éléments suivants :
-    - **Nom** : Définissez le nom de votre redirection.
-    - **Lorsque le message arrive et remplit toutes ces conditions** : Si votre redirection s'applique à tous les messages, sélectionnez <code className="action">[Appliquer à tous les messages]</code>.
+    Dans la fenêtre, complétez les éléments suivants :
+    - **Nom** : Définissez le nom de votre redirection.
+    - **Lorsque le message arrive et remplit toutes ces conditions** : Si votre redirection s'applique à tous les messages, sélectionnez <code className="action">[Appliquer à tous les messages]</code>.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/emails-all-04.png" loading="lazy" />
   </Tab>
   <Tab label="Étape 5">
-    Ensuite, dans la même fenêtre :
+    Ensuite, dans la même fenêtre :
     
-    **Effectuer toutes les opérations suivantes** : C'est ici que vous appliquez la redirection. Sélectionnez <code className="action">Transférer, rediriger ou envoyer</code> puis <code className="action">Rediriger le message vers...</code>.
+    **Effectuer toutes les opérations suivantes** : C'est ici que vous appliquez la redirection. Sélectionnez <code className="action">Transférer, rediriger ou envoyer</code> puis <code className="action">Rediriger le message vers...</code>.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/emails-all-05.png" loading="lazy" />
   </Tab>
@@ -358,7 +358,7 @@ Pour appliquer une **redirection simple** (voir le [schéma 1](#diagram) au déb
 ##### Zimbra <a name="redirect-webmail-zimbra"></a>
 
 :::tip
-Ce chapitre concerne les offres suivantes :
+Ce chapitre concerne les offres suivantes :
 
 - **MX Plan** ayant la mention zimbra pour le webmail.
 <Region zones={['eu']}>
@@ -376,7 +376,7 @@ Dans notre exemple ci-dessous, nous avons choisi de rediriger l'ensemble des e-m
 :::
 
 
-Suivez les étapes ci-dessous en cliquant sur les onglets pour mettre en place votre redirection :
+Suivez les étapes ci-dessous en cliquant sur les onglets pour mettre en place votre redirection :
 
 <Tabs>
   <Tab label="Étape 1">
@@ -411,7 +411,7 @@ Pour plus de détails sur l'utilisation du webmail Zimbra, consultez notre guide
 
 Depuis votre service MX Plan, sélectionnez le domaine concerné.
 
-Sélectionnez, ci-dessous, l'onglet correspondant à la technologie e-mail utilisée par votre service MX Plan :
+Sélectionnez, ci-dessous, l'onglet correspondant à la technologie e-mail utilisée par votre service MX Plan :
 
 <Tabs>
   <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
@@ -436,7 +436,7 @@ Sélectionnez, ci-dessous, l'onglet correspondant à la technologie e-mail utili
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 
-Rendez-vous sur le [webmail](https://www.ovhcloud.com/fr/mail/). Saisissez **l'adresse e-mail** et le **mot de passe** pour vous y connecter. Depuis l'interface du webmail OWA, suivez les étapes en cliquant sur les onglets ci-dessous :
+Rendez-vous sur le [webmail](https://www.ovhcloud.com/fr/mail/). Saisissez **l'adresse e-mail** et le **mot de passe** pour vous y connecter. Depuis l'interface du webmail OWA, suivez les étapes en cliquant sur les onglets ci-dessous :
 
 <Tabs>
   <Tab label="Étape 1">
@@ -461,7 +461,7 @@ Vous trouverez la fenêtre permettant de gérer vos redirections et filtres.
 
 ##### Zimbra <a name="redirect-delete-zimbra"></a>
 
-Rendez-vous sur le [webmail](https://www.ovhcloud.com/fr/mail/). Saisissez **l'adresse e-mail** et le **mot de passe** pour vous y connecter. Depuis l'interface du webmail Zimbra, suivez les étapes en cliquant sur les onglets ci-dessous :
+Rendez-vous sur le [webmail](https://www.ovhcloud.com/fr/mail/). Saisissez **l'adresse e-mail** et le **mot de passe** pour vous y connecter. Depuis l'interface du webmail Zimbra, suivez les étapes en cliquant sur les onglets ci-dessous :
 
 <Tabs>
   <Tab label="Étape 1">
@@ -490,11 +490,11 @@ Créer un alias pour votre adresse e-mail vous permet de communiquer une adresse
 
 Depuis votre service e-mail (Exchange, Email Pro ou MX Plan), cliquez sur l'onglet <code className="action">Comptes e-mail</code>.
 
-Pour ajouter un alias à votre compte e-mail, suivez les étapes décrites en cliquant successivement sur chaque onglet ci-dessous :
+Pour ajouter un alias à votre compte e-mail, suivez les étapes décrites en cliquant successivement sur chaque onglet ci-dessous :
 
 <Tabs>
   <Tab label="Étape 1">
-    Dans le tableau qui s'affiche, vous trouverez une colonne `Alias`.
+    Le tableau comporte une colonne `Alias`.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/email-alias012.png" loading="lazy" />
   </Tab>
@@ -514,7 +514,7 @@ Pour ajouter un alias à votre compte e-mail, suivez les étapes décrites en cl
 <Region zones={['eu']}>
 #### MX Plan Roundcube <a name="alias-mxplan-roundcube"></a>
 
-Pour créer un alias sur un compte email MX Plan Roundcube, vous devez le faire de la même façon qu'une redirection. Il suffit de déterminer une adresse e-mail qui n'existe pas sur votre nom de domaine et de pointer vers une adresse existante. Suivez le chapitre [MX Plan / MX redirect](#redirect-manager-mxplan) dans la partie "créer une redirection" depuis ce guide.
+Pour créer un alias sur un compte email MX Plan Roundcube, vous devez le faire de la même façon qu'une redirection. Il suffit de déterminer une adresse e-mail qui n'existe pas sur votre nom de domaine et de pointer vers une adresse existante. Suivez le chapitre [MX Plan / MX redirect](#redirect-manager-mxplan) dans la partie « créer une redirection » depuis ce guide.
 </Region>
 
 <Region zones={['eu']}>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utiliser les alias et redirections e-mail
 description: Découvrez comment gérer vos alias et redirections e-mail
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Depuis votre service MX Plan, sélectionnez le domaine concerné.
 Dans notre exemple, il s'agit d'une **redirection avec copie locale** (voir le [schéma 2](#diagram) au début de ce guide). Si cela correspond à votre besoin, suivez les étapes ci-dessous en cliquant sur l'onglet correspondant à la technologie webmail utilisée par votre MX Plan :
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Par défaut, vous êtes dans l'onglet <code className="action">Informations générales</code> de votre MX Plan. Cliquez sur l'onglet <code className="action">Emails</code> puis à droite sur le bouton <code className="action">Gestion des redirections</code>.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utiliser les alias et redirections e-mail
 description: Découvrez comment gérer vos alias et redirections e-mail
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -17,17 +17,17 @@ import { Panel } from '@components/Panel';
 
 ## Objectif
 
-Les comptes e-mail de votre offre OVHcloud sont accessibles grâce au mot de passe qui leur est associé. La modification de celui-ci peut se faire de 2 manières selon votre offre e-mail :
+Les comptes e-mail de votre offre OVHcloud sont accessibles grâce au mot de passe qui leur est associé. La modification de celui-ci peut se faire de 2 manières selon votre offre e-mail :
 
-- Depuis le Webmail
+- Depuis le webmail
 - Via l'espace client OVHcloud
 
 **Découvrez comment modifier le mot de passe d'une adresse e-mail OVHcloud.**
 
 ## Prérequis
 
-- Selon la méthode que vous utilisez : être connecté à l'adresse e-mail depuis le [webmail](https://www.ovhcloud.com/fr/mail/).
-- Disposer d'une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
+- Selon la méthode que vous utilisez : être connecté à l'adresse e-mail depuis le [webmail](https://www.ovhcloud.com/fr/mail/).
+- Disposer d'une solution e-mail OVHcloud préalablement configurée, parmi les suivantes :
     <Region zones={['eu']}>
     - **MX Plan** proposée avec nos [offres d’hébergement web](https://www.ovhcloud.com/fr/web-hosting/) ou incluse dans un [hébergement gratuit](https://www.ovhcloud.com/fr/domains/free-web-hosting/).
     </Region>
@@ -125,13 +125,13 @@ Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook 
 </Region>
 
 
-Suivez les instructions selon votre offre :
+Suivez les instructions selon votre offre :
 
 <ZoneTabs>
   <Tab label="MX Plan (Zimbra / OWA)">
     Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
 
-Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
+Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre affiche les comptes e-mail existants. <br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
@@ -139,25 +139,25 @@ Cliquez sur le bouton <code className="action">...</code> puis sur <code classNa
   <Tab label="MX Plan (Roundcube)">
     Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
 
-Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Emails</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
+Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Emails</code>. La fenêtre affiche les comptes e-mail existants. <br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Changer le mot de passe</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
-    Cliquez sur <code className="action">Email Pro</code>, puis choisissez le nom de la plateforme concernée. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants.<br/>
+    Cliquez sur <code className="action">Email Pro</code>, puis choisissez le nom de la plateforme concernée. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre affiche les comptes e-mail existants.<br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-emailpro01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Exchange" availableIn={['eu', 'ca']}>
-    Cliquez sur <code className="action">Microsoft</code> / <code className="action">Exchange</code>, puis choisissez le nom de la plateforme concernée. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants.<br/>
+    Cliquez sur <code className="action">Microsoft</code> / <code className="action">Exchange</code>, puis choisissez le nom de la plateforme concernée. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre affiche les comptes e-mail existants.<br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-exchange01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Zimbra" availableIn={['eu']}>
-    Cliquez sur <code className="action">Zimbra Mail</code> puis dirigez-vous vers l'onglet <code className="action">Compte email</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
+    Cliquez sur <code className="action">Zimbra Mail</code> puis dirigez-vous vers l'onglet <code className="action">Compte email</code>. La fenêtre affiche les comptes e-mail existants. <br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-zimbra01.png" loading="lazy" /><br/>
@@ -167,7 +167,7 @@ Cliquez sur le bouton <code className="action">...</code> puis sur <code classNa
 
 ### Modifier le mot de passe depuis le webmail
 
-La modification de votre mot de passe via le webmail est disponible pour les offres email OVHcloud utilisant **OWA** (**O**utlook **W**eb **A**pp) et Zimbra :
+La modification de votre mot de passe via le webmail est disponible pour les offres email OVHcloud utilisant **OWA** (**O**utlook **W**eb **A**pp) et Zimbra :
 
 <Region zones={['eu']}>
 
@@ -214,11 +214,11 @@ Cliquez sur le bouton <i className="icons-gear-concept icons-masterbrand-blue"><
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step3.png" loading="lazy" />
 
-Sur la nouvelle page qui s'affiche, dans la partie latérale de gauche, dépliez l'onglet « Général » dans l'arborescence, puis cliquez sur <code className="action">Mon compte</code>. Cliquez enfin sur <code className="action">Modifier votre mot de passe</code>.
+Sur la nouvelle page, dans la partie latérale de gauche, dépliez l'onglet « Général » dans l'arborescence, puis cliquez sur <code className="action">Mon compte</code>. Cliquez enfin sur <code className="action">Modifier votre mot de passe</code>.
 
 <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/mxplan-password-new-step4.png" loading="lazy" />
 
-Sur la nouvelle fenêtre qui apparaît, commencez par renseigner votre mot de passe actuel. Écrivez alors votre nouveau mot de passe, puis confirmez-le. Cliquez sur le bouton <code className="action">Enregistrer</code> pour sauvegarder la modification.
+Sur la nouvelle fenêtre, commencez par renseigner votre mot de passe actuel. Écrivez alors votre nouveau mot de passe, puis confirmez-le. Cliquez sur le bouton <code className="action">Enregistrer</code> pour sauvegarder la modification.
 
 :::info
 Vous devrez renseigner le nouveau mot de passe sur tous les appareils où l’adresse e-mail a été configurée.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modifier le mot de passe d'une adresse e-mail"
 description: "Découvrez comment modifier le mot de passe d'une adresse e-mail OVHcloud"
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -139,7 +139,7 @@ Cliquez sur le bouton <code className="action">...</code> puis sur <code classNa
   <Tab label="MX Plan Zimbra et OWA">
     Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
 
-Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Emails</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
+Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -128,21 +128,21 @@ Consultez votre messagerie en ligne, sans installation, via le webmail [Outlook 
 Suivez les instructions selon votre offre :
 
 <ZoneTabs>
-  <Tab label="MX Plan - Roundcube">
-    Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
-
-Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Emails</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
-
-Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Changer le mot de passe</code>.<br/><br/>
-    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="MX Plan Zimbra et OWA">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
 
 Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
 
 Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Si vous ne connaissez pas le type d'offre MX Plan que vous possédez, consultez notre paragraphe [Identifiez votre offre MX Plan](#whichmxplan).<br/><br/>
+
+Cliquez sur <code className="action">MX Plan</code> puis choisissez le nom du service MX Plan concerné. Positionnez-vous sur l'onglet <code className="action">Emails</code>. La fenêtre qui apparaît affiche les comptes e-mail existants. <br/>
+
+Cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Changer le mot de passe</code>.<br/><br/>
+    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     Cliquez sur <code className="action">Email Pro</code>, puis choisissez le nom de la plateforme concernée. Positionnez-vous sur l'onglet <code className="action">Comptes e-mail</code>. La fenêtre qui apparaît affiche les comptes e-mail existants.<br/>

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Que faire en cas d'adresse e-mail bloquée pour spam ?
 description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Sélectionnez l'offre e-mail concernée dans les onglets suivants :
     
     <img className="thumbnail" alt="Colonne statut Spam dans l'onglet Comptes e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
-
-    Lors du blocage, **aucun ticket d'assistance n'est généré automatiquement** et l'adresse n'est plus accessible (webmail Zimbra et envoi désactivés).
-
-    Pour faire débloquer l'adresse :
-
-    1. Effectuez les vérifications décrites à [l'étape 1](#step1), à partir des éléments accessibles (postes utilisateurs, logiciels tiers, redirections visibles depuis un autre accès).
-    2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud.
-    3. Dans le ticket, précisez :
-        - L'adresse e-mail concernée par le blocage ;
-        - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
-        - Les actions correctives déjà engagées (analyses antivirus, suppression d'expéditeurs non légitimes, ajout du filtre SPAM/DCE, etc.).
-
-    Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Si le blocage concerne une adresse e-mail MX Plan avec le webmail **Roundcube**, aucun ticket d'assistance n'est généré.
 
@@ -243,6 +227,22 @@ Sélectionnez l'offre e-mail concernée dans les onglets suivants :
 
     Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Cet onglet s'applique à toutes les adresses utilisant la technologie **Zimbra** : **MX Plan - Zimbra**, **Zimbra Starter** et **Zimbra Pro**. Le processus de déblocage est identique pour ces trois offres.
+
+    Lors du blocage, **aucun ticket d'assistance n'est généré automatiquement** et l'adresse n'est plus accessible (webmail Zimbra et envoi désactivés).
+
+    Pour faire débloquer l'adresse :
+
+    1. Effectuez les vérifications décrites à [l'étape 1](#step1), à partir des éléments accessibles (postes utilisateurs, logiciels tiers, redirections visibles depuis un autre accès).
+    2. **Créez manuellement un ticket d'assistance** depuis votre espace client OVHcloud.
+    3. Dans le ticket, précisez :
+        - L'adresse e-mail concernée par le blocage ;
+        - Le service associé (MX Plan, Zimbra Starter ou Zimbra Pro) et son identifiant ;
+        - Les actions correctives déjà engagées (analyses antivirus, suppression d'expéditeurs non légitimes, ajout du filtre SPAM/DCE, etc.).
+
+    Une fois le ticket traité par le support, l'adresse est débloquée. L'[étape 3](#step3) ne s'applique pas dans ce cas.
   </Tab>
 </ZoneTabs>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
-title: Que faire en cas d'adresse e-mail bloquée pour spam ?
-description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud."
+title: Que faire en cas d'adresse e-mail bloquée pour spam ?
+description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
@@ -264,14 +264,14 @@ Le ticket d'assistance se présente comme suit :
 >
 > Nous avons actuellement détecté **X** message(s) suspect(s).
 >
-> Afin de nous aider à réactiver l'envoi d'e-mail pour l'adresse : **address@example.com**,
-> répondez à cet e-mail en complétant les questions suivantes :
+> Afin de nous aider à réactiver l'envoi d'e-mail pour l'adresse : **address@example.com**,
+> répondez à cet e-mail en complétant les questions suivantes :
 >
-> - Êtes-vous l'émetteur de l'e-mail en question (voir l'entête ci-dessous) ?
+> - Êtes-vous l'émetteur de l'e-mail en question (voir l'entête ci-dessous) ?
 >
-> - Avez-vous une règle de redirection vers une autre adresse e-mail ?
+> - Avez-vous une règle de redirection vers une autre adresse e-mail ?
 >
-> - Avez-vous répondu à un Spam ?
+> - Avez-vous répondu à un Spam ?
 >
 > Ces réponses nous aideront à réactiver votre compte rapidement.
 
@@ -289,7 +289,7 @@ Si un nouveau mot de passe est nécessaire, veillez à ce qu'il soit suffisammen
 
 ## Aller plus loin
 
-Pour gérer les alias et redirections de votre adresse e-mail, consultez le guide [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections).
+Pour gérer les alias et redirections de votre adresse e-mail, consultez le guide « [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections) ».
 
 <Region zones={['eu']}>
 
@@ -299,7 +299,7 @@ Pour consulter vos filtres et réponses automatiques depuis le webmail, consulte
 
 <Region zones={['ca', 'apac']}>
 
-Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez le guide [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+Pour consulter vos filtres et réponses automatiques depuis le webmail, consultez le guide « [Outlook Web App (OWA)](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ».
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Que faire en cas d'adresse e-mail bloquée pour spam ?
 description: "Débloquez une adresse e-mail bloquée pour spam : identifiez la cause de l'activité suspecte, corrigez-la et contactez le support OVHcloud"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare gli alias e i reindirizzamenti email
 description: Come gestire gli alias e i reindirizzamenti email
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ Dal tuo servizio MX Plan, seleziona il dominio interessato.
 Nel nostro esempio, si tratta di un **reindirizzamento con copia in locale** (vedi lo [schema 2](#diagram) all'inizio di questa guida). Se ciò corrisponde alle tue necessità, segui gli step indicati qui sotto nella scheda corrispondente alla tecnologia Webmail utilizzata dal tuo MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube/MX Plan Outlook Web App/Redirect">
+  <Tab label="MX Plan Roundcube/MX Plan OWA/Redirect">
     Di default, ti trovi nella scheda <code className="action">Informazioni generali</code> del tuo MX Plan. Clicca sulla scheda <code className="action">Email</code> e poi sul pulsante <code className="action">Gestisci i reindirizzamenti</code> a destra.
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -214,7 +214,7 @@ Dal tuo servizio MX Plan, seleziona il dominio interessato.
 Nel nostro esempio, si tratta di un **reindirizzamento con copia in locale** (vedi lo [schema 2](#diagram) all'inizio di questa guida). Se ciò corrisponde alle tue necessità, segui gli step indicati qui sotto nella scheda corrispondente alla tecnologia Webmail utilizzata dal tuo MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube/MX Plan OWA/Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Di default, ti trovi nella scheda <code className="action">Informazioni generali</code> del tuo MX Plan. Clicca sulla scheda <code className="action">Email</code> e poi sul pulsante <code className="action">Gestisci i reindirizzamenti</code> a destra.
     
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />
@@ -414,7 +414,7 @@ Dal tuo servizio MX Plan, seleziona il dominio interessato.
 Seleziona qui sotto la scheda corrispondente alla tecnologia email utilizzata dal tuo servizio MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube/MX Plan OWA/Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     - Di default, ti trovi nella scheda <code className="action">Informazioni generali</code> del tuo MX Plan.
     - Clicca sulla scheda <code className="action">Email</code> e poi a destra sul pulsante <code className="action">Gestione dei reindirizzamenti</code>.
     

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare gli alias e i reindirizzamenti email
 description: Come gestire gli alias e i reindirizzamenti email
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -171,7 +171,7 @@ Dal servizio MX Plan, nella scheda <code className="action">Informazioni general
 **Riepilogo**
 
 - [Creare un reindirizzamento](#redirect)
-    - [Dallo Spazio Cliente OVH](#redirect-manager)
+    - [Dallo Spazio Cliente OVHcloud](#redirect-manager)
         - [MX Plan / redirect](#redirect-manager-mxplan)
      - [Dalla webmail](#redirect-webmail)
         - [Outlook Web App (OWA)](#redirect-webmail-owa)
@@ -179,7 +179,7 @@ Dal servizio MX Plan, nella scheda <code className="action">Informazioni general
         - [Zimbra](#redirect-webmail-zimbra)
         </Region>
 - [Elimina un reindirizzamento](#redirect-delete)
-    - [MX Plan dallo Spazio Cliente OVH](#redirect-delete)
+    - [MX Plan dallo Spazio Cliente OVHcloud](#redirect-delete)
     - [Outlook Web App (OWA)](#redirect-delete-owa)
     <Region zones={['eu']}>
     - [Zimbra](#redirect-delete-zimbra)

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -127,21 +127,21 @@ Consultate la posta elettronica online, senza installazione, tramite la webmail 
 Segui le indicazioni fornite:
 
 <ZoneTabs>
-  <Tab label="Email MX Plan (versione storica)">
-    Se non ricordi il tipo di offerta MX Plan, consulta il paragrafo [Identifica la tua offerta MX Plan](#whichmxplan).<br/>
-
-Clicca su <code className="action">MX Plan</code> e poi seleziona il nome del servizio MX Plan. Clicca sulla scheda <code className="action">Email</code>. Visualizzi una finestra con tutti gli account email esistenti. <br/>
-
-Clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica la password</code>.<br/><br/>
-    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="Email MX Plan (nuova versione)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Se non ricordi il tipo di offerta MX Plan, consulta il paragrafo [Identifica la tua offerta MX Plan](#whichmxplan).<br/>
 
 Clicca su <code className="action">MX Plan</code> e poi seleziona il nome del servizio MX Plan. Clicca sulla scheda <code className="action">Account email</code>. Visualizzi una finestra con tutti gli account email esistenti. <br/>
 
 Clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Se non ricordi il tipo di offerta MX Plan, consulta il paragrafo [Identifica la tua offerta MX Plan](#whichmxplan).<br/>
+
+Clicca su <code className="action">MX Plan</code> e poi seleziona il nome del servizio MX Plan. Clicca sulla scheda <code className="action">Email</code>. Visualizzi una finestra con tutti gli account email esistenti. <br/>
+
+Clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica la password</code>.<br/><br/>
+    <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="Email Pro" availableIn={['eu']}>
     Clicca su <code className="action">Email Pro</code> e seleziona il nome della piattaforma. Clicca sulla scheda <code className="action">Account email</code>. Visualizzi una finestra con tutti gli account email esistenti.<br/>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Modifica la password di un indirizzo email
 description: Come modificare la password di un indirizzo email OVHcloud
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -138,7 +138,7 @@ Clicca sul pulsante <code className="action">...</code> e poi su <code className
   <Tab label="Email MX Plan (nuova versione)">
     Se non ricordi il tipo di offerta MX Plan, consulta il paragrafo [Identifica la tua offerta MX Plan](#whichmxplan).<br/>
 
-Clicca su <code className="action">MX Plan</code> e poi seleziona il nome del servizio MX Plan. Clicca sulla scheda <code className="action">Email</code>. Visualizzi una finestra con tutti gli account email esistenti. <br/>
+Clicca su <code className="action">MX Plan</code> e poi seleziona il nome del servizio MX Plan. Clicca sulla scheda <code className="action">Account email</code>. Visualizzi una finestra con tutti gli account email esistenti. <br/>
 
 Clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica</code>.<br/><br/>
     <img className="thumbnail" alt="email" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -19,7 +19,7 @@ import { Panel } from '@components/Panel';
 
 Gli account email del servizio OVHcloud sono accessibili tramite la password associata. La modifica può essere effettuata in 2 modi diversi a seconda del servizio di posta:
 
-- Dalla Webmail
+- Dalla webmail
 - Dallo Spazio Cliente
 
 **Questa guida ti mostra come modificare la password di un indirizzo email OVHcloud.**
@@ -85,7 +85,7 @@ Quando modifichi la password del tuo indirizzo email, sarà necessario apportare
 :::
 
 
-### Modifica la password dallo Spazio Cliente OVH <a name="controlpanel"></a>
+### Modifica la password dallo Spazio Cliente OVHcloud <a name="controlpanel"></a>
 
 :::warning
 Per motivi di sicurezza, ti consigliamo di non utilizzare due volte la stessa password, sceglierne una che non ha alcun rapporto con le tue informazioni personali (ad esempio, eviti le indicazioni del tuo cognome, nome e data di nascita) e rinnovarla regolarmente.

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cosa fare se un indirizzo e-mail è bloccato per spam?
-description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud."
+description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cosa fare se un indirizzo e-mail è bloccato per spam?
 description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Seleziona l'offerta e-mail interessata nelle seguenti schede:
     
     <img className="thumbnail" alt="Colonna stato Spam nella scheda Account email MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Questa scheda si applica a tutti gli indirizzi che utilizzano la tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. La procedura di sblocco è identica per queste tre offerte.
-
-    Al momento del blocco, **non viene generato automaticamente alcun ticket di assistenza** e l'indirizzo non è più accessibile (webmail Zimbra e invio disattivati).
-
-    Per far sbloccare l'indirizzo:
-
-    1. Effettua le verifiche descritte nella [fase 1](#step1), a partire dagli elementi accessibili (postazioni utenti, software di terze parti, reindirizzamenti visibili da un altro accesso).
-    2. **Crea manualmente un ticket di assistenza** dal tuo Spazio Cliente OVHcloud.
-    3. Nel ticket, specifica:
-        - L'indirizzo e-mail interessato dal blocco;
-        - Il servizio associato (MX Plan, Zimbra Starter o Zimbra Pro) e il suo identificativo;
-        - Le azioni correttive già intraprese (analisi antivirus, eliminazione di mittenti non legittimi, aggiunta del filtro SPAM/DCE, ecc.).
-
-    Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Se il blocco riguarda un indirizzo e-mail MX Plan con il webmail **Roundcube**, non viene generato alcun ticket di assistenza.
 
@@ -243,6 +227,22 @@ Seleziona l'offerta e-mail interessata nelle seguenti schede:
 
     Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Questa scheda si applica a tutti gli indirizzi che utilizzano la tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. La procedura di sblocco è identica per queste tre offerte.
+
+    Al momento del blocco, **non viene generato automaticamente alcun ticket di assistenza** e l'indirizzo non è più accessibile (webmail Zimbra e invio disattivati).
+
+    Per far sbloccare l'indirizzo:
+
+    1. Effettua le verifiche descritte nella [fase 1](#step1), a partire dagli elementi accessibili (postazioni utenti, software di terze parti, reindirizzamenti visibili da un altro accesso).
+    2. **Crea manualmente un ticket di assistenza** dal tuo Spazio Cliente OVHcloud.
+    3. Nel ticket, specifica:
+        - L'indirizzo e-mail interessato dal blocco;
+        - Il servizio associato (MX Plan, Zimbra Starter o Zimbra Pro) e il suo identificativo;
+        - Le azioni correttive già intraprese (analisi antivirus, eliminazione di mittenti non legittimi, aggiunta del filtro SPAM/DCE, ecc.).
+
+    Una volta elaborato il ticket dal supporto, l'indirizzo viene sbloccato. La [fase 3](#step3) non si applica in questo caso.
   </Tab>
 </ZoneTabs>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cosa fare se un indirizzo e-mail è bloccato per spam?
 description: "Sblocca un indirizzo e-mail bloccato per spam: individua la causa dell'attività sospetta, correggila e contatta il supporto OVHcloud"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z aliasów i przekierowań e-mail
 description: Dowiedz się, jak zarządzać aliasami i przekierowaniami e-mail
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Korzystanie z aliasów i przekierowań e-mail
 description: Dowiedz się, jak zarządzać aliasami i przekierowaniami e-mail
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ W usłudze MX Plan wybierz odpowiednią domenę.
 W poniższym przykładzie mamy do czynienia z **przekierowaniem z kopią lokalną** (patrz [schemat 2](#diagram) na początku tego przewodnika). Jeśli to odpowiada Twoim potrzebom, wykonaj poniższe kroki, klikając zakładkę odpowiadającą technologii webmail używanej przez Twój MX Plan:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Domyślnie znajdujesz się w zakładce <code className="action">Informacje ogólne</code> usługi MX Plan. Kliknij zakładkę <code className="action">E-maile</code>, a następnie przycisk <code className="action">Zarządzanie przekierowaniami</code>.
     
     <img className="thumbnail" alt="Emaile" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Zmiana hasła do konta e-mail
 description: Dowiedz się, jak zmienić hasło do konta e-mail OVHcloud
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -138,7 +138,7 @@ Kliknij przycisk, <code className="action">...</code> a następnie <code classNa
   <Tab label="E-maile MX Plan (nowa wersja)">
     Jeśli nie wiesz, jakiego typu jest Twoja oferta MX Plan, zapoznaj się z naszym punktem [Sprawdź ofertę MX Plan](#whichmxplan).<br/>
 
-Kliknij <code className="action">MX Plan</code>, po czym wybierz odpowiednią usługę MX Plan. Przejdź do zakładki <code className="action">E-maile</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail. <br/>
+Kliknij <code className="action">MX Plan</code>, po czym wybierz odpowiednią usługę MX Plan. Przejdź do zakładki <code className="action">Konta e-mail</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail. <br/>
 
 Kliknij przycisk, po czym <code className="action">...</code> kliknij <code className="action">Zmień</code>.<br/><br/>
     <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -127,21 +127,21 @@ Sprawdzaj pocztę online, bez instalacji, przez webmail [Outlook Web App (OWA)](
 Postępuj zgodnie z instrukcjami zawartymi w Twojej ofercie:
 
 <ZoneTabs>
-  <Tab label="E-maile MX Plan (wersja historyczna)">
-    Jeśli nie wiesz, jakiego typu jest Twoja oferta MX Plan, zapoznaj się z naszym punktem [Sprawdź ofertę MX Plan](#whichmxplan).<br/>
-
-Kliknij <code className="action">MX Plan</code>, po czym wybierz odpowiednią usługę MX Plan. Przejdź do zakładki <code className="action">E-maile</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail. <br/>
-
-Kliknij przycisk, <code className="action">...</code> a następnie <code className="action">Zmień hasło</code>.<br/><br/>
-    <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="E-maile MX Plan (nowa wersja)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Jeśli nie wiesz, jakiego typu jest Twoja oferta MX Plan, zapoznaj się z naszym punktem [Sprawdź ofertę MX Plan](#whichmxplan).<br/>
 
 Kliknij <code className="action">MX Plan</code>, po czym wybierz odpowiednią usługę MX Plan. Przejdź do zakładki <code className="action">Konta e-mail</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail. <br/>
 
 Kliknij przycisk, po czym <code className="action">...</code> kliknij <code className="action">Zmień</code>.<br/><br/>
     <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Jeśli nie wiesz, jakiego typu jest Twoja oferta MX Plan, zapoznaj się z naszym punktem [Sprawdź ofertę MX Plan](#whichmxplan).<br/>
+
+Kliknij <code className="action">MX Plan</code>, po czym wybierz odpowiednią usługę MX Plan. Przejdź do zakładki <code className="action">E-maile</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail. <br/>
+
+Kliknij przycisk, <code className="action">...</code> a następnie <code className="action">Zmień hasło</code>.<br/><br/>
+    <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
     Kliknij <code className="action">E-mail Pro</code>, po czym wybierz odpowiednią platformę. Przejdź do zakładki <code className="action">Konta e-mail</code>. Pojawi się okno, w którym widoczne są istniejące konta e-mail.<br/>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Adres e-mail zablokowany z powodu spamu: co zrobić?"
-description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
+description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adres e-mail zablokowany z powodu spamu: co zrobić?"
 description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adres e-mail zablokowany z powodu spamu: co zrobić?"
 description: "Odblokuj adres e-mail zablokowany z powodu spamu: zidentyfikuj przyczynę podejrzanej aktywności, usuń ją i skontaktuj się z pomocą techniczną OVHcloud."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Wybierz odpowiednią usługę e-mail w poniższych zakładkach:
     
     <img className="thumbnail" alt="Kolumna Status z wartością Spam w zakładce Konta e-mail dla MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Ta zakładka dotyczy wszystkich adresów wykorzystujących technologię **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** i **Zimbra Pro**. Procedura odblokowania jest identyczna dla tych trzech usług.
-
-    Gdy blokada zostaje zastosowana, **żadne zgłoszenie pomocy technicznej nie jest generowane automatycznie**, a adres nie jest już dostępny (zarówno webmail Zimbra, jak i wysyłanie e-maili są wyłączone).
-
-    Aby uzyskać odblokowanie adresu:
-
-    1. Wykonaj kontrole opisane w [etapie 1](#step1) w oparciu o elementy, do których masz dostęp (urządzenia użytkowników, oprogramowanie zewnętrzne, przekierowania widoczne z innego dostępu).
-    2. **Utwórz ręcznie zgłoszenie pomocy technicznej** z poziomu Twojego Panelu klienta OVHcloud.
-    3. W zgłoszeniu podaj:
-        - Adres e-mail, którego dotyczy blokada;
-        - Powiązaną usługę (MX Plan, Zimbra Starter lub Zimbra Pro) oraz jej identyfikator;
-        - Działania naprawcze już podjęte (skanowanie antywirusowe, usunięcie nielegalnych nadawców, dodanie filtra SPAM/DCE itd.).
-
-    Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Jeśli blokada dotyczy adresu e-mail MX Plan z webmail **Roundcube**, żadne zgłoszenie pomocy technicznej nie jest generowane.
 
@@ -243,6 +227,22 @@ Wybierz odpowiednią usługę e-mail w poniższych zakładkach:
 
     Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Ta zakładka dotyczy wszystkich adresów wykorzystujących technologię **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** i **Zimbra Pro**. Procedura odblokowania jest identyczna dla tych trzech usług.
+
+    Gdy blokada zostaje zastosowana, **żadne zgłoszenie pomocy technicznej nie jest generowane automatycznie**, a adres nie jest już dostępny (zarówno webmail Zimbra, jak i wysyłanie e-maili są wyłączone).
+
+    Aby uzyskać odblokowanie adresu:
+
+    1. Wykonaj kontrole opisane w [etapie 1](#step1) w oparciu o elementy, do których masz dostęp (urządzenia użytkowników, oprogramowanie zewnętrzne, przekierowania widoczne z innego dostępu).
+    2. **Utwórz ręcznie zgłoszenie pomocy technicznej** z poziomu Twojego Panelu klienta OVHcloud.
+    3. W zgłoszeniu podaj:
+        - Adres e-mail, którego dotyczy blokada;
+        - Powiązaną usługę (MX Plan, Zimbra Starter lub Zimbra Pro) oraz jej identyfikator;
+        - Działania naprawcze już podjęte (skanowanie antywirusowe, usunięcie nielegalnych nadawców, dodanie filtra SPAM/DCE itd.).
+
+    Gdy zgłoszenie zostanie przetworzone przez pomoc techniczną, adres zostaje odblokowany. [Etap 3](#step3) nie ma w tym przypadku zastosowania.
   </Tab>
 </ZoneTabs>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar os alias e reencaminhamentos de e-mail
 description: Saiba como gerir os seus alias e reencaminhamentos de e-mail
-lastUpdated: 2026-08-27
+lastUpdated: 2026-06-08
 availableIn: [eu, ca, apac]
 ---
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Utilizar os alias e reencaminhamentos de e-mail
 description: Saiba como gerir os seus alias e reencaminhamentos de e-mail
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -214,7 +214,7 @@ A partir do seu serviço MX Plan, selecione o domínio em questão.
 No nosso exemplo, trata-se de um **reencaminhamento com cópia local** (ver [esquema 2](#diagram) no início deste guia). Se for necessário, clique no separador correspondente à tecnologia webmail utilizada pelo MX Plan e siga as etapas abaixo:
 
 <Tabs>
-  <Tab label="MX Plan Roundcube / MX Plan Outlook Web App / Redirect">
+  <Tab label="MX Plan Roundcube / MX Plan OWA / Redirect">
     Por predefinição, está no separador <code className="action">Informações gerais</code> do seu MX Plan. Clique no separador <code className="action">E-mails</code> e, a seguir, no botão <code className="action">Gestão dos reencaminhamentos</code>.
     
     <img className="thumbnail" alt="emails" src="/images/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections/mxplan-legacy-1.png" loading="lazy" />

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alterar a palavra-passe de um endereço de e-mail
 description: Saiba como alterar a palavra-passe de um endereço de e-mail da OVHcloud
-lastUpdated: 2026-06-08
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -138,7 +138,7 @@ Clique no botão <code className="action">...</code> e, a seguir, em <code class
   <Tab label="E-mails MX Plan (nova versão)">
     Se não conhece o tipo de oferta MX Plan que possui, consulte o nosso parágrafo [Identifique a sua oferta MX Plan](#whichmxplan).<br/>
 
-Clique em <code className="action">E-mails</code> e escolha o nome do serviço MX Plan em causa. Aceda ao separador <code className="action">E-mails</code>. Na nova janela, podem ver-se as contas de e-mail existentes. <br/>
+Clique em <code className="action">Contas de e-mail</code> e escolha o nome do serviço MX Plan em causa. Aceda ao separador <code className="action">E-mails</code>. Na nova janela, podem ver-se as contas de e-mail existentes. <br/>
 
 Clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.<br/><br/>
     <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -19,7 +19,7 @@ import { Panel } from '@components/Panel';
 
 As contas de e-mail da sua oferta OVHcloud são acessíveis graças à palavra-passe associada. A alteração pode ser feita de duas formas consoante a sua oferta de e-mail:
 
-- A partir do Webmail
+- A partir do webmail
 - Através da Área de Cliente da OVHcloud
 
 **Saiba como alterar a palavra-passe de um endereço de e-mail da OVHcloud.**

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password.mdx
@@ -127,21 +127,21 @@ Consulte o seu e-mail online, sem instalação, através do webmail [Outlook Web
 Siga as instruções indicadas na oferta:
 
 <ZoneTabs>
-  <Tab label="E-mails MX Plan (versão histórica)">
-    Se não conhece o tipo de oferta MX Plan que possui, consulte o nosso parágrafo [Identifique a sua oferta MX Plan](#whichmxplan).<br/>
-
-Clique em <code className="action">E-mails</code> e escolha o nome do serviço MX Plan em causa. Aceda ao separador <code className="action">E-mails</code>. Na nova janela, podem ver-se as contas de e-mail existentes. <br/>
-
-Clique no botão <code className="action">...</code> e, a seguir, em <code className="action">Alterar a palavra-passe</code>.<br/><br/>
-    <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
-  </Tab>
-  <Tab label="E-mails MX Plan (nova versão)">
+  <Tab label="MX Plan (Zimbra / OWA)">
     Se não conhece o tipo de oferta MX Plan que possui, consulte o nosso parágrafo [Identifique a sua oferta MX Plan](#whichmxplan).<br/>
 
 Clique em <code className="action">Contas de e-mail</code> e escolha o nome do serviço MX Plan em causa. Aceda ao separador <code className="action">E-mails</code>. Na nova janela, podem ver-se as contas de e-mail existentes. <br/>
 
 Clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.<br/><br/>
     <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-new01.png" loading="lazy" /><br/>
+  </Tab>
+  <Tab label="MX Plan (Roundcube)">
+    Se não conhece o tipo de oferta MX Plan que possui, consulte o nosso parágrafo [Identifique a sua oferta MX Plan](#whichmxplan).<br/>
+
+Clique em <code className="action">E-mails</code> e escolha o nome do serviço MX Plan em causa. Aceda ao separador <code className="action">E-mails</code>. Na nova janela, podem ver-se as contas de e-mail existentes. <br/>
+
+Clique no botão <code className="action">...</code> e, a seguir, em <code className="action">Alterar a palavra-passe</code>.<br/><br/>
+    <img className="thumbnail" alt="e-mail" src="/images/web-cloud/email-and-collaborative-solutions/mx-plan/email-change-password/email-password-mxplan-legacy01.png" loading="lazy" /><br/>
   </Tab>
   <Tab label="E-mail Pro" availableIn={['eu']}>
     Clique em <code className="action">E-mail Pro</code> e escolha o nome da plataforma em questão. Aceda ao separador <code className="action">Contas de e-mail</code>. Na nova janela, podem ver-se as contas de e-mail existentes.<br/>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Endereço de e-mail bloqueado por spam: o que fazer?"
-description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
+description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud"
 lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
@@ -44,10 +44,10 @@ Quando o seu endereço de e-mail é bloqueado por spam, isto significa que foi d
 - **Ligação direta:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
 - **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code> > Selecione o seu serviço Zimbra
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Ligação direta:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Selecione a sua plataforma
+- **Ligação direta:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
+- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Selecione a sua plataforma
 
 **Exchange:**
 
@@ -181,12 +181,12 @@ Selecione a oferta de e-mail em causa nos seguintes separadores:
     
     <img className="thumbnail" alt="Coluna estado bloqueado no separador Contas de e-mail Exchange" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-01.png" loading="lazy" />
   </Tab>
-  <Tab label="Email Pro">
+  <Tab label="E-mail Pro">
     Aceda ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "estado" à direita do endereço de e-mail em causa indicar "Spam", clique nessa menção e depois em <code className="action">Responder ao ticket</code>. O endereço de e-mail não é desbloqueado automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas. <br/>
 
     Avance para a [etapa 3](#step3) do guia.
     
-    <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail Email Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
+    <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail E-mail Pro" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-02.png" loading="lazy" />
   </Tab>
   <Tab label="MX Plan - OWA">
     Aceda ao separador <code className="action">Contas de e-mail</code> da sua plataforma. Se a coluna "estado" à direita do endereço de e-mail em causa indicar "Spam", clique nessa menção e depois em <code className="action">Responder ao ticket</code>. O endereço de e-mail não é desbloqueado automaticamente. Contacte o suporte através do ticket de assistência, respondendo às 3 questões colocadas.<br/>

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Endereço de e-mail bloqueado por spam: o que fazer?"
 description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud."
-lastUpdated: 2026-07-13
+lastUpdated: 2026-08-27
 availableIn: [eu, ca, apac]
 ---
 
@@ -195,22 +195,6 @@ Selecione a oferta de e-mail em causa nos seguintes separadores:
     
     <img className="thumbnail" alt="Coluna estado Spam no separador Contas de e-mail MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam/blocked-for-SPAM-01-03.png" loading="lazy" />
   </Tab>
-  <Tab label="Zimbra" availableIn={['eu']}>
-    Este separador aplica-se a todos os endereços que utilizam a tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. O processo de desbloqueio é idêntico para estas três ofertas.
-
-    No momento do bloqueio, **não é gerado automaticamente nenhum ticket de assistência** e o endereço deixa de estar acessível (webmail Zimbra e envio desativados).
-
-    Para que o endereço seja desbloqueado:
-
-    1. Efetue as verificações descritas na [etapa 1](#step1), a partir dos elementos acessíveis (postos de utilizador, softwares de terceiros, reencaminhamentos visíveis a partir de outro acesso).
-    2. **Crie manualmente um ticket de assistência** a partir da sua área de cliente OVHcloud.
-    3. No ticket, indique:
-        - O endereço de e-mail abrangido pelo bloqueio;
-        - O serviço associado (MX Plan, Zimbra Starter ou Zimbra Pro) e o respetivo identificador;
-        - As ações corretivas já realizadas (análises antivírus, eliminação de remetentes não legítimos, adição do filtro SPAM/DCE, etc.).
-
-    Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
-  </Tab>
   <Tab label="MX Plan - Roundcube" availableIn={['eu']}>
     Se o bloqueio disser respeito a um endereço de e-mail MX Plan com o webmail **Roundcube**, não é gerado nenhum ticket de assistência.
 
@@ -243,6 +227,22 @@ Selecione a oferta de e-mail em causa nos seguintes separadores:
 
     Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
 
+  </Tab>
+  <Tab label="Zimbra" availableIn={['eu']}>
+    Este separador aplica-se a todos os endereços que utilizam a tecnologia **Zimbra**: **MX Plan - Zimbra**, **Zimbra Starter** e **Zimbra Pro**. O processo de desbloqueio é idêntico para estas três ofertas.
+
+    No momento do bloqueio, **não é gerado automaticamente nenhum ticket de assistência** e o endereço deixa de estar acessível (webmail Zimbra e envio desativados).
+
+    Para que o endereço seja desbloqueado:
+
+    1. Efetue as verificações descritas na [etapa 1](#step1), a partir dos elementos acessíveis (postos de utilizador, softwares de terceiros, reencaminhamentos visíveis a partir de outro acesso).
+    2. **Crie manualmente um ticket de assistência** a partir da sua área de cliente OVHcloud.
+    3. No ticket, indique:
+        - O endereço de e-mail abrangido pelo bloqueio;
+        - O serviço associado (MX Plan, Zimbra Starter ou Zimbra Pro) e o respetivo identificador;
+        - As ações corretivas já realizadas (análises antivírus, eliminação de remetentes não legítimos, adição do filtro SPAM/DCE, etc.).
+
+    Assim que o ticket for tratado pelo suporte, o endereço será desbloqueado. A [etapa 3](#step3) não se aplica neste caso.
   </Tab>
 </ZoneTabs>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/troubleshooting/locked-for-spam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Endereço de e-mail bloqueado por spam: o que fazer?"
 description: "Desbloqueie um endereço de e-mail bloqueado por spam: identifique a causa da atividade suspeita, corrija-a e contacte o suporte da OVHcloud"
-lastUpdated: 2026-08-27
+lastUpdated: 2026-07-13
 availableIn: [eu, ca, apac]
 ---
 


### PR DESCRIPTION
Customer feedback (onegate, 2026-03-24): *"The tabs new MX Plan and old MX Plan are swapped... Please, swap them adequately."*

## The tabs were not swapped — the defect was elsewhere

Each tab carried the matching screenshot and the matching action (`Change password` for the legacy offer, `Edit` for the new generation), in all 7 locales. But **both tabs sent the reader to the same Control Panel tab — the legacy one**.

| | Control Panel tab cited | Reality |
|---|---|---|
| MX Plan legacy | `Emails` | correct (`email_tab_EMAIL`) |
| MX Plan new generation | `Emails` ❌ | it is `Email accounts` (`emailpro_tab_ACCOUNT`) |

A reader on the new generation was told to open a tab that only exists on the *other* offer. That is exactly what makes the tabs feel swapped.

> [!NOTE]
> The guide already used the correct string for its **Email Pro** tab — served by the same `emailpro` module — in all 7 locales. It had simply never been applied to MX Plan.

## 1. `email-change-password` — the reported guide

- the new-generation tab now names the right Control Panel tab: `Comptes e-mail` (fr), `Email accounts` (en), `E-Mail-Accounts` (de), `Cuentas de correo` (es), `Account email` (it), `Konta e-mail` (pl), `Contas de e-mail` (pt);
- the new generation comes **first**, as in `delete-email-account`, since it is the common case;
- both tabs are named after the **technology** — `MX Plan (Zimbra / OWA)` and `MX Plan (Roundcube)` — instead of "new version" / "legacy version".

That last point matters: these tabs link to a section titled *"Identify the email technology for your MX Plan solution"*, which has the reader look up Roundcube, Zimbra or OWA in the Control Panel. They then had to guess that Zimbra meant "new version". The **French file already used the technology naming** while the six other locales used the generation naming — the guide contradicted itself across languages.

Also fixed here: `MXplan` written without a space (es), and the missing hyphen in `E-Mail-Accounts` (de).

## 2. Two sibling guides

- **`locked-for-spam`** — the two MX Plan tabs were separated by the Zimbra tab, forcing the reader to jump over an unrelated offer. Order is now `Exchange · Email Pro · MX Plan - OWA · MX Plan - Roundcube · Zimbra`.
- **`feature-redirections`** — the same tab read `MX Plan Outlook Web App / Redirect` in one group and `MX Plan OWA / Redirect` in the other. Both use OWA now. The Italian file spelled the variant without spaces around the slashes and needed its own pass.

## 3. Audited and deliberately left alone

Two further guides were checked and **not** changed, because their naming is justified by their content:

- `email-generalities` is entirely about MX Plan, so naming its tabs `Roundcube` / `Zimbra` / `OWA` avoids repeating "MX Plan" on every tab;
- `email-manage-quota` groups by webmail and lists the products each one covers (`OWA: MX Plan / Email Pro / Exchange`), which its content requires.

The Control Panel tab defect was checked against five sibling guides and **exists in none of them**.

## 4. Proofread pass on the three modified guides

Objective fixes, same 7 locales:

- `locked-for-spam`: the `description` ended with a full stop, unlike its two sibling guides;
- "OVH" alone became **OVHcloud** — 1 occurrence in English, 3 in Italian;
- Portuguese: `Email Pro` became `E-mail Pro` in `locked-for-spam`, matching the terminology CSV **and** the two other guides of this branch;
- **webmail** lowercased as a common noun in fr, en, it and pt — Spanish already wrote it that way, and the section heading of that same guide reads "via webmail". German keeps its capital, as any German noun does;
- French: non-breaking spaces on 54 lines, chevrons around two guide citations and a quoted section title;
- English and French rewording: `in order to` → `to`, and 8 redundant relative clauses removed (`the window that appears will display all email accounts` → `the tab lists all your email accounts`).

<details>
<summary><b>Deliberately kept as-is</b></summary>

- **`SPAM` in capitals** — it quotes the Control Panel column name: `email_tab_table_header_account_bloqued` reads *"Blocked due to SPAM"* in English and *"Bloqué pour SPAM"* in French.
- **`Webmail` capitalised** when it cites the interface field of the same name, and throughout the German files, where common nouns take a capital.
- **`E-Mail Pro` / `E-mail Pro`** in German, Polish and Portuguese — the terminology CSV prescribes those spellings; the linter flags them wrongly.
- **140 `<br/>` in prose** — removing them would drop intended line breaks inside numbered lists nested in tabs. That is a formatting rework, not a proofread, and it deserves its own branch.

</details>

## Validation

- `content:lint` passes
- GitHub CI passes on the head commit
- every tab label checked against `Messages_{lang}.json` for its own locale
- screenshot ↔ tab pairing verified after the reordering
- pre-pass run on the 21 files: 445 candidates, 76 applied, 369 dismissed with a documented reason
- `lastUpdated` bumped on `email-change-password` only — the two sibling guides changed in ways the reader does not read differently, so their date stands
- tab labels reconciled across all 7 locales: the German file named the Zimbra tab `Zimbra MX Plan`, contradicting its own legend `MX Plan Zimbra`, and the Italian one dropped the spaces around the slashes

3 guides × 7 locales, 6 commits.
