### PR TITLE
chore(scripts): apply Biome formatting to 5 drifted files

### DIFF
--- a/components/ManagerLink/ManagerLink.tsx
+++ b/components/ManagerLink/ManagerLink.tsx
@@ -267,9 +267,11 @@ export function ManagerLink({
             <span className="ovh-api-dropdown__option-url">
               {/* In `urls` mode show the actual target's host, not the
                   manager host (e.g. api.eu.ovhcloud.com for API links). */}
-              {(urls?.[r] ?? REGIONS[r].managerHost)
-                .replace(/^https:\/\//, '')
-                .split(/[/?#]/)[0]}
+              {
+                (urls?.[r] ?? REGIONS[r].managerHost)
+                  .replace(/^https:\/\//, '')
+                  .split(/[/?#]/)[0]
+              }
             </span>
           </button>
         );

--- a/config/sidebar/supplements.ts
+++ b/config/sidebar/supplements.ts
@@ -33,7 +33,10 @@ const localizedUrls: Record<string, Record<Locale, string>> = {
 export function getHeaderItems(locale: Locale): SidebarItem[] {
   return [
     { sectionHeaderText: 'sidebar.documentation' } as SidebarItem,
-    { text: 'sidebar.apiReference', link: 'https://api.eu.ovhcloud.com/console/' },
+    {
+      text: 'sidebar.apiReference',
+      link: 'https://api.eu.ovhcloud.com/console/',
+    },
     {
       text: 'sidebar.productChangelog',
       link: localizedUrls.changelog[locale],

--- a/plugins/remarkNoUnresolvedFragments.ts
+++ b/plugins/remarkNoUnresolvedFragments.ts
@@ -1,6 +1,6 @@
 import type { Root, Text } from 'mdast';
-import type { VFile } from 'vfile';
 import { visit } from 'unist-util-visit';
+import type { VFile } from 'vfile';
 
 const TOKEN_PATTERN = /\[\[fragment:([^\]\s]*)\]\]/;
 

--- a/scripts/content-lint.ts
+++ b/scripts/content-lint.ts
@@ -10,7 +10,7 @@
  *   pnpm content:lint <files...>     # scan only the given files
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 type Rule = (file: string, lines: string[]) => string[];
@@ -21,15 +21,22 @@ type Rule = (file: string, lines: string[]) => string[];
  */
 const blankLineBeforeCalloutClose: Rule = (file, lines) => {
   const FENCE = /^\s*```/;
-  const CLOSE = /^:::\s*$/; 
+  const CLOSE = /^:::\s*$/;
   const LIST = /^\s*([-*+]|\d+[.)])\s/;
 
   const findings: string[] = [];
   let inCode = false;
   for (let i = 0; i < lines.length; i++) {
     if (FENCE.test(lines[i])) inCode = !inCode;
-    else if (!inCode && i > 0 && CLOSE.test(lines[i]) && LIST.test(lines[i - 1])) {
-      findings.push(`${file}:${i + 1}: add a blank line before the closing ":::"`);
+    else if (
+      !inCode &&
+      i > 0 &&
+      CLOSE.test(lines[i]) &&
+      LIST.test(lines[i - 1])
+    ) {
+      findings.push(
+        `${file}:${i + 1}: add a blank line before the closing ":::"`,
+      );
     }
   }
   return findings;

--- a/theme/components/SyncedTabs/index.tsx
+++ b/theme/components/SyncedTabs/index.tsx
@@ -203,8 +203,9 @@ function useKeepTabAnchored(rootRef: React.RefObject<HTMLDivElement | null>) {
     }
 
     const labelTop = () =>
-      root.querySelector<HTMLElement>('.rp-tabs__label')?.getBoundingClientRect()
-        .top ?? null;
+      root
+        .querySelector<HTMLElement>('.rp-tabs__label')
+        ?.getBoundingClientRect().top ?? null;
     let before: number | null = null;
 
     // Capture phase (before React swaps): remember the row's viewport position.


### PR DESCRIPTION
These files predate the current Biome config and were reported as unformatted by the repo's own tooling. Running `biome check --write` on them produces exactly this diff.

- format: ManagerLink.tsx, supplements.ts, content-lint.ts, SyncedTabs/index.tsx
- organizeImports: remarkNoUnresolvedFragments.ts

No behaviour change. The only non-whitespace edit is a trailing space removed after a statement terminator in content-lint.ts, outside the adjacent regex literal; its rule was re-tested against matching and non-matching input.

Split out of the FOA docs branch so that PR stays docs-only.

First committed by @tomadele on #680 and re-created here to keep isolated subjects.