### PR TITLE
feat(object-storage): add Object Storage landing page

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -839,7 +839,7 @@
             + [How to prevent your emails from being marked as spam](bare-metal-cloud/dedicated-servers/mail-sending-optimization)
     + [Storage and Backup](products/public-cloud-storage)
         + [Object Storage](products/public-cloud-storage-object-storage)
-            + [S3 compatible](products/public-cloud-storage-object-storage-s3)
+            + [S3 compatible](products/public-cloud-storage-object-storage-s3){landing=storage-and-backup/object-storage/landing-page-object-storage}
                 + [Key Concepts](products/public-cloud-storage-object-storage-s3-key-concepts)
                     + [Object Storage - Choosing the right storage class for your needs](storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs)
                     + [Object Storage - Endpoints and Object Storage geoavailability](storage-and-backup/object-storage/s3-location)
@@ -2272,7 +2272,7 @@
 + Storage and Backup
     + [Object Storage](products/storage-object-storage)
         + [Overview](storage-and-backup/object-storage/overview)
-        + [S3 compatible](products/storage-object-storage-s3)
+        + [S3 compatible](products/storage-object-storage-s3){landing=storage-and-backup/object-storage/landing-page-object-storage}
             + [Key Concepts](products/storage-object-storage-s3-key-concepts)
                 + [Object Storage - Choosing the right storage class for your needs](storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs)
                 + [Object Storage - Endpoints and Object Storage geoavailability](storage-and-backup/object-storage/s3-location)

--- a/docs/de/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — OVHcloud Dokumentation"
 description: "Speichern, teilen und bereitstellen von unstrukturierten Daten mit dem S3-kompatiblen Object Storage von OVHcloud."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Speichern und stellen Sie beliebige Mengen unstrukturierter Daten mit dem S3-kompatiblen Object Storage von OVHcloud bereit."

--- a/docs/de/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — OVHcloud Dokumentation"
+description: "Speichern, teilen und bereitstellen von unstrukturierten Daten mit dem S3-kompatiblen Object Storage von OVHcloud."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Speichern und stellen Sie beliebige Mengen unstrukturierter Daten mit dem S3-kompatiblen Object Storage von OVHcloud bereit."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Weiterführende Informationen
+  items:
+    - title: OVHcloud Community besuchen
+      link: https://community.ovhcloud.com/
+    - title: "Roadmap & Changelog ansehen"
+      link: https://www.ovhcloud.com/de/roadmap-changelog/
+    - title: Discord beitreten
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Fragen? OVHcloud Support kontaktieren"
+  description: "Finden Sie die Antworten auf Ihre Fragen in unserem Help Center."
+  actions:
+    - text: Support kontaktieren
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+OVHcloud Object Storage ist ein S3<sup>1</sup>-kompatibler Dienst zum Speichern und Bereitstellen beliebiger Mengen unstrukturierter Daten. Die Buckets sind über die Standard-S3-API zugänglich und mit dem gesamten S3-Ökosystem kompatibel. Für die kostengünstige Langzeitarchivierung steht die bandbasierte Speicherklasse Cold Archive zur Verfügung.
+
+## Erste Schritte
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Erste Schritte mit Object Storage" description="Erstellen Sie Ihren ersten Bucket und laden Sie Objekte über das Kundencenter hoch." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Die passende Speicherklasse auswählen" description="Vergleichen Sie Standard, High Performance und Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoints und Geoverfügbarkeit" description="Verfügbare Regionen, Endpoints und Bereitstellungsmodi." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Antworten auf die häufigsten Fragen." />
+</CardGrid>
+
+## Konfiguration
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Anwendungsfälle für Lifecycle und Replikation" description="Kombinieren Sie Lifecycle-Regeln und Replikation, um typische Anforderungen der Datenverwaltung zu erfüllen." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Asynchrone Replikation" description="Replizieren Sie Objekte zwischen Buckets in derselben oder einer anderen Region." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Machen Sie Objekte für einen festgelegten Aufbewahrungszeitraum unveränderlich." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Konfigurieren Sie Cross-Origin Resource Sharing für Ihre Buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Server Access Logging" description="Erfassen Sie detaillierte Anfrage-Logs eines Buckets für Sicherheits- und Zugriffsaudits." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Ein Objekt extern teilen" description="Erstellen Sie eine vorsignierte URL, um ein Objekt ohne Offenlegung Ihrer Zugangsdaten zu teilen." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Objekt-Metadaten abrufen" description="Rufen Sie ETag, Größe, Speicherklasse und Checksummen ab, ohne das Objekt herunterzuladen." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Statische Website hosten" description="Stellen Sie eine statische Website direkt aus einem Object Storage Bucket bereit." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS mit eigener Domain" description="Stellen Sie Ihre statische Website über HTTPS mit Ihrem eigenen Domainnamen bereit." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Buckets mit einem vRack verbinden" description="Verbinden Sie Object Storage mit anderen Ressourcen in einem privaten Netzwerk." />
+</CardGrid>
+
+## Tools & Integrationen
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Mounten, synchronisieren und übertragen Sie Daten mit der Rclone-CLI." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Verwalten Sie Buckets und Objekte über die Befehlszeile." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Stellen Sie Buckets mit dem OVHcloud Terraform Provider bereit und konfigurieren Sie sie." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Nutzen Sie Object Storage als Backup-Ziel für Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Verbinden Sie Nextcloud mit einem Object Storage Bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Verbinden Sie ownCloud mit einem Object Storage Bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Nutzen Sie Object Storage mit Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Nutzen Sie Object Storage als Replikationsziel für Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Sicherheit
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Identitäts- und Zugriffsverwaltung" description="Erstellen Sie S3-Benutzer und steuern Sie den Zugriff über IAM-Richtlinien." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="Bucket ACL" description="Legen Sie Zugriffsregeln für einzelne Buckets fest." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Modell der geteilten Verantwortung" description="Was OVHcloud verwaltet und wofür Sie verantwortlich sind." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Cold Archive im Überblick" description="Funktionsweise der bandbasierten Langzeitarchivierung und ihre Einsatzzwecke." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Erste Schritte mit Cold Archive" description="Erstellen Sie einen Cold Archive Container und archivieren Sie Ihre ersten Objekte." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Objekte aus Cold Archive wiederherstellen" description="Tauen Sie Objekte auf und rufen Sie sie aus der Speicherklasse Cold Archive ab." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Cold Storage – geteilte Verantwortung" description="Modell der geteilten Verantwortung für Archivierungs- und Wiederherstellungsdienste." />
+</CardGrid>
+
+## Fehlerbehebung & Grenzen
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Technische Grenzen" description="Feste Grenzwerte für Objektgröße, Anfrageraten und unterstützte S3-Operationen." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Spezifikationen der Local Zones" description="Besondere Merkmale und Grenzen von Object Storage in den Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Kompatibilität mit der S3-API" description="Welche Funktionen der S3-API von OVHcloud Object Storage unterstützt werden." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Performance optimieren" description="Byte Range Fetch, parallele Anfragen und weitere Optimierungsmethoden." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Datei-Uploads optimieren" description="Beschleunigen Sie die Übertragung Ihrer Dateien in einen Bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Bereitstellungsmodi im Vergleich" description="Unterschiede zwischen den Bereitstellungen 3-AZ, 1-AZ und Local Zone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Von einem anderen S3-Anbieter migrieren" description="Übertragen Sie Ihre Daten von einem S3-kompatiblen Anbieter zu OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Von Swift zu S3 migrieren" description="Wechseln Sie von OVHcloud Swift Object Storage zum S3-kompatiblen Object Storage." />
+</CardGrid>
+
+<sup>1</sup>: S3 ist eine Marke von Amazon Technologies, Inc. Der OVHcloud Dienst wird nicht von Amazon Technologies, Inc. gesponsert, unterstützt oder ist anderweitig mit dieser verbunden.

