### PR TITLE
docs(kms): add OpenTofu to third-party integrations listing

### DIFF
--- a/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Offizielle Drittanbieter-Integrationen mit OVHcloud KMS
 description: Entdecken Sie Drittanwendungen, die offiziell mit OVHcloud KMS integriert sind, und finden Sie die Dokumentation zur Einrichtung jeder Integration
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Ziel
@@ -26,6 +26,7 @@ Die folgende Tabelle wird aktualisiert, sobald neue von OVHcloud gepflegte Integ
 | **Kubernetes** | ETCD-Verschlüsselung im Ruhezustand über `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Kubernetes-ETCD mit OVHcloud KMS verschlüsseln](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | KMS-gestützte OCI-Image-Signierung (`ovhcloud://` URI) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-Unseal über das `ovhcloud` Seal | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [OVHcloud KMS Seal (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | State/Plan-Verschlüsselung über externen Key Provider | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Produkte, die über das [KMIP-Protokoll](/guides/manage-and-operate/kms/kms-kmip) kompatibel sind (VMware, Nutanix, MongoDB, OpenBao usw.), sind hier nicht aufgeführt: Diese Integrationen werden von den jeweiligen Herstellern gepflegt, nicht von OVHcloud.

--- a/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/de/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -26,7 +26,7 @@ Die folgende Tabelle wird aktualisiert, sobald neue von OVHcloud gepflegte Integ
 | **Kubernetes** | ETCD-Verschlüsselung im Ruhezustand über `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Kubernetes-ETCD mit OVHcloud KMS verschlüsseln](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | KMS-gestützte OCI-Image-Signierung (`ovhcloud://` URI) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-Unseal über das `ovhcloud` Seal | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [OVHcloud KMS Seal (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
-| **OpenTofu** | State/Plan-Verschlüsselung über externen Key Provider | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
+| **OpenTofu** | State/Plan-Verschlüsselung über einen externen Key Provider | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Produkte, die über das [KMIP-Protokoll](/guides/manage-and-operate/kms/kms-kmip) kompatibel sind (VMware, Nutanix, MongoDB, OpenBao usw.), sind hier nicht aufgeführt: Diese Integrationen werden von den jeweiligen Herstellern gepflegt, nicht von OVHcloud.

--- a/docs/en/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/en/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Official third-party integrations with OVHcloud KMS
 description: Discover third-party applications officially integrated with OVHcloud KMS and find the documentation to set up each integration
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Objective
@@ -26,6 +26,7 @@ The table below is updated as new OVHcloud-maintained integrations are released.
 | **Kubernetes** | ETCD encryption at rest via `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Encrypt Kubernetes ETCD with OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | KMS-backed OCI image signing (`ovhcloud://` URI) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal via `ovhcloud` seal | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [OVHcloud KMS seal (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | State/plan encryption via external key provider | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Products compatible via the [KMIP protocol](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) are not listed here: those integrations are maintained by their respective vendors, not by OVHcloud.

--- a/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integraciones oficiales de terceros con OVHcloud KMS
 description: Descubra las aplicaciones de terceros integradas oficialmente con OVHcloud KMS y acceda a la documentación para configurar cada integración
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Objetivo
@@ -26,6 +26,7 @@ La siguiente tabla se actualiza cada vez que se publica una nueva integración m
 | **Kubernetes** | Cifrado de ETCD en reposo mediante `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Cifrar ETCD de Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Firma de imágenes OCI mediante KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal mediante el seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | Cifrado state/plan mediante key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Los productos compatibles mediante el [protocolo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) no figuran en esta lista: esas integraciones las mantienen sus respectivos editores, no OVHcloud.

--- a/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/es/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -26,7 +26,7 @@ La siguiente tabla se actualiza cada vez que se publica una nueva integración m
 | **Kubernetes** | Cifrado de ETCD en reposo mediante `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Cifrar ETCD de Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Firma de imágenes OCI mediante KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal mediante el seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
-| **OpenTofu** | Cifrado state/plan mediante key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
+| **OpenTofu** | Cifrado state/plan mediante un key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Los productos compatibles mediante el [protocolo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) no figuran en esta lista: esas integraciones las mantienen sus respectivos editores, no OVHcloud.

--- a/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Intégrations tierces officielles avec OVHcloud KMS
 description: Découvrez les applications tierces officiellement intégrées à OVHcloud KMS et accédez à la documentation pour configurer chaque intégration
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Objectif
@@ -26,6 +26,7 @@ Le tableau ci-dessous est mis à jour à chaque nouvelle intégration maintenue 
 | **Kubernetes** | Chiffrement ETCD au repos via `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Chiffrer ETCD de Kubernetes avec OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Signature d'images OCI via KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal via le seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | Chiffrement state/plan via key provider externe | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Les produits compatibles via le [protocole KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) ne figurent pas dans cette liste : ces intégrations sont maintenues par leurs éditeurs respectifs, et non par OVHcloud.

--- a/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/fr/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -26,7 +26,7 @@ Le tableau ci-dessous est mis à jour à chaque nouvelle intégration maintenue 
 | **Kubernetes** | Chiffrement ETCD au repos via `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Chiffrer ETCD de Kubernetes avec OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Signature d'images OCI via KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal via le seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
-| **OpenTofu** | Chiffrement state/plan via key provider externe | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
+| **OpenTofu** | Chiffrement state/plan via un key provider externe | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Les produits compatibles via le [protocole KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) ne figurent pas dans cette liste : ces intégrations sont maintenues par leurs éditeurs respectifs, et non par OVHcloud.

--- a/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrazioni ufficiali di terze parti con OVHcloud KMS
 description: Scopri le applicazioni di terze parti integrate ufficialmente con OVHcloud KMS e accedi alla documentazione per configurare ogni integrazione
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Obiettivo
@@ -26,6 +26,7 @@ La tabella seguente viene aggiornata a ogni nuova integrazione mantenuta da OVHc
 | **Kubernetes** | Crittografia ETCD a riposo tramite `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Cifrare ETCD di Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Firma di immagini OCI tramite KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal tramite il seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | Crittografia state/plan tramite key provider esterno | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 I prodotti compatibili tramite il [protocollo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, ecc.) non figurano in questo elenco: tali integrazioni sono mantenute dai rispettivi fornitori, non da OVHcloud.

--- a/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/it/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -26,7 +26,7 @@ La tabella seguente viene aggiornata a ogni nuova integrazione mantenuta da OVHc
 | **Kubernetes** | Crittografia ETCD a riposo tramite `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Cifrare ETCD di Kubernetes con OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Firma di immagini OCI tramite KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal tramite il seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
-| **OpenTofu** | Crittografia state/plan tramite key provider esterno | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
+| **OpenTofu** | Crittografia state/plan tramite un key provider esterno | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 I prodotti compatibili tramite il [protocollo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, ecc.) non figurano in questo elenco: tali integrazioni sono mantenute dai rispettivi fornitori, non da OVHcloud.

--- a/docs/pl/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/pl/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Oficjalne integracje zewnętrzne z OVHcloud KMS
 description: Poznaj aplikacje zewnętrzne oficjalnie zintegrowane z OVHcloud KMS i znajdź dokumentację umożliwiającą skonfigurowanie każdej integracji
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Wprowadzenie
@@ -26,6 +26,7 @@ Poniższa tabela jest aktualizowana wraz z udostępnianiem nowych integracji utr
 | **Kubernetes** | Szyfrowanie ETCD w spoczynku za pomocą `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Szyfrowanie ETCD Kubernetes za pomocą OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Podpisywanie obrazów OCI za pomocą KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal za pomocą seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | Szyfrowanie state/plan za pomocą zewnętrznego key provider | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Produkty zgodne z [protokołem KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao itd.) nie są wymienione na tej liście: te integracje są utrzymywane przez odpowiednich dostawców, a nie przez OVHcloud.

--- a/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -26,7 +26,7 @@ A tabela abaixo é atualizada sempre que é publicada uma nova integração mant
 | **Kubernetes** | Encriptação ETCD em repouso através de `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Encriptar o ETCD do Kubernetes com o OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Assinatura de imagens OCI através do KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal através do seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
-| **OpenTofu** | Encriptação state/plan através de key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
+| **OpenTofu** | Encriptação state/plan através de um key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Os produtos compatíveis através do [protocolo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) não figuram nesta lista: essas integrações são mantidas pelos respetivos editores, e não pela OVHcloud.

--- a/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
+++ b/docs/pt/guides/manage-and-operate/kms/third-party-integrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrações oficiais de terceiros com o OVHcloud KMS
 description: Descubra as aplicações de terceiros oficialmente integradas com o OVHcloud KMS e aceda à documentação para configurar cada integração
-lastUpdated: 2026-07-29
+lastUpdated: 2026-09-01
 ---
 
 ## Objetivo
@@ -26,6 +26,7 @@ A tabela abaixo é atualizada sempre que é publicada uma nova integração mant
 | **Kubernetes** | Encriptação ETCD em repouso através de `okms-k8s-encryption-provider` | [okms-k8s-encryption-provider](https://github.com/ovh/okms-k8s-encryption-provider) | [Encriptar o ETCD do Kubernetes com o OVHcloud KMS](/guides/manage-and-operate/kms/kms-etcd) |
 | **Cosign** | Assinatura de imagens OCI através do KMS (URI `ovhcloud://`) | [sigstore-kms-ovhcloud](https://github.com/ovh/sigstore-kms-ovhcloud) | [Secure Image Signing with Cosign and OVHcloud KMS](https://blog.ovhcloud.com/secure-image-signing-cosign-ovhcloud-kms/)<br/>[Cosign key management (OVHcloud)](https://docs.sigstore.dev/cosign/key_management/overview/#ovhcloud) |
 | **OpenBao** | Auto-unseal através do seal `ovhcloud` | [openbao-plugins](https://github.com/openbao/openbao-plugins) | [Seal OVHcloud KMS (OpenBao)](https://openbao.org/docs/configuration/seal/ovhcloud/) |
+| **OpenTofu** | Encriptação state/plan através de key provider externo | [opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) | [OVHcloud KMS (external) (OpenTofu)](https://opentofu.org/docs/v1.13/language/state/encryption/#ovhcloud-kms-external) |
 
 :::info
 Os produtos compatíveis através do [protocolo KMIP](/guides/manage-and-operate/kms/kms-kmip) (VMware, Nutanix, MongoDB, OpenBao, etc.) não figuram nesta lista: essas integrações são mantidas pelos respetivos editores, e não pela OVHcloud.


### PR DESCRIPTION
## Summary
- Add OpenTofu to the official OVHcloud KMS third-party integrations table (state/plan encryption via external key provider).
- Link the `opentofu-kms-ovhcloud` plugin and the OpenTofu encryption docs.