### PR TITLE
SK-2728 - WEB - Email - Exchange - Make the Microsoft 365 conflict findable and document the alias remedy

### DIFF
--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - E-Mail-Account auf klassischem Outlook für Windows einrichten
 description: Informationen zum Konfigurieren eines Exchange Accounts in einem klassischen Outlook für Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -71,6 +71,12 @@ Um Outlook Classic auf Ihrem Windows-Computer zu installieren, laden Sie es von 
 Geben Sie nach Abschluss der Installation in der Windows-Suchleiste "Outlook" ein, um die beiden Versionen bei der Installation voneinander zu unterscheiden. Sie können dann den Unterschied wie folgt sehen.
 
 <img className="thumbnail" alt="Outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Fordert Outlook wiederholt Microsoft 365-Anmeldedaten an, statt sich mit Ihrem OVHcloud Exchange Server zu verbinden, wurde zuerst ein Microsoft Konto mit derselben E-Mail-Adresse gefunden. Unsere Anleitung [Exchange - Outlook-Anmeldeaufforderungen für Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) erklärt, wie Sie die Ursache erkennen und beheben.
 
 :::
 
@@ -180,5 +186,7 @@ Weitere Informationen zum Einrichten einer E-Mail-Adresse über die Outlook-App 
 [Konfiguration Ihrer MX Plan Adresse mit Outlook für Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Konfiguration von E-Mail Pro auf Outlook für Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Outlook-Anmeldeaufforderungen für Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ Exchange Accounts können auf verschiedenen, kompatiblen E-Mail-Clients eingeric
 ## Voraussetzungen
 
 - Sie verfügen über einen [Exchange Account](https://www.ovhcloud.com/de/emails/hosted-exchange/).
-- Sie haben die Windows Anwendung [Outlook Classic](https://support.microsoft.com/de-de/office/installieren-oder-erneutes-installieren-des-klassischen-outlook-auf-einem-windows-pc-5c94902b-31a5-4274-abb0-b07f4661edf5).
+- Sie haben die Windows Anwendung [Outlook Classic](https://support.microsoft.com/de-de/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc).
 - Sie verfügen über Anmeldeinformationen für die E-Mail-Adresse, die Sie konfigurieren möchten.
 - Der OVHcloud SRV-Eintrag muss in der DNS-Zone der Domain korrekt konfiguriert sein. Lesen Sie hierzu unsere Anleitung "[Eine Domain zu Ihrer Exchange Dienstleistung hinzufügen](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain)".
 
@@ -66,7 +66,7 @@ Sie verwenden Outlook für Mac? Die zugehörige Dokumentation finden Sie hier: [
 :::warning
 Bevor Sie mit der Konfiguration Ihres Accounts beginnen, ist es wichtig zu beachten, dass die mit Windows 11 kostenlos mitgelieferte Outlook-Anwendung [nicht kompatibel](https://learn.microsoft.com/de-de/microsoft-365-apps/outlook/get-started/supported-account-types) mit den OVHcloud Exchange-Lösungen, auch als *on-premises* bezeichnet, ist. Sie müssen die Version **Outlook Classic** verwenden.
 
-Um Outlook Classic auf Ihrem Windows-Computer zu installieren, laden Sie es von der Microsoft-Seite "[Installieren oder Erneutes Installieren des klassischen Outlook auf einem Windows-PC](https://support.microsoft.com/de-de/office/installieren-oder-erneutes-installieren-des-klassischen-outlook-auf-einem-windows-pc-5c94902b-31a5-4274-abb0-b07f4661edf5)" herunter und installieren Sie es.
+Um Outlook Classic auf Ihrem Windows-Computer zu installieren, laden Sie es von der Microsoft-Seite "[Installieren oder Erneutes Installieren des klassischen Outlook auf einem Windows-PC](https://support.microsoft.com/de-de/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)" herunter und installieren Sie es.
 
 Geben Sie nach Abschluss der Installation in der Windows-Suchleiste "Outlook" ein, um die beiden Versionen bei der Installation voneinander zu unterscheiden. Sie können dann den Unterschied wie folgt sehen.
 
@@ -178,7 +178,7 @@ Wenn Sie eine Änderung vornehmen, die den Verlust der Daten Ihres E-Mail-Accoun
 ## Weiterführende Informationen <a name="go-further"></a>
 
 :::info
-Weitere Informationen zum Einrichten einer E-Mail-Adresse über die Outlook-App auf Windows finden Sie im [Microsoft Help Center](https://support.microsoft.com/de-de/office/add-mail-account-in-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Weitere Informationen zum Einrichten einer E-Mail-Adresse über die Outlook-App auf Windows finden Sie im [Microsoft Help Center](https://support.microsoft.com/de-de/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ Dieses Verhalten geht auf eine Outlook-Funktion namens "Direct Connect to Office
 
 - Sie verfügen über eine bereits eingerichtete [Exchange OVHcloud Lösung](/links/web/emails-hosted-exchange).
 - Sie verfügen über die Anwendung [Outlook Classic](https://support.microsoft.com/de-de/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 oder Microsoft 365) unter Windows.
-- Sie verfügen über Administratorzugriff auf den Client-Computer, um die Windows-Registrierung zu bearbeiten.
+- Sie verfügen über Administratorzugriff auf den Client-Computer, um die Windows-Registrierung zu bearbeiten. Dies ist nicht erforderlich, wenn Sie die unten beschriebene Alternative verwenden.
 - Der OVHcloud SRV-Eintrag muss in der DNS-Zone der Domain korrekt konfiguriert sein. Lesen Sie hierzu unsere Anleitung [Eine Domain zu Ihrer Exchange Dienstleistung hinzufügen](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Outlook-Anmeldeaufforderungen für Office 365"
 description: Diagnostizieren und beheben Sie die Outlook-Anmeldeaufforderungen, die auf Office 365 verweisen, obwohl Ihr Postfach auf Exchange OVHcloud gehostet wird
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Wenn die OVHcloud Konfiguration korrekt ist, die Anmeldefenster jedoch weiterhin
 Dieses Verhalten wird in 2 Hauptsituationen ausgelöst:
 
 - **Die Domain wurde in einem Office 365 Tenant deklariert.** Wenn Sie eine Domain zu einem Microsoft 365 Tenant hinzufügen, geht Microsoft davon aus, dass sich die Postfächer dieser Domain in der Cloud befinden. Outlook verbindet sich dann mit dem Autodiscover von Office 365 anstatt mit dem von OVHcloud.
-- **Ein identischer Account wurde in Office 365 erstellt.** Wenn ein Postfach oder ein Benutzer mit derselben E-Mail-Adresse (oder demselben UPN) in einem Microsoft 365 Tenant existiert, kann Outlook zu diesem Cloud-Account umgeleitet werden anstatt zu Ihrem Exchange OVHcloud Account.
+- **Ein Microsoft Konto verwendet bereits dieselbe E-Mail-Adresse.** Das kann ein Benutzer in einem Microsoft 365 Tenant sein, mit derselben Adresse oder demselben UPN. Es kann ebenso ein **persönliches Microsoft Konto** sein – etwa eines, das zur Aktivierung einer Office-Lizenz erstellt wurde –, dessen Anmeldeadresse Ihre Exchange-Adresse ist. In beiden Fällen findet Outlook dieses Konto zuerst und folgt ihm, obwohl kein Postfach damit verknüpft ist.
 
 :::tip
 Wenn Sie Office 365 für diese Domain nicht mehr verwenden, sollten Sie auch die betreffende Domain oder den betreffenden Account aus dem Microsoft 365 Tenant entfernen. Die nachfolgende Lösung bleibt jedoch erforderlich, solange Outlook weiterhin den Office 365 Endpunkt bevorzugt.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 Unter Windows 11 mit Office 2024 LTSC (und allgemeiner bei neueren Versionen) befindet sich der Schlüssel `AutoDiscover` nicht mehr im Systemkontext, sondern im **Kontext des angemeldeten Benutzers**. Starten Sie den Registrierungs-Editor (oder die Eingabeaufforderung) daher mit der Sitzung des betreffenden Benutzers und nicht als Administrator eines anderen Accounts.
 :::
+
+### Alternative: die Anmeldeadresse des Microsoft Kontos ändern
+
+Stammt der Konflikt von einem **persönlichen Microsoft Konto**, können Sie die Ursache beseitigen, statt sie zu umgehen. Diese Methode erfordert keine Administratorrechte auf dem Computer und ist damit die einzige Option auf einem von Ihrer IT-Abteilung verwalteten Arbeitsplatz.
+
+1. Erstellen Sie einen Alias für Ihren OVHcloud Exchange Account. Folgen Sie dazu unserer Anleitung [E-Mail Alias und Weiterleitung verwenden](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan).
+1. Melden Sie sich bei [account.microsoft.com](https://account.microsoft.com) an, öffnen Sie **Ihre Infos** und dann **Verwalten, wie Sie sich bei Microsoft anmelden**, und fügen Sie diesen Alias Ihrem Microsoft Konto hinzu. Die Bestätigungsnachricht erreicht Ihr Exchange Postfach, da der Alias darauf verweist.
+1. Legen Sie den Alias als **primären** Alias fest und entfernen Sie anschließend Ihre Exchange-Adresse aus dem Microsoft Konto.
+
+Outlook findet für Ihre Exchange-Adresse kein Microsoft Konto mehr, und der Autodiscover greift auf den OVHcloud Server zurück.
+
+:::warning
+Microsoft setzt eigene Grenzen: maximal 10 Aliase pro Konto, der primäre Alias kann höchstens zweimal pro Woche geändert werden, und eine mit einem Geschäfts-, Schul- oder Unikonto verknüpfte Adresse kann nicht primär werden. Diese Methode gilt daher nur für ein persönliches Microsoft Konto. Verwenden Sie für einen Microsoft 365 Tenant den Registrierungsschlüssel oben.
+
+:::
+
 
 ### Die Verbindung zu Exchange OVHcloud überprüfen
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ Dieses Verhalten wird in 2 Hauptsituationen ausgelöst:
 - **Ein Microsoft Konto verwendet bereits dieselbe E-Mail-Adresse.** Das kann ein Benutzer in einem Microsoft 365 Tenant sein, mit derselben Adresse oder demselben UPN. Es kann ebenso ein **persönliches Microsoft Konto** sein – etwa eines, das zur Aktivierung einer Office-Lizenz erstellt wurde –, dessen Anmeldeadresse Ihre Exchange-Adresse ist. In beiden Fällen findet Outlook dieses Konto zuerst und folgt ihm, obwohl kein Postfach damit verknüpft ist.
 
 :::tip
-Wenn Sie Office 365 für diese Domain nicht mehr verwenden, sollten Sie auch die betreffende Domain oder den betreffenden Account aus dem Microsoft 365 Tenant entfernen. Die nachfolgende Lösung bleibt jedoch erforderlich, solange Outlook weiterhin den Office 365 Endpunkt bevorzugt.
+Wenn Sie Office 365 für diese Domain nicht mehr verwenden, sollten Sie auch die betreffende Domain oder den betreffenden Account aus dem Microsoft 365 Tenant entfernen. Solange Outlook weiterhin den Office 365 Endpunkt bevorzugt, benötigen Sie eine der beiden nachfolgenden Lösungen.
 :::
+
+Es folgen zwei Lösungen. Der **Registrierungsschlüssel** funktioniert unabhängig von der Ursache, erfordert jedoch Administratorrechte auf dem Computer. Stammt der Konflikt von einem **persönlichen Microsoft Konto**, beseitigt das Ändern seiner Anmeldeadresse die Ursache und erfordert keine solchen Rechte.
 
 ### Die Lösung anwenden: der Registrierungsschlüssel `ExcludeExplicitO365Endpoint`
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ You can configure Exchange accounts on email clients, if they are compatible. By
 ## Requirements
 
 - An [OVHcloud Exchange account](https://www.ovhcloud.com/en-gb/emails/hosted-exchange/)
-- [Outlook Classic](https://support.microsoft.com/en-gb/office/install-or-reinstall-classic-outlook-on-a-windows-pc-5c94902b-31a5-4274-abb0-b07f4661edf5) for Windows installed on your device
+- [Outlook Classic](https://support.microsoft.com/en-gb/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) for Windows installed on your device
 - Login credentials for the email account to be configured
 - The OVHcloud SRV record must be correctly configured in the domain name’s DNS zone. Please refer to our guide on [Adding a domain name to an Exchange service](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
@@ -56,7 +56,7 @@ If you experience any difficulties carrying out these operations, we recommend t
 
 
 :::info
-Are you using Outlook for Mac? Refer to our documentation: [Configuring your Exchange account in Outlook for Mac.](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
+Are you using Outlook for Mac? Refer to our documentation: [Configuring your Exchange account in Outlook for Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
 
 :::
 
@@ -66,7 +66,7 @@ Are you using Outlook for Mac? Refer to our documentation: [Configuring your Exc
 :::warning
 Before you begin configuring your account, it is important to note that the Outlook application included free with Windows 11 is [incompatible](https://learn.microsoft.com/en-gb/microsoft-365-apps/outlook/get-started/supported-account-types) with OVHcloud Exchange solutions, known as on-premises. You will need to use the classic **Outlook** version.
 
-To install Outlook Classic on your Windows computer, download it from the Microsoft page "[Install or reinstall Outlook Classic on a Windows PC](https://support.microsoft.com/en-gb/office/install-or-reinstall-classic-outlook-on-a-windows-pc-5c94902b-31a5-4274-abb0-b07f4661edf5)", and install it.
+To install Outlook Classic on your Windows computer, download it from the Microsoft page "[Install or reinstall Outlook Classic on a Windows PC](https://support.microsoft.com/en-gb/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)", and install it.
 
 Once the installation is complete, to distinguish between the two versions when they are installed, type "Outlook" in the Windows search bar. You can then see the difference as below.
 
@@ -178,7 +178,7 @@ If you need to make a change that could lead to the loss of your email account d
 ## Go further <a name="go-further"></a>
 
 :::info
-For more information about configuring an email address from the Outlook app on Windows, see [Microsoft Help Center](https://support.microsoft.com/en-gb/office/add-email-account-in-Outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+For more information about configuring an email address from the Outlook app on Windows, see [Microsoft Help Center](https://support.microsoft.com/en-gb/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -15,7 +15,7 @@ import { Region } from '@components/Zone';
 
 ## Objective
 
-You can configure Exchange accounts on email clients, if they are compatible. By doing so, you can use your email address through your preferred email application. Microsoft Outlook is the recommended software for using an Exchange email address with its collaborative features.
+You can configure an Exchange account in any compatible email client, and use your address from the application you prefer. Microsoft Outlook is the recommended software for using an Exchange email address with its collaborative features.
 
 **Find out how to configure your Exchange account in Outlook for Windows**
 
@@ -91,9 +91,9 @@ If Outlook keeps asking for Microsoft 365 credentials instead of connecting to y
 
 **On Windows 11, the Outlook classic interface may differ when you add an account.**
 
-Depending on the Outlook usage history on the concerned computer, a specific configuration may lead to the display of a different interface. In some cases, the so-called "modern" interface (**interface 1**) may be disabled in favour of the historical interface (**interface 2**).
+Depending on how Outlook has been used on that computer, the interface may differ. In some cases, the so-called "modern" interface (**interface 1**) may be disabled in favour of the historical interface (**interface 2**).
 
-This is why we invite you to consult the chapter corresponding to the interface displayed on your screen.
+Follow the section matching the interface you see.
 
 <Tabs>
   <Tab label="Interface 1">
@@ -132,12 +132,12 @@ We recommend that you check the configuration of the domain name associated with
     
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange02.png" loading="lazy" />
     
-    - If your domain name configuration is valid, a message authorizing connection to the OVHcloud Exchange server may appear. Click on <code className="action">Allow</code> **(1)** to allow the automatic configuration of your Exchange account.
+    - If your domain name configuration is valid, a message authorising connection to the OVHcloud Exchange server may appear. Click on <code className="action">Allow</code> **(1)** to allow the automatic configuration of your Exchange account.
     - A second authentication window appears, enter the password of your email address **(2)**.
     
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange03.png" loading="lazy" />
 
-After authorization and authentication to the OVHcloud Exchange server, the configuration will be completed and your account will be operational.
+Once authorised and authenticated, the configuration completes and your account is ready to use.
   </Tab>
 </Tabs>
 
@@ -151,7 +151,7 @@ Your Exchange email address and all of its collaborative features are also avail
 ### Modifying existing settings
 
 :::warning
-It is not possible to modify the server settings of an Exchange account. If you encounter an anomaly related to synchronization with the server, it is necessary to delete the Outlook account and reconfigure it. To do this, follow the instructions below.
+You cannot modify the server settings of an Exchange account. If synchronisation with the server fails, delete the Outlook account and configure it again. To do this, follow the instructions below.
 
 :::
 
@@ -173,7 +173,7 @@ Once the Exchange account is deleted, follow the "[Add the account](#add-account
 
 ### Retrieving a backup of your email address
 
-If you need to make a change that could lead to the loss of your email account data, we advise you to make a backup of the email account concerned beforehand. To do this, please read the "**Exporting from Windows**" section in our guide on [Migrating your email address manually](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration#exporting-from-windows).
+If you need to make a change that could lead to the loss of your email account data, back up the email account first. To do this, please read the "**Exporting from Windows**" section in our guide on [Migrating your email address manually](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration#exporting-from-windows).
 
 ## Go further <a name="go-further"></a>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Configure your email account on Outlook for Windows
 description: Find out how to configure your Exchange account in Outlook for Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -71,6 +71,12 @@ To install Outlook Classic on your Windows computer, download it from the Micros
 Once the installation is complete, to distinguish between the two versions when they are installed, type "Outlook" in the Windows search bar. You can then see the difference as below.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+If Outlook keeps asking for Microsoft 365 credentials instead of connecting to your OVHcloud Exchange server, a Microsoft account using the same email address is being found first. Our guide [Exchange - Outlook sign-in prompts to Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) explains how to identify the cause and fix it.
 
 :::
 
@@ -180,5 +186,7 @@ For more information about configuring an email address from the Outlook app on 
 [Configuring your MX Plan address in Outlook for Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Configuring your Email Pro account in Outlook for Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Outlook sign-in prompts to Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Join our [community of users](/links/community).

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -76,7 +76,7 @@ Once the installation is complete, to distinguish between the two versions when 
 
 
 :::info
-If Outlook keeps asking for Microsoft 365 credentials instead of connecting to your OVHcloud Exchange server, a Microsoft account using the same email address is being found first. Our guide [Exchange - Outlook sign-in prompts to Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) explains how to identify the cause and fix it.
+If Outlook keeps asking for Microsoft 365 credentials instead of connecting to your OVHcloud Exchange server, it has found a Microsoft account that uses the same email address. Our guide [Exchange - Outlook sign-in prompts to Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) explains how to identify the cause and fix it.
 
 :::
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -56,7 +56,7 @@ When you add the account, this automatic settings lookup (autodiscover) is visib
 
 ### Identifying the symptoms
 
-You are likely affected by this problem if you notice the following:
+You are affected if you see the following:
 
 - A Microsoft 365 sign-in window appears repeatedly in Outlook and keeps asking for credentials.
 - The message "Tell us the account you want to use to open autodiscover.xml" appears.

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ This behaviour is caused by an Outlook feature called "Direct Connect to Office 
 
 - Have an [Exchange OVHcloud solution](/links/web/emails-hosted-exchange) already set up.
 - Have the [classic Outlook](https://support.microsoft.com/en-gb/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) application (Outlook 2016, 2019, 2021 or Microsoft 365) on Windows.
-- Have administrator access to the client computer to edit the Windows registry.
+- Have administrator access to the client computer to edit the Windows registry. This is not required if you use the alternative described below.
 - The OVHcloud SRV record must be correctly configured in the domain name's DNS zone. See our guide [Add a domain name to your Exchange service](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Outlook sign-in prompts to Office 365"
 description: Diagnose and fix the recurring Outlook sign-in prompts pointing to Office 365 when your mailbox is actually hosted on Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ If the OVHcloud configuration is correct but the sign-in windows persist, the ca
 This behaviour is triggered in 2 main situations:
 
 - **The domain name has been declared on an Office 365 tenant.** When you add a domain to a Microsoft 365 tenant, Microsoft assumes that the mailboxes for that domain are in the cloud. Outlook then connects to the Office 365 autodiscover instead of the OVHcloud one.
-- **An identical account has been created in Office 365.** If a mailbox or user with the same email address (or the same UPN) exists in a Microsoft 365 tenant, Outlook may be redirected to that cloud account rather than to your Exchange OVHcloud account.
+- **A Microsoft account already uses the same email address.** This can be a user in a Microsoft 365 tenant, with the same address or the same UPN. It can just as well be a **personal Microsoft account** — one created to activate an Office licence, for example — whose sign-in address is your Exchange address. In both cases Outlook finds that account first and follows it, even though no mailbox is attached to it.
 
 :::tip
 If you no longer use Office 365 for this domain, also consider removing the relevant domain or account from the Microsoft 365 tenant. The fix below remains necessary, however, as long as Outlook continues to favour the Office 365 endpoint.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 On Windows 11 with Office 2024 LTSC (and, more broadly, on recent versions), the `AutoDiscover` key is no longer in the system context but in the **context of the logged-in user**. Therefore, launch the Registry Editor (or the command prompt) in the session of the affected user, not as an administrator of another account.
 :::
+
+### Alternative: change the sign-in address of the Microsoft account
+
+If the conflict comes from a **personal Microsoft account**, you can remove the cause instead of working around it. This method requires no administrator rights on the computer, which makes it the only option on a workstation managed by your IT department.
+
+1. Create an alias on your OVHcloud Exchange account, following our guide [Using email aliases and redirections](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan).
+1. Sign in to [account.microsoft.com](https://account.microsoft.com), open **Your info** then **Manage how you sign in to Microsoft**, and add this alias to your Microsoft account. The verification message arrives in your Exchange mailbox, since the alias points to it.
+1. Set the alias as the **primary** alias, then remove your Exchange address from the Microsoft account.
+
+Outlook no longer finds a Microsoft account for your Exchange address, and autodiscover falls back to the OVHcloud server.
+
+:::warning
+Microsoft applies its own limits: 10 aliases per account at most, the primary alias can be changed at most twice a week, and an address linked to a work or school account cannot be made primary. This method therefore applies to a personal Microsoft account only. For a Microsoft 365 tenant, use the registry key above.
+
+:::
+
 
 ### Checking the connection to Exchange OVHcloud
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ This behaviour is triggered in 2 main situations:
 - **A Microsoft account already uses the same email address.** This can be a user in a Microsoft 365 tenant, with the same address or the same UPN. It can equally be a **personal Microsoft account** — one created to activate an Office licence, for example — whose sign-in address is your Exchange address. In both cases Outlook finds that account first and follows it, even though no mailbox is attached to it.
 
 :::tip
-If you no longer use Office 365 for this domain, also consider removing the relevant domain or account from the Microsoft 365 tenant. The fix below remains necessary, however, as long as Outlook continues to favour the Office 365 endpoint.
+If you no longer use Office 365 for this domain, also consider removing the relevant domain or account from the Microsoft 365 tenant. As long as Outlook keeps favouring the Office 365 endpoint, you still need one of the two fixes below.
 :::
+
+Two fixes follow. The **registry key** works whatever the cause, but requires administrator rights on the computer. If the conflict comes from a **personal Microsoft account**, changing its sign-in address removes the cause and needs no such rights.
 
 ### Applying the fix: the `ExcludeExplicitO365Endpoint` registry key
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -86,7 +86,7 @@ If the OVHcloud configuration is correct but the sign-in windows persist, the ca
 This behaviour is triggered in 2 main situations:
 
 - **The domain name has been declared on an Office 365 tenant.** When you add a domain to a Microsoft 365 tenant, Microsoft assumes that the mailboxes for that domain are in the cloud. Outlook then connects to the Office 365 autodiscover instead of the OVHcloud one.
-- **A Microsoft account already uses the same email address.** This can be a user in a Microsoft 365 tenant, with the same address or the same UPN. It can just as well be a **personal Microsoft account** — one created to activate an Office licence, for example — whose sign-in address is your Exchange address. In both cases Outlook finds that account first and follows it, even though no mailbox is attached to it.
+- **A Microsoft account already uses the same email address.** This can be a user in a Microsoft 365 tenant, with the same address or the same UPN. It can equally be a **personal Microsoft account** — one created to activate an Office licence, for example — whose sign-in address is your Exchange address. In both cases Outlook finds that account first and follows it, even though no mailbox is attached to it.
 
 :::tip
 If you no longer use Office 365 for this domain, also consider removing the relevant domain or account from the Microsoft 365 tenant. The fix below remains necessary, however, as long as Outlook continues to favour the Office 365 endpoint.
@@ -142,7 +142,7 @@ If the conflict comes from a **personal Microsoft account**, you can remove the 
 Outlook no longer finds a Microsoft account for your Exchange address, and autodiscover falls back to the OVHcloud server.
 
 :::warning
-Microsoft applies its own limits: 10 aliases per account at most, the primary alias can be changed at most twice a week, and an address linked to a work or school account cannot be made primary. This method therefore applies to a personal Microsoft account only. For a Microsoft 365 tenant, use the registry key above.
+Microsoft applies its own limits: 10 aliases per account, the primary alias can only be changed twice a week, and an address linked to a work or school account cannot be made primary. This method therefore applies to a personal Microsoft account only. For a Microsoft 365 tenant, use the registry key above.
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ Es posible configurar sus cuentas Exchange en el cliente de correo que usted uti
 ## Requisitos
 
 - Tener un servicio [Exchange](https://www.ovhcloud.com/es-es/emails-exchange/).
-- Tener la [versión clásica de Outlook](https://support.microsoft.com/es-es/office/instalar-o-reinstalar-la-versi%C3%B3n-cl%C3%A1sica-de-outlook-en-un-equipo-pc-con-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) en Windows.
+- Tener la [versión clásica de Outlook](https://support.microsoft.com/es-es/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) en Windows.
 - Disponer del nombre de usuario y de la contraseña de la cuenta de correo electrónico que quiera configurar.
 - El registro SRV de OVHcloud debe estar correctamente configurado en la zona DNS del dominio. No dude en consultar nuestra guía "[Añadir un dominio a un servicio Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain)".
 
@@ -46,7 +46,7 @@ Es posible configurar sus cuentas Exchange en el cliente de correo que usted uti
 [[fragment:support-scope]]
 
 :::info
-Si utiliza Outlook y posterior para Mac, consulte nuestra guía "[Configurar una cuenta Exchange en Outlook para Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac)".
+Si utiliza Outlook para Mac, consulte nuestra guía "[Configurar una cuenta Exchange en Outlook para Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac)".
 
 :::
 
@@ -56,7 +56,7 @@ Si utiliza Outlook y posterior para Mac, consulte nuestra guía "[Configurar una
 :::warning
 Antes de empezar a configurar, es importante tener en cuenta que la aplicación Outlook incluida gratuitamente con Windows 11 es [incompatible](https://learn.microsoft.com/es-es/microsoft-365-apps/outlook/get-started/supported-account-types) con los productos Exchange OVHcloud, llamados *on-premises*. Deberá utilizar la **versión clásica de Outlook**.
 
-Para instalar la versión clásica de Outlook en el equipo Windows, descárguela de la página de Microsoft "[Instalar o reinstalar la versión clásica de Outlook en un equipo PC con Windows](https://support.microsoft.com/es-es/office/instalar-o-reinstalar-la-versi%C3%B3n-cl%C3%A1sica-de-outlook-en-un-equipo-pc-con-windows-5c94902b-31a5-4274-abb0-b07f4661edf5)" e instálela.
+Para instalar la versión clásica de Outlook en el equipo Windows, descárguela de la página de Microsoft "[Instalar o reinstalar la versión clásica de Outlook en un equipo PC con Windows](https://support.microsoft.com/es-es/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)" e instálela.
 
 Una vez finalizada la instalación, para distinguir entre las dos versiones una vez instaladas, escriba "Outlook" en la barra de búsqueda de Windows. Podrá ver la diferencia como se muestra a continuación.
 
@@ -168,7 +168,7 @@ Si necesita realizar alguna operación que pueda provocar la pérdida de los dat
 ## Más información <a name="go-further"></a>
 
 :::info
-Para obtener más información sobre la configuración de una dirección de correo electrónico desde la aplicación Outlook en Windows, consulte [el Centro de ayuda de Microsoft](https://support.microsoft.com/es-es/office/agregar-cuenta-de-correo-en-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Para obtener más información sobre la configuración de una dirección de correo electrónico desde la aplicación Outlook en Windows, consulte [el Centro de ayuda de Microsoft](https://support.microsoft.com/es-es/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Configurar una cuenta de correo en Outlook clásico para Windows
 description: Cómo configurar una cuenta Exchange en Outlook clásico para Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -61,6 +61,12 @@ Para instalar la versión clásica de Outlook en el equipo Windows, descárguela
 Una vez finalizada la instalación, para distinguir entre las dos versiones una vez instaladas, escriba "Outlook" en la barra de búsqueda de Windows. Podrá ver la diferencia como se muestra a continuación.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Si Outlook solicita repetidamente credenciales de Microsoft 365 en lugar de conectarse a su servidor Exchange de OVHcloud, es porque se encuentra primero una cuenta Microsoft que utiliza la misma dirección de correo. Nuestra guía "[Exchange - Ventanas de conexión de Outlook a Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)" explica cómo identificar la causa y corregirla.
 
 :::
 
@@ -170,5 +176,7 @@ Para obtener más información sobre la configuración de una dirección de corr
 [Configurar una cuenta de correo electrónico en Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Configurar una cuenta Email Pro en Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Ventanas de conexión de Outlook a Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ Este comportamiento se desencadena en 2 situaciones principales:
 - **Una cuenta Microsoft ya utiliza la misma dirección de correo.** Puede tratarse de un usuario de un tenant de Microsoft 365, con la misma dirección o el mismo UPN. También puede tratarse de una **cuenta Microsoft personal** —creada para activar una licencia de Office, por ejemplo— cuya dirección de conexión es su dirección Exchange. En ambos casos, Outlook encuentra esa cuenta primero y la sigue, aunque no tenga ningún buzón asociado.
 
 :::tip
-Si no utiliza (o ya no utiliza) Office 365 para este dominio, considere también eliminar el dominio o la cuenta en cuestión del tenant de Microsoft 365. No obstante, la corrección que se indica a continuación sigue siendo necesaria mientras Outlook continúe dando prioridad al endpoint de Office 365.
+Si no utiliza (o ya no utiliza) Office 365 para este dominio, considere también eliminar el dominio o la cuenta en cuestión del tenant de Microsoft 365. Mientras Outlook continúe dando prioridad al endpoint de Office 365, seguirá siendo necesaria una de las dos correcciones que se indican a continuación.
 :::
+
+A continuación se describen dos correcciones. La **clave de registro** funciona sea cual sea la causa, pero requiere derechos de administrador en el ordenador. Si el conflicto proviene de una **cuenta Microsoft personal**, cambiar su dirección de conexión elimina la causa y no requiere esos derechos.
 
 ### Aplicar la corrección: la clave de registro `ExcludeExplicitO365Endpoint`
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ Este comportamiento proviene de una funcionalidad de Outlook llamada "Direct Con
 
 - Disponer de una [solución Exchange OVHcloud](/links/web/emails-hosted-exchange) ya instalada.
 - Disponer de la aplicación [Outlook clásico](https://support.microsoft.com/es-es/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 o Microsoft 365) en Windows.
-- Disponer de acceso de administrador al equipo cliente para modificar el registro de Windows.
+- Disponer de acceso de administrador al equipo cliente para modificar el registro de Windows. No es necesario si aplica la solución alternativa descrita más abajo.
 - El registro SRV de OVHcloud debe estar correctamente configurado en la zona DNS del dominio. Consulte nuestra guía [Añadir un dominio a un servicio Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Ventanas de conexión de Outlook a Office 365"
 description: Diagnostique y corrija las ventanas de conexión de Outlook que apuntan a Office 365 cuando su buzón está en Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Si la configuración de OVHcloud es correcta pero las ventanas de conexión pers
 Este comportamiento se desencadena en 2 situaciones principales:
 
 - **El dominio se ha declarado en un tenant de Office 365.** Cuando añade un dominio a un tenant de Microsoft 365, Microsoft considera que los buzones de ese dominio se encuentran en la nube. Outlook se conecta entonces al autodiscover de Office 365 en lugar del de OVHcloud.
-- **Se ha creado una cuenta idéntica en Office 365.** Si existe un buzón o un usuario con la misma dirección de correo electrónico (o el mismo UPN) en un tenant de Microsoft 365, Outlook puede ser redirigido a esa cuenta en la nube en lugar de a su cuenta Exchange OVHcloud.
+- **Una cuenta Microsoft ya utiliza la misma dirección de correo.** Puede tratarse de un usuario de un tenant de Microsoft 365, con la misma dirección o el mismo UPN. También puede tratarse de una **cuenta Microsoft personal** —creada para activar una licencia de Office, por ejemplo— cuya dirección de conexión es su dirección Exchange. En ambos casos, Outlook encuentra esa cuenta primero y la sigue, aunque no tenga ningún buzón asociado.
 
 :::tip
 Si no utiliza (o ya no utiliza) Office 365 para este dominio, considere también eliminar el dominio o la cuenta en cuestión del tenant de Microsoft 365. No obstante, la corrección que se indica a continuación sigue siendo necesaria mientras Outlook continúe dando prioridad al endpoint de Office 365.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 En Windows 11 con Office 2024 LTSC (y, de forma más general, las versiones recientes), la clave `AutoDiscover` ya no se encuentra en el contexto del sistema, sino en el **contexto del usuario conectado**. Por lo tanto, ejecute el Editor del Registro (o el símbolo del sistema) con la sesión del usuario en cuestión, y no como administrador de otra cuenta.
 :::
+
+### Solución alternativa: cambiar la dirección de conexión de la cuenta Microsoft
+
+Si el conflicto proviene de una **cuenta Microsoft personal**, puede eliminar la causa en lugar de sortearla. Este método no requiere derechos de administrador en el ordenador, lo que lo convierte en la única opción en un puesto gestionado por su departamento informático.
+
+1. Cree un alias en su cuenta Exchange de OVHcloud siguiendo nuestra guía "[Utilizar los alias y redirecciones de correo](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan)".
+1. Conéctese a [account.microsoft.com](https://account.microsoft.com), abra **Su información** y luego **Administrar el modo en que inicia sesión en Microsoft**, y añada este alias a su cuenta Microsoft. El mensaje de verificación llega a su buzón Exchange, ya que el alias apunta a él.
+1. Defina este alias como alias **principal** y elimine después su dirección Exchange de la cuenta Microsoft.
+
+Outlook ya no encuentra ninguna cuenta Microsoft para su dirección Exchange, y el autodiscover recurre al servidor de OVHcloud.
+
+:::warning
+Microsoft impone sus propios límites: 10 alias como máximo por cuenta, el alias principal solo puede cambiarse dos veces por semana y una dirección vinculada a una cuenta profesional o educativa no puede convertirse en principal. Por tanto, este método solo se aplica a una cuenta Microsoft personal. Para un tenant de Microsoft 365, utilice la clave de registro anterior.
+
+:::
+
 
 ### Comprobar la conexión a Exchange OVHcloud
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -26,7 +26,7 @@ Les comptes Exchange peuvent être configurés sur différents logiciels de mess
 - Disposer d'une offre [Exchange](https://www.ovhcloud.com/fr/emails-exchange/).
 - Disposer de l'application [Outlook classique](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) sur Windows.
 - Posséder les identifiants relatifs à l'adresse e-mail que vous souhaitez paramétrer.
-- Le champ SRV d'OVHcloud doit être correctement configuré dans la zone DNS du nom de domaine, n'hésitez pas à consulter notre guide [Ajouter un nom de domaine sur son service Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
+- Le champ SRV d'OVHcloud doit être correctement configuré dans la zone DNS du nom de domaine, n'hésitez pas à consulter notre guide « [Ajouter un nom de domaine sur son service Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) ».
 
 <Region zones={['eu', 'ca']}>
 
@@ -51,7 +51,7 @@ Nous vous recommandons de faire appel à un [partenaire spécialisé](https://ma
 
 
 :::info
-Vous utilisez Outlook pour Mac ? Consultez notre documentation : [Configurer son compte Exchange sur Outlook pour Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
+Vous utilisez Outlook pour Mac ? Consultez notre documentation : [Configurer son compte Exchange sur Outlook pour Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
 
 :::
 
@@ -61,9 +61,9 @@ Vous utilisez Outlook pour Mac ? Consultez notre documentation : [Configurer son
 :::warning
 Avant de débuter votre configuration, il est important de noter que l'application Outlook incluse gratuitement avec Windows 11 est [incompatible](https://learn.microsoft.com/fr-fr/microsoft-365-apps/outlook/get-started/supported-account-types) avec les offres Exchange OVHcloud, dites *on-premises*. Vous devrez utiliser la version **Outlook classique**.
 
-Pour installer Outlook classique sur votre ordinateur Windows, téléchargez-le depuis la page Microsoft « [Installer ou réinstaller Outlook classique sur un PC Windows](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) », et installez-le.
+Pour installer Outlook classique sur votre ordinateur Windows, téléchargez-le depuis la page Microsoft « [Installer ou réinstaller Outlook classique sur un PC Windows](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) », et installez-le.
 
-Une fois l'installation terminée, pour distinguer les deux versions lorsqu'elles sont installées, tapez « Outlook » dans la barre de recherche Windows. Vous pourrez alors constater la différence comme ci-dessous.
+Une fois l'installation terminée, pour distinguer les deux versions lorsqu'elles sont installées, tapez « Outlook » dans la barre de recherche Windows. Vous pourrez alors constater la différence comme ci-dessous.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
 
@@ -78,17 +78,17 @@ Si Outlook réclame en boucle des identifiants Microsoft 365 au lieu de se conne
 
 ### Ajouter le compte <a name="add-account"></a>
 
-- **Lors du premier démarrage de l'application** : un assistant de configuration s'affiche et vous invite à renseigner votre adresse e-mail.
+- **Lors du premier démarrage de l'application** : un assistant de configuration s'affiche et vous invite à renseigner votre adresse e-mail.
 
-- **Si un compte a déjà été paramétré** : cliquez sur <code className="action">Fichier</code> dans la barre de menu en haut de votre écran, puis sur <code className="action">Ajouter un compte</code>.
+- **Si un compte a déjà été paramétré** : cliquez sur <code className="action">Fichier</code> dans la barre de menu en haut de votre écran, puis sur <code className="action">Ajouter un compte</code>.
 
 <img className="thumbnail" alt="Outlook" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange01.png" loading="lazy" />
 
 **Sur Windows 11, l'interface d'Outlook classique peut différer lorsque vous ajoutez un compte.**
 
-Selon l’historique d’utilisation d’Outlook sur le poste concerné, une configuration spécifique peut entraîner l’affichage d’une interface différente. Dans certains cas, l’interface dite « moderne » (**interface 1**) peut être désactivée au profit de l’interface historique (**interface 2**).
+Selon l’usage qui a été fait d’Outlook sur ce poste, l’interface peut différer. Dans certains cas, l’interface dite « moderne » (**interface 1**) peut être désactivée au profit de l’interface historique (**interface 2**).
 
-C’est pourquoi nous vous invitons à consulter le chapitre correspondant à l’interface affichée sur votre écran.
+Suivez la partie correspondant à l’interface que vous voyez.
 
 <Tabs>
   <Tab label="Interface 1">
@@ -118,17 +118,17 @@ Nous vous recommandons de vérifier la configuration du nom de domaine paramétr
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-legacy-exchange05.png" loading="lazy" />
   </Tab>
   <Tab label="Interface 2">
-    - Laissez `Compte de courrier` sélectionné et complétez les informations suivantes :
-        - **Nom** : définissez un nom d'affichage.
-        - **Adresse de courrier** : saisissez votre adresse e-mail complète.
-        - **Mot de passe** : saisissez le mot de passe associé à votre adresse e-mail.
-        - **Confirmer le mot de passe** : saisissez à nouveau le mot de passe associé à votre adresse e-mail.
+    - Laissez `Compte de courrier` sélectionné et complétez les informations suivantes :
+        - **Nom** : définissez un nom d'affichage.
+        - **Adresse de courrier** : saisissez votre adresse e-mail complète.
+        - **Mot de passe** : saisissez le mot de passe associé à votre adresse e-mail.
+        - **Confirmer le mot de passe** : saisissez à nouveau le mot de passe associé à votre adresse e-mail.
     - Cliquez sur <code className="action">Suivant</code> pour continuer.
     
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange02.png" loading="lazy" />
     
     - Si la configuration de votre nom de domaine est correcte, un message d'autorisation de connexion au serveur Exchange d'OVHcloud peut s'afficher. Cliquez sur <code className="action">Autoriser</code> **(1)** pour permettre la configuration automatique de votre compte Exchange.
-    - Une seconde fenêtre d'authentification apparaît : saisissez le mot de passe de votre adresse e-mail **(2)**.
+    - Une seconde fenêtre d'authentification apparaît : saisissez le mot de passe de votre adresse e-mail **(2)**.
     
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange03.png" loading="lazy" />
 
@@ -139,9 +139,9 @@ Une fois l’autorisation et l’authentification effectuées sur le serveur Exc
 
 ### Utiliser l'adresse e-mail
 
-Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
+Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
 
-Votre adresse e-mail Exchange, ainsi que toutes ses fonctions collaboratives, sont également disponibles via l'interface [OWA](https://www.ovhcloud.com/fr/mail/). Pour toute question relative à son utilisation, n'hésitez pas à consulter notre guide [Consulter son compte Exchange depuis l’interface OWA](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa).
+Votre adresse e-mail Exchange, ainsi que toutes ses fonctions collaboratives, sont également disponibles via l'interface [OWA](https://www.ovhcloud.com/fr/mail/). Pour toute question relative à son utilisation, n'hésitez pas à consulter notre guide « [Consulter son compte Exchange depuis l’interface OWA](/guides/web-cloud/email-and-collaborative-solutions/using-the-outlook-web-app-webmail/email-owa) ».
 
 ### Modifier les paramètres existants
 
@@ -151,7 +151,7 @@ Il n'est pas possible de modifier les paramètres serveur d'un compte Exchange. 
 :::
 
 
-Si votre compte e-mail est déjà paramétré et que vous devez accéder aux paramètres du compte pour le supprimer :
+Si votre compte e-mail est déjà paramétré et que vous devez accéder aux paramètres du compte pour le supprimer :
 
 - Allez dans <code className="action">Fichier</code> depuis la barre de menu en haut de votre écran.
 - Sélectionnez le compte à modifier dans le menu déroulant **(1)**.
@@ -164,11 +164,11 @@ Si votre compte e-mail est déjà paramétré et que vous devez accéder aux par
 
 <img className="thumbnail" alt="Outlook" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-exchange05.png" loading="lazy" />
 
-Une fois le compte Exchange supprimé, suivez la partie « [Ajouter le compte](#add-account) » de ce guide pour reconfigurer votre compte e-mail.
+Une fois le compte Exchange supprimé, suivez la partie « [Ajouter le compte](#add-account) » de ce guide pour reconfigurer votre compte e-mail.
 
 ### Récupérer une sauvegarde de votre adresse e-mail
 
-Si vous devez effectuer une manipulation qui risquerait d'entraîner la perte des données de votre compte e-mail, nous vous conseillons d'effectuer une sauvegarde préalable du compte e-mail concerné. Pour ce faire, consulter le paragraphe « **Exporter depuis Windows** » sur notre guide [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration#exporter-depuis-windows).
+Si vous devez effectuer une manipulation qui risquerait d'entraîner la perte des données de votre compte e-mail, nous vous conseillons d'effectuer une sauvegarde préalable du compte e-mail concerné. Pour ce faire, consultez le paragraphe « **Exporter depuis Windows** » sur notre guide « [Migrer manuellement votre adresse e-mail](/guides/web-cloud/email-and-collaborative-solutions/migrating/manual-email-migration#exporter-depuis-windows) ».
 
 ## Aller plus loin
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Configurer son compte e-mail sur Outlook classique pour Windows
 description: Découvrez comment configurer un compte Exchange sur Outlook classique pour Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -66,6 +66,12 @@ Pour installer Outlook classique sur votre ordinateur Windows, téléchargez-le 
 Une fois l'installation terminée, pour distinguer les deux versions lorsqu'elles sont installées, tapez « Outlook » dans la barre de recherche Windows. Vous pourrez alors constater la différence comme ci-dessous.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Si Outlook réclame en boucle des identifiants Microsoft 365 au lieu de se connecter à votre serveur Exchange OVHcloud, c'est qu'un compte Microsoft utilisant la même adresse e-mail est trouvé en premier. Notre guide « [Exchange - Fenêtres de connexion Outlook vers Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) » explique comment identifier la cause et la corriger.
 
 :::
 
@@ -175,5 +181,7 @@ Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'appl
 [Configurer son adresse e-mail comprise dans l’offre MX Plan ou dans une offre d’hébergement web sur Outlook pour Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Configurer son compte Email Pro sur Outlook pour Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Fenêtres de connexion Outlook vers Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ Les comptes Exchange peuvent être configurés sur différents logiciels de mess
 ## Prérequis
 
 - Disposer d'une offre [Exchange](https://www.ovhcloud.com/fr/emails-exchange/).
-- Disposer de l'application [Outlook classique](https://support.microsoft.com/fr-fr/office/installer-ou-r%C3%A9installer-outlook-classique-sur-un-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) sur Windows.
+- Disposer de l'application [Outlook classique](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) sur Windows.
 - Posséder les identifiants relatifs à l'adresse e-mail que vous souhaitez paramétrer.
 - Le champ SRV d'OVHcloud doit être correctement configuré dans la zone DNS du nom de domaine, n'hésitez pas à consulter notre guide [Ajouter un nom de domaine sur son service Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
@@ -51,7 +51,7 @@ Nous vous recommandons de faire appel à un [partenaire spécialisé](https://ma
 
 
 :::info
-Vous utilisez Outlook et ultérieur pour Mac ? Consultez notre documentation : [Configurer son compte Exchange sur Outlook pour Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
+Vous utilisez Outlook pour Mac ? Consultez notre documentation : [Configurer son compte Exchange sur Outlook pour Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
 
 :::
 
@@ -61,7 +61,7 @@ Vous utilisez Outlook et ultérieur pour Mac ? Consultez notre documentation : [
 :::warning
 Avant de débuter votre configuration, il est important de noter que l'application Outlook incluse gratuitement avec Windows 11 est [incompatible](https://learn.microsoft.com/fr-fr/microsoft-365-apps/outlook/get-started/supported-account-types) avec les offres Exchange OVHcloud, dites *on-premises*. Vous devrez utiliser la version **Outlook classique**.
 
-Pour installer Outlook classique sur votre ordinateur Windows, téléchargez-le depuis la page Microsoft « [Installer ou réinstaller Outlook classique sur un PC Windows](https://support.microsoft.com/fr-fr/office/installer-ou-r%C3%A9installer-outlook-classique-sur-un-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) », et installez-le.
+Pour installer Outlook classique sur votre ordinateur Windows, téléchargez-le depuis la page Microsoft « [Installer ou réinstaller Outlook classique sur un PC Windows](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) », et installez-le.
 
 Une fois l'installation terminée, pour distinguer les deux versions lorsqu'elles sont installées, tapez « Outlook » dans la barre de recherche Windows. Vous pourrez alors constater la différence comme ci-dessous.
 
@@ -113,7 +113,7 @@ Nous vous recommandons de vérifier la configuration du nom de domaine paramétr
 
     
     - Si la configuration de votre nom de domaine est correcte, un message d'autorisation de connexion aux serveurs d'OVHcloud peut s'afficher. Acceptez-le pour permettre la configuration automatique de votre compte Exchange.
-    - Définissez ensuite la période de conservation des éléments de vote compte Exchange, **en local sur votre ordinateur**. Cliquez sur <code className="action">Suivant</code>, puis sur <code className="action">Terminé</code>.
+    - Définissez ensuite la période de conservation des éléments de votre compte Exchange, **en local sur votre ordinateur**. Cliquez sur <code className="action">Suivant</code>, puis sur <code className="action">Terminé</code>.
     
     <img className="thumbnail" alt="exchange" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/config-outlook-legacy-exchange05.png" loading="lazy" />
   </Tab>
@@ -173,7 +173,7 @@ Si vous devez effectuer une manipulation qui risquerait d'entraîner la perte de
 ## Aller plus loin
 
 :::info
-Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'application Outlook sur Windows, consultez [le centre d'aide Microsoft](https://support.microsoft.com/fr-fr/office/ajouter-un-compte-de-courrier-dans-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'application Outlook sur Windows, consultez [le centre d'aide Microsoft](https://support.microsoft.com/fr-FR/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -71,7 +71,7 @@ Une fois l'installation terminée, pour distinguer les deux versions lorsqu'elle
 
 
 :::info
-Si Outlook réclame en boucle des identifiants Microsoft 365 au lieu de se connecter à votre serveur Exchange OVHcloud, c'est qu'un compte Microsoft utilisant la même adresse e-mail est trouvé en premier. Notre guide « [Exchange - Fenêtres de connexion Outlook vers Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) » explique comment identifier la cause et la corriger.
+Si Outlook réclame en boucle des identifiants Microsoft 365 au lieu de se connecter à votre serveur Exchange OVHcloud, c'est qu'il trouve d'abord un compte Microsoft portant la même adresse e-mail. Notre guide « [Exchange - Fenêtres de connexion Outlook vers Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365) » explique comment identifier la cause et la corriger.
 
 :::
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -56,7 +56,7 @@ Lors de l'ajout du compte, cette recherche automatique des paramètres (autodisc
 
 ### Identifier les symptômes
 
-Vous êtes probablement concerné par ce problème si vous constatez les éléments suivants :
+Vous êtes concerné si vous observez ce qui suit :
 
 - Une fenêtre de connexion Microsoft 365 s'affiche en boucle dans Outlook et redemande sans cesse les identifiants.
 - Le message « Indiquez le compte à utiliser pour ouvrir autodiscover.xml » apparaît.

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Fenêtres de connexion Outlook vers Office 365"
 description: Diagnostiquez et corrigez les fenêtres de connexion Outlook qui pointent vers Office 365 alors que votre boîte mail est sur Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Si la configuration OVHcloud est correcte mais que les fenêtres de connexion pe
 Ce comportement se déclenche dans 2 situations principales :
 
 - **Le nom de domaine a été déclaré sur un tenant Office 365.** Lorsque vous ajoutez un domaine à un tenant Microsoft 365, Microsoft considère que les boîtes mail de ce domaine se trouvent dans le cloud. Outlook se connecte alors à l'autodiscover Office 365 au lieu de celui d'OVHcloud.
-- **Un compte identique a été créé dans Office 365.** Si une boîte mail ou un utilisateur portant la même adresse e-mail (ou le même UPN) existe dans un tenant Microsoft 365, Outlook peut être redirigé vers ce compte cloud plutôt que vers votre compte Exchange OVHcloud.
+- **Un compte Microsoft utilise déjà la même adresse e-mail.** Il peut s'agir d'un utilisateur d'un tenant Microsoft 365, portant la même adresse ou le même UPN. Il peut tout aussi bien s'agir d'un **compte Microsoft personnel** — créé pour activer une licence Office, par exemple — dont l'adresse de connexion est votre adresse Exchange. Dans les deux cas, Outlook trouve ce compte en premier et le suit, alors même qu'aucune boîte mail n'y est rattachée.
 
 :::tip
 Si vous n'utilisez pas (ou plus) Office 365 pour ce domaine, pensez également à supprimer le domaine ou le compte concerné du tenant Microsoft 365. Le correctif ci-dessous reste toutefois nécessaire tant qu'Outlook continue de privilégier l'endpoint Office 365.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 Sous Windows 11 avec Office 2024 LTSC (et, plus largement, les versions récentes), la clé `AutoDiscover` ne se trouve plus dans le contexte système mais dans le **contexte de l'utilisateur connecté**. Lancez donc l'Éditeur du Registre (ou l'invite de commandes) avec la session de l'utilisateur concerné, et non en tant qu'administrateur d'un autre compte.
 :::
+
+### Solution alternative : changer l'adresse de connexion du compte Microsoft
+
+Si le conflit provient d'un **compte Microsoft personnel**, vous pouvez supprimer la cause plutôt que la contourner. Cette méthode ne demande aucun droit administrateur sur l'ordinateur, ce qui en fait la seule option sur un poste géré par votre service informatique.
+
+1. Créez un alias sur votre compte Exchange OVHcloud, en suivant notre guide « [Utiliser les alias et redirections e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan) ».
+1. Connectez-vous à [account.microsoft.com](https://account.microsoft.com), ouvrez **Vos informations** puis **Gérer la façon dont vous vous connectez à Microsoft**, et ajoutez cet alias à votre compte Microsoft. Le message de vérification arrive dans votre boîte Exchange, puisque l'alias pointe vers elle.
+1. Définissez cet alias comme alias **principal**, puis retirez votre adresse Exchange du compte Microsoft.
+
+Outlook ne trouve plus de compte Microsoft pour votre adresse Exchange, et l'autodiscover se rabat sur le serveur OVHcloud.
+
+:::warning
+Microsoft impose ses propres limites : 10 alias au maximum par compte, l'alias principal ne peut être changé que deux fois par semaine, et une adresse liée à un compte professionnel ou scolaire ne peut pas devenir principale. Cette méthode ne vaut donc que pour un compte Microsoft personnel. Pour un tenant Microsoft 365, utilisez la clé de registre ci-dessus.
+
+:::
+
 
 ### Vérifier la connexion à Exchange OVHcloud
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ Ce comportement se déclenche dans 2 situations principales :
 - **Un compte Microsoft utilise déjà la même adresse e-mail.** Il peut s'agir d'un utilisateur d'un tenant Microsoft 365, portant la même adresse ou le même UPN. Il peut tout aussi bien s'agir d'un **compte Microsoft personnel** — créé pour activer une licence Office, par exemple — dont l'adresse de connexion est votre adresse Exchange. Dans les deux cas, Outlook trouve ce compte en premier et le suit, alors même qu'aucune boîte mail n'y est rattachée.
 
 :::tip
-Si vous n'utilisez pas (ou plus) Office 365 pour ce domaine, pensez également à supprimer le domaine ou le compte concerné du tenant Microsoft 365. Le correctif ci-dessous reste toutefois nécessaire tant qu'Outlook continue de privilégier l'endpoint Office 365.
+Si vous n'utilisez pas (ou plus) Office 365 pour ce domaine, pensez également à supprimer le domaine ou le compte concerné du tenant Microsoft 365. Tant qu'Outlook continue de privilégier l'endpoint Office 365, l'un des deux correctifs ci-dessous reste nécessaire.
 :::
+
+Deux correctifs suivent. La **clé de registre** fonctionne quelle que soit la cause, mais demande des droits administrateur sur l'ordinateur. Si le conflit provient d'un **compte Microsoft personnel**, changer son adresse de connexion supprime la cause et ne demande aucun droit particulier.
 
 ### Appliquer le correctif : la clé de registre `ExcludeExplicitO365Endpoint`
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ Ce comportement provient d'une fonctionnalité d'Outlook appelée « Direct Con
 
 - Disposer d'une [solution Exchange OVHcloud](/links/web/emails-hosted-exchange) déjà installée.
 - Disposer de l'application [Outlook classique](https://support.microsoft.com/fr-FR/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 ou Microsoft 365) sur Windows.
-- Disposer d'un accès administrateur au poste client pour modifier le registre Windows.
+- Disposer d'un accès administrateur au poste client pour modifier le registre Windows. Ce n'est pas nécessaire si vous appliquez la solution alternative décrite plus bas.
 - L'enregistrement SRV OVHcloud doit être correctement configuré dans la zone DNS du nom de domaine. Consultez notre guide « [Ajouter un nom de domaine sur son service Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain) ».
 
 <Region zones={['eu', 'ca']}>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Configurare un account email su Outlook classico per Windows
 description: Come configurare un account Exchange su Outlook classico per Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -61,6 +61,12 @@ Per installare Outlook classico sul computer Windows, scaricarlo dalla pagina Mi
 Al termine dell'installazione, per distinguere le due versioni quando vengono installate, digitare Outlook nella barra di ricerca di Windows. La differenza è visibile come mostrato qui di seguito.
 
 <img className="thumbnail" alt="outlook di Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Se Outlook richiede ripetutamente le credenziali Microsoft 365 invece di connettersi al server Exchange OVHcloud, significa che viene trovato per primo un account Microsoft che utilizza lo stesso indirizzo email. La nostra guida "[Exchange - Finestre di connessione Outlook a Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)" spiega come individuare la causa e correggerla.
 
 :::
 
@@ -170,5 +176,7 @@ Per ulteriori informazioni sulla configurazione di un indirizzo e-mail dall'appl
 [Configurare un account email su Outlook per Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Configurare un account Email Pro su Outlook per Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Finestre di connessione Outlook a Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ Gli account Exchange possono essere configurati su client di posta compatibili, 
 ## Prerequisiti
 
 - Disporre di una soluzione [Exchange](https://www.ovhcloud.com/it/emails-exchange/)
-- Aver installato [Outlook classico](https://support.microsoft.com/it-it/office/installare-o-reinstallare-la-versione-classica-di-outlook-in-un-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) su Windows.
+- Aver installato [Outlook classico](https://support.microsoft.com/it-it/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) su Windows.
 - Disporre delle credenziali associate all’indirizzo email da configurare
 - Il record SRV di OVHcloud deve essere configurato correttamente nella zona DNS del nome di dominio, consulta la nostra guida "[Aggiungere un dominio sul servizio Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain)".
 
@@ -46,7 +46,7 @@ Gli account Exchange possono essere configurati su client di posta compatibili, 
 [[fragment:support-scope]]
 
 :::info
-Utilizzi Outlook e poi per Mac? Consulta la nostra documentazione: [Configurare un account Exchange su Outlook per Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
+Utilizzi Outlook per Mac? Consulta la nostra documentazione: [Configurare un account Exchange su Outlook per Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
 
 :::
 
@@ -56,7 +56,7 @@ Utilizzi Outlook e poi per Mac? Consulta la nostra documentazione: [Configurare 
 :::warning
 Prima di iniziare la configurazione, è importante notare che l’applicazione Outlook inclusa gratuitamente con Windows 11 è [incompatibile](https://learn.microsoft.com/it-it/microsoft-365-apps/outlook/get-started/supported-account-types) con le offerte Exchange OVHcloud, *on-premises*. Lei dovrà utilizzare la versione **Outlook classica**.
 
-Per installare Outlook classico sul computer Windows, scaricarlo dalla pagina Microsoft "[Installa o reinstalla Outlook classico su un PC Windows](https://support.microsoft.com/it-it/office/installare-o-reinstallare-la-versione-classica-di-outlook-in-un-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5)" e installarlo.
+Per installare Outlook classico sul computer Windows, scaricarlo dalla pagina Microsoft "[Installa o reinstalla Outlook classico su un PC Windows](https://support.microsoft.com/it-it/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)" e installarlo.
 
 Al termine dell'installazione, per distinguere le due versioni quando vengono installate, digitare Outlook nella barra di ricerca di Windows. La differenza è visibile come mostrato qui di seguito.
 
@@ -168,7 +168,7 @@ Se è necessario effettuare un'operazione che potrebbe comportare la perdita dei
 ## Per saperne di più <a name="go-further"></a>
 
 :::info
-Per ulteriori informazioni sulla configurazione di un indirizzo e-mail dall'applicazione Outlook su Windows, vedere [Microsoft Help Center](https://support.microsoft.com/it-it/office/aggiungere-un-account-di-posta-in-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Per ulteriori informazioni sulla configurazione di un indirizzo e-mail dall'applicazione Outlook su Windows, vedere [Microsoft Help Center](https://support.microsoft.com/it-it/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Finestre di connessione Outlook a Office 365"
 description: Diagnostica e correggi le finestre di connessione di Outlook che puntano a Office 365 mentre la tua casella è su Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Se la configurazione OVHcloud è corretta ma le finestre di connessione persisto
 Questo comportamento si verifica in 2 situazioni principali:
 
 - **Il nome di dominio è stato dichiarato su un tenant Office 365.** Quando aggiungi un dominio a un tenant Microsoft 365, Microsoft considera che le caselle di questo dominio si trovino nel cloud. Outlook si connette quindi all'autodiscover Office 365 invece di quello di OVHcloud.
-- **Un account identico è stato creato in Office 365.** Se una casella o un utente con lo stesso indirizzo email (o lo stesso UPN) esiste in un tenant Microsoft 365, Outlook può essere reindirizzato verso questo account cloud anziché verso il tuo account Exchange OVHcloud.
+- **Un account Microsoft utilizza già lo stesso indirizzo email.** Può trattarsi di un utente di un tenant Microsoft 365, con lo stesso indirizzo o lo stesso UPN. Può altrettanto trattarsi di un **account Microsoft personale** — creato per attivare una licenza Office, per esempio — il cui indirizzo di accesso è il tuo indirizzo Exchange. In entrambi i casi Outlook trova questo account per primo e lo segue, anche se non vi è associata alcuna casella.
 
 :::tip
 Se non utilizzi (o non utilizzi più) Office 365 per questo dominio, ricordati anche di eliminare il dominio o l'account interessato dal tenant Microsoft 365. La correzione qui di seguito resta tuttavia necessaria finché Outlook continua a privilegiare l'endpoint Office 365.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 Su Windows 11 con Office 2024 LTSC (e, più in generale, le versioni recenti), la chiave `AutoDiscover` non si trova più nel contesto di sistema ma nel **contesto dell'utente connesso**. Avvia quindi l'Editor del Registro di sistema (o il prompt dei comandi) con la sessione dell'utente interessato, e non come amministratore di un altro account.
 :::
+
+### Soluzione alternativa: modificare l'indirizzo di accesso dell'account Microsoft
+
+Se il conflitto proviene da un **account Microsoft personale**, è possibile eliminare la causa invece di aggirarla. Questo metodo non richiede alcun diritto di amministratore sul computer, il che ne fa l'unica opzione su una postazione gestita dal tuo servizio informatico.
+
+1. Crea un alias sul tuo account Exchange OVHcloud, seguendo la nostra guida "[Utilizzare gli alias e i reindirizzamenti email](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan)".
+1. Accedi a [account.microsoft.com](https://account.microsoft.com), apri **Le tue info** poi **Gestisci l'accesso a Microsoft**, e aggiungi questo alias al tuo account Microsoft. Il messaggio di verifica arriva nella tua casella Exchange, poiché l'alias punta a essa.
+1. Imposta questo alias come alias **principale**, poi rimuovi il tuo indirizzo Exchange dall'account Microsoft.
+
+Outlook non trova più alcun account Microsoft per il tuo indirizzo Exchange e l'autodiscover ricade sul server OVHcloud.
+
+:::warning
+Microsoft applica i propri limiti: 10 alias al massimo per account, l'alias principale può essere modificato al massimo due volte a settimana e un indirizzo associato a un account aziendale o scolastico non può diventare principale. Questo metodo vale quindi solo per un account Microsoft personale. Per un tenant Microsoft 365, utilizza la chiave di registro sopra.
+
+:::
+
 
 ### Verificare la connessione a Exchange OVHcloud
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ Questo comportamento deriva da una funzionalità di Outlook chiamata "Direct Con
 
 - Disporre di una [soluzione Exchange OVHcloud](/links/web/emails-hosted-exchange) già installata.
 - Disporre dell'applicazione [Outlook classico](https://support.microsoft.com/it-it/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 o Microsoft 365) su Windows.
-- Disporre di un accesso amministratore alla postazione client per modificare il registro di Windows.
+- Disporre di un accesso amministratore alla postazione client per modificare il registro di Windows. Non è necessario se applichi la soluzione alternativa descritta più avanti.
 - Il record SRV di OVHcloud deve essere configurato correttamente nella zona DNS del nome di dominio. Consulta la nostra guida [Aggiungere un dominio sul servizio Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ Questo comportamento si verifica in 2 situazioni principali:
 - **Un account Microsoft utilizza già lo stesso indirizzo email.** Può trattarsi di un utente di un tenant Microsoft 365, con lo stesso indirizzo o lo stesso UPN. Può altrettanto trattarsi di un **account Microsoft personale** — creato per attivare una licenza Office, per esempio — il cui indirizzo di accesso è il tuo indirizzo Exchange. In entrambi i casi Outlook trova questo account per primo e lo segue, anche se non vi è associata alcuna casella.
 
 :::tip
-Se non utilizzi (o non utilizzi più) Office 365 per questo dominio, ricordati anche di eliminare il dominio o l'account interessato dal tenant Microsoft 365. La correzione qui di seguito resta tuttavia necessaria finché Outlook continua a privilegiare l'endpoint Office 365.
+Se non utilizzi (o non utilizzi più) Office 365 per questo dominio, ricordati anche di eliminare il dominio o l'account interessato dal tenant Microsoft 365. Finché Outlook continua a privilegiare l'endpoint Office 365, resta necessaria una delle due correzioni qui di seguito.
 :::
+
+Seguono due correzioni. La **chiave di registro** funziona qualunque sia la causa, ma richiede i diritti di amministratore sul computer. Se il conflitto proviene da un **account Microsoft personale**, modificare il suo indirizzo di accesso elimina la causa e non richiede tali diritti.
 
 ### Applicare la correzione: la chiave di registro `ExcludeExplicitO365Endpoint`
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Konfiguracja konta e-mail w programie Outlook dla systemu Windows
 description: Dowiedz się, jak skonfigurować konto Exchange w programie Outlook dla systemu Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -61,6 +61,12 @@ Aby zainstalować klasyczną wersję Outlook na swoim komputerze z Windows, pobi
 Po zakończeniu instalacji, aby odróżnić dwie wersje, gdy są zainstalowane, wpisz "Outlook" w pasku wyszukiwania systemu Windows. Możesz następnie zobaczyć różnicę, jak poniżej.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Jeśli Outlook wielokrotnie prosi o dane logowania Microsoft 365 zamiast połączyć się z serwerem Exchange OVHcloud, oznacza to, że najpierw zostaje znalezione konto Microsoft używające tego samego adresu e-mail. Nasz przewodnik "[Exchange - Outlook wyświetla monity logowania do Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)" wyjaśnia, jak zidentyfikować przyczynę i ją usunąć.
 
 :::
 
@@ -170,5 +176,7 @@ Aby uzyskać więcej informacji na temat konfigurowania konta e-mail z poziomu a
 [Konfiguracja konta e-mail, zawartego w usłudze MX Plan lub usłudze hostingu, w programie Outlook na urządzeniu z systemem Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016).
 
 [Konfiguracja konta E-mail Pro w programie Outlook na urządzeniu z systemem Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Outlook wyświetla monity logowania do Office 365](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Dołącz do [grona naszych użytkowników](/links/community).

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ Konta Exchange mogą być skonfigurowane w jednym z kompatybilnych programów po
 ## Wymagania początkowe
 
 - Wykupienie usługi [Exchange](https://www.ovhcloud.com/pl/emails-exchange/).
-- Posiadanie aplikacji [klasyczny program Outlook](https://support.microsoft.com/pl-pl/office/instalowanie-lub-ponowne-instalowanie-klasycznego-programu-outlook-na-komputerze-z-systemem-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) w systemie Windows.
+- Posiadanie aplikacji [klasyczny program Outlook](https://support.microsoft.com/pl-pl/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) w systemie Windows.
 - Dane do logowania do konta e-mail, które chcesz skonfigurować
 - Pole SRV OVHcloud musi być poprawnie skonfigurowane w strefie DNS domeny. Sprawdź nasz przewodnik [Dodaj domenę do usługi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
@@ -46,7 +46,7 @@ Konta Exchange mogą być skonfigurowane w jednym z kompatybilnych programów po
 [[fragment:support-scope]]
 
 :::info
-Używasz programu Outlook i później na urządzeniu Mac? Zapoznaj się z naszą dokumentacją: [Konfiguracja konta Exchange w programie Outlook na urządzeniu Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
+Używasz programu Outlook na urządzeniu Mac? Zapoznaj się z naszą dokumentacją: [Konfiguracja konta Exchange w programie Outlook na urządzeniu Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac).
 
 :::
 
@@ -56,7 +56,7 @@ Używasz programu Outlook i później na urządzeniu Mac? Zapoznaj się z naszą
 :::warning
 Przed rozpoczęciem konfigurowania swojego konta ważne jest, aby zauważyć, że aplikacja Outlook, która jest dostarczana za darmo z Windows 11, jest [niekompatybilna](https://learn.microsoft.com/pl-pl/microsoft-365-apps/outlook/get-started/supported-account-types) z rozwiązaniami OVHcloud Exchange, znanymi jako lokalne. Będziesz musiał użyć **klasycznej wersjiOutlook**.
 
-Aby zainstalować klasyczną wersję Outlook na swoim komputerze z Windows, pobierz ją ze strony Microsofta "[Instalowanie lub ponowne instalowanie klasycznego programu Outlook na komputerze z systemem Windows](https://support.microsoft.com/pl-pl/office/instalowanie-lub-ponowne-instalowanie-klasycznego-programu-outlook-na-komputerze-z-systemem-windows-5c94902b-31a5-4274-abb0-b07f4661edf5)", a następnie zainstaluj.
+Aby zainstalować klasyczną wersję Outlook na swoim komputerze z Windows, pobierz ją ze strony Microsofta "[Instalowanie lub ponowne instalowanie klasycznego programu Outlook na komputerze z systemem Windows](https://support.microsoft.com/pl-pl/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)", a następnie zainstaluj.
 
 Po zakończeniu instalacji, aby odróżnić dwie wersje, gdy są zainstalowane, wpisz "Outlook" w pasku wyszukiwania systemu Windows. Możesz następnie zobaczyć różnicę, jak poniżej.
 
@@ -168,7 +168,7 @@ Jeśli musisz wykonać operację, która może spowodować utratę danych przypi
 ## Sprawdź również <a name="go-further"></a>
 
 :::info
-Aby uzyskać więcej informacji na temat konfigurowania konta e-mail z poziomu aplikacji Outlook na urządzeniach z systemem Windows, zobacz [Centrum pomocy Microsoft](https://support.microsoft.com/pl-pl/office/dodawanie-konta-e-mail-do-programu-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Aby uzyskać więcej informacji na temat konfigurowania konta e-mail z poziomu aplikacji Outlook na urządzeniach z systemem Windows, zobacz [Centrum pomocy Microsoft](https://support.microsoft.com/pl-pl/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ To zachowanie jest wywoływane w 2 głównych sytuacjach:
 - **Konto Microsoft używa już tego samego adresu e-mail.** Może to być użytkownik dzierżawcy Microsoft 365, o tym samym adresie lub tej samej nazwie UPN. Może to być również **osobiste konto Microsoft** — utworzone na przykład w celu aktywacji licencji Office — którego adresem logowania jest Twój adres Exchange. W obu przypadkach program Outlook znajduje to konto jako pierwsze i podąża za nim, mimo że nie jest z nim powiązana żadna skrzynka pocztowa.
 
 :::tip
-Jeśli nie używasz już Office 365 dla tej domeny, rozważ również usunięcie odpowiedniej domeny lub konta z dzierżawcy Microsoft 365. Poniższe rozwiązanie pozostaje jednak konieczne, dopóki program Outlook nadal preferuje punkt końcowy Office 365.
+Jeśli nie używasz już Office 365 dla tej domeny, rozważ również usunięcie odpowiedniej domeny lub konta z dzierżawcy Microsoft 365. Dopóki program Outlook nadal preferuje punkt końcowy Office 365, konieczne pozostaje jedno z dwóch poniższych rozwiązań.
 :::
+
+Poniżej opisano dwa rozwiązania. **Klucz rejestru** działa niezależnie od przyczyny, ale wymaga uprawnień administratora na komputerze. Jeśli konflikt wynika z **osobistego konta Microsoft**, zmiana jego adresu logowania usuwa przyczynę i nie wymaga takich uprawnień.
 
 ### Zastosowanie rozwiązania: klucz rejestru `ExcludeExplicitO365Endpoint`
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ To zachowanie wynika z funkcji programu Outlook o nazwie "Direct Connect to Offi
 
 - Posiadanie skonfigurowanego już [rozwiązania Exchange OVHcloud](/links/web/emails-hosted-exchange).
 - Posiadanie aplikacji [klasyczny program Outlook](https://support.microsoft.com/pl-pl/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 lub Microsoft 365) w systemie Windows.
-- Posiadanie dostępu administratora do komputera klienckiego w celu edycji rejestru systemu Windows.
+- Posiadanie dostępu administratora do komputera klienckiego w celu edycji rejestru systemu Windows. Nie jest to konieczne, jeśli zastosujesz rozwiązanie alternatywne opisane poniżej.
 - Rekord SRV OVHcloud musi być poprawnie skonfigurowany w strefie DNS domeny. Sprawdź nasz przewodnik [Dodaj domenę do usługi Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Outlook wyświetla monity logowania do Office 365"
 description: Zdiagnozuj i rozwiąż powtarzające się monity logowania Outlooka do Office 365, gdy Twoja skrzynka pocztowa jest hostowana na Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Jeśli konfiguracja OVHcloud jest poprawna, ale okna logowania nadal się pojawi
 To zachowanie jest wywoływane w 2 głównych sytuacjach:
 
 - **Domena została zadeklarowana w dzierżawcy Office 365.** Gdy dodajesz domenę do dzierżawcy Microsoft 365, Microsoft uznaje, że skrzynki pocztowe tej domeny znajdują się w chmurze. Program Outlook łączy się wówczas z funkcją autodiscover Office 365 zamiast z tą należącą do OVHcloud.
-- **Identyczne konto zostało utworzone w Office 365.** Jeśli skrzynka pocztowa lub użytkownik o tym samym adresie e-mail (lub tej samej nazwie UPN) istnieje w dzierżawcy Microsoft 365, program Outlook może zostać przekierowany do tego konta w chmurze zamiast do Twojego konta Exchange OVHcloud.
+- **Konto Microsoft używa już tego samego adresu e-mail.** Może to być użytkownik dzierżawcy Microsoft 365, o tym samym adresie lub tej samej nazwie UPN. Może to być również **osobiste konto Microsoft** — utworzone na przykład w celu aktywacji licencji Office — którego adresem logowania jest Twój adres Exchange. W obu przypadkach program Outlook znajduje to konto jako pierwsze i podąża za nim, mimo że nie jest z nim powiązana żadna skrzynka pocztowa.
 
 :::tip
 Jeśli nie używasz już Office 365 dla tej domeny, rozważ również usunięcie odpowiedniej domeny lub konta z dzierżawcy Microsoft 365. Poniższe rozwiązanie pozostaje jednak konieczne, dopóki program Outlook nadal preferuje punkt końcowy Office 365.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 W systemie Windows 11 z pakietem Office 2024 LTSC (i, szerzej, w nowszych wersjach) klucz `AutoDiscover` nie znajduje się już w kontekście systemu, lecz w **kontekście zalogowanego użytkownika**. Dlatego uruchom Edytor rejestru (lub wiersz polecenia) w sesji użytkownika, którego to dotyczy, a nie jako administrator innego konta.
 :::
+
+### Rozwiązanie alternatywne: zmiana adresu logowania konta Microsoft
+
+Jeśli konflikt wynika z **osobistego konta Microsoft**, możesz usunąć przyczynę zamiast ją obchodzić. Ta metoda nie wymaga uprawnień administratora na komputerze, co czyni ją jedyną możliwością na stanowisku zarządzanym przez dział informatyczny.
+
+1. Utwórz alias na koncie Exchange OVHcloud, postępując zgodnie z naszym przewodnikiem "[Korzystanie z aliasów i przekierowań e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan)".
+1. Zaloguj się na [account.microsoft.com](https://account.microsoft.com), otwórz **Twoje informacje**, a następnie **Zarządzaj sposobem logowania do konta Microsoft** i dodaj ten alias do konta Microsoft. Wiadomość weryfikacyjna trafi do skrzynki Exchange, ponieważ alias na nią wskazuje.
+1. Ustaw ten alias jako alias **główny**, a następnie usuń adres Exchange z konta Microsoft.
+
+Program Outlook nie znajduje już konta Microsoft dla Twojego adresu Exchange, a funkcja autodiscover wraca do serwera OVHcloud.
+
+:::warning
+Microsoft narzuca własne ograniczenia: maksymalnie 10 aliasów na konto, alias główny można zmieniać najwyżej dwa razy w tygodniu, a adres powiązany z kontem służbowym lub szkolnym nie może stać się główny. Ta metoda dotyczy zatem wyłącznie osobistego konta Microsoft. W przypadku dzierżawcy Microsoft 365 użyj klucza rejestru powyżej.
+
+:::
+
 
 ### Sprawdzenie połączenia z Exchange OVHcloud
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -1,7 +1,7 @@
 ---
 title: Exchange - Configurar uma conta de e-mail no Outlook clássico para Windows
 description: Descubra como configurar uma conta Exchange no Outlook clássico para Windows
-lastUpdated: 2026-01-30
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -61,6 +61,12 @@ Para instalar o Outlook clássico no seu computador Windows, transfira-o a parti
 Quando a instalação for concluída, para distinguir as duas versões quando instaladas, digite "Outlook" na barra de pesquisa do Windows. Poderá verificar a diferença como se mostra a seguir.
 
 <img className="thumbnail" alt="outlook Windows" src="/images/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016/outlook-windows-identify01.png" loading="lazy" />
+
+:::
+
+
+:::info
+Se o Outlook pedir repetidamente credenciais Microsoft 365 em vez de se ligar ao seu servidor Exchange OVHcloud, é porque é encontrada primeiro uma conta Microsoft que utiliza o mesmo endereço de e-mail. O nosso guia "[Exchange - Início de sessão do Outlook (Office 365)](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)" explica como identificar a causa e corrigi-la.
 
 :::
 
@@ -170,5 +176,7 @@ Para obter mais informações sobre a configuração de um endereço de e-mail a
 [Configurar um endereço de e-mail no Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-outlook-2016)
 
 [Configurar uma conta E-mail Pro no Outlook para Windows](/guides/web-cloud/email-and-collaborative-solutions/email-pro/outlook-windows-configuration)
+
+[Exchange - Início de sessão do Outlook (Office 365)](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365)
 
 Fale com nossa [comunidade de utilizadores](/links/community).

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016.mdx
@@ -24,7 +24,7 @@ As contas Exchange podem ser usadas com vários softwares de e-mail (desde que s
 ## Requisitos
 
 - Ter o serviço [E-mail Pro](https://www.ovhcloud.com/pt/emails/).
-- Ter a aplicação [Outlook clássico](https://support.microsoft.com/pt-pt/office/instalar-ou-reinstalar-o-outlook-cl%C3%A1ssico-num-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5) em Windows.
+- Ter a aplicação [Outlook clássico](https://support.microsoft.com/pt-pt/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) em Windows.
 - Dispor das credenciais do endereço de e-mail que pretende configurar.
 - O campo SRV da OVHcloud deve estar corretamente configurado na zona DNS do domínio. Por favor, consulte o nosso guia "[Adicionar um domínio ao serviço Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain)".
 
@@ -46,7 +46,7 @@ As contas Exchange podem ser usadas com vários softwares de e-mail (desde que s
 [[fragment:support-scope]]
 
 :::info
-Utiliza o Outlook e posterior para Mac? consulte o nosso manual "[Configurar uma conta Exchange no Outlook para Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac)".
+Utiliza o Outlook para Mac? consulte o nosso manual "[Configurar uma conta Exchange no Outlook para Mac](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-outlook-2016-mac)".
 
 :::
 
@@ -56,7 +56,7 @@ Utiliza o Outlook e posterior para Mac? consulte o nosso manual "[Configurar uma
 :::warning
 Antes de iniciar a sua configuração, é importante notar que a aplicação Outlook incluída gratuitamente no Windows 11 é [incompatível](https://learn.microsoft.com/pt-pt/microsoft-365-apps/outlook/get-started/supported-account-types) com as ofertas Exchange OVHcloud, ditas *on-premises*. Deverá utilizar a versão **Outlook clássico**.
 
-Para instalar o Outlook clássico no seu computador Windows, transfira-o a partir da página Microsoft "[Instalar ou reinstalar o Outlook clássico num PC Windows](https://support.microsoft.com/pt-pt/office/instalar-ou-reinstalar-o-outlook-cl%C3%A1ssico-num-pc-windows-5c94902b-31a5-4274-abb0-b07f4661edf5)", e instale-o.
+Para instalar o Outlook clássico no seu computador Windows, transfira-o a partir da página Microsoft "[Instalar ou reinstalar o Outlook clássico num PC Windows](https://support.microsoft.com/pt-pt/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc)", e instale-o.
 
 Quando a instalação for concluída, para distinguir as duas versões quando instaladas, digite "Outlook" na barra de pesquisa do Windows. Poderá verificar a diferença como se mostra a seguir.
 
@@ -168,7 +168,7 @@ Se tiver de efetuar uma operação suscetível de causar a perda dos dados da su
 ## Quer saber mais? <a name="go-further"></a>
 
 :::info
-Para obter mais informações sobre a configuração de um endereço de e-mail a partir da aplicação Outlook no Windows, consulte o [Centro de Ajuda da Microsoft](https://support.microsoft.com/pt-pt/office/adicionar-uma-conta-de-correio-em-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
+Para obter mais informações sobre a configuração de um endereço de e-mail a partir da aplicação Outlook no Windows, consulte o [Centro de Ajuda da Microsoft](https://support.microsoft.com/pt-pt/Outlook/getstarted/add-an-email-account-to-outlook-for-windows).
 
 :::
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -89,8 +89,10 @@ Este comportamento é despoletado em 2 situações principais:
 - **Uma conta Microsoft já utiliza o mesmo endereço de e-mail.** Pode tratar-se de um utilizador de um tenant Microsoft 365, com o mesmo endereço ou o mesmo UPN. Pode igualmente tratar-se de uma **conta Microsoft pessoal** — criada para ativar uma licença Office, por exemplo — cujo endereço de início de sessão é o seu endereço Exchange. Em ambos os casos, o Outlook encontra esta conta em primeiro lugar e segue-a, embora nenhuma caixa de correio lhe esteja associada.
 
 :::tip
-Se não utiliza (ou já não utiliza) o Office 365 para este domínio, lembre-se também de eliminar o domínio ou a conta em causa do tenant Microsoft 365. No entanto, a correção abaixo continua a ser necessária enquanto o Outlook continuar a privilegiar o endpoint Office 365.
+Se não utiliza (ou já não utiliza) o Office 365 para este domínio, lembre-se também de eliminar o domínio ou a conta em causa do tenant Microsoft 365. Enquanto o Outlook continuar a privilegiar o endpoint Office 365, continua a ser necessária uma das duas correções abaixo.
 :::
+
+Seguem-se duas correções. A **chave de registo** funciona seja qual for a causa, mas exige direitos de administrador no computador. Se o conflito provém de uma **conta Microsoft pessoal**, alterar o seu endereço de início de sessão elimina a causa e não exige esses direitos.
 
 ### Aplicar a correção: a chave de registo `ExcludeExplicitO365Endpoint`
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Exchange - Início de sessão do Outlook (Office 365)"
 description: Diagnostique e corrija janelas de início de sessão do Outlook que apontam para Office 365 quando a sua caixa de correio está alojada no Exchange OVHcloud
-lastUpdated: 2026-06-24
+lastUpdated: 2026-08-28
 availableIn: [eu, ca]
 ---
 
@@ -86,7 +86,7 @@ Se a configuração OVHcloud estiver correta mas as janelas de início de sessã
 Este comportamento é despoletado em 2 situações principais:
 
 - **O nome de domínio foi declarado num tenant Office 365.** Quando adiciona um domínio a um tenant Microsoft 365, a Microsoft considera que as caixas de correio deste domínio se encontram na cloud. O Outlook liga-se então ao autodiscover do Office 365 em vez do da OVHcloud.
-- **Foi criada uma conta idêntica no Office 365.** Se existir uma caixa de correio ou um utilizador com o mesmo endereço de e-mail (ou o mesmo UPN) num tenant Microsoft 365, o Outlook pode ser reencaminhado para essa conta na cloud em vez de para a sua conta Exchange OVHcloud.
+- **Uma conta Microsoft já utiliza o mesmo endereço de e-mail.** Pode tratar-se de um utilizador de um tenant Microsoft 365, com o mesmo endereço ou o mesmo UPN. Pode igualmente tratar-se de uma **conta Microsoft pessoal** — criada para ativar uma licença Office, por exemplo — cujo endereço de início de sessão é o seu endereço Exchange. Em ambos os casos, o Outlook encontra esta conta em primeiro lugar e segue-a, embora nenhuma caixa de correio lhe esteja associada.
 
 :::tip
 Se não utiliza (ou já não utiliza) o Office 365 para este domínio, lembre-se também de eliminar o domínio ou a conta em causa do tenant Microsoft 365. No entanto, a correção abaixo continua a ser necessária enquanto o Outlook continuar a privilegiar o endpoint Office 365.
@@ -130,6 +130,22 @@ reg add HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover /t
 :::warning
 No Windows 11 com Office 2024 LTSC (e, de forma mais geral, as versões recentes), a chave `AutoDiscover` já não se encontra no contexto do sistema, mas no **contexto do utilizador com sessão iniciada**. Inicie então o Editor de Registo (ou a linha de comandos) com a sessão do utilizador em causa, e não como administrador de outra conta.
 :::
+
+### Solução alternativa: alterar o endereço de início de sessão da conta Microsoft
+
+Se o conflito provém de uma **conta Microsoft pessoal**, pode eliminar a causa em vez de a contornar. Este método não exige quaisquer direitos de administrador no computador, o que faz dele a única opção num posto gerido pelo seu departamento informático.
+
+1. Crie um alias na sua conta Exchange OVHcloud, seguindo o nosso guia "[Utilizar os alias e reencaminhamentos de e-mail](/guides/web-cloud/email-and-collaborative-solutions/common-email-features/feature-redirections#alias-exchange-emp-mxplan)".
+1. Inicie sessão em [account.microsoft.com](https://account.microsoft.com), abra **As suas informações** e depois **Gerir a forma como inicia sessão na Microsoft**, e adicione este alias à sua conta Microsoft. A mensagem de verificação chega à sua caixa Exchange, uma vez que o alias aponta para ela.
+1. Defina este alias como alias **principal** e retire depois o seu endereço Exchange da conta Microsoft.
+
+O Outlook deixa de encontrar uma conta Microsoft para o seu endereço Exchange, e o autodiscover recorre ao servidor da OVHcloud.
+
+:::warning
+A Microsoft impõe os seus próprios limites: 10 alias no máximo por conta, o alias principal só pode ser alterado duas vezes por semana e um endereço associado a uma conta profissional ou escolar não pode tornar-se principal. Este método aplica-se, portanto, apenas a uma conta Microsoft pessoal. Para um tenant Microsoft 365, utilize a chave de registo acima.
+
+:::
+
 
 ### Verificar a ligação ao Exchange OVHcloud
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/outlook-connecting-to-office-365.mdx
@@ -20,7 +20,7 @@ Este comportamento provém de uma funcionalidade do Outlook denominada "Direct C
 
 - Dispor de uma [solução Exchange OVHcloud](/links/web/emails-hosted-exchange) já instalada.
 - Dispor da aplicação [Outlook clássico](https://support.microsoft.com/pt-pt/Outlook/install-or-reinstall-classic-outlook-on-a-windows-pc) (Outlook 2016, 2019, 2021 ou Microsoft 365) em Windows.
-- Dispor de um acesso de administrador ao posto cliente para modificar o registo do Windows.
+- Dispor de um acesso de administrador ao posto cliente para modificar o registo do Windows. Não é necessário se aplicar a solução alternativa descrita mais abaixo.
 - O registo SRV da OVHcloud deve estar corretamente configurado na zona DNS do nome de domínio. Consulte o nosso guia [Adicionar um domínio ao serviço Exchange](/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain).
 
 <Region zones={['eu', 'ca']}>


### PR DESCRIPTION
Customer feedback (onegate, 2026-02-26): *"Il manque une information capitale dans cette doc : si le mail de l'utilisateur qui est configuré dans Outlook sert également de mail principal de compte côté Microsoft 365 et bien Outlook bypass l'autodiscover et ira systématiquement chercher sur 365... Plusieurs personnes se plaignent qu'OVH n'indique rien là dessus."*

## The mechanism is real, and Microsoft documents it

**Direct Connect to Microsoft 365** is one of the eight AutoDiscover lookup methods Outlook implements, and `ExcludeExplicitO365Endpoint` is one of the registry values that control them, under `HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\AutoDiscover`. Checked against [Microsoft's own documentation](https://learn.microsoft.com/en-us/previous-versions/troubleshoot/outlook/unexpected-autodiscover-behavior), not the forum thread the customer linked.

## OVHcloud does document it — just nowhere the customer would look

A dedicated guide already exists: `microsoft-exchange/outlook-connecting-to-office-365`, created by **SK-2638**, 7 locales, published in **June 2026** — four months after this report. It explains Direct Connect and gives the registry fix.

Three things kept the customer from finding it, or from using it.

| | |
|---|---|
| **The link only went one way** | The troubleshooting guide points to the configuration guide. The reverse was missing. A sweep of **all 30 Exchange guides** found that **not one** links to it — only the troubleshooting landing page and the sidebar do. A reader following the configuration guide and hitting the loop had no path to the fix. |
| **The cause was written for enterprises** | The guide said *"an identical account created in Office 365"*, *"a user in a Microsoft 365 tenant"*, *"the same UPN"*. It never said "personal" or "licence". |
| **The only remedy required admin rights** | The guide's own requirements say so. An employee on a workstation managed by their IT department was stuck. |

> [!NOTE]
> The reported case is a **personal** Microsoft account, typically created to activate an Office licence. The Microsoft thread says it plainly: *"il y a des gens qui ont un compte chez eux, par exemple pour leur licence Office, mais une boite mail ailleurs"*. That reader does not recognise themselves in the word "tenant", and concludes OVHcloud says nothing about their problem. That is exactly the complaint.

## 1. `how-to-configure-outlook-2016` — the reported guide

- a callout in the **Instructions** section, right before adding the account, points to the troubleshooting guide;
- the same guide is added to **Go further**.

## 2. `outlook-connecting-to-office-365` — the guide that had the answer

- the **second cause** now covers both a Microsoft 365 tenant user *and* a personal Microsoft account created for an Office licence, and explains that Outlook follows that account **even though no mailbox is attached to it**;
- **new section — change the sign-in address of the Microsoft account**: create an alias on the OVHcloud Exchange account, add it to the Microsoft account at `account.microsoft.com`, make it primary, then remove the Exchange address. This removes the cause instead of working around it, and needs **no administrator rights**;
- the section states the limits **Microsoft** imposes, which neither the customer nor the forum thread mentioned: at most 10 aliases per account, the primary alias can be changed at most twice a week, and an address linked to a work or school account **cannot** be made primary. That is what separates the two remedies — **the alias for a personal account, the registry key for a tenant**;
- the administrator-rights requirement is now qualified, since the alias method does not need it.

Verified before writing: OVHcloud Exchange does expose alias endpoints (`/email/exchange/…/account/{primaryEmailAddress}/alias`, GET/POST/DELETE), and the alias guide's anchor exists in all 7 locales.

## 3. Audited, deliberately not changed

- **`office-outlook-license`** — not relevant. The OVHcloud licence is a key and an ISO; no Microsoft account sign-in is involved. Read before concluding.
- **`diagnostic-advanced`** — its two "Microsoft 365" hits are the DNS record name `_autodiscover._tcp`.
- **`how-to-configure-outlook-2016-mac`** — **no source** establishes that Outlook for Mac performs the same bypass, and `ExcludeExplicitO365Endpoint` is a Windows registry key. Not documenting a behaviour that cannot be proven.

## 4. Proofread pass on both guides

- **21 Microsoft URLs** replaced with their canonical target. They only resolved through a redirect, while the sibling guide already used the correct form — two guides on the same subject, two generations of URL. All refetched afterwards: HTTP 200, no redirect.
- **`Outlook et ultérieur pour Mac`** in five locales — a leftover from *"Outlook 2016 and later"* whose version number had been dropped. The Italian read literally *"Outlook e poi per Mac"*, "Outlook and then for Mac". English and German were already clean.
- **French**: a typo (`de vote compte` for `de votre compte`), 11 missing non-breaking spaces, 3 guide citations without chevrons, and an infinitive where the imperative was needed.
- **English**: en-GB and en-US spellings coexisted (`authorisation` next to `authorization` and `synchronization`), and a full stop sat inside a link label.
- **10 rewordings** in EN and FR, mostly circumlocutions and calqued passives.

<details>
<summary><b>Pre-pass candidates dismissed, with the reason</b></summary>

- **3 × `Email Pro`** (`pl`, `pt`) — the terminology CSV prescribes `E-mail Pro` for those locales.
- A **chevron-spacing** decision worth flagging: the French file was left mixed, 4 non-breaking spaces against 5 regular ones. Measured across the French email corpus: **729 regular against 66 non-breaking** — the corpus convention is the regular space, but the sibling guide in this very PR is 12/12 non-breaking, which is also correct French typography. The file is now uniform on the non-breaking space (9/9), matching its twin. Five pre-existing occurrences were touched. Say the word if you would rather have it the other way.

</details>

## Validation

- `content:lint` passes
- **all 56 external links fetched** — the 307/429 responses on `ovhcloud.com` are bot protection, confirmed by the 429 on the Italian page
- every action button checked against `Messages_{lang}.json`: the **four genuine Control Panel labels are correct in all 7 locales**; the rest are Outlook labels, outside that source of truth
- 12 fragment tokens valid, no `<Api>` tag, zones `eu`/`ca` coherent, 7 locales present as real translations
- heading count compared before and after in all 14 files — nothing silently dropped
- German QA: 165 formal forms, 0 informal · Portuguese QA: pt-PT markers present
- `lastUpdated` bumped on both guides: the reader gets a path they did not have, and a remedy that was not written down
- a diff-scoped proofread pass reworded four sentences, all of them in prose added by this PR
- the two fixes are now introduced together, so a reader without administrator rights knows straight away that the alias route exists


2 guides × 7 locales, 14 files, 3 commits, +250 / −82.

---

**Out of scope, deliberately not fixed:**

- `Domaine associés` instead of `Domaines associés` in `exchange-dns-cname` and `exchange-adding-domain`, twice each.
- The Portuguese guide cites the Outlook button as `Conexão`, where pt-PT would say `Ligação`. A Portuguese speaker with Outlook in front of them should confirm — it is a Microsoft label, absent from `Messages_pt_PT.json`.
- Across the French email corpus, **729 chevron pairs** use a regular space instead of a non-breaking one.