--- a/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,91 @@
+---
+title: "Object Storage S3 — OVHcloud documentation"
+description: "Store, share, and serve unstructured data with OVHcloud S3-compatible Object Storage."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Store and serve any amount of unstructured data with OVHcloud S3-compatible Object Storage."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Go further
+  items:
+    - title: Visit the OVHcloud community
+      link: https://community.ovhcloud.com/
+    - title: View the roadmap & changelog
+      link: https://www.ovhcloud.com/en/roadmap-changelog/
+    - title: Join Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Questions? Access OVHcloud support"
+  description: "Find the answer to your questions in our help centre."
+  actions:
+    - text: Access support
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+OVHcloud Object Storage is an S3-compatible service for storing and serving any volume of unstructured data. Buckets are accessible via the standard S3 API and compatible with the broader S3 ecosystem. A tape-backed Cold Archive storage class is available for long-term archiving at low cost.
+
+## Getting started
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Getting started with Object Storage" description="Create your first bucket and upload objects from the Control Panel." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Choosing the right storage class" description="Compare Standard, High Performance, and Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoints and geoavailability" description="Available regions, endpoints, and deployment modes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Answers to the most frequently asked questions." />
+</CardGrid>
+
+## Configuration
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Asynchronous replication" description="Replicate objects across buckets in the same or a different region." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Make objects immutable for a defined retention period." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configure cross-origin resource sharing on your buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Share an object externally" description="Generate a pre-signed URL to share an object without exposing credentials." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Static website hosting" description="Serve a static website directly from an Object Storage bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Connect buckets to a vRack" description="Link Object Storage to other resources in a private network." />
+</CardGrid>
+
+## Tools & integrations
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Mount, sync, and transfer data with the Rclone CLI." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Manage buckets and objects from the command line." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Provision and configure buckets with the OVHcloud Terraform provider." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Use Object Storage as a Veeam backup target." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Connect Nextcloud to an Object Storage bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Use Object Storage with Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Security
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Identity and access management" description="Create S3 users and control access with IAM policies." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="Bucket ACL" description="Set access control rules on individual buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Shared responsibility model" description="What OVHcloud manages and what you are responsible for." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Getting started with Cold Archive" description="Create a Cold Archive container and archive your first objects." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Restoring objects from Cold Archive" description="Unfreeze and retrieve objects from the Cold Archive storage class." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Cold Storage shared responsibility" description="Shared responsibility model for archive and restoration services." />
+</CardGrid>
+
+## Troubleshooting & limits
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Technical limitations" description="Hard limits on object size, request rates, and supported S3 operations." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Deployment modes comparison" description="Differences between 3-AZ, 1-AZ, and Local Zone deployments." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrate from another S3 provider" description="Move your data from an S3-compatible provider to OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrate from Swift to S3" description="Move from OVHcloud Swift Object Storage to S3-compatible Object Storage." />
+</CardGrid>

--- a/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — OVHcloud documentation"
 description: "Store, share, and serve unstructured data with OVHcloud S3-compatible Object Storage."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Store and serve any amount of unstructured data with OVHcloud S3-compatible Object Storage."

--- a/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -26,7 +26,7 @@ cta:
 
 import { LinkCard } from '@components/LinkCard';
 
-OVHcloud Object Storage is an S3-compatible service for storing and serving any volume of unstructured data. Buckets are accessible via the standard S3 API and compatible with the broader S3 ecosystem. A tape-backed Cold Archive storage class is available for long-term archiving at low cost.
+OVHcloud Object Storage is an S3<sup>1</sup>-compatible service for storing and serving any volume of unstructured data. Buckets are accessible via the standard S3 API and compatible with the broader S3 ecosystem. A tape-backed Cold Archive storage class is available for long-term archiving at low cost.
 
 ## Getting started
 
