### PR TITLE
 FIX - PUBLIC CLOUD - Block Storage - Set OCFS2 guide lastUpdated to its creation date.

### DIFF
--- a/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-ocfs2.mdx
+++ b/docs/en/guides/public-cloud/compute/storage-classic-multi-attach-ocfs2.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure Classic Multi-Attach Block Storage with OCFS2
 description: Learn how to set up a shared OCFS2 cluster filesystem across multiple instances using a Classic Multi-Attach Block Storage volume in 3AZ regions
-lastUpdated: 2026-06-22
+lastUpdated: 2026-08-31
 ---
 
 ## Introduction

--- a/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-ocfs2.mdx
+++ b/docs/fr/guides/public-cloud/compute/storage-classic-multi-attach-ocfs2.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer le Classic Block Storage Multi-Attach avec OCFS2
 description: Apprenez à mettre en place un système de fichiers cluster OCFS2 partagé entre plusieurs instances à l'aide d'un volume Classic Block Storage Multi-Attach dans les régions 3AZ
-lastUpdated: 2026-06-22
+lastUpdated: 2026-08-31
 ---
 
 ## Introduction


### PR DESCRIPTION
The guide was merged on 2026-08-31 (#344) but carried lastUpdated: 2026-06-22 — the date written while the PR was being drafted, never refreshed before the merge.

That makes the guide invisible to the monthly newsletter: it is absent from August (its date says June) and absent from June (the file did not exist yet). The date is also wrong for readers, understating the guide as two months older than it is.

Only the EN and FR files carry a real date; the de/es/it/pl/pt paths are symlinks to EN and follow automatically.