### PR TITLE
SK-2727 - WEB - Email - Fix the MX Plan migration path for Roundcube and align the migration scope

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Umzug zu Exchange, Email Pro oder Zimbra
 description: Migrieren Sie Ihren MX Plan E-Mail-Account zu Exchange, Email Pro oder Zimbra und behalten Sie Ihre Nachrichten, Kontakte und Ordner
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -117,10 +117,18 @@ Die E-Mail-Technologie Ihrer MX Plan-Angebot kann je nach Aktivierungsdatum Ihre
 ### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra
 
 :::warning
-Dieser Abschnitt betrifft alle MX Plan-Dienste, die die Webmail-Technologie Roundcube, Zimbra oder OWA nutzen.
-
 <Region zones={['eu']}>
-Wenn Sie jedoch einen MX Plan-Dienst mit Roundcube Webmail zu einer OVHcloud E-Mail Pro- oder Exchange-Plattform migrieren möchten, folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro](#roundcube-mxplan).
+Dieser Abschnitt betrifft MX Plan-Dienste, die die Webmail-Technologie Zimbra oder OWA nutzen. Er gilt nicht für einen MX Plan-Dienst mit Roundcube Webmail, da dessen E-Mail-Accounts nicht umbenannt werden können.
+
+Um einen MX Plan-Dienst mit Roundcube Webmail zu migrieren:
+
+- zu einer E-Mail Pro- oder Exchange-Plattform: Folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro](#roundcube-mxplan) dieses Guides.
+- zu einer Zimbra-Plattform: Folgen Sie unserer Anleitung [Zimbra - MX Plan E-Mail-Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra).
+
+</Region>
+
+<Region zones={['ca']}>
+Dieser Abschnitt betrifft MX Plan-Dienste, die die Webmail-Technologie OWA nutzen.
 </Region>
 
 :::
@@ -150,7 +158,7 @@ Die Migration Ihres MX Plan erfolgt in 3 Schritten: **Umbenennen**, **Erstellen*
 
 1\. **Umbenennen** der zu migrierenden MX Plan-Accounts mit einem vorläufigen Namen (Beispiel: Um den Account *john.smith@mydomain.ovh* zu migrieren, ändern Sie diesen zu *john.smith01@mydomain.ovh*).
 
-Klicken Sie im Tab <code className="action">E-Mails</code> auf den Button <code className="action">...</code> und dann auf <code className="action">Account bearbeiten</code>.
+Klicken Sie im Tab <code className="action">E-Mail-Accounts</code> auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.
 
 <img className="thumbnail" alt="Konfiguration des MX Plan-Kontos für die Migration im OVHcloud Kundencenter, Schritt 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
@@ -297,6 +305,8 @@ Sie können auch Ihre E-Mail-Accounts manuell auf Ihr neues OVHcloud E-Mail-Ange
 
 <Region zones={['eu']}>
 [Erste Schritte mit dem Zimbra-Angebot](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - MX Plan E-Mail-Account migrieren](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Geben Sie dem zu migrierenden E-Mail-Account einen temporären Namen (Beispiel: 
 
 Klicken Sie dazu im Tab <code className="action">E-Mail-Accounts</code> Ihres Dienstes auf den Button <code className="action">...</code> und dann auf <code className="action">Ändern</code>.
 
-<img className="thumbnail" alt="Umbenennen eines E-Mail-Kontos auf der Zielplattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Umbenennen eines E-Mail-Kontos auf der Quell-Plattform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Erstellen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Accounts zwischen OVHcloud-Plattformen migrieren
-description: Migrieren Sie E-Mail-Accounts zwischen zwei OVHcloud-Plattformen (Exchange, Email Pro, MX Plan), ohne Nachrichten, Kontakte oder Ordner zu verlieren
-lastUpdated: 2026-08-25
+description: Migrieren Sie E-Mail-Accounts zwischen zwei OVHcloud-Plattformen (Exchange, Email Pro, Zimbra, MX Plan), ohne Nachrichten, Kontakte oder Ordner zu verlieren
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Ziel
 
 <Region zones={['eu']}>
-Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform auf eine andere Exchange-, E-Mail Pro-, MX Plan- oder Zimbra-Plattform migrieren. In dieser Anleitung wird ein zweistufiger Migrationsprozess beschrieben:
+Sie möchten Ihre E-Mail-Adressen von einer Exchange-, E-Mail Pro- oder Zimbra-Plattform auf eine andere Exchange-, E-Mail Pro-, MX Plan- oder Zimbra-Plattform migrieren. In dieser Anleitung wird ein zweistufiger Migrationsprozess beschrieben:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Um eine MX Plan Lösung nach Exchange zu migrieren, folgen Sie unserer Anleitung
 
 
 <Region zones={['eu']}>
-**Diese Anleitung erklärt, wie Sie E-Mail-Adressen von Exchange oder E-Mail Pro auf eine andere Exchange- oder E-Mail Pro-Plattform migrieren.**
+**Diese Anleitung erklärt, wie Sie E-Mail-Adressen von Exchange, E-Mail Pro oder Zimbra auf eine andere Exchange-, E-Mail Pro-, Zimbra- oder MX Plan-Plattform migrieren.**
 </Region>
 
 <Region zones={['ca']}>
-**Diese Anleitung erklärt, wie Sie E-Mail-Adressen von Exchange auf eine andere Exchange-Plattform migrieren.**
+**Diese Anleitung erklärt, wie Sie E-Mail-Adressen von Exchange auf eine andere Exchange- oder MX Plan-Plattform migrieren.**
 </Region>
 
 ## Voraussetzungen
 
 - Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](/links/web/emails-hosted-exchange) oder [E-Mail Pro](/links/web/email-pro) oder [Zimbra](/links/web/emails-zimbra) Accounts.
-- Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
+- Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Um eine MX Plan Lösung nach Exchange zu migrieren, folgen Sie unserer Anleitung
 
 ## Voraussetzungen
 
+<Region zones={['eu']}>
 - Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](/links/web/emails-hosted-exchange) oder [E-Mail Pro](/links/web/email-pro) oder [Zimbra](/links/web/emails-zimbra) Accounts.
 - Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
+</Region>
+
+<Region zones={['ca']}>
+- Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](/links/web/emails-hosted-exchange) Accounts.
+- Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -82,9 +82,9 @@ Whatever migration method you use, we strongly recommend backing up your mailbox
 
 ### Step 1: Defining your project
 
-Email Pro and Exchange solutions have a common feature base. However, there are differences in use cases. By choosing an Exchange account, you get all the collaborative features, such as calendars and contact synchronisation. The Email Pro solution offers a few advanced features as well, but they are limited to webmail use only.
+Email Pro and Exchange share a common set of features. However, there are differences in use cases. By choosing an Exchange account, you get all the collaborative features, such as calendars and contact synchronisation. The Email Pro solution offers a few advanced features as well, but they are limited to webmail use only.
 
-It is important to choose the solution you would like to migrate your MX Plan email accounts to before initiating the process. To help you decide, the [OVHcloud professional email solutions page](/links/web/emails) offers a detailed comparison of the available services. You can also manage a mixed solution and use one or more Email Pro and Exchange accounts for the same domain name. Furthermore, if you need to migrate multiple accounts, we recommend that you set up a migration plan.
+Choose the solution you want to migrate your MX Plan email accounts to before starting. To help you decide, the [OVHcloud professional email solutions page](/links/web/emails) offers a detailed comparison of the available services. You can also manage a mixed solution and use one or more Email Pro and Exchange accounts for the same domain name. Furthermore, if you need to migrate multiple accounts, we recommend that you set up a migration plan.
 
 ### Step 2: Ordering your Email Pro or Exchange accounts
 
@@ -100,10 +100,10 @@ Once an account has been delivered, it is essential to keep it in the "@configur
 
 ### Step 3: Carrying out the migration
 
-Before starting your migration, you will need to identify the version of the MX Plan you are migrating from.
+Before starting your migration, identify the version of the MX Plan you are migrating from.
 
 :::info
-The email technology of your MX Plan offer may vary depending on the date of activation of your offer or if a migration has recently taken place. This technology is particularly distinguished by the interface of its webmail. To identify it from your control panel, follow these steps:
+The email technology of your MX Plan offer may vary depending on the date of activation of your offer or if a migration has recently taken place. You can recognise it by its webmail interface. To identify it from your control panel, follow these steps:
 
 1. The <code className="action">General information</code> tab is selected by default.
 1. Note the technology used under the mention **webmail** in the `Subscription` box.
@@ -138,7 +138,7 @@ This section concerns MX Plan services using the OWA webmail technology.
 :::warning
 If you have just ordered your new email solution, first add the domain name to your email platform, then start your migration. <br/> - *For example, to migrate the "myemail@mydomain.ovh" account, you need to add the domain name "mydomain.ovh" to your platform.*
 
-Select the <code className="action">Associated Domains</code> or <code className="action">Domain</code> tab on your platform, then click on <code className="action">Add a domain</code>. Once the domain name is added, make sure that the mention `OK` or <code className="action">Active</code> is present in the `Status` column.
+Select the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform, then click on <code className="action">Add a domain</code>. Once the domain name is added, make sure that the mention `OK` or <code className="action">Active</code> is present in the `Status` column.
 
 <img className="thumbnail" alt="Adding the domain name to the destination email platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
