### PR TITLE
Feat(compute):  update lifecycle guide

### DIFF
--- a/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/de/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/en/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/es/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Cycle de vie et annonces de fin de vie/support des images et distributions
 description: Découvrez le cycle de vie et les annonces de fin de vie et de support des distributions et logiciels pour votre VPS ou votre instance Public Cloud
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objectif
@@ -43,7 +43,7 @@ Veuillez noter au préalable que :
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Nom de code | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Veuillez noter au préalable que :
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | Novembre 2024 | Mai 2027 | Mai 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | Mai 2024 | Mai 2024 | Mars 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Veuillez noter au préalable que :
 | CloudLinux OS 7 | Avril 2015 | Juin 2024 | Juin 2024 |
 | CloudLinux OS 6 | Février 2011 | Juin 2024 | Juin 2024 |
 
-#### Debian
+### Debian
 
 | Version | Nom de code | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Veuillez noter au préalable que :
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | Août 2021 | Août 2024 | Août 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | Juillet 2019 | Septembre 2022 | Juin 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Veuillez noter au préalable que :
 | Fedora Linux 39 | Novembre 2023 | Novembre 2024 | Novembre 2024 |
 | Fedora Linux 38 | Avril 2023 | Mai 2024 | Mai 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Sortie de la distribution | Fin de vie attendue |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | 2 décembre 2025 | 30 septembre 2026 |
-| 14.3 | 10 juin 2025 | 30 juin 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | 10 juin 2025 | 30 juin 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | Sortie de la licence | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Veuillez noter au préalable que :
 | Windows Server 2019 | Novembre 2018 | Janvier 2024 | Janvier 2029 |
 | Windows Server 2016 | Octobre 2016 | Janvier 2022 | Janvier 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Nom de code | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- | ------- |
@@ -111,7 +111,7 @@ Veuillez noter au préalable que :
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | Septembre 2021 | Avril 2023 | Avril 2023 |
 
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Nom de code | Sortie de la distribution | Fin de support standard | Fin de vie |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/fr/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud suit le cycle de vie officiel de chaque distribution. Toutes les source
 | Rocky Linux                   | [Cycle de vie](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Cycle de vie](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Cycle de vie](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support)     |
+| FreeBSD                       | [Cycle de vie](https://www.freebsd.org/security/)                                          |
 
 ## Annonces de fin de support / fin de vie
 
@@ -79,6 +80,13 @@ Veuillez noter au préalable que :
 | Fedora Linux 40 | Avril 2024 | Mai 2025 | Mai 2025 |
 | Fedora Linux 39 | Novembre 2023 | Novembre 2024 | Novembre 2024 |
 | Fedora Linux 38 | Avril 2023 | Mai 2024 | Mai 2024 |
+
+#### FreeBSD
+
+| Version | Sortie de la distribution | Fin de vie attendue |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | 2 décembre 2025 | 30 septembre 2026 |
+| 14.3 | 10 juin 2025 | 30 juin 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/it/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pl/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |

--- a/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
@@ -25,6 +25,7 @@ OVHcloud follows the official life cycle of each distribution. All sources of in
 | Rocky Linux                   | [Life Cycle](https://wiki.rockylinux.org/rocky/version/)                                  |
 | CloudLinux                    | [Life Cycle](https://docs.cloudlinux.com/introduction/#cloudlinux-os-life-cycle)          |
 | Windows Server                | [Life Cycle](https://learn.microsoft.com/en-us/microsoft-365-apps/end-of-support/windows-server-support) |
+| FreeBSD                       | [Life Cycle](https://www.freebsd.org/security/)                                          |
 
 ## End of Support/End of Life Announcements
 
@@ -79,6 +80,13 @@ Please note that:
 | Fedora Linux 40 | April 2024 | Until EoL | May 2025 |
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
+
+#### FreeBSD
+
+| Version | Distribution Release | Expected End of life |
+| ------- | ------- | ------- |
+| [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
+| 14.3 | June 10, 2025 | June 30, 2026 |
 
 #### Microsoft Windows Server
 

--- a/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
+++ b/docs/pt/guides/public-cloud/compute/image-life-cycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Public Cloud & VPS - Image and OS life cycle and end of life/support announcements
 description: Discover the lifecycle and end-of-life/end-of-support announcements for distributions and softwares for your VPS or Public Cloud instance
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -43,7 +43,7 @@ Please note that:
 :::
 
 
-#### AlmaLinuxOS
+### AlmaLinuxOS
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -51,7 +51,7 @@ Please note that:
 | [9](https://wiki.almalinux.org/release-notes/9.5.html) | Teal Serval | November 2024 | May 2027 | May 2032 |
 | [8](https://wiki.almalinux.org/release-notes/8.10.html) | Cerulean Leopard | May 2024 | May 2024 | March 2029 |
 
-#### CloudLinux
+### CloudLinux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -60,7 +60,7 @@ Please note that:
 | CloudLinux OS 7 | April 2015 | June 2024 | June 2024 |
 | CloudLinux OS 6 | February 2011 | June 2024 | June 2024 |
 
-#### Debian
+### Debian
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -69,7 +69,7 @@ Please note that:
 | 11 | [Bullseye](https://wiki.debian.org/DebianBullseye) | August 2021 | August 2024 | August 2026 |
 | 10 | [Buster](https://wiki.debian.org/DebianBuster) | July 2019 | September 2022 | June 2024 |
 
-#### Fedora Linux
+### Fedora Linux
 
 | Version | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -81,14 +81,14 @@ Please note that:
 | Fedora Linux 39 | November 2023 | Until EoL | November 2024 |
 | Fedora Linux 38 | April 2023 | Until EoL | May 2024 |
 
-#### FreeBSD
+### FreeBSD
 
 | Version | Distribution Release | Expected End of life |
 | ------- | ------- | ------- |
 | [15.0](https://www.freebsd.org/releases/15.0R/announce/) | December 2, 2025 | September 30, 2026 |
-| 14.3 | June 10, 2025 | June 30, 2026 |
+| [14.3](https://www.freebsd.org/releases/14.3R/announce/) | June 10, 2025 | June 30, 2026 |
 
-#### Microsoft Windows Server
+### Microsoft Windows Server
 
 | Version | License release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- |
@@ -97,7 +97,7 @@ Please note that:
 | Windows Server 2019 | November 2018 | January 2024 | January 2029 |
 | Windows Server 2016 | October 2016 | January 2022 | January 2027 |
 
-#### Ubuntu
+### Ubuntu
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |
@@ -110,7 +110,7 @@ Please note that:
 | Ubuntu 20.04.6 LTS | [Focal Fossa](https://wiki.ubuntu.com/FocalFossa) | March 2023 | April 2025 | April 2025 |
 | Ubuntu 18.04.6 LTS | [Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver) | September 2021 | April 2023 | April 2023 |
 
-#### Rocky Linux
+### Rocky Linux
 
 | Version | Code name | Distribution Release | End of Standard Support | End of life |
 | ------- | ------- | ------- | ------- | ------- |


### PR DESCRIPTION
Ajoute FreeBSD (15.0, 14.3) au tableau de fin de vie du guide image-life-cycle, dans les 7 locales (en, fr, de, es, it, pl, pt). 

Dates vérifiées sur freebsd.org (security + releases).