### PR TITLE
fix(account): replace non-standard e-invoicing motif codes

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/electronic-invoicing-errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comprendre et corriger les erreurs de facturation électronique
 description: Découvrez quel code sélectionner selon le motif d'erreur constaté sur une facture OVHcloud et comment corriger vos données pour vos prochaines factures
-lastUpdated: 2026-08-25
+lastUpdated: 2026-09-01
 ---
 
 <Banner kind="siret-fr" />
@@ -93,7 +93,7 @@ Les statuts sont attribués depuis votre plateforme et ne peuvent pas être modi
 Les tableaux ci-dessous concernent le **cas 1** : vous signalez un désaccord depuis votre plateforme. Identifiez d'abord le motif qui correspond à votre situation, puis sélectionnez le code associé. La dernière colonne indique la marche à suivre pour que vos **prochaines** factures soient émises correctement.
 
 :::info
-Les codes en majuscules (`TX_TVA_ERR`, `SIRET_ERR`, `NON_CONFORME`, etc.) sont ceux de la norme **AFNOR XP Z12-012** (annexe A), qui définit les motifs associés aux statuts du cycle de vie de la facture. Ils sont communs à l'ensemble des plateformes agréées. Le libellé affiché sur votre plateforme peut être formulé différemment.
+Les codes ci-dessous sont ceux de la norme **AFNOR XP Z12-012** (annexe A), qui définit les motifs associés aux statuts du cycle de vie de la facture. Ils sont communs à l'ensemble des plateformes agréées. Le libellé affiché sur votre plateforme peut être formulé différemment. Les tableaux reprennent les motifs les plus courants sur les factures OVHcloud : votre plateforme peut proposer d'autres codes prévus par la norme.
 
 :::
 
@@ -135,17 +135,12 @@ Les codes en majuscules (`TX_TVA_ERR`, `SIRET_ERR`, `NON_CONFORME`, etc.) sont c
 |---|---|---|
 | SIRET erroné ou absent | `SIRET_ERR` | [Erreurs d'identification de votre entreprise](#erreurs-didentification-de-votre-entreprise) |
 | Modalités de paiement incorrectes | `MODPAI_ERR` | [Erreurs de paiement](#erreurs-de-paiement) |
-| Prix unitaires incorrects (variante) | `Prix_Unit_Inc` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| Remise erronée (variante) | `Remise_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| Quantité facturée incorrecte (variante) | `Quantité_Err` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| Article facturé incorrect (variante) | `Article_INC` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-| Problème de livraison (variante) | `PRB_LIV` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Prix unitaires incorrects | `PU_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Remise erronée | `REM_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Quantité facturée incorrecte | `QTE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Article facturé incorrect | `ART_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
+| Problème de livraison | `LIVR_INCOMP` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
 | Qualité d'article livré incorrecte | `QUALITE_ERR` | [Écarts entre la commande et la facture](#écarts-entre-la-commande-et-la-facture) |
-
-:::info
-Certaines plateformes affichent, pour le statut « Approuvé partiellement », des variantes de libellé (`Prix_Unit_Inc`, `Remise_ERR`, `Quantité_Err`, `Article_INC`, `PRB_LIV`). Elles correspondent aux mêmes motifs que les codes normalisés indiqués ci-dessus et relèvent de la même marche à suivre.
-
-:::
 
 ### Erreurs d'identification de votre entreprise
 
@@ -189,13 +184,13 @@ Le prélèvement de votre facture a déjà été effectué sur le moyen de paiem
 
 ### Écarts entre la commande et la facture
 
-**Codes concernés :** litige 207 – `REF_ERR`, `PU_ERR`, `REM_ERR`, `ART_ERR`, `QTE_ERR`, `LIVR_INCOMP` ; Refusé – 210 – `TRANSAC_INC`, `EMMET_INC`, `MONTANTTOTAL_ERR`, `CALCUL_ERR` ; Approuvé partiellement – 206 – `Prix_Unit_Inc`, `Remise_ERR`, `Quantité_Err`, `Article_INC`, `PRB_LIV`.
+**Codes concernés :** litige 207 – `REF_ERR`, `PU_ERR`, `REM_ERR`, `ART_ERR`, `QTE_ERR`, `LIVR_INCOMP` ; Refusé – 210 – `TRANSAC_INC`, `EMMET_INC`, `MONTANTTOTAL_ERR`, `CALCUL_ERR` ; Approuvé partiellement – 206 – `PU_ERR`, `REM_ERR`, `QTE_ERR`, `ART_ERR`, `LIVR_INCOMP`, `QUALITE_ERR`.
 
 Ces motifs signalent un écart entre votre commande initiale et la facture émise. Consultez votre commande initiale sur la page <ManagerLink to="/#/billing/orders">Mes commandes</ManagerLink> et vérifiez que les produits, services et options qu'elle contient correspondent bien à ceux figurant sur votre facture, disponible sur la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>.
 
 La marche à suivre est décrite dans la section « [Vérifier votre commande en cas d'erreur de facturation](/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders) » du guide dédié à la gestion de vos commandes.
 
-Pour les produits **facturés à la consommation** (litige 207 – `QTE_ERR`, Approuvé partiellement – 206 – `Quantité_Err`), faites le point sur cette même page : la facturation de ce type se base sur votre consommation du mois précédent. Un écart apparent peut donc correspondre à un usage réel supérieur à celui attendu.
+Pour les produits **facturés à la consommation** (litige 207 – `QTE_ERR`, Approuvé partiellement – 206 – `QTE_ERR`), faites le point sur cette même page : la facturation de ce type se base sur votre consommation du mois précédent. Un écart apparent peut donc correspondre à un usage réel supérieur à celui attendu.
 
 Si le **numéro de commande (PO)** est absent ou incorrect sur votre facture, renseignez-le dans votre espace client avant l'émission de vos prochaines factures, en vous aidant du guide « [Notion de Numéro de commande ou Purchase Order (PO)](/guides/account-and-service-management/managing-billing-payments-and-services/purchase-order) ».
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders.mdx
@@ -1,7 +1,7 @@
 ---
 title: Gérer mes commandes OVHcloud
 description: Découvrez comment gérer vos commandes chez OVHcloud
-lastUpdated: 2026-07-24
+lastUpdated: 2026-09-01
 ---
 
 <Banner kind="siret-fr" />
@@ -132,16 +132,16 @@ Une erreur peut être constatée sur une facture au regard de votre commande ini
 
 | Litige (207) | Refusé (210) | Approuvé partiellement (206) |
 |---|---|---|
-| litige 207 – REF_ERR | Refusé – 210 – TRANSAC_INC | Approuvé Partiellement – 206 – Prix_Unit_Inc |
-| litige 207 – PU_ERR | Refusé – 210 – EMMET_INC | Approuvé Partiellement – 206 – Remise_ERR |
-| litige 207 – REM_ERR | Refusé – 210 – MONTANTTOTAL_ERR | Approuvé Partiellement – 206 – Quantité_Err |
-| litige 207 – ART_ERR | Refusé – 210 – CALCUL_ERR | Approuvé Partiellement – 206 – Article_INC |
-| litige 207 – LIVR_INCOMP | Refusé – 210 – NON_CONFORME | Approuvé Partiellement – 206 – PRB_LIV |
+| litige 207 – REF_ERR | Refusé – 210 – TRANSAC_INC | Approuvé Partiellement – 206 – PU_ERR |
+| litige 207 – PU_ERR | Refusé – 210 – EMMET_INC | Approuvé Partiellement – 206 – REM_ERR |
+| litige 207 – REM_ERR | Refusé – 210 – MONTANTTOTAL_ERR | Approuvé Partiellement – 206 – QTE_ERR |
+| litige 207 – ART_ERR | Refusé – 210 – CALCUL_ERR | Approuvé Partiellement – 206 – ART_ERR |
+| litige 207 – LIVR_INCOMP | Refusé – 210 – NON_CONFORME | Approuvé Partiellement – 206 – LIVR_INCOMP |
 | litige 207 – QTE_ERR | | |
 
 Si vous êtes concerné par la facturation électronique, nous vous invitons à consulter votre commande initiale et à vérifier que les produits, services et options qu'elle contient correspondent bien à ceux figurant sur votre facture, disponible sur la page <ManagerLink to="/#/billing/history">Mes factures</ManagerLink>.
 
-Pour les produits facturés à la consommation (litige 207 – QTE_ERR, Approuvé Partiellement – 206 – Quantité_Err), faites le point sur cette même page. La facturation de ce type se base sur votre consommation du mois précédent.
+Pour les produits facturés à la consommation (litige 207 – QTE_ERR, Approuvé Partiellement – 206 – QTE_ERR), faites le point sur cette même page. La facturation de ce type se base sur votre consommation du mois précédent.
 
 En cas de facturation en double (Refusé – 210 – DOUBLE_FACT) ou de numéro de commande erroné (Refusé – 210 – CMD_ERR), consultez également les paiements associés à vos factures. Pour cela, reportez-vous à la section [Suivre vos paiements](/guides/account-and-service-management/managing-billing-payments-and-services/invoice-management#suivre-vos-paiements) du guide dédié à la gestion de vos factures.
 

--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/update-vat-rate.mdx
@@ -1,7 +1,7 @@
 ---
 title: Renseigner votre numéro de SIRET
 description: Découvrez comment renseigner votre numéro de SIRET, mettre à jour le taux de TVA et corriger l'adresse de facturation de votre compte OVHcloud
-lastUpdated: 2026-08-31
+lastUpdated: 2026-09-01
 ---
 
 ## Objectif
@@ -14,7 +14,7 @@ Ce guide explique comment renseigner votre numéro de SIRET depuis votre profil.
 
 - une erreur de taux de TVA (litige 207 – TX_TVA_ERR) ;
 - une erreur de SIRET (litige 207 – SIRET_ERR ; Approuvé Partiellement – 206 – SIRET_ERR) ;
-- une erreur de destinataire (Refusé – 210 – DEST-ERR, cas de multi-société dans un groupe).
+- une erreur de destinataire (Refusé – 210 – DEST_ERR, cas de multi-société dans un groupe).
 
 :::warning
 La mise à jour de vos informations depuis votre espace client ne corrige pas les factures déjà émises : elle est prise en compte à partir de votre prochaine facture. Par exemple, un numéro de SIRET mis à jour le 15 septembre sera appliqué à la facture d'octobre, sans réédition de celle de septembre.


### PR DESCRIPTION
An e-invoicing expert confirmed against AFNOR XP Z12-012 annexe A (v1.4, 2026) that five tokens documented as codes are not codes at all: someone abbreviated the French label instead of copying the code. Each maps to a real code from the same standard.

  Prix_Unit_Inc  -> PU_ERR       (Prix unitaires incorrects)
  Remise_ERR     -> REM_ERR      (Remise erronee)
  Quantite_Err   -> QTE_ERR      (Quantite facturee incorrecte)
  Article_INC    -> ART_ERR      (Article facture incorrect)
  PRB_LIV        -> LIVR_INCOMP  (Probleme de livraison)

ovh-orders.mdx was the origin: its "Approuve partiellement" column held the 207 column's codes re-typed as shortened labels. update-vat-rate.mdx also spelled DEST_ERR with a hyphen, which no platform would match.

Note the five codes were NOT simply deleted as duplicates. The standard allows all five on both "En litige" and "Approuvee partiellement", and the 206 table listed them nowhere else, so removing the rows would have dropped five legitimate motifs from that status.

Also in electronic-invoicing-errors.mdx:
- dropped the claim that these were per-platform label variants; the standard contradicts it, they are transcription errors
- added QUALITE_ERR to the 206 "codes concernes" list
- the AFNOR callout now states the tables cover the motifs most common on OVHcloud invoices and that a platform may offer others, since the guide documents a curated subset rather than the full 51-code list

Verified: all 99 code occurrences across the billing guides exist in the standard, every code/status pairing is one the standard permits, and the 30 table labels match annexe A. Three labels keep a readable form over the spec's raw string (DOUBLE FACTURE, CODE_ROUTAGE Absent ou Erronne, and a stray article in ADR_ERR) - same meaning, better French.

lastUpdated bumped on all three guides.