@@ -41,12 +41,18 @@ OVHcloud Object Storage is an S3-compatible service for storing and serving any 
 
 <CardGrid>
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Lifecycle and replication use cases" description="Combine lifecycle rules and replication to solve common data management needs." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Asynchronous replication" description="Replicate objects across buckets in the same or a different region." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Make objects immutable for a defined retention period." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configure cross-origin resource sharing on your buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Server access logging" description="Record detailed request logs on a bucket for security and access audits." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Share an object externally" description="Generate a pre-signed URL to share an object without exposing credentials." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Retrieve object metadata" description="Fetch ETag, size, storage class, and checksums without downloading the object." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Static website hosting" description="Serve a static website directly from an Object Storage bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS on a custom domain" description="Serve your static website over HTTPS using your own domain name." />
   <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Connect buckets to a vRack" description="Link Object Storage to other resources in a private network." />
 </CardGrid>
 
@@ -59,7 +65,9 @@ OVHcloud Object Storage is an S3-compatible service for storing and serving any 
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Provision and configure buckets with the OVHcloud Terraform provider." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Use Object Storage as a Veeam backup target." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Connect Nextcloud to an Object Storage bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Connect ownCloud to an Object Storage bucket." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Use Object Storage with Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Use Object Storage as a replication target for Pure Storage FlashBlade." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
 </CardGrid>
 
@@ -75,6 +83,7 @@ OVHcloud Object Storage is an S3-compatible service for storing and serving any 
 ## Cold Archive
 
 <CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Cold Archive overview" description="How tape-backed long-term archiving works and what it is designed for." />
   <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Getting started with Cold Archive" description="Create a Cold Archive container and archive your first objects." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Restoring objects from Cold Archive" description="Unfreeze and retrieve objects from the Cold Archive storage class." />
   <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
@@ -85,7 +94,13 @@ OVHcloud Object Storage is an S3-compatible service for storing and serving any 
 
 <CardGrid>
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Technical limitations" description="Hard limits on object size, request rates, and supported S3 operations." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Local Zones specifications" description="Specific characteristics and limits of Object Storage in Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="S3 API compliance" description="Which S3 API features OVHcloud Object Storage supports." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Optimising performance" description="Byte range fetch, parallel requests, and other tuning methods." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Optimise file uploads" description="Speed up transfers of your files into a bucket." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Deployment modes comparison" description="Differences between 3-AZ, 1-AZ, and Local Zone deployments." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrate from another S3 provider" description="Move your data from an S3-compatible provider to OVHcloud Object Storage." />
   <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrate from Swift to S3" description="Move from OVHcloud Swift Object Storage to S3-compatible Object Storage." />
 </CardGrid>
+
+<sup>1</sup>: S3 is a trademark of Amazon Technologies, Inc. OVHcloud's service is not sponsored by, endorsed by, or otherwise affiliated with Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — Documentación de OVHcloud"
+description: "Almacene, comparta y distribuya datos no estructurados con el Object Storage compatible con S3 de OVHcloud."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Almacene y distribuya cualquier volumen de datos no estructurados con el Object Storage compatible con S3 de OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Más información
+  items:
+    - title: Visitar la comunidad OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consultar el roadmap y el changelog
+      link: https://www.ovhcloud.com/es/roadmap-changelog/
+    - title: Unirse a Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "¿Tiene preguntas? Acceda al soporte de OVHcloud"
+  description: "Encuentre la respuesta a sus preguntas en nuestro centro de ayuda."
+  actions:
+    - text: Acceder al soporte
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+OVHcloud Object Storage es un servicio compatible con S3<sup>1</sup> para almacenar y distribuir cualquier volumen de datos no estructurados. Los buckets son accesibles a través de la API S3 estándar y son compatibles con el ecosistema S3 en su conjunto. La clase de almacenamiento Cold Archive, basada en cinta, está disponible para el archivado a largo plazo a bajo coste.
+
+## Primeros pasos
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Primeros pasos con Object Storage" description="Cree su primer bucket y suba objetos desde el área de cliente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Elegir la clase de almacenamiento adecuada" description="Compare Standard, High Performance y Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoints y disponibilidad geográfica" description="Regiones, endpoints y modos de despliegue disponibles." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Respuestas a las preguntas más frecuentes." />
+</CardGrid>
+
+## Configuración
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Casos de uso de lifecycle y replicación" description="Combine reglas de ciclo de vida y replicación para resolver necesidades habituales de gestión de datos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Replicación asíncrona" description="Replique objetos entre buckets de la misma región o de otra región." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Haga que sus objetos sean inmutables durante un periodo de retención definido." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configure el intercambio de recursos de origen cruzado en sus buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Registro de accesos al servidor" description="Registre logs detallados de las peticiones de un bucket para auditorías de seguridad y de acceso." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Compartir un objeto externamente" description="Genere una URL prefirmada para compartir un objeto sin exponer sus credenciales." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Consultar los metadatos de un objeto" description="Obtenga el ETag, el tamaño, la clase de almacenamiento y las sumas de verificación sin descargar el objeto." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Alojar un sitio web estático" description="Distribuya un sitio web estático directamente desde un bucket de Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS en un dominio personalizado" description="Distribuya su sitio web estático en HTTPS con su propio nombre de dominio." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Conectar buckets a un vRack" description="Conecte Object Storage a otros recursos de una red privada." />
+</CardGrid>
+
+## Herramientas e integraciones
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Monte, sincronice y transfiera datos con la CLI de Rclone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Gestione buckets y objetos desde la línea de comandos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Cree y configure buckets con el proveedor Terraform de OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Utilice Object Storage como destino de backup de Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Conecte Nextcloud a un bucket de Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Conecte ownCloud a un bucket de Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Utilice Object Storage con Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Utilice Object Storage como destino de replicación de Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Seguridad
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Gestión de identidades y accesos" description="Cree usuarios S3 y controle los accesos con políticas IAM." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="ACL de bucket" description="Defina reglas de control de acceso en cada bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Modelo de responsabilidad compartida" description="Qué gestiona OVHcloud y de qué es usted responsable." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Descripción general de Cold Archive" description="Cómo funciona el archivado a largo plazo en cinta y para qué está diseñado." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Primeros pasos con Cold Archive" description="Cree un contenedor Cold Archive y archive sus primeros objetos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Restaurar objetos de Cold Archive" description="Descongele y recupere objetos de la clase de almacenamiento Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Responsabilidad compartida de Cold Storage" description="Modelo de responsabilidad compartida para los servicios de archivado y restauración." />
+</CardGrid>
+
+## Resolución de problemas y límites
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Límites técnicos" description="Límites estrictos de tamaño de objeto, tasa de peticiones y operaciones S3 admitidas." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Especificaciones de Local Zones" description="Características y límites específicos de Object Storage en Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Conformidad con la API S3" description="Qué funcionalidades de la API S3 admite OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Optimizar el rendimiento" description="Byte range fetch, peticiones en paralelo y otros métodos de ajuste." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Optimizar el envío de archivos" description="Acelere la transferencia de sus archivos a un bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Comparación de los modos de despliegue" description="Diferencias entre los despliegues 3-AZ, 1-AZ y Local Zone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrar desde otro proveedor S3" description="Traslade sus datos desde un proveedor compatible con S3 a OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrar de Swift a S3" description="Pase del Object Storage Swift de OVHcloud al Object Storage compatible con S3." />
+</CardGrid>
+
+<sup>1</sup>: S3 es una marca de Amazon Technologies, Inc. El servicio de OVHcloud no está patrocinado, respaldado ni afiliado de ninguna manera a Amazon Technologies, Inc.