@@ -157,7 +157,7 @@ Your MX Plan migration will be done in 3 main steps: **Renaming**, **Creating** 
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Rename** the MX Plan account to be migrated with a temporary name (example: to migrate the MX plan account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
+1\. **Rename** the MX Plan account to be migrated with a temporary name (example: to migrate the MX Plan account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
 In the <code className="action">Email accounts</code> tab for your MX Plan platform, click the <code className="action">...</code> button, then <code className="action">Edit</code>.
 
@@ -204,7 +204,7 @@ This section concerns only MX Plan services using the Roundcube webmail technolo
 
 
 :::info
-Your OVHcloud account must be the administrative **and** technical contact for the MX plan service to be migrated, **as well as** for the Email Pro or Exchange service you are migrating to.
+Your OVHcloud account must be the administrative **and** technical contact for the MX Plan service to be migrated, **as well as** for the Email Pro or Exchange service you are migrating to.
 
 For more information on editing contacts, please refer to our guide on [managing contacts for your services](/guides/account-and-service-management/account-information/managing-contacts).
 
@@ -220,7 +220,7 @@ You can migrate from two interfaces:<br/>
 >
 > <img className="thumbnail" alt="Checking that no redirection is set on the MX Plan account" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
-Once you are ready, follow the steps below, depending on the interface you have selected. Please note that the migration time depends on the quantity of content to be migrated to your new account. This may vary from a few minutes to several hours.
+Once you are ready, follow the steps below, depending on the interface you have selected. The migration time depends on how much content is migrated to your new account. This may vary from a few minutes to several hours.
 
 :::warning
 Once the migration is confirmed, you will no longer be able to access your old MX Plan email account, or cancel the migration process. We strongly advise you to carry out this operation at a favourable time.
@@ -242,7 +242,7 @@ To migrate from this interface, go to the <ManagerLink to="/#/web/email_domain">
 
 <img className="thumbnail" alt="Accessing the migration tool from the MX Plan interface" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/access_the_migration_tool.png" loading="lazy" />
 
-In the window that appears, select the destination service (the one you want to migrate the account to), then click <code className="action">Next</code>. If the user has at least one "empty" account (i.e. one that has not yet been set up), the migration will be carried out to one of these accounts. Once you have done this, read the information listed, confirm it, then click <code className="action">Next</code> to continue editing.
+In the window that appears, select the destination service (the one you want to migrate the account to), then click <code className="action">Next</code>. If you have at least one "empty" account (i.e. one that has not yet been set up), the migration will be carried out to one of these accounts. Once you have done this, read the information listed, confirm it, then click <code className="action">Next</code> to continue editing.
 
 If you do not have an empty account, an <code className="action">Order accounts</code> button will appear. Follow the steps, then wait until the accounts are installed to start the migration.
 
@@ -257,11 +257,11 @@ Finally, confirm the password for the source email account (the one you want to 
 At this stage, your email addresses should already be migrated and functional. For security reasons, we invite you to make sure that the configuration of your domain is correct by consulting your control panel.
 
 <Region zones={['eu']}>
-To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the <code className="action">Associated Domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostic</code> section or column.
+To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostic</code> section or column.
 </Region>
 
 <Region zones={['ca']}>
-To do this, select the relevant Exchange service, then go to the <code className="action">Associated Domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostic</code> section or column.
+To do this, select the relevant Exchange service, then go to the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform. Check the <code className="action">Diagnostic</code> section or column.
 </Region>
 
 <img className="thumbnail" alt="Checking the DNS records of the associated domain names" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
@@ -272,7 +272,7 @@ If you have just migrated or modified a DNS record for your domain, it may take 
 :::
 
 
-To modify the configuration, click on the red badge and complete the requested operation. This operation requires a propagation time of 4 to 24 hours maximum before it is fully effective.
+To modify the configuration, click on the red badge and complete the requested operation. This operation can take up to 24 hours to propagate fully.
 
 ### Step 5: Using your migrated email accounts
 
@@ -288,7 +288,7 @@ When you first log in to your new email account, the migrated content may be par
 
 The default folders, such as "sent items" or "trash" appear in English ("Sent items" and "Trash"), except for the folders you have created.
 
-After a migration, please check all of the folders and subfolders in your account to ensure that all of the elements are present.
+After a migration, check every folder and subfolder in your account to make sure nothing is missing.
 
 ### Migrating manually
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrate to Exchange, Email Pro or Zimbra
 description: Migrate your MX Plan email account to an Exchange, Email Pro or Zimbra offer while keeping your messages, contacts and folders
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -118,10 +118,18 @@ The email technology of your MX Plan offer may vary depending on the date of act
 ### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra
 
 :::warning
-This section concerns all MX Plan services using the Roundcube, Zimbra or OWA webmail technology.
-
 <Region zones={['eu']}>
-However, if you want to migrate an MX Plan service using the Roundcube webmail to an OVHcloud Email Pro or Exchange platform, follow the section "[Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro](#roundcube-mxplan)" of this guide.
+This section concerns MX Plan services using the Zimbra or OWA webmail technology. It does not apply to an MX Plan service using the Roundcube webmail, because its email accounts cannot be renamed.
+
+To migrate an MX Plan service using the Roundcube webmail:
+
+- to an Email Pro or Exchange platform, follow the section "[Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro](#roundcube-mxplan)" of this guide;
+- to a Zimbra platform, follow our guide on [Zimbra - Migrate an MX Plan email account](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra).
+
+</Region>
+
+<Region zones={['ca']}>
+This section concerns MX Plan services using the OWA webmail technology.
 </Region>
 
 :::
@@ -151,7 +159,7 @@ Your MX Plan migration will be done in 3 main steps: **Renaming**, **Creating** 
 
 1\. **Rename** the MX Plan account to be migrated with a temporary name (example: to migrate the MX plan account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the <code className="action">Email accounts</code> tab for your MX Plan platform, click the <code className="action">...</code> button, then <code className="action">Modify the account</code>.
+In the <code className="action">Email accounts</code> tab for your MX Plan platform, click the <code className="action">...</code> button, then <code className="action">Edit</code>.
 
 <img className="thumbnail" alt="Configuring the MX Plan account for migration in the Control Panel, step 1" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account01.png" loading="lazy" />
 
@@ -298,6 +306,8 @@ You can also manually migrate your email addresses to your new OVHcloud email so
 
 <Region zones={['eu']}>
 [Getting started with the Zimbra offer](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migrate an MX Plan email account](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Rename the email account to be migrated with a provisional name (example: to mig
 
 In the <code className="action">Email accounts</code> tab for your email platform, click on the <code className="action">...</code> button, then <code className="action">Edit</code>.
 
-<img className="thumbnail" alt="Renaming an email account on the destination platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renaming an email account on the source platform" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Create
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate email accounts between OVHcloud platforms
-description: Migrate email accounts between two OVHcloud platforms (Exchange, Email Pro or MX Plan) without losing your messages, contacts or folders
-lastUpdated: 2026-08-25
+description: Migrate email accounts between two OVHcloud platforms (Exchange, Email Pro, Zimbra or MX Plan) without losing your messages, contacts or folders
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Objective
 
 <Region zones={['eu']}>
-You want to migrate your email addresses on an Exchange or Email Pro platform to another Exchange, Email Pro, MX Plan or Zimbra platform. In this guide, a two-phase migration process is described:
+You want to migrate your email addresses on an Exchange, Email Pro or Zimbra platform to another Exchange, Email Pro, MX Plan or Zimbra platform. In this guide, a two-phase migration process is described:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ To migrate an MX Plan solution to an Exchange platform, please follow our guide 
 
 
 <Region zones={['eu']}>
-**This guide explains how to migrate email addresses from one Exchange or Email Pro platform to another Exchange or Email Pro platform.**
+**This guide explains how to migrate email addresses from one Exchange, Email Pro or Zimbra platform to another Exchange, Email Pro, Zimbra or MX Plan platform.**
 </Region>
 
 <Region zones={['ca']}>
-**This guide explains how to migrate email addresses from one Exchange platform to another Exchange platform.**
+**This guide explains how to migrate email addresses from one Exchange platform to another Exchange or MX Plan platform.**
 </Region>
 
 ## Requirements
 
 - A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) or [Email Pro](/links/web/email-pro) accounts or [Zimbra](/links/web/emails-zimbra).
-- A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+- A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ To migrate an MX Plan solution to an Exchange platform, please follow our guide 
 
 ## Requirements
 
+<Region zones={['eu']}>
 - A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) or [Email Pro](/links/web/email-pro) accounts or [Zimbra](/links/web/emails-zimbra).
 - A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+</Region>
+
+<Region zones={['ca']}>
+- A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) accounts.
+- A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -84,7 +91,7 @@ Whatever migration method you use, we strongly recommend backing up your mailbox
 ### Configuring the destination platform
 
 :::warning
-Before starting your migration, if you have just ordered your new email offer, first add the domain name to your email platform. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
+If you have just ordered your new email offer, add the domain name to your email platform before starting your migration. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
 
 Select the <code className="action">Associated domains</code> or <code className="action">Domain</code> tab on your platform, then click on <code className="action">Add a domain</code>. Once the domain name is added, make sure the `OK` or <code className="action">Active</code> mention is present in the `Status` column.
 
@@ -170,7 +177,7 @@ If you have just migrated or modified a DNS record for your domain, it may take 
 :::
 
 
-To modify the configuration, click on the red box and complete the requested operation. It can take between 4 and a maximum of 24 hours for DNS changes to propagate fully.
+To modify the configuration, click on the red box and complete the requested operation. DNS changes can take up to 24 hours to propagate fully.
 
 ### Use your migrated email addresses
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar a Exchange, Email Pro o Zimbra
 description: Migre su cuenta de correo MX Plan a una oferta Exchange, Email Pro o Zimbra conservando sus mensajes, contactos y carpetas
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -117,10 +117,18 @@ La tecnología de correo de su oferta MX Plan puede variar según la fecha de ac
 ### 3.1 Migración manual de una oferta MX Plan a Exchange, Email Pro o Zimbra
 
 :::warning
-Esta sección se aplica a todos los servicios MX Plan que utilizan la tecnología de webmail Roundcube, Zimbra u OWA.
-
 <Region zones={['eu']}>
-Sin embargo, si desea migrar un servicio MX Plan que utilice el webmail Roundcube a una plataforma Email Pro o Exchange OVHcloud, siga la sección "[Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro](#roundcube-mxplan)" de esta guía.
+Esta sección se aplica a los servicios MX Plan que utilizan la tecnología de webmail Zimbra u OWA. No se aplica a un servicio MX Plan que utilice el webmail Roundcube, ya que sus cuentas de correo no pueden renombrarse.
+
+Para migrar un servicio MX Plan que utilice el webmail Roundcube:
+
+- a una plataforma Email Pro o Exchange, siga la sección "[Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro](#roundcube-mxplan)" de esta guía;
+- a una plataforma Zimbra, consulte nuestra guía "[Zimbra - Migrar una cuenta de correo MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)".
+
+</Region>
+
+<Region zones={['ca']}>
+Esta sección se aplica a los servicios MX Plan que utilizan la tecnología de webmail OWA.
 </Region>
 
 :::
@@ -295,6 +303,8 @@ También puede migrar manualmente sus direcciones de correo a su nueva solución
 
 <Region zones={['eu']}>
 [Primeros pasos con la oferta de Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migrar una cuenta de correo MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Renombra la cuenta de correo que quiera migrar con un nombre provisional (por ej
 
 En la pestaña <code className="action">Cuentas de correo</code> de su plataforma de correo, haga clic en el botón <code className="action">...</code> y luego en <code className="action">Editar</code>.
 
-<img className="thumbnail" alt="Renombrar una cuenta de correo electrónico en la plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renombrar una cuenta de correo electrónico en la plataforma fuente" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Crear
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar cuentas de correo entre plataformas de OVHcloud
-description: Migre cuentas de correo entre dos plataformas de OVHcloud (Exchange, Email Pro, MX Plan) sin perder sus mensajes, contactos ni carpetas
-lastUpdated: 2026-08-25
+description: Migre cuentas de correo entre dos plataformas de OVHcloud (Exchange, Email Pro, Zimbra, MX Plan) sin perder sus mensajes, contactos ni carpetas
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Objetivo
 
 <Region zones={['eu']}>
-Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchange o Email Pro a otra plataforma Exchange, Email Pro, MX Plan o Zimbra, esta guía explica cómo realizar la migración en dos fases:
+Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchange, Email Pro o Zimbra a otra plataforma Exchange, Email Pro, MX Plan o Zimbra, esta guía explica cómo realizar la migración en dos fases:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Para migrar una solución MX Plan a una plataforma Exchange, consulte nuestra gu
 
 
 <Region zones={['eu']}>
-**Esta guía explica cómo migrar las direcciones de correo de una plataforma Exchange o Email Pro a otra plataforma Exchange o Email Pro.**
+**Esta guía explica cómo migrar las direcciones de correo de una plataforma Exchange, Email Pro o Zimbra a otra plataforma Exchange, Email Pro, Zimbra o MX Plan.**
 </Region>
 
 <Region zones={['ca']}>
-**Esta guía explica cómo migrar las direcciones de correo de una plataforma Exchange a otra plataforma Exchange.**
+**Esta guía explica cómo migrar las direcciones de correo de una plataforma Exchange a otra plataforma Exchange o MX Plan.**
 </Region>
 
 ## Requisitos
 
 - Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) o [Zimbra](/links/web/emails-zimbra).
-- Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+- Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Para migrar una solución MX Plan a una plataforma Exchange, consulte nuestra gu
 
 ## Requisitos
 
+<Region zones={['eu']}>
 - Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) o [Zimbra](/links/web/emails-zimbra).
 - Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+</Region>
+
+<Region zones={['ca']}>
+- Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](/links/web/emails-hosted-exchange).
+- Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -120,7 +120,7 @@ La technologie e-mail de votre offre MX Plan peut varier selon la date d’activ
 
 :::warning
 <Region zones={['eu']}>
-Cette partie concerne les services MX Plan utilisant la technologie webmail Zimbra ou OWA. Elle ne s’applique pas à un service MX Plan utilisant le webmail Roundcube, car ses comptes e-mail ne peuvent pas être renommés.
+Cette partie concerne les services MX Plan utilisant la technologie webmail Zimbra ou OWA. Elle ne s'applique pas à un service MX Plan utilisant le webmail Roundcube, car ses comptes e-mail ne peuvent pas être renommés.
 
 Pour migrer un service MX Plan utilisant le webmail Roundcube :
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -85,7 +85,7 @@ Quelle que soit la méthode de migration, nous vous recommandons vivement de sau
 
 Les solutions Email Pro et Exchange disposent d'une base de fonctionnalités commune. Néanmoins, des différences subsistent selon les cas d'utilisation. En choisissant une adresse Exchange, vous disposez de la totalité des fonctions collaboratives, comme la synchronisation du calendrier et des contacts. La solution Email Pro, quant à elle, en propose quelques-unes mais celles-ci sont limitées à une utilisation via un webmail uniquement.
 
-Avant de poursuivre, il est donc important de savoir vers quelle offre vous souhaitez migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](/links/web/emails) qui propose un comparatif détaillé des offres. Vous pouvez cumuler les solutions et donc utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
+Avant de poursuivre, choisissez l'offre vers laquelle migrer vos adresses e-mail MX Plan. Pour vous aider dans ce choix, consultez la page des [solutions e-mails professionnelles d'OVHcloud](/links/web/emails) qui propose un comparatif détaillé des offres. Vous pouvez cumuler les solutions et donc utiliser pour un même nom de domaine un ou plusieurs comptes Email Pro et Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
 
 ### Étape 2 : Commander vos comptes Email Pro ou Exchange
 
@@ -101,13 +101,13 @@ Une fois le compte commandé, laissez-le sous la forme « @configureme.me » dan
 
 ### Étape 3 : Réaliser la migration
 
-Avant de débuter votre migration, il vous faudra identifier la version du MX Plan depuis lequel vous migrez.
+Avant de débuter votre migration, identifiez la version du MX Plan depuis lequel vous migrez.
 
 :::info
-La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l’identifier depuis votre espace client, suivez ces étapes :
+La technologie e-mail de votre offre MX Plan peut varier selon la date d'activation de votre offre ou si une migration a récemment eu lieu. Vous la reconnaissez à l'interface de son webmail. Pour l'identifier depuis votre espace client, suivez ces étapes :
 
-1. L’onglet <code className="action">Informations générales</code> est sélectionné par défaut.
-1. Relevez la technologie utilisée sous la mention **webmail** dans l’encadré `Abonnement`.
+1. L'onglet <code className="action">Informations générales</code> est sélectionné par défaut.
+1. Relevez la technologie utilisée sous la mention **webmail** dans l'encadré `Abonnement`.
 
 <img className="thumbnail" alt="Panneau d'abonnement MX Plan affichant la technologie Webmail dans l'espace client OVHcloud" src="/images/assets/schemas/emails/technology-email.png" loading="lazy" />
 
@@ -139,7 +139,7 @@ Cette partie concerne les services MX Plan utilisant la technologie webmail OWA.
 :::warning
 Si vous venez de commander votre nouvelle offre e-mail, ajoutez d'abord le nom de domaine à votre plateforme e-mail, avant de commencer votre migration. <br/> - *Par exemple, pour migrer le compte « myemail@mydomain.ovh », vous devez ajouter le nom de domaine « mydomain.ovh » à votre plateforme.*
 
-Sélectionnez l’onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
+Sélectionnez l'onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
 
 <img className="thumbnail" alt="Ajout du nom de domaine à la plateforme e-mail de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/account_migration_adddomain.png" loading="lazy" />
 
@@ -158,7 +158,7 @@ La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**, **Cré
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
+1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX Plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme MX Plan, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
@@ -205,7 +205,7 @@ Cette partie concerne uniquement les services MX Plan utilisant la technologie w
 
 
 :::info
-Votre compte OVHcloud doit préalablement être contact administrateur **et** contact technique du service MX plan à migrer, **ainsi que** du service Email Pro ou Exchange vers lequel vous migrez.
+Votre compte OVHcloud doit préalablement être contact administrateur **et** contact technique du service MX Plan à migrer, **ainsi que** du service Email Pro ou Exchange vers lequel vous migrez.
 
 Pour plus d'information sur les changements de contacts, consultez notre guide pour [gérer les contacts de ses services](/guides/account-and-service-management/account-information/managing-contacts).
 
@@ -221,12 +221,12 @@ La migration peut être effectuée depuis deux interfaces :<br/>
 >
 > <img className="thumbnail" alt="Vérification de l'absence de redirection sur le compte MX Plan" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-legacy-redirect.png" loading="lazy" />
 
-Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selon l'interface sélectionnée. Nous vous rappelons que le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
+Une fois prêt, poursuivez selon l'interface choisie. Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
 :::warning
 Une fois la migration confirmée, vous ne pourrez plus accéder à votre ancienne adresse e-mail MX Plan ni annuler le processus de migration. Nous vous conseillons vivement de réaliser cette opération à un horaire propice.
 
-Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les messages déjà réceptionnés ainsi que ceux reçus ne seront pas perdus. Tous seront immédiatement accessibles depuis votre nouveau compte.
+Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les messages déjà reçus comme ceux qui arriveront ne seront pas perdus. Tous seront immédiatement accessibles depuis votre nouveau compte.
 
 :::
 
@@ -268,16 +268,16 @@ Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'o
 <img className="thumbnail" alt="Vérification des enregistrements DNS des noms de domaine associés" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
-Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l’affichage dans l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.
+Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l'affichage dans l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.
 
 :::
 
 
-Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. Cette dernière nécessite un temps de propagation de 4 à 24 heures maximum avant d’être pleinement effective.
+Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. La propagation peut prendre jusqu'à 24 heures.
 
 ### Étape 5 : Utiliser vos adresses e-mail migrées
 
-Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+Il ne vous reste plus qu'à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l'adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
 
 Si vous avez configuré l'un des comptes migrés sur un client de messagerie (comme Outlook), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration. Pour vous aider dans vos manipulations, consultez notre documentation depuis les sections des guides consacrées à [Email Pro](/guides/web-cloud/email-and-collaborative-solutions/email-pro/landing-page-email-pro) et [Hosted Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/landing-page-microsoft-exchange). Si vous n'êtes pas en mesure de reconfigurer le compte dans l'immédiat, l'accès via l'applicatif en ligne est toujours possible.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrer vers Exchange, Email Pro ou Zimbra
 description: Migrez votre compte e-mail MX Plan vers une offre Exchange, Email Pro ou Zimbra en conservant vos messages, contacts et dossiers
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -119,10 +119,18 @@ La technologie e-mail de votre offre MX Plan peut varier selon la date d’activ
 ### 3.1 Migration manuelle d'une offre MX Plan vers Exchange, Email Pro ou Zimbra
 
 :::warning
-Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Roundcube, Zimbra ou OWA.
-
 <Region zones={['eu']}>
-Néanmoins, si vous souhaitez migrer un service MX Plan utilisant le webmail Roundcube vers une plateforme Email Pro ou Exchange OVHcloud, suivez la partie « [Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro](#roundcube-mxplan) » de ce guide.
+Cette partie concerne les services MX Plan utilisant la technologie webmail Zimbra ou OWA. Elle ne s’applique pas à un service MX Plan utilisant le webmail Roundcube, car ses comptes e-mail ne peuvent pas être renommés.
+
+Pour migrer un service MX Plan utilisant le webmail Roundcube :
+
+- vers une plateforme Email Pro ou Exchange, suivez la partie « [Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro](#roundcube-mxplan) » de ce guide ;
+- vers une plateforme Zimbra, suivez notre guide « [Zimbra - Migrer un compte e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra) ».
+
+</Region>
+
+<Region zones={['ca']}>
+Cette partie concerne les services MX Plan utilisant la technologie webmail OWA.
 </Region>
 
 :::
@@ -299,6 +307,8 @@ Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvel
 
 <Region zones={['eu']}>
 [Premiers pas avec l'offre Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migrer un compte e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous inviton
 
 ## Prérequis
 
+<Region zones={['eu']}>
 - Disposer d'une plateforme **« source »** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou [Email Pro](/links/web/email-pro) configurés ou [Zimbra](/links/web/emails-zimbra).
 - Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+</Region>
+
+<Region zones={['ca']}>
+- Disposer d'une plateforme **« source »** avec des comptes [Exchange](/links/web/emails-hosted-exchange) configurés.
+- Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}
@@ -86,7 +93,7 @@ Quelle que soit la méthode de migration, nous vous recommandons vivement de sau
 :::warning
 Avant de commencer votre migration, si vous venez de commander votre nouvelle offre e-mail, ajoutez d'abord le nom de domaine à votre plateforme e-mail. Si vous migrez vers une plateforme MX Plan, le nom de domaine attaché étant « fixe », vous pouvez directement passer à [l'étape suivante](#accountsmigration).
 
-Sélectionnez l’onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
+Sélectionnez l'onglet <code className="action">Domaines associés</code> ou <code className="action">Domaine</code> sur votre plateforme, puis cliquez sur <code className="action">Ajouter un domaine</code>. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou <code className="action">Actif</code> est bien présente dans la colonne `Statut`.
 
 <img className="thumbnail" alt="Ajout du nom de domaine à la plateforme e-mail de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/account_migration_adddomain.png" loading="lazy" />
 
@@ -165,16 +172,16 @@ Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, pui
 <img className="thumbnail" alt="Vérification des enregistrements DNS des noms de domaine associés" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/check_the_dns_records_associated_domains.png" loading="lazy" />
 
 :::info
-Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l’affichage dans l’<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.
+Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l'affichage dans l'<ManagerLink to="/">espace client OVHcloud</ManagerLink> nécessite quelques heures pour se mettre à jour.
 
 :::
 
 
-Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. Cette dernière nécessite un temps de propagation de 4 à 24 heures maximum avant d’être pleinement effective.
+Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. La propagation peut prendre jusqu'à 24 heures.
 
 ### Utiliser vos adresses e-mail migrées
 
-Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+Il ne vous reste plus qu'à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l'adresse [webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
 
 Si vous avez configuré l'un des comptes migrés sur un client de messagerie (exemple : Outlook, Thunderbird), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration.
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrer des comptes e-mail entre plateformes OVHcloud
-description: Migrez des comptes e-mail entre deux plateformes OVHcloud (Exchange, Email Pro, MX Plan) sans perdre vos messages, contacts ni dossiers
-lastUpdated: 2026-08-25
+description: Migrez des comptes e-mail entre deux plateformes OVHcloud (Exchange, Email Pro, Zimbra, MX Plan) sans perdre vos messages, contacts ni dossiers
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Objectif
 
 <Region zones={['eu']}>
-Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra. Vous trouverez dans ce guide un processus de migration en deux phases :
+Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange, Email Pro ou Zimbra vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra. Vous trouverez dans ce guide un processus de migration en deux phases :
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Pour migrer une solution MX Plan vers une plateforme Exchange, nous vous inviton
 
 
 <Region zones={['eu']}>
-**Découvrez comment migrer les adresses e-mail d'une plateforme Exchange ou Email Pro vers une autre plateforme Exchange ou Email Pro.**
+**Découvrez comment migrer les adresses e-mail d'une plateforme Exchange, Email Pro ou Zimbra vers une autre plateforme Exchange, Email Pro, Zimbra ou MX Plan.**
 </Region>
 
 <Region zones={['ca']}>
-**Découvrez comment migrer les adresses e-mail d'une plateforme Exchange vers une autre plateforme Exchange.**
+**Découvrez comment migrer les adresses e-mail d'une plateforme Exchange vers une autre plateforme Exchange ou MX Plan.**
 </Region>
 
 ## Prérequis
 
 - Disposer d'une plateforme **« source »** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou [Email Pro](/links/web/email-pro) configurés ou [Zimbra](/links/web/emails-zimbra).
-- Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+- Disposer d'une plateforme de **« destination »** avec des comptes [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Renommez le compte e-mail à migrer avec un nom provisoire (exemple : pour migr
 
 Dans l'onglet <code className="action">Comptes e-mail</code> de votre plateforme e-mail, cliquez sur le bouton <code className="action">...</code> puis sur <code className="action">Modifier</code>.
 
-<img className="thumbnail" alt="Renommage d'un compte e-mail sur la plateforme de destination" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renommage d'un compte e-mail sur la plateforme source" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Créer
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -81,7 +81,7 @@ Qualunque sia il metodo di migrazione scelto, ti consigliamo vivamente di esegui
 
 ### Passaggio 1: Definisci il tuo progetto
 
-Le soluzioni Email Pro ed Exchange dispongono di una base di funzionalità comune. Permangono, tuttavia, differenze a seconda dei casi di utilizzo. Scegliendo un indirizzo Exchange, disporrete di tutte le funzioni collaborative, come la sincronizzazione del calendario e dei contatti. Email Pro, invece, ne propone alcune ma sono limitate all'utilizzo esclusivamente via Webmail.
+Le soluzioni Email Pro ed Exchange dispongono di una base di funzionalità comune. Permangono, tuttavia, differenze a seconda dei casi di utilizzo. Scegliendo un indirizzo Exchange, disporrete di tutte le funzioni collaborative, come la sincronizzazione del calendario e dei contatti. Email Pro, invece, ne propone alcune ma sono limitate all'utilizzo esclusivamente via webmail.
 
 Prima di proseguire, è importante sapere verso quale offerta vuoi migrare i tuoi indirizzi email MX Plan. Per maggiori informazioni, consulta la pagina delle [soluzioni email professionali di OVHcloud](/links/web/emails) che propone un confronto dettagliato delle offerte. Puoi cumulare le soluzioni e quindi utilizzare per uno stesso dominio uno o più account Email Pro ed Exchange. In caso di migrazione di più account, ti consigliamo di impostare un piano di migrazione.
 
@@ -156,7 +156,7 @@ La migrazione del tuo MX Plan avverrà in 3 step, **Rinominare**, **Creare** e *
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Rinomina** l'account MX Plan da migrare con un nome provvisorio (ad esempio: per migrare l'account MX plan *john.smith@mydomain.ovh*, rinominalo in *john.smith01@mydomain.ovh*).
+1\. **Rinomina** l'account MX Plan da migrare con un nome provvisorio (ad esempio: per migrare l'account MX Plan *john.smith@mydomain.ovh*, rinominalo in *john.smith01@mydomain.ovh*).
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma MX Plan, clicca sul pulsante <code className="action">...</code> e poi su <code className="action">Modifica</code>.
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrare verso Exchange, Email Pro o Zimbra
 description: Migra il tuo account email MX Plan verso un'offerta Exchange, Email Pro o Zimbra mantenendo messaggi, contatti e cartelle
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -117,10 +117,18 @@ La tecnologia e-mail della vostra offerta MX Plan può variare in base alla data
 ### 3.1 Migrazione manuale di un'offerta MX Plan verso Exchange, Email Pro o Zimbra
 
 :::warning
-Questa parte riguarda tutti i servizi MX Plan che utilizzano la tecnologia webmail Roundcube, Zimbra o OWA.
-
 <Region zones={['eu']}>
-Tuttavia, se desiderate migrare un servizio MX Plan che utilizza il webmail Roundcube verso una piattaforma Email Pro o Exchange OVHcloud, seguite la parte "[Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro](#roundcube-mxplan)" di questa guida.
+Questa parte riguarda i servizi MX Plan che utilizzano la tecnologia webmail Zimbra o OWA. Non si applica a un servizio MX Plan che utilizza il webmail Roundcube, perché i suoi account email non possono essere rinominati.
+
+Per migrare un servizio MX Plan che utilizza il webmail Roundcube:
+
+- verso una piattaforma Email Pro o Exchange, seguite la parte "[Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro](#roundcube-mxplan)" di questa guida;
+- verso una piattaforma Zimbra, consultate la nostra guida "[Zimbra - Migrare un account email MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)".
+
+</Region>
+
+<Region zones={['ca']}>
+Questa parte riguarda i servizi MX Plan che utilizzano la tecnologia webmail OWA.
 </Region>
 
 :::
@@ -297,6 +305,8 @@ Inoltre, è possibile migrare manualmente i tuoi indirizzi email verso il nuovo 
 
 <Region zones={['eu']}>
 [Primi passi con l'offerta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migrare un account email MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Rinomina l'account email da migrare con un nome provvisorio (ad esempio: per mig
 
 Nella scheda <code className="action">Account email</code> della tua piattaforma email, clicca sui tre puntini <code className="action">...</code> e poi su <code className="action">Modifica</code>.
 
-<img className="thumbnail" alt="Rinomina di un account email sulla piattaforma di destinazione" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Rinomina di un account email sulla piattaforma sorgente" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Crea
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrare account email tra piattaforme OVHcloud
-description: Migra account email tra due piattaforme OVHcloud (Exchange, Email Pro, MX Plan) senza perdere messaggi, contatti e cartelle
-lastUpdated: 2026-08-25
+description: Migra account email tra due piattaforme OVHcloud (Exchange, Email Pro, Zimbra, MX Plan) senza perdere messaggi, contatti e cartelle
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Obiettivo
 
 <Region zones={['eu']}>
-Per migrare i tuoi indirizzi email presenti su una piattaforma Exchange o Email Pro su un'altra piattaforma Exchange, Email Pro, MX Plan o Zimbra. In questa guida trovi il processo di migrazione in due fasi:
+Per migrare i tuoi indirizzi email presenti su una piattaforma Exchange, Email Pro o Zimbra su un'altra piattaforma Exchange, Email Pro, MX Plan o Zimbra. In questa guida trovi il processo di migrazione in due fasi:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Per migrare una soluzione MX Plan verso una piattaforma Exchange, consulta la gu
 
 
 <Region zones={['eu']}>
-**Questa guida ti mostra come migrare gli indirizzi email da una piattaforma Exchange o Email Pro verso un'altra piattaforma Exchange o Email Pro.**
+**Questa guida ti mostra come migrare gli indirizzi email da una piattaforma Exchange, Email Pro o Zimbra verso un'altra piattaforma Exchange, Email Pro, Zimbra o MX Plan.**
 </Region>
 
 <Region zones={['ca']}>
-**Questa guida ti mostra come migrare gli indirizzi email da una piattaforma Exchange verso un'altra piattaforma Exchange.**
+**Questa guida ti mostra come migrare gli indirizzi email da una piattaforma Exchange verso un'altra piattaforma Exchange o MX Plan.**
 </Region>
 
 ## Prerequisiti
 
 - Disporre di una piattaforma **"sorgente"** con conti [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) configurati o [Zimbra](/links/web/emails-zimbra).
-- Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
+- Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Per migrare una soluzione MX Plan verso una piattaforma Exchange, consulta la gu
 
 ## Prerequisiti
 
+<Region zones={['eu']}>
 - Disporre di una piattaforma **"sorgente"** con conti [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) configurati o [Zimbra](/links/web/emails-zimbra).
 - Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
+</Region>
+
+<Region zones={['ca']}>
+- Disporre di una piattaforma **"sorgente"** con conti [Exchange](/links/web/emails-hosted-exchange) configurati.
+- Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -156,7 +156,7 @@ Migracja MX Plan przebiega 3 etapach. **Zmień nazwę**, **Utwórz** i **Migracj
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Zmień nazwę** konta MX Plan, które chcesz przenieść, używając tymczasowej nazwy (na przykład: aby przenieść konto MX plan *john.smith@mydomain.ovh*, zmień nazwę konta na *john.smith01@mydomain.ovh*).
+1\. **Zmień nazwę** konta MX Plan, które chcesz przenieść, używając tymczasowej nazwy (na przykład: aby przenieść konto MX Plan *john.smith@mydomain.ovh*, zmień nazwę konta na *john.smith01@mydomain.ovh*).
 
 W zakładce <code className="action">Konta e-mail</code> na Twojej platformie MX Plan kliknij przycisk <code className="action">...</code>, a następnie <code className="action">Zmień</code>.
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migracja do Exchange, Email Pro lub Zimbra
 description: Zmigruj konto e-mail MX Plan do oferty Exchange, Email Pro lub Zimbra, zachowując wiadomości, kontakty i foldery
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -117,10 +117,18 @@ Technologia e-maila oferty MX Plan może się różnić w zależności od daty a
 ### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra
 
 :::warning
-Ta sekcja dotyczy wszystkich usług MX Plan korzystających z technologii webmaila Roundcube, Zimbra lub OWA.
-
 <Region zones={['eu']}>
-Jednak jeśli chcesz przenieść usługę MX Plan korzystającą z webmaila Roundcube do platformy E-mail Pro lub Exchange OVHcloud, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro](#roundcube-mxplan)" tego przewodnika.
+Ta sekcja dotyczy usług MX Plan korzystających z technologii webmaila Zimbra lub OWA. Nie dotyczy usługi MX Plan korzystającej z webmaila Roundcube, ponieważ nazw jej kont e-mail nie można zmienić.
+
+Aby przenieść usługę MX Plan korzystającą z webmaila Roundcube:
+
+- do platformy E-mail Pro lub Exchange, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro](#roundcube-mxplan)" tego przewodnika;
+- do platformy Zimbra, zapoznaj się z naszym przewodnikiem "[Zimbra - Migracja konta e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)".
+
+</Region>
+
+<Region zones={['ca']}>
+Ta sekcja dotyczy usług MX Plan korzystających z technologii webmaila OWA.
 </Region>
 
 :::
@@ -297,6 +305,8 @@ Możesz również ręcznie przenieść Twoje konta e-mail do nowej usługi e-mai
 
 <Region zones={['eu']}>
 [Przewodniki Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migracja konta e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Zmień nazwę konta e-mail, które chcesz przenieść, używając tymczasowej na
 
 W karcie <code className="action">Konta e-mail</code> Twojej platformy e-mail kliknij przycisk <code className="action">...</code>, a następnie <code className="action">Zmień</code>.
 
-<img className="thumbnail" alt="Zmiana nazwy konta e-mail na platformie docelowej" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Zmiana nazwy konta e-mail na platformie źródłowej" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Stwórz
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Aby przenieść rozwiązanie MX Plan na platformę Exchange, zapoznaj się z nas
 
 ## Wymagania początkowe
 
+<Region zones={['eu']}>
 - Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](/links/web/emails-hosted-exchange) lub [E-mail Pro](/links/web/email-pro) lub [Zimbra](/links/web/emails-zimbra).
 - Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
+</Region>
+
+<Region zones={['ca']}>
+- Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](/links/web/emails-hosted-exchange).
+- Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migracja kont e-mail między platformami OVHcloud
-description: Migruj konta e-mail między dwiema platformami OVHcloud (Exchange, Email Pro, MX Plan) bez utraty wiadomości, kontaktów i folderów
-lastUpdated: 2026-08-25
+description: Migruj konta e-mail między dwiema platformami OVHcloud (Exchange, Email Pro, Zimbra, MX Plan) bez utraty wiadomości, kontaktów i folderów
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Wprowadzenie
 
 <Region zones={['eu']}>
-Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail Pro na inną platformę Exchange, E-mail Pro, MX Plan lub Zimbra. W tym przewodniku znajdziesz dwuetapowy proces migracji:
+Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange, E-mail Pro lub Zimbra na inną platformę Exchange, E-mail Pro, MX Plan lub Zimbra. W tym przewodniku znajdziesz dwuetapowy proces migracji:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Aby przenieść rozwiązanie MX Plan na platformę Exchange, zapoznaj się z nas
 
 
 <Region zones={['eu']}>
-**Dowiedz się, jak przenieść konta e-mail z platformy Exchange lub E-mail Pro na inną platformę Exchange lub E-mail Pro.**
+**Dowiedz się, jak przenieść konta e-mail z platformy Exchange, E-mail Pro lub Zimbra na inną platformę Exchange, E-mail Pro, Zimbra lub MX Plan.**
 </Region>
 
 <Region zones={['ca']}>
-**Dowiedz się, jak przenieść konta e-mail z platformy Exchange na inną platformę Exchange.**
+**Dowiedz się, jak przenieść konta e-mail z platformy Exchange na inną platformę Exchange lub MX Plan.**
 </Region>
 
 ## Wymagania początkowe
 
 - Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](/links/web/emails-hosted-exchange) lub [E-mail Pro](/links/web/email-pro) lub [Zimbra](/links/web/emails-zimbra).
-- Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
+- Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: MX Plan - Migrar para Exchange, Email Pro ou Zimbra
 description: Migre a sua conta de e-mail MX Plan para uma oferta Exchange, Email Pro ou Zimbra mantendo mensagens, contactos e pastas
-lastUpdated: 2026-08-25
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -117,10 +117,18 @@ A tecnologia de e-mail da sua oferta MX Plan pode variar consoante a data de ati
 ### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra
 
 :::warning
-Esta secção aplica-se a todos os serviços MX Plan que utilizam a tecnologia webmail Roundcube, Zimbra ou OWA.
-
 <Region zones={['eu']}>
-No entanto, se pretender migrar um serviço MX Plan que utiliza o webmail Roundcube para uma plataforma E-mail Pro ou Exchange OVHcloud, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro](#roundcube-mxplan)" deste guia.
+Esta secção aplica-se aos serviços MX Plan que utilizam a tecnologia webmail Zimbra ou OWA. Não se aplica a um serviço MX Plan que utiliza o webmail Roundcube, uma vez que as suas contas de e-mail não podem ser renomeadas.
+
+Para migrar um serviço MX Plan que utiliza o webmail Roundcube:
+
+- para uma plataforma E-mail Pro ou Exchange, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro](#roundcube-mxplan)" deste guia;
+- para uma plataforma Zimbra, consulte o nosso guia "[Zimbra - Migrar uma conta de e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)".
+
+</Region>
+
+<Region zones={['ca']}>
+Esta secção aplica-se aos serviços MX Plan que utilizam a tecnologia webmail OWA.
 </Region>
 
 :::
@@ -297,6 +305,8 @@ Também pode migrar manualmente os seus endereços de e-mail para a nova oferta 
 
 <Region zones={['eu']}>
 [Primeiros passos com a oferta Zimbra](/guides/web-cloud/email-and-collaborative-solutions/zimbra/getting-started-zimbra)
+
+[Zimbra - Migrar uma conta de e-mail MX Plan](/guides/web-cloud/email-and-collaborative-solutions/zimbra/migrate-mxplan-to-zimbra)
 </Region>
 
 Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel.mdx
@@ -156,7 +156,7 @@ A migração do seu MX Plan far-se-á em 3 grandes etapas, **Renomear**, **Criar
 
 <video className="thumbnail" autoPlay loop muted playsInline aria-label="Exchange" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-control-panel/mxplan-migration-configure-account.mp4" />
 
-1\. **Altere** o nome da conta MX Plan para migrar com um nome provisório (exemplo: para migrar a conta MX plan *john.smith@mydomain.ovh*, renome-a em *john.smith01@mydomain.ovh*).
+1\. **Altere** o nome da conta MX Plan para migrar com um nome provisório (exemplo: para migrar a conta MX Plan *john.smith@mydomain.ovh*, renome-a em *john.smith01@mydomain.ovh*).
 
 No separador <code className="action">Contas de e-mail</code> da plataforma MX Plan, clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.
 
@@ -203,7 +203,7 @@ Esta secção aplica-se apenas aos serviços MX Plan que utilizam a tecnologia w
 
 
 :::info
-A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX plan a migrar, **bem como** do serviço E-mail Pro ou Exchange para o qual migra.
+A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX Plan a migrar, **bem como** do serviço E-mail Pro ou Exchange para o qual migra.
 
 Para mais informações sobre as alterações de contactos, consulte o nosso guia para [gerir os contactos dos seus serviços](/guides/account-and-service-management/account-information/managing-contacts).
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -116,7 +116,7 @@ Dê um nome provisório à conta de e-mail a migrar (exemplo: para migrar a cont
 
 No separador <code className="action">Contas de e-mail</code> da sua plataforma de e-mail, clique no botão <code className="action">...</code> e depois em <code className="action">Alterar</code>.
 
-<img className="thumbnail" alt="Renomear uma conta de e-mail na plataforma de destino" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
+<img className="thumbnail" alt="Renomear uma conta de e-mail na plataforma fonte" src="/images/web-cloud/email-and-collaborative-solutions/migrating/migration-platform/migration_platform04.png" loading="lazy" />
 
 #### Criar
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrar contas de e-mail entre plataformas OVHcloud
-description: Migre contas de e-mail entre duas plataformas OVHcloud (Exchange, Email Pro, MX Plan) sem perder mensagens, contactos ou pastas
-lastUpdated: 2026-08-25
+description: Migre contas de e-mail entre duas plataformas OVHcloud (Exchange, Email Pro, Zimbra, MX Plan) sem perder mensagens, contactos ou pastas
+lastUpdated: 2026-08-27
 availableIn: [eu, ca]
 ---
 
@@ -11,7 +11,7 @@ import { Region } from '@components/Zone';
 ## Objetivo
 
 <Region zones={['eu']}>
-Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou E-mail Pro para outra plataforma Exchange, E-mail Pro, MX Plan ou Zimbra. Neste guia, poderá encontrar um processo de migração em duas fases:
+Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange, E-mail Pro ou Zimbra para outra plataforma Exchange, E-mail Pro, MX Plan ou Zimbra. Neste guia, poderá encontrar um processo de migração em duas fases:
 </Region>
 
 <Region zones={['ca']}>
@@ -36,17 +36,17 @@ Para migrar uma solução MX Plan para uma plataforma Exchange, sugerimos que si
 
 
 <Region zones={['eu']}>
-**Saiba como migrar os endereços de e-mail de uma plataforma Exchange ou E-mail Pro para outra plataforma Exchange ou E-mail Pro.**
+**Saiba como migrar os endereços de e-mail de uma plataforma Exchange, E-mail Pro ou Zimbra para outra plataforma Exchange, E-mail Pro, Zimbra ou MX Plan.**
 </Region>
 
 <Region zones={['ca']}>
-**Saiba como migrar os endereços de e-mail de uma plataforma Exchange para outra plataforma Exchange.**
+**Saiba como migrar os endereços de e-mail de uma plataforma Exchange para outra plataforma Exchange ou MX Plan.**
 </Region>
 
 ## Requisitos
 
 - Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](/links/web/emails-hosted-exchange) ou [E-mail Pro](/links/web/email-pro) ou [Zimbra](/links/web/emails-zimbra).
-- Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
+- Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/migrating/migration-platform.mdx
@@ -45,8 +45,15 @@ Para migrar uma solução MX Plan para uma plataforma Exchange, sugerimos que si
 
 ## Requisitos
 
+<Region zones={['eu']}>
 - Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](/links/web/emails-hosted-exchange) ou [E-mail Pro](/links/web/email-pro) ou [Zimbra](/links/web/emails-zimbra).
 - Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/emails-zimbra) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
+</Region>
+
+<Region zones={['ca']}>
+- Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](/links/web/emails-hosted-exchange).
+- Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
+</Region>
 
 {/* CP-NAV-START:web-mx-plan */}
 {/* CP-NAV-START:web-email-pro */}


### PR DESCRIPTION
Customer feedback (onegate, 2026-03-05): *"According to the guide the client should first change the name of the mailbox on the initial service. But for old MX Plan it's impossible... The client didn't figure out on her own how to work it around."*

## She is right — the rename does not exist on an MX Plan Roundcube

Section 3.1 announced that it covered **all** MX Plan technologies, and its first step is to rename the source account. Three independent sources say that step is impossible on the Roundcube generation.

| Source | What it says |
|---|---|
| API — `email.domain.Account` | `accountName`, `domain` and `email` are **read-only**. Only `description` and `size` can be modified. |
| Control Panel — `email-domain-email-account-update.html` | The "Modify the account" modal declares exactly two fields: `accountDescription` and `accountSize`. |
| Live check in the Control Panel | The modal shows `Account description` and `Account size`. **No address field.** |

For comparison, the new generation (`emailpro` module) exposes `login` and `completeDomain`, and the API marks `login` as modifiable. The procedure only ever worked for Zimbra and OWA.

> [!NOTE]
> The button on that step opens a modal titled "Modify the account". It opens — it just has nothing to rename. That is what makes the dead end so hard to diagnose from the reader's side.

## Why this exact case fell through

Section 3.1 already redirected Roundcube readers to section 3.2 — but 3.2 covers **Exchange and Email Pro only**. `Roundcube → Zimbra` therefore stayed in 3.1, whose first step cannot be performed, while the guide title promises "or **Zimbra**".

The correct procedure already existed, in `zimbra/migrate-mxplan-to-zimbra`. It inverts the trick: create a **temporary Zimbra address**, migrate into it with OMM, delete the MX Plan account, then rename the **destination**. Renaming a Zimbra account is possible.

No migration guide linked to it — only three files inside `zimbra/` did.

## 1. `migration-control-panel` — the reported guide

- section 3.1 now states the technologies it really covers, says **why** Roundcube is excluded, and routes those readers: section 3.2 for Email Pro and Exchange, the dedicated guide for Zimbra;
- that dedicated guide is also added to "Go further";
- **CA gets its own sentence** — the `/email/domain` API does not exist there, so the zone has no Roundcube at all and the exception does not apply to it;
- **the button was wrong in `en` and `de`.** With 3.1 scoped to the new generation, the action is `Edit` (`exchange_tab_ACCOUNTS_menu_edit`). English cited `Modify the account` — the *legacy* label — and German combined the legacy tab `E-Mails` with the legacy button. The five other locales were already correct; the fix had simply never been propagated.

## 2. `migration-platform` — found while auditing the sibling guides

The guide contradicted itself three times about its own scope:

| Statement | Source | Destination |
|---|---|---|
| Objective | Exchange, Email Pro | Exchange, Email Pro, MX Plan, Zimbra |
| Bold summary | Exchange, Email Pro | Exchange, Email Pro |
| Requirements | Exchange, Email Pro, **Zimbra** | Exchange, Email Pro, MX Plan |

Its own **"Special cases"** instructions settle it: they handle Zimbra as a *source*, and MX Plan and Zimbra STARTER as *destinations*. The three statements and the frontmatter description are now aligned on that — no product decision was required, the body of the guide had the answer.

The `Requirements` block was also **not zone-gated at all**, while Canada has neither Email Pro nor Zimbra (`/email/pro` and Zimbra are both absent from `ca.api.ovh.com`). It is now split EU / CA. The CA variants are produced by **removing** the out-of-zone products from the existing localized sentences — never re-translated — and every `ca` block was re-read afterwards to confirm no EU product leaked through.

Also fixed: the screenshot of the **Rename** step was captioned *"on the destination platform"* in all 7 locales, while that step renames the **source**.

## 3. Audited and clean

- `manual-email-migration` and `omm-migrate-email-account-to-ovhcloud` carry no rename instruction on an MX Plan source.
- A corpus-wide search found **exactly one** such instruction in the whole email documentation — the one fixed here.

<details>
<summary><b>Checked live in the Control Panel</b></summary>

- **Legacy tabs**: `General information · Emails · Mailing lists · Ongoing jobs`. No `Email accounts`.
- **Legacy account menu**: `Modify the account · Change password · Delete account · Delegation management · Migrate account`.
- **Section 3.2** matches the interface exactly: `Emails` tab → `...` → `Migrate account`.
- **The identification method** described before 3.1 is accurate: `General information` → `Subscription` box → `Webmail: Roundcube`.

Nothing was submitted and no service was modified — the modals were opened and cancelled.

</details>

## 4. Proofread pass on both guides

- `MX plan` written with a lowercase *p* — 8 occurrences across `en`, `fr`, `it`, `pl`, `pt`;
- `Associated Domains` → `Associated domains`, the Manager value (`emailpro_tab_DOMAIN`); the sibling guide already spelled it correctly;
- Italian: `via Webmail` lowercased in prose — Spanish, Portuguese and Polish already used the common noun;
- French: 17 curly apostrophes straightened, and a mistranslation corrected — *"les messages déjà réceptionnés ainsi que ceux reçus"* said "received" twice, where the English reads *existing and newly arriving*;
- English: a third-person slip (*"If the user has…"*) in a guide that addresses the reader directly, and a self-contradictory *"4 to 24 hours maximum"*;
- 11 rewordings in EN and FR — mostly calqued passives such as *"This technology is particularly distinguished by the interface of its webmail"* → *"You can recognise it by its webmail interface"*.

<details>
<summary><b>Pre-pass candidates dismissed, with the reason</b></summary>

- **72 × `Email Pro`** — the terminology CSV prescribes `E-Mail Pro` (de) and `E-mail Pro` (pl, pt). The files are compliant; the rule ignores the localized variants.
- **28 × `no-blank-before-list`** — lists sitting directly under a `<Region>`. Counted across the English corpus: **78 written that way against 37 with a blank line**. It is the repository's majority form and it renders correctly.
- **21 × `<br/>` in prose** — the known formatting backlog, out of scope here.
- **11 × `webmail-case`** — 9 in German, where common nouns take a capital, and the rest are alt-texts quoting the interface field literally named `Webmail`.

</details>

## Validation

- `content:lint` passes
- heading count compared before and after in all 14 files — nothing was silently dropped
- `<Region>` tags balanced in all 14 files; every `ca` block re-read to confirm no EU product leaked in
- every action button and tab label checked against `Messages_{lang}.json` in its own locale
- the single external link fetched — HTTP 200
- no `<Api>` tag, no text fragment in scope
- German QA: 245 formal forms, 0 informal · Portuguese QA: 0 Brazilian marker, pt-PT markers present
- `lastUpdated` bumped on **both** guides: the migration path changes for the reader, and so does the stated scope

2 guides × 7 locales, 14 files, 5 commits, +235 / −116.
