### PR TITLE
fix(i18n): add EN fallback symlinks for 6 sidebar guides

### DIFF
--- a/docs/de/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/de/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/reversibility/cold-storage.mdx

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx

--- a/docs/de/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/de/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/public-cloud/network-services/weight-load-balancer-member.mdx

--- a/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/de/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx

--- a/docs/es/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/es/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/reversibility/cold-storage.mdx

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx

--- a/docs/es/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/es/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/public-cloud/network-services/weight-load-balancer-member.mdx

--- a/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/es/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx

--- a/docs/it/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/it/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/reversibility/cold-storage.mdx

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx

--- a/docs/it/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/it/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/public-cloud/network-services/weight-load-balancer-member.mdx

--- a/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/it/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx

--- a/docs/pl/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/pl/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/reversibility/cold-storage.mdx

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx

--- a/docs/pl/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/pl/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/public-cloud/network-services/weight-load-balancer-member.mdx

--- a/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/pl/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx

--- a/docs/pt/guides/account-and-service-management/reversibility/cold-storage.mdx
+++ b/docs/pt/guides/account-and-service-management/reversibility/cold-storage.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/account-and-service-management/reversibility/cold-storage.mdx

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility.mdx

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst.mdx

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr.mdx

--- a/docs/pt/guides/public-cloud/network-services/weight-load-balancer-member.mdx
+++ b/docs/pt/guides/public-cloud/network-services/weight-load-balancer-member.mdx
@@ -1,0 +1,1 @@
+../../../../en/guides/public-cloud/network-services/weight-load-balancer-member.mdx

--- a/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
+++ b/docs/pt/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx
@@ -1,0 +1,1 @@
+../../../../../en/guides/storage-and-backup/backup-and-disaster-recovery-solutions/third-party-software/automated-plakar.mdx


### PR DESCRIPTION
Six guides are referenced in config/sidebar/index.md but absent from de/es/it/pl/pt, so they return 404 in those locales. Add the standard EN fallback symlinks (relative, pointing at docs/en/guides/...).

Guides:
- account-and-service-management/reversibility/cold-storage
- hosted-private-cloud/nutanix-on-ovhcloud/nutanix-hardware-compatibility
- hosted-private-cloud/nutanix-on-ovhcloud/set-up-mst
- hosted-private-cloud/nutanix-on-ovhcloud/set-up-pcbr
- public-cloud/network-services/weight-load-balancer-member
- storage-and-backup/.../third-party-software/automated-plakar

Deliberately excluded, where a missing file is intentional because the product or feature is not available in that market:
- web-cloud/messaging/sms/* in de/pt (SMS not sold there)
- sms-hlr, sms-with-reply, time-2-chat in es/it/pl (features not available even where SMS is sold)
- bare-metal-cloud/virtual-private-servers/n8n-sms in de/pt (depends on the SMS API)
- web-cloud/internet/internet-access/* (FR-only product)