--- a/docs/es/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — Documentación de OVHcloud"
 description: "Almacene, comparta y distribuya datos no estructurados con el Object Storage compatible con S3 de OVHcloud."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Almacene y distribuya cualquier volumen de datos no estructurados con el Object Storage compatible con S3 de OVHcloud."

--- a/docs/fr/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — documentation OVHcloud"
 description: "Stockez, partagez et diffusez vos données non structurées avec l'Object Storage OVHcloud compatible S3."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Stockez et diffusez n'importe quel volume de données non structurées avec l'Object Storage OVHcloud compatible S3."

--- a/docs/fr/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — documentation OVHcloud"
+description: "Stockez, partagez et diffusez vos données non structurées avec l'Object Storage OVHcloud compatible S3."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Stockez et diffusez n'importe quel volume de données non structurées avec l'Object Storage OVHcloud compatible S3."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Aller plus loin
+  items:
+    - title: Échangez avec notre communauté d'utilisateurs
+      link: https://community.ovhcloud.com/
+    - title: "Consulter la roadmap et le changelog"
+      link: https://www.ovhcloud.com/fr/roadmap-changelog/
+    - title: Rejoindre le Discord OVHcloud
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Une question ? Contactez le support OVHcloud"
+  description: "Trouvez la réponse à vos questions dans notre centre d'aide."
+  actions:
+    - text: Accéder au support
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+L'Object Storage OVHcloud est un service compatible S3<sup>1</sup> permettant de stocker et de diffuser n'importe quel volume de données non structurées. Vos buckets sont accessibles via l'API S3 standard et compatibles avec l'ensemble de l'écosystème S3. Une classe de stockage Cold Archive, adossée à des bandes magnétiques, est disponible pour l'archivage longue durée à faible coût.
+
+## Premiers pas
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Premiers pas avec Object Storage" description="Créez votre premier bucket et téléversez des objets depuis l'espace client." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Choisir une classe de stockage" description="Comparez les classes Standard, Haute Performance et Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoints et géo-disponibilité" description="Régions, endpoints et modes de déploiement disponibles." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Les réponses aux questions les plus fréquentes." />
+</CardGrid>
+
+## Configuration
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Règles lifecycle" description="Faites expirer ou transitionner automatiquement vos objets selon leur ancienneté ou leur préfixe." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Cas d'usage lifecycle et réplication" description="Combinez règles lifecycle et réplication pour répondre aux besoins courants de gestion des données." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Gestion de versions" description="Conservez plusieurs versions d'un objet et récupérez-les après une suppression accidentelle." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Réplication asynchrone" description="Répliquez vos objets entre buckets dans la même région ou dans une région différente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Écritures conditionnelles" description="Utilisez les en-têtes If-Match et If-None-Match pour éviter les écrasements et les accès concurrents." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Rendez vos objets immuables pendant une durée de rétention définie." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configurez le partage des ressources entre origines multiples sur vos buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Server Access Logging" description="Enregistrez des journaux de requêtes détaillés sur un bucket pour vos audits de sécurité et d'accès." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Partager un objet en externe" description="Générez une URL pré-signée pour partager un objet sans exposer vos identifiants." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Récupérer les métadonnées d'un objet" description="Obtenez l'ETag, la taille, la classe de stockage et les sommes de contrôle sans télécharger l'objet." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Téléversement depuis le navigateur (POST)" description="Permettez à vos utilisateurs de téléverser directement depuis leur navigateur via un formulaire signé côté serveur." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Hébergement de site statique" description="Diffusez un site web statique directement depuis un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS sur un domaine personnalisé" description="Diffusez votre site statique en HTTPS avec votre propre nom de domaine." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Connecter vos buckets à un vRack" description="Reliez votre Object Storage à d'autres ressources au sein d'un réseau privé." />
+</CardGrid>
+
+## Outils et intégrations
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Montez, synchronisez et transférez vos données avec la ligne de commande Rclone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Gérez vos buckets et vos objets depuis la ligne de commande." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transférez vos fichiers avec WinSCP sous Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Créez et configurez vos buckets avec le provider Terraform OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Utilisez l'Object Storage comme cible de sauvegarde Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Connectez Nextcloud à un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Connectez ownCloud à un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Utilisez l'Object Storage avec Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Utilisez l'Object Storage comme cible de réplication pour Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Compatibilité des applications tierces" description="La liste complète des applications et clients S3 compatibles." />
+</CardGrid>
+
+## Sécurité
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Gestion des identités et des accès" description="Créez des utilisateurs S3 et contrôlez leurs accès avec des politiques IAM." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="Bucket ACL" description="Définissez des règles de contrôle d'accès sur chaque bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Chiffrement côté serveur (SSE-C / SSE-OMK)" description="Chiffrez vos objets au repos avec des clés fournies par vous ou gérées par OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Partage des responsabilités" description="Ce qu'OVHcloud gère et ce qui reste à votre charge." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Présentation de Cold Archive" description="Le fonctionnement de l'archivage longue durée sur bande et les usages auxquels il répond." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Premiers pas avec Cold Archive" description="Créez un conteneur Cold Archive et archivez vos premiers objets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Restaurer des objets depuis Cold Archive" description="Déverrouillez et récupérez vos objets depuis la classe de stockage Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="FAQ Cold Archive" description="Les réponses aux questions fréquentes sur Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Responsabilité partagée Cold Storage" description="Le partage des responsabilités pour les services d'archivage et de restauration." />
+</CardGrid>
+
+## Dépannage et limites
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Limites techniques" description="Les limites strictes de taille d'objet, de débit de requêtes et d'opérations S3 prises en charge." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Spécifications Local Zones" description="Les caractéristiques et limites spécifiques de l'Object Storage en Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Conformité à l'API S3" description="Les fonctionnalités de l'API S3 prises en charge par l'Object Storage OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Optimiser les performances" description="Lecture par plage d'octets, requêtes parallèles et autres méthodes d'optimisation." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Optimiser l'envoi de vos fichiers" description="Accélérez le transfert de vos fichiers vers un bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Comparaison des modes de déploiement" description="Les différences entre les déploiements 3-AZ, 1-AZ et Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrer depuis un autre fournisseur S3" description="Déplacez vos données depuis un fournisseur compatible S3 vers l'Object Storage OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrer de Swift vers S3" description="Passez de l'Object Storage Swift OVHcloud à l'Object Storage compatible S3." />
+</CardGrid>
+
+<sup>1</sup> : S3 est une marque déposée appartenant à Amazon Technologies, Inc. Les services de OVHcloud ne sont pas sponsorisés, approuvés, ou affiliés de quelque manière que ce soit.

--- a/docs/it/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — Documentazione OVHcloud"
 description: "Archiviate, condividete e distribuite dati non strutturati con l'Object Storage OVHcloud compatibile S3."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Archiviate e distribuite qualsiasi volume di dati non strutturati con l'Object Storage OVHcloud compatibile S3."

--- a/docs/it/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — Documentazione OVHcloud"
+description: "Archiviate, condividete e distribuite dati non strutturati con l'Object Storage OVHcloud compatibile S3."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Archiviate e distribuite qualsiasi volume di dati non strutturati con l'Object Storage OVHcloud compatibile S3."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Per saperne di più
+  items:
+    - title: Confrontatevi con la nostra community di utenti
+      link: https://community.ovhcloud.com/
+    - title: "Consultare la roadmap e il changelog"
+      link: https://www.ovhcloud.com/it/roadmap-changelog/
+    - title: Unitevi al Discord OVHcloud
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Una domanda? Contattate l'assistenza OVHcloud"
+  description: "Trovate la risposta alle vostre domande nel nostro centro assistenza."
+  actions:
+    - text: Accedere all'assistenza
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+L'Object Storage OVHcloud è un servizio compatibile S3<sup>1</sup> per archiviare e distribuire qualsiasi volume di dati non strutturati. I bucket sono accessibili tramite l'API S3 standard e compatibili con l'ecosistema S3 nel suo complesso. Una classe di storage Cold Archive, basata su supporti a nastro, è disponibile per l'archiviazione a lungo termine a basso costo.
+
+## Primi passi
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Primi passi con Object Storage" description="Create il vostro primo bucket e caricate degli oggetti dallo Spazio Cliente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Scegliere la classe di storage" description="Confrontate Standard, High Performance e Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoint e geodisponibilità" description="Region, endpoint e modalità di deployment disponibili." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Le risposte alle domande più frequenti." />
+</CardGrid>
+
+## Configurazione
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Casi d'uso lifecycle e replica" description="Combinate le regole di lifecycle e la replica per rispondere alle esigenze più comuni di gestione dei dati." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Replica asincrona" description="Replicate gli oggetti tra bucket nella stessa region o in una region differente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Rendete i vostri oggetti immutabili per un periodo di retention definito." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configurate la condivisione delle risorse cross-origin sui vostri bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Log di accesso al server" description="Registrate log dettagliati delle richieste su un bucket per gli audit di sicurezza e di accesso." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Condividere un oggetto all'esterno" description="Generate un URL pre-firmato per condividere un oggetto senza esporre le vostre credenziali." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Recuperare i metadati di un oggetto" description="Ottenete ETag, dimensione, classe di storage e checksum senza scaricare l'oggetto." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Hosting di un sito statico" description="Distribuite un sito web statico direttamente da un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS su un dominio personalizzato" description="Distribuite il vostro sito statico in HTTPS utilizzando il vostro nome di dominio." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Collegare dei bucket a un vRack" description="Collegate Object Storage ad altre risorse all'interno di una rete privata." />
+</CardGrid>
+
+## Strumenti e integrazioni
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Montate, sincronizzate e trasferite i vostri dati con la CLI Rclone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Gestite bucket e oggetti dalla riga di comando." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Create e configurate dei bucket con il provider Terraform OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Utilizzate Object Storage come destinazione di backup Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Collegate Nextcloud a un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Collegate ownCloud a un bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Utilizzate Object Storage con Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Utilizzate Object Storage come destinazione di replica per Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Sicurezza
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Gestione di identità e accessi" description="Create degli utenti S3 e controllate gli accessi con le policy IAM." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="ACL dei bucket" description="Definite delle regole di controllo degli accessi sui singoli bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Modello di responsabilità condivisa" description="Ciò che OVHcloud gestisce e ciò di cui siete responsabili." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Panoramica di Cold Archive" description="Come funziona l'archiviazione a lungo termine su nastro e a quali usi è destinata." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Primi passi con Cold Archive" description="Create un container Cold Archive e archiviate i vostri primi oggetti." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Ripristinare oggetti da Cold Archive" description="Sbloccate e recuperate gli oggetti dalla classe di storage Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Responsabilità condivisa Cold Storage" description="Modello di responsabilità condivisa per i servizi di archiviazione e ripristino." />
+</CardGrid>
+
+## Risoluzione dei problemi e limiti
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Limiti tecnici" description="Limiti sulla dimensione degli oggetti, sulla frequenza delle richieste e sulle operazioni S3 supportate." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Specifiche delle Local Zones" description="Caratteristiche e limiti specifici di Object Storage nelle Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Conformità all'API S3" description="Quali funzionalità dell'API S3 sono supportate da Object Storage OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Ottimizzare le performance" description="Byte range fetch, richieste parallele e altri metodi di ottimizzazione." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Ottimizzare l'invio dei file" description="Accelerate il trasferimento dei vostri file verso un bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Confronto delle modalità di deployment" description="Le differenze tra i deployment 3-AZ, 1-AZ e Local Zone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrare da un altro provider S3" description="Trasferite i vostri dati da un provider compatibile S3 verso Object Storage OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrare da Swift a S3" description="Passate dall'Object Storage Swift di OVHcloud all'Object Storage compatibile S3." />
+</CardGrid>
+
+<sup>1</sup>: S3 è un marchio di Amazon Technologies, Inc. Il servizio OVHcloud non è sponsorizzato, approvato o altrimenti affiliato con Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — dokumentacja OVHcloud"
+description: "Przechowuj, udostępniaj i dostarczaj dane nieustrukturyzowane dzięki kompatybilnej z S3 usłudze OVHcloud Object Storage."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Przechowuj i udostępniaj dowolną ilość danych nieustrukturyzowanych dzięki kompatybilnej z S3 usłudze OVHcloud Object Storage."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Sprawdź również
+  items:
+    - title: Odwiedź społeczność OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Przejrzyj mapę drogową i rejestr zmian
+      link: https://www.ovhcloud.com/pl/roadmap-changelog/
+    - title: Dołącz do Discorda
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Masz pytania? Skontaktuj się z pomocą techniczną OVHcloud"
+  description: "Znajdź odpowiedź na swoje pytania w naszym centrum pomocy."
+  actions:
+    - text: Przejdź do pomocy technicznej
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+OVHcloud Object Storage to kompatybilna z S3<sup>1</sup> usługa do przechowywania i udostępniania dowolnej ilości danych nieustrukturyzowanych. Buckety są dostępne za pośrednictwem standardowego API S3 i kompatybilne z szerokim ekosystemem S3. Klasa przestrzeni dyskowej Cold Archive, oparta na taśmach magnetycznych, umożliwia długoterminową archiwizację przy niskich kosztach.
+
+## Pierwsze kroki
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Pierwsze kroki z Object Storage" description="Utwórz pierwszy bucket i wgraj obiekty z Panelu klienta." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Wybór odpowiedniej klasy przestrzeni dyskowej" description="Porównaj klasy Standard, High Performance i Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Punkty końcowe i dostępność geograficzna" description="Dostępne regiony, punkty końcowe i tryby wdrożenia." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Odpowiedzi na najczęściej zadawane pytania." />
+</CardGrid>
+
+## Konfiguracja
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Przypadki użycia cyklu życia i replikacji" description="Połącz reguły cyklu życia i replikację, aby zaspokoić typowe potrzeby w zakresie zarządzania danymi." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Replikacja asynchroniczna" description="Replikuj obiekty między bucketami w tym samym lub w innym regionie." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Nadaj obiektom niezmienność na określony okres retencji." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Skonfiguruj mechanizm cross-origin resource sharing w swoich bucketach." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Rejestrowanie dostępu do serwera" description="Zapisuj szczegółowe logi żądań dla bucketu na potrzeby audytów bezpieczeństwa i dostępu." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Udostępnianie obiektu na zewnątrz" description="Wygeneruj wstępnie podpisany adres URL, aby udostępnić obiekt bez ujawniania danych uwierzytelniających." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Pobieranie metadanych obiektu" description="Pobierz ETag, rozmiar, klasę przestrzeni dyskowej i sumy kontrolne bez pobierania samego obiektu." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Hosting strony statycznej" description="Udostępniaj stronę statyczną bezpośrednio z bucketu Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS we własnej domenie" description="Udostępniaj swoją stronę statyczną przez HTTPS z użyciem własnej nazwy domeny." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Podłączanie bucketów do vRacka" description="Połącz Object Storage z innymi zasobami w sieci prywatnej." />
+</CardGrid>
+
+## Narzędzia i integracje
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Montuj, synchronizuj i przenoś dane za pomocą interfejsu wiersza poleceń Rclone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Zarządzaj bucketami i obiektami z wiersza poleceń." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Twórz i konfiguruj buckety za pomocą dostawcy Terraform OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Wykorzystaj Object Storage jako miejsce docelowe kopii zapasowych Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Podłącz Nextcloud do bucketu Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Podłącz ownCloud do bucketu Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Korzystaj z Object Storage z Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Wykorzystaj Object Storage jako miejsce docelowe replikacji dla Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Bezpieczeństwo
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Zarządzanie tożsamością i dostępem" description="Twórz użytkowników S3 i kontroluj dostęp za pomocą polityk IAM." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="Bucket ACL" description="Ustaw reguły kontroli dostępu dla poszczególnych bucketów." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Model współodpowiedzialności" description="Za co odpowiada OVHcloud, a za co odpowiadasz Ty." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Cold Archive — przegląd" description="Jak działa długoterminowa archiwizacja na taśmach magnetycznych i do czego została zaprojektowana." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Pierwsze kroki z Cold Archive" description="Utwórz kontener Cold Archive i zarchiwizuj pierwsze obiekty." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Przywracanie obiektów z Cold Archive" description="Odmroź i pobierz obiekty z klasy przestrzeni dyskowej Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Współodpowiedzialność Cold Storage" description="Model współodpowiedzialności dla usług archiwizacji i przywracania danych." />
+</CardGrid>
+
+## Rozwiązywanie problemów i ograniczenia
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Ograniczenia techniczne" description="Twarde limity dotyczące rozmiaru obiektów, liczby żądań i obsługiwanych operacji S3." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Specyfikacja Local Zones" description="Szczególne właściwości i ograniczenia Object Storage w Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Zgodność z API S3" description="Które funkcje API S3 są obsługiwane przez OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Optymalizacja wydajności" description="Pobieranie zakresów bajtów, żądania równoległe i inne metody optymalizacji." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Optymalizacja wysyłania plików" description="Przyspiesz transfer swoich plików do bucketu." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Porównanie trybów wdrożenia" description="Różnice między wdrożeniami 3-AZ, 1-AZ i Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migracja od innego dostawcy S3" description="Przenieś swoje dane od dostawcy kompatybilnego z S3 do OVHcloud Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migracja ze Swift do S3" description="Przejdź z OVHcloud Swift Object Storage na kompatybilną z S3 usługę Object Storage." />
+</CardGrid>
+
+<sup>1</sup>: S3 jest znakiem towarowym Amazon Technologies, Inc. Usługa OVHcloud nie jest sponsorowana, popierana ani w żaden sposób powiązana z Amazon Technologies, Inc.

--- a/docs/pl/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — dokumentacja OVHcloud"
 description: "Przechowuj, udostępniaj i dostarczaj dane nieustrukturyzowane dzięki kompatybilnej z S3 usłudze OVHcloud Object Storage."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Przechowuj i udostępniaj dowolną ilość danych nieustrukturyzowanych dzięki kompatybilnej z S3 usłudze OVHcloud Object Storage."

--- a/docs/pt/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Object Storage S3 — documentação OVHcloud"
 description: "Armazene, partilhe e distribua dados não estruturados com o Object Storage compatível com S3 da OVHcloud."
-lastUpdated: 2026-07-02
+lastUpdated: 2026-08-31
 pageType: landing
 banner: true
 tagline: "Armazene e distribua qualquer volume de dados não estruturados com o Object Storage compatível com S3 da OVHcloud."

--- a/docs/pt/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/landing-page-object-storage.mdx
@@ -1,0 +1,106 @@
+---
+title: "Object Storage S3 — documentação OVHcloud"
+description: "Armazene, partilhe e distribua dados não estruturados com o Object Storage compatível com S3 da OVHcloud."
+lastUpdated: 2026-07-02
+pageType: landing
+banner: true
+tagline: "Armazene e distribua qualquer volume de dados não estruturados com o Object Storage compatível com S3 da OVHcloud."
+availableIn: [eu, ca, apac]
+goFurther:
+  title: Quer saber mais?
+  items:
+    - title: Visitar a comunidade OVHcloud
+      link: https://community.ovhcloud.com/
+    - title: Consultar o roadmap e o changelog
+      link: https://www.ovhcloud.com/pt/roadmap-changelog/
+    - title: Juntar-se ao Discord
+      link: https://discord.gg/ovhcloud
+cta:
+  title: "Tem dúvidas? Aceda ao suporte OVHcloud"
+  description: "Encontre a resposta às suas questões no nosso centro de ajuda."
+  actions:
+    - text: Aceder ao suporte
+      link: https://help.ovhcloud.com/
+      theme: brand
+---
+
+import { LinkCard } from '@components/LinkCard';
+
+O Object Storage da OVHcloud é um serviço compatível com S3<sup>1</sup> para armazenar e distribuir qualquer volume de dados não estruturados. Os buckets estão acessíveis através da API S3 padrão e são compatíveis com o ecossistema S3 mais amplo. Está disponível uma classe de armazenamento Cold Archive baseada em fita para arquivamento a longo prazo a baixo custo.
+
+## Primeiros passos
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-getting-started-with-object-storage" title="Começar a utilizar o Object Storage" description="Crie o seu primeiro bucket e envie objetos a partir da área de cliente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-choosing-the-right-storage-class-for-your-needs" title="Escolher a classe de armazenamento adequada" description="Compare as classes Standard, High Performance e Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-location" title="Endpoints e disponibilidade geográfica" description="Regiões, endpoints e modos de implementação disponíveis." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-faq" title="FAQ" description="Respostas às questões mais frequentes." />
+</CardGrid>
+
+## Configuração
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-lifecycle" title="Lifecycle rules" description="Automatically expire or transition objects based on age or prefix." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-use-cases-lifecycle-replication" title="Casos de utilização de lifecycle e replicação" description="Combine regras de ciclo de vida e replicação para responder a necessidades comuns de gestão de dados." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-versioning" title="Versioning" description="Keep multiple versions of an object and recover from accidental deletes." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-asynchronous-replication" title="Replicação assíncrona" description="Replique objetos entre buckets na mesma região ou numa região diferente." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-conditional-writes" title="Conditional writes" description="Use If-Match and If-None-Match headers to prevent overwrites and race conditions." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-managing-object-lock" title="Object Lock (WORM)" description="Torne os seus objetos imutáveis durante um período de retenção definido." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-setting-up-cors" title="CORS" description="Configure o cross-origin resource sharing nos seus buckets." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-server-access-logging" title="Registo de acessos ao servidor" description="Registe logs detalhados dos pedidos num bucket para auditorias de segurança e de acessos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-share-object-externally" title="Partilhar um objeto externamente" description="Gere um URL pré-assinado para partilhar um objeto sem expor as suas credenciais." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-get-object-attributes" title="Obter os metadados de um objeto" description="Consulte o ETag, o tamanho, a classe de armazenamento e as checksums sem descarregar o objeto." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-post-object-upload" title="Browser-based uploads (POST)" description="Let users upload straight from their browser with a server-signed form." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website" title="Alojamento de um site estático" description="Distribua um site estático diretamente a partir de um bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-website-https" title="HTTPS num domínio personalizado" description="Distribua o seu site estático em HTTPS utilizando o seu próprio nome de domínio." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/connect-other-ressources-in-vrack-private-network" title="Ligar buckets a um vRack" description="Ligue o Object Storage a outros recursos numa rede privada." />
+</CardGrid>
+
+## Ferramentas e integrações
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-rclone" title="Rclone" description="Monte, sincronize e transfira dados com a linha de comandos Rclone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3cmd" title="S3cmd" description="Gira os seus buckets e objetos a partir da linha de comandos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-winscp" title="WinSCP" description="Transfer files with WinSCP on Windows." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-terraform" title="Terraform" description="Crie e configure buckets com o provider Terraform da OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-veeam" title="Veeam" description="Utilize o Object Storage como destino de backup do Veeam." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-nextcloud" title="Nextcloud" description="Ligue o Nextcloud a um bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-owncloud" title="ownCloud" description="Ligue o ownCloud a um bucket Object Storage." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-cohesity-netbackup" title="Cohesity NetBackup" description="Utilize o Object Storage com o Cohesity NetBackup." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-pure-storage-flashblade" title="Pure Storage FlashBlade" description="Utilize o Object Storage como destino de replicação do Pure Storage FlashBlade." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-ecosystem" title="Third-party application compatibility" description="Full list of compatible applications and S3 clients." />
+</CardGrid>
+
+## Segurança
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-identity-and-access-management" title="Gestão de identidades e de acessos" description="Crie utilizadores S3 e controle os acessos com políticas IAM." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-bucket-acl" title="ACL de bucket" description="Defina regras de controlo de acesso em cada bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-encrypt-your-objects-with-sse-c" title="Server-side encryption (SSE-C / SSE-OMK)" description="Encrypt objects at rest with customer-provided or OVHcloud-managed keys." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-object-storage-responsibility-model" title="Modelo de responsabilidade partilhada" description="O que a OVHcloud gere e aquilo de que o cliente é responsável." />
+</CardGrid>
+
+## Cold Archive
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-overview" title="Visão geral do Cold Archive" description="Como funciona o arquivamento a longo prazo em fita e para que foi concebido." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-getting-started" title="Começar a utilizar o Cold Archive" description="Crie um contentor Cold Archive e arquive os seus primeiros objetos." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-restoring-objects" title="Restaurar objetos do Cold Archive" description="Descongele e recupere objetos da classe de armazenamento Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-archive-faq" title="Cold Archive FAQ" description="Answers to frequently asked questions about Cold Archive." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/cold-storage-responsibility-model" title="Responsabilidade partilhada do Cold Storage" description="Modelo de responsabilidade partilhada para os serviços de arquivamento e de restauro." />
+</CardGrid>
+
+## Resolução de problemas e limites
+
+<CardGrid>
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-limitations" title="Limites técnicos" description="Limites máximos de tamanho dos objetos, de taxa de pedidos e operações S3 suportadas." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-local-zones-limitations" title="Especificações das Local Zones" description="Características e limites específicos do Object Storage nas Local Zones." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-s3-compliancy" title="Conformidade com a API S3" description="Quais as funcionalidades da API S3 suportadas pelo Object Storage da OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-performance-optimization" title="Otimizar o desempenho" description="Byte range fetch, pedidos em paralelo e outros métodos de otimização." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-optimise-the-sending-of-your-files" title="Otimizar o envio de ficheiros" description="Acelere a transferência dos seus ficheiros para um bucket." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-regions-comparison" title="Comparação dos modos de implementação" description="Diferenças entre as implementações 3-AZ, 1-AZ e Local Zone." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration" title="Migrar de outro fornecedor S3" description="Transfira os seus dados de um fornecedor compatível com S3 para o Object Storage da OVHcloud." />
+  <LinkCard href="/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3" title="Migrar do Swift para o S3" description="Passe do Object Storage Swift da OVHcloud para o Object Storage compatível com S3." />
+</CardGrid>
+
+<sup>1</sup>: S3 é uma marca registada da Amazon Technologies, Inc. O serviço OVHcloud não é patrocinado, endossado ou de outra forma afiliado à Amazon Technologies, Inc.


### PR DESCRIPTION
Add a landing page for the Object Storage universe, grouping the existing guides into six themed sections: getting started, configuration, tools and integrations, security, Cold Archive, and troubleshooting.

Originally written as part of PR #344 (branch feat-blockstorage-guide-ocfs), which also carried the new Block Storage OCFS2 guide. That PR mixed two unrelated topics, so the landing page is extracted here to be reviewed and merged independently. The page content is unchanged from the original.