### PR TITLE
fix(theme): keep "View as Markdown" label out of the search index

### DIFF
--- a/scripts/combine-builds.ts
+++ b/scripts/combine-builds.ts
@@ -448,7 +448,12 @@ const EXCLUDE_SELECTORS =
   '.rp-sidebar, .rp-outline, .rp-nav, .rp-doc-layout__sidebar, ' +
   '.rp-doc-layout__outline, .rspress-breadcrumbs, .rp-doc-footer, ' +
   '.rp-home-layout__content, .rp-search-button, .rp-callout__title, button, ' +
-  '.header-anchor, [data-pagefind-ignore], .ovh-api-main, .ovh-api-region-select';
+  '.header-anchor, [data-pagefind-ignore], .ovh-api-main, .ovh-api-region-select, ' +
+  // The "View as Markdown" / PDF / Ask-AI toolbar renders inside `.rp-doc`
+  // right after the <h1>. `button` covers the two <button> controls, but the
+  // Markdown link is an <a> and leaked its label into every result excerpt.
+  // Excluding the container covers anything added to the toolbar later.
+  '.rp-llms-container, .rp-llms-view-options__trigger';
 
 const indexResults = await Promise.allSettled(
   builtLocales.map(async (locale) => {

--- a/theme/components/LlmsOpenButton/index.tsx
+++ b/theme/components/LlmsOpenButton/index.tsx
@@ -38,6 +38,12 @@ export function LlmsOpenButton() {
       rel="noopener noreferrer"
       className="rp-llms-button"
       title={t('llmsOpenButton.title')}
+      // Keeps the label out of the Pagefind index: this toolbar renders
+      // inside `.rp-doc` right after the <h1>, so without this the text
+      // leaked into the excerpt of every search result. The sibling PDF /
+      // "Ask AI" controls are already covered by the `button` exclude
+      // selector in scripts/combine-builds.ts; this <a> was not.
+      data-pagefind-ignore
     >
       <MdIcon />
       <span>{t('llmsOpenButton.label')}</span>


### PR DESCRIPTION
The LLM toolbar renders inside `.rp-doc` immediately after the `<h1>`, so Pagefind indexed its labels as the first body content of every guide. The "View as Markdown" text therefore appeared in the excerpt of every search result.

The exclude list in scripts/combine-builds.ts already had a bare `button` selector, which covered the PDF and Ask-AI controls. LlmsOpenButton renders an `<a>`, so it slipped through.

- Add `data-pagefind-ignore` to the `<a>` (the exclude list already honours it).
- Exclude the toolbar containers too, so a future non-`<button>` control in that toolbar cannot reintroduce the leak.

Verified on a full FR build: 0 of 1756 index fragments contain the label, and indexed content now runs from the H1 straight to the guide's first sentence. The button itself is unchanged and still visible.