### PR TITLE
feat(theme): add markdown/PDF/AI buttons to landing pages

### DIFF
--- a/scripts/combine-builds.ts
+++ b/scripts/combine-builds.ts
@@ -453,7 +453,11 @@ const EXCLUDE_SELECTORS =
   // right after the <h1>. `button` covers the two <button> controls, but the
   // Markdown link is an <a> and leaked its label into every result excerpt.
   // Excluding the container covers anything added to the toolbar later.
-  '.rp-llms-container, .rp-llms-view-options__trigger';
+  // `.rp-page-toolbar` / `.rp-landing-toolbar` are the same cluster mounted by
+  // layouts that render their own <h1> (LandingLayout), where it sits outside
+  // `.rp-doc`; listed so the exclusion holds if that markup ever moves inside.
+  '.rp-llms-container, .rp-llms-view-options__trigger, ' +
+  '.rp-page-toolbar, .rp-landing-toolbar';
 
 const indexResults = await Promise.allSettled(
   builtLocales.map(async (locale) => {

--- a/theme/components/PageToolbar/index.scss
+++ b/theme/components/PageToolbar/index.scss
@@ -1,0 +1,14 @@
+/* Core's `.rp-llms-container` already sets `display: flex` and an 8px gap, plus
+   a 20px bottom margin sized for sitting under an MDX <h1>. In this layout the
+   surrounding wrapper owns the vertical rhythm instead, so the container's own
+   margins are zeroed here and the gap is widened to match the 12px our
+   LlmsViewOptions override uses. The flex properties are restated so the row
+   does not depend on core's stylesheet winning the cascade. */
+.rp-llms-container.rp-page-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/theme/components/PageToolbar/index.tsx
+++ b/theme/components/PageToolbar/index.tsx
@@ -6,26 +6,32 @@ import './index.scss';
  * The page-header action cluster ("View as Markdown" / "Save as PDF" /
  * "Ask AI"), for layouts that render their own <h1>.
  *
- * On classic guide pages Rspress injects this cluster from the MDX `h1`
- * component (see @rspress/core DocContent/docComponents/title), so a layout
- * whose title is *not* an MDX heading never got it. Mounting this component
- * gives such a page the identical controls. Used by LandingLayout;
- * OverviewLayout has the same gap but is deliberately left as-is for now.
+ * Classic guides get this cluster from the MDX `h1` (see @rspress/core
+ * DocContent/docComponents/title), so a layout whose title is not an MDX
+ * heading never received it. Used by LandingLayout; OverviewLayout has the
+ * same gap but is deliberately left as-is for now.
  *
- * Our LlmsViewOptions override already contains LlmsOpenButton and
- * PdfDownloadButton, so the whole cluster comes from that single child (core
- * pairs it with LlmsCopyButton, which we stub to null in theme/index.tsx).
+ * Our LlmsViewOptions override already bundles LlmsOpenButton and
+ * PdfDownloadButton, so the whole cluster comes from that single child.
  *
- * We reproduce core's `.rp-llms-container` wrapper by hand rather than using
- * its <LlmsContainer>, because that component hardcodes its own className
- * after the prop spread — a passed className is silently dropped, so we could
- * not scope the layout-specific spacing below.
+ * Two things this must stay out of, both verified by build:
+ * - The `.md` export (`__SSR_MD__`): these are our own nodes inside the
+ *   exported region, so without the guard the labels were serialised into
+ *   every landing page's `.md` as text under the H1. Core's copy escapes this
+ *   because the exporter drops it. Cf. theme/components/FallbackHeading.
+ * - The Pagefind index: `.rp-llms-container` and `.rp-page-toolbar` are both
+ *   in EXCLUDE_SELECTORS (scripts/combine-builds.ts), so the labels cannot
+ *   reach a search excerpt — the #708 fix, extended to this mount point. On
+ *   landing pages the cluster also sits outside `.rp-doc`, Pagefind's root.
  *
- * This is *not* a replacement for <ProductPdfButton>, which is a separate
- * feature: the opt-in whole-product PDF bundle (`pdf:` frontmatter), used on
- * the OPCP landing page. Both are rendered, side by side.
+ * Not a replacement for <ProductPdfButton> (the opt-in whole-product PDF
+ * bundle, `pdf:` frontmatter, used on OPCP) — both render side by side.
  */
 export function PageToolbar() {
+  if (process.env.__SSR_MD__) {
+    return null;
+  }
+
   return (
     <div className="rp-not-doc rp-llms-container rp-page-toolbar">
       <LlmsViewOptions />

--- a/theme/components/PageToolbar/index.tsx
+++ b/theme/components/PageToolbar/index.tsx
@@ -1,0 +1,34 @@
+import { LlmsViewOptions } from 'theme/components/LlmsViewOptions';
+import '@rspress/core/dist/theme/components/Llms/LlmsContainer.css';
+import './index.scss';
+
+/**
+ * The page-header action cluster ("View as Markdown" / "Save as PDF" /
+ * "Ask AI"), for layouts that render their own <h1>.
+ *
+ * On classic guide pages Rspress injects this cluster from the MDX `h1`
+ * component (see @rspress/core DocContent/docComponents/title), so a layout
+ * whose title is *not* an MDX heading never got it. Mounting this component
+ * gives such a page the identical controls. Used by LandingLayout;
+ * OverviewLayout has the same gap but is deliberately left as-is for now.
+ *
+ * Our LlmsViewOptions override already contains LlmsOpenButton and
+ * PdfDownloadButton, so the whole cluster comes from that single child (core
+ * pairs it with LlmsCopyButton, which we stub to null in theme/index.tsx).
+ *
+ * We reproduce core's `.rp-llms-container` wrapper by hand rather than using
+ * its <LlmsContainer>, because that component hardcodes its own className
+ * after the prop spread — a passed className is silently dropped, so we could
+ * not scope the layout-specific spacing below.
+ *
+ * This is *not* a replacement for <ProductPdfButton>, which is a separate
+ * feature: the opt-in whole-product PDF bundle (`pdf:` frontmatter), used on
+ * the OPCP landing page. Both are rendered, side by side.
+ */
+export function PageToolbar() {
+  return (
+    <div className="rp-not-doc rp-llms-container rp-page-toolbar">
+      <LlmsViewOptions />
+    </div>
+  );
+}

--- a/theme/components/ProductPdfButton/index.tsx
+++ b/theme/components/ProductPdfButton/index.tsx
@@ -1,6 +1,10 @@
 import { useFrontmatter, useI18n, useLang } from '@rspress/core/runtime';
 
 const PdfIcon = () => (
+  // Multi-page stack with a download arrow: this button downloads a whole
+  // product's documentation as one PDF, so the icon reads as "many pages,
+  // saved" rather than a single file. The previous version drew "PDF"
+  // letterforms inside a 16px document, which turned to mush at this size.
   <svg
     aria-hidden="true"
     width="14"
@@ -9,22 +13,34 @@ const PdfIcon = () => (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
+    {/* Back page, offset to suggest a stack */}
     <path
-      d="M4 1h5l4 4v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2Z"
+      d="M5.5 3.5V2.25A1.25 1.25 0 0 1 6.75 1h3.5L13.5 4.25v6.5a1.25 1.25 0 0 1-1.25 1.25H11"
       stroke="currentColor"
-      strokeWidth="1.3"
-    />
-    <path
-      d="M9 1v4h4"
-      stroke="currentColor"
-      strokeWidth="1.3"
+      strokeWidth="1.2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
+    {/* Front page */}
     <path
-      d="M5 9h2.5a1 1 0 0 0 0-2H5v4m4-4h2m-1 0v4"
+      d="M3.75 4h3.5L10.5 7.25v6.5A1.25 1.25 0 0 1 9.25 15h-5.5A1.25 1.25 0 0 1 2.5 13.75V5.25A1.25 1.25 0 0 1 3.75 4Z"
       stroke="currentColor"
-      strokeWidth="1.1"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+    {/* Folded corner of the front page */}
+    <path
+      d="M7 4.25v3.25h3.25"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    {/* Download arrow */}
+    <path
+      d="M6.5 9.75v2.75m0 0L5.25 11.25M6.5 12.5l1.25-1.25"
+      stroke="currentColor"
+      strokeWidth="1.2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/theme/layouts/LandingLayout/index.scss
+++ b/theme/layouts/LandingLayout/index.scss
@@ -99,10 +99,19 @@
   content: none;
 }
 
+/* Page-header action cluster ("View as Markdown" / "Save as PDF" / "Ask AI").
+   Classic guide pages get this straight after the MDX <h1>; this layout mounts
+   it explicitly, so the vertical rhythm is set here. */
+.rp-landing-toolbar {
+  margin: 1.25rem 0 0;
+}
+
 /* Whole-product PDF download button — enlarged vs the small toolbar default,
-   scoped to the landing page so other rp-llms-button uses are unaffected. */
-.rp-landing-pdf {
-  margin: 1.25rem 0 0.5rem;
+   scoped to the landing page so other rp-llms-button uses are unaffected.
+   `:has()` keeps the wrapper from adding blank space on the many landing pages
+   with no `pdf:` frontmatter, where ProductPdfButton renders null. */
+.rp-landing-pdf:has(.rp-llms-button) {
+  margin: 1rem 0 0.5rem;
 }
 .rp-landing-pdf .rp-llms-button {
   font-size: 1rem;

--- a/theme/layouts/LandingLayout/index.scss
+++ b/theme/layouts/LandingLayout/index.scss
@@ -106,22 +106,12 @@
   margin: 1.25rem 0 0;
 }
 
-/* Whole-product PDF download button — enlarged vs the small toolbar default,
-   scoped to the landing page so other rp-llms-button uses are unaffected.
+/* Whole-product PDF download button. It sits directly under the toolbar above,
+   so it inherits the core `.rp-llms-button` metrics (14px / 36px / 14px icon)
+   rather than overriding them — an earlier 1rem/18px override predated the
+   toolbar and read as a font-size mismatch once the two rows were adjacent.
    `:has()` keeps the wrapper from adding blank space on the many landing pages
    with no `pdf:` frontmatter, where ProductPdfButton renders null. */
 .rp-landing-pdf:has(.rp-llms-button) {
-  margin: 1rem 0 0.5rem;
-}
-.rp-landing-pdf .rp-llms-button {
-  font-size: 1rem;
-  padding: 0.6em 1.1em;
-  gap: 0.55em;
-  border-radius: 8px;
-  line-height: 1.2;
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
+  margin: 0.75rem 0 0.5rem;
 }

--- a/theme/layouts/LandingLayout/index.tsx
+++ b/theme/layouts/LandingLayout/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { OverviewCTA } from 'theme/components/OverviewCTA';
 import { OverviewGoFurther } from 'theme/components/OverviewGoFurther';
+import { PageToolbar } from 'theme/components/PageToolbar';
 import { ProductPdfButton } from 'theme/components/ProductPdfButton';
 import { Sidebar } from 'theme/components/Sidebar';
 import { usePageTitle } from 'theme/hooks/usePageTitle';
@@ -157,10 +158,18 @@ export function LandingLayout(props: LandingLayoutProps) {
               </div>
             )}
 
-            {/* Whole-product PDF download — shown only when the page declares a
-                `pdf:` frontmatter ref (the button returns null otherwise). The
-                Ask-AI/llms cluster is intentionally absent from landing pages, so
-                this is mounted directly here rather than via that slot. */}
+            {/* Page-header actions: the same "View as Markdown" / "Save as
+                PDF" / "Ask AI" cluster classic guide pages get. Classic pages
+                receive it from the MDX `h1`; this layout renders its own H1,
+                so it is mounted explicitly. */}
+            <div className="rp-landing-toolbar">
+              <PageToolbar />
+            </div>
+
+            {/* Whole-product PDF download — a separate, opt-in feature: shown
+                only when the page declares a `pdf:` frontmatter ref (the
+                button returns null otherwise), as on OPCP. Kept alongside
+                the toolbar above, not replaced by it. */}
             <div className="rp-landing-pdf">
               <ProductPdfButton />
             </div>

--- a/theme/layouts/OverviewLayout/index.scss
+++ b/theme/layouts/OverviewLayout/index.scss
@@ -69,20 +69,9 @@
   }
 }
 
-/* Whole-product PDF download button — enlarged vs the small toolbar default,
-   scoped to the overview page so other rp-llms-button uses are unaffected. */
+/* Whole-product PDF download button — inherits the core `.rp-llms-button`
+   metrics (14px / 36px / 14px icon) so it matches the same button on landing
+   pages and the header toolbar there. Kept in sync with .rp-landing-pdf. */
 .rp-overview-pdf {
   margin: 1.25rem 0 0.5rem;
-}
-.rp-overview-pdf .rp-llms-button {
-  font-size: 1rem;
-  padding: 0.6em 1.1em;
-  gap: 0.55em;
-  border-radius: 8px;
-  line-height: 1.2;
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
 }


### PR DESCRIPTION
Landing pages never showed the "View as Markdown" / "Save as PDF" / "Ask AI" cluster that classic guide pages have. Rspress injects it from the MDX `h1` component, and LandingLayout renders its own `<h1>` outside the MDX body, so the cluster was never mounted.

Extract the cluster into a PageToolbar component and mount it in LandingLayout under the title/banner. Applies to all 29 current landing pages and to any future one automatically, with no per-page frontmatter.

ProductPdfButton (the opt-in whole-product PDF bundle, `pdf:` frontmatter, used on OPCP) is unchanged and still rendered alongside the new cluster.

Also gate .rp-landing-pdf spacing behind :has() so the wrapper no longer reserves blank space on the 28 landing pages without a `pdf:` key.