### PR TITLE
docs(opcp): add guide on allocating and de-allocating a node

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -602,6 +602,7 @@
             + [Getting started with your OPCP](hosted-private-cloud/opcp/getting-started)
             + [How to install a controller](hosted-private-cloud/opcp/install-controller)
             + [Node lifecycle](hosted-private-cloud/opcp/node-lifecycle)
+            + [How to allocate and de-allocate a node for a project](hosted-private-cloud/opcp/how-to-allocate-node)
             + [How to use the APIs and obtain the credentials](hosted-private-cloud/opcp/how-to-use-api-and-get-credentials)
             + [How to install an instance from the Horizon interface](hosted-private-cloud/opcp/how-to-setup-instance)
             + [How to setup an instance using the OpenStack CLI](hosted-private-cloud/opcp/how-to-setup-instance-from-cli)

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-allocate-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-allocate-node.mdx
@@ -1,0 +1,231 @@
+---
+title: How to allocate and de-allocate a node for a project
+description: Learn how to reserve an OPCP Core node for an OpenStack project with an Ironic allocation, and how to release it
+lastUpdated: 2026-09-03
+---
+
+## Objective
+
+On an **OVHcloud On-Prem Cloud Platform (OPCP)**, the physical servers of your rack are enrolled in Ironic, the OpenStack bare metal service. Deploying an operating system on one of them **does not require a reservation**: by default, a deployment draws from the shared pool of `available` nodes, and Ironic picks whichever node matches the requested characteristics.
+
+An **allocation** answers a different need: **guaranteeing that a node is used only by a given project**. Creating an allocation means asking Ironic *"find me a node matching these characteristics (resource class, traits) and reserve it for this project"*. Once the allocation is `active`, the node leaves the pool a deployment can draw from: no other allocation can take it, and it is no longer picked by another project's deployment. This is what lets you dedicate a specific hardware profile to a project, or set capacity aside ahead of a deployment.
+
+An allocation is therefore a **claim**, not a deployment. The node stays in the `available` provisioning state and simply gets its `instance_uuid` and `allocation_uuid` fields set. Installing an operating system remains a separate operation, performed afterwards with `openstack baremetal node deploy` or by creating an instance, as described in the [How to setup an instance using the OpenStack CLI](/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli) guide.
+
+**This guide explains how to check that a node can be allocated, how to reserve it for a project, how to verify the reservation, and how to release it.**
+
+:::warning
+This guide applies to **OPCP Core**, that is when you drive the platform directly through the OpenStack APIs and the Ironic service.
+
+If your service was deployed through the **[CloudStore](/guides/hosted-private-cloud/opcp/cloudstore-getting-started)**, do not use these commands: resources are allocated by the service itself when you deploy its controller and its apps from the service catalog, and you select the target hosts through the CloudStore interface. Allocating a node manually with Ironic under a CloudStore-managed service can conflict with that orchestration.
+:::
+
+:::info
+In OpenStack, a node corresponds to a physical server in the OPCP rack.
+
+In this guide, the term **node** is therefore used to refer to a physical server.
+:::
+
+## Requirements
+
+- Being an administrator of the [OPCP](https://www.ovhcloud.com/en-gb/hosted-private-cloud/onprem-cloud-platform/) infrastructure.
+- **[OpenStack CLI configured](/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials)** with the required permissions (`clouds.yaml` or environment variables).
+- Having read the [Lifecycle of an OPCP node](/guides/hosted-private-cloud/opcp/node-lifecycle) guide.
+- Knowing the **ID of the OpenStack project** the node must be reserved for.
+
+## Instructions
+
+### 1. Check which nodes can be allocated
+
+A node is a valid candidate for an allocation only if **all** of the conditions below are met. Naming a node explicitly with `--candidate-node` does **not** bypass any of them.
+
+| Field | Expected value |
+|---|---|
+| `resource_class` | On OPCP, nodes enrolled by the discovery chain carry the `discovered` resource class |
+| `provision_state` | `available` |
+| `instance_uuid` | Unset |
+| `maintenance` | `False` |
+| `power_state` | Not `None` |
+| `owner` | Equal to the owner of the allocation, when that field is set — see step 5 |
+| `traits` | A superset of the requested traits |
+
+**Traits** are the qualitative attributes of a node (hardware capabilities, hardware profile). They are assigned automatically during discovery, as described in the [Lifecycle of an OPCP node](/guides/hosted-private-cloud/opcp/node-lifecycle) guide, and their naming and matching rules are documented in the [OpenStack Ironic documentation](https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html).
+
+To list the nodes that are actually allocatable at a given time:
+
+```bash
+openstack baremetal node list --provision-state available --resource-class discovered \
+  --fields uuid name traits maintenance instance_uuid owner power_state
+```
+
+### 2. Create an allocation
+
+```bash
+openstack baremetal allocation create \
+  --resource-class discovered \
+  --candidate-node <node-name> \
+  --owner <project-id> \
+  --name my-workload-01 \
+  --wait 60
+```
+
+| Option | Description |
+|---|---|
+| `--resource-class` | **Mandatory**. The resource class of the requested node |
+| `--owner` | **Mandatory**. The project the node is reserved for. See step 5 |
+| `--candidate-node` | Repeatable and ordered by preference. Accepts a node name or UUID. Omit it to let Ironic pick a node itself |
+| `--trait` | Repeatable, for example `--trait CUSTOM_VCF`. Requested traits are combined with a logical AND |
+| `--name` | A handle that can be used in place of the allocation UUID in every command |
+| `--wait [timeout]` | Block until the allocation reaches the `active` or `error` state |
+
+An allocation goes from `allocating` to either:
+
+- `active`: the allocation succeeded and its `node_uuid` field is populated;
+- `error`: the allocation failed. Delete the allocation and create it again. Its name stays reserved until it is deleted.
+
+### 3. List and display allocations
+
+```bash
+openstack baremetal allocation list --long
+```
+
+```bash
+openstack baremetal allocation show my-workload-01
+```
+
+```bash
+openstack baremetal allocation list --node <node-name>
+```
+
+On a successful allocation, the following values are returned:
+
+```bash
+| node_uuid  | cf5dfb7b-3e5f-4189-894b-63b8675cabf1 |
+| state      | active                               |
+| last_error | None                                 |
+```
+
+### 4. Check the node side
+
+```bash
+openstack baremetal node show <node-name> \
+  -f json -c provision_state -c instance_uuid -c allocation_uuid
+```
+
+**Example output:**
+
+```json
+{
+  "provision_state": "available",
+  "instance_uuid": "f8867871-9c2c-4dae-b0c3-0a50a5359090",
+  "allocation_uuid": "f8867871-9c2c-4dae-b0c3-0a50a5359090"
+}
+```
+
+Both UUIDs are equal to the allocation UUID, and `provision_state` is still `available`. This is the expected state after an allocation: the node is reserved but not deployed.
+
+To get the same information for every node of a resource class:
+
+```bash
+openstack baremetal node list --resource-class discovered \
+  --fields name provision_state instance_uuid allocation_uuid
+```
+
+### 5. Troubleshooting: reserving a node owned by another project
+
+#### 5.1 What the owner of a node is
+
+In Ironic, every node carries an `owner` field which names the OpenStack project that **administers** the hardware. This field drives access control: when a request arrives with a project scope, Ironic only shows and only lets you act on the nodes owned by that project.
+
+On OPCP, nodes are **not** enrolled by hand. When a server is installed and booted in the rack, it is discovered and enrolled automatically by the control plane. That automation runs under its own OpenStack project, and Ironic stamps the project ID of the requester on to the node when no owner is given explicitly. As a result, a freshly discovered node is owned by the **platform administration project used by discovery**, and not by the project in which you intend to run your workload.
+
+#### 5.2 Why the allocation fails
+
+An allocation also has an `owner`. When it is set, Ironic adds `owner=<owner of the allocation>` to the query selecting the candidate nodes. A node owned by another project is therefore never a candidate, **even when it is designated explicitly with `--candidate-node`**.
+
+This is what makes the problem confusing: with a token scoped to a project, the `owner` of the allocation is filled in automatically with the ID of your project. So you request a node that you can see in `available` state, and the allocation still fails, because Ironic is looking for `available` nodes belonging to *your* project, while the node still belongs to the discovery project.
+
+Whatever the actual cause, the allocation only ever fails with one of these two messages, which only mention the resource class:
+
+```bash
+no available nodes match the resource class discovered
+```
+
+```bash
+none of the requested nodes are available and match the resource class discovered
+```
+
+The first one is returned when no candidate node was given, the second one when `--candidate-node` was used. Both mean the same thing: **the query selecting the candidate nodes returned nothing**.
+
+#### 5.3 Diagnosing
+
+Check every condition listed in step 1, starting with the owner of the node:
+
+```bash
+openstack baremetal node show <node-name> -f value -c owner
+```
+
+If the value returned is not the ID of the project the node is being reserved for, this is the cause of the failure.
+
+#### 5.4 Resolving
+
+Two strategies are possible, depending on whether you want the node to be **durably assigned** to a project or not.
+
+**Strategy 1 — transfer ownership of the node to the target project (recommended).**
+
+This is the normal way of handing a node over to a project. As an infrastructure administrator, you transfer ownership once, and the project can then allocate and deploy on the node on its own:
+
+```bash
+openstack baremetal node set <node-name> --owner <project-id>
+```
+
+Then create the allocation again as described in step 2. Note that ownership of a node grants an elevated level of access to **all** the members of the owning project.
+
+**Strategy 2 — create the allocation with the current owner of the node.**
+
+Ownership of the node stays unchanged and the reservation is made on behalf of the project that owns it. This suits a one-off administrative reservation, for example on a node kept in the administration pool:
+
+```bash
+openstack baremetal allocation create \
+  --resource-class discovered \
+  --candidate-node <node-name> \
+  --owner <node-owner-project-id> \
+  --name my-workload-01
+```
+
+This strategy requires a token allowing you to set an arbitrary owner on the allocation. With a token scoped to a project, the field is forced to the ID of your project, and only strategy 1 works.
+
+### 6. Release an allocation
+
+If the node was deployed, that is if its `provision_state` is `active`, undeploy it first:
+
+```bash
+openstack baremetal node undeploy <node-name>
+```
+
+Then delete the allocation to release the claim:
+
+```bash
+openstack baremetal allocation delete my-workload-01
+```
+
+The `instance_uuid` and `allocation_uuid` fields are cleared and the node becomes allocatable again.
+
+:::warning
+- Deleting an allocation does **not** undeploy the node. Always undeploy it first.
+- The operation is refused with an `HTTP 400` or `HTTP 409` error while the node is in a transient state (`deploying`, `deleting`, `cleaning`). Wait for the state machine to settle.
+- Undeploying triggers automated cleaning, which includes a full disk erase in the default OPCP configuration. Returning to the `available` state therefore takes some time.
+:::
+
+## Go further
+
+- [Lifecycle of an OPCP node](/guides/hosted-private-cloud/opcp/node-lifecycle)
+- [How to see the node inventory](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+- [How to setup an instance using the OpenStack CLI](/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli)
+- [OpenStack Ironic documentation - Allocations](https://docs.openstack.org/ironic/latest/user/deploy.html)
+- [OpenStack Ironic documentation - Node multi-tenancy and ownership](https://docs.openstack.org/ironic/latest/admin/node-multitenancy.html)
+- [OpenStack Ironic documentation - Scheduling based on traits](https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html)
+
+For training or technical assistance implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and have your project analyzed by our experts.
+
+Join our [community of users](/links/community).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-allocate-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-allocate-node.mdx
@@ -1,0 +1,231 @@
+---
+title: "Allouer et désallouer un nœud à un projet"
+description: "Découvrez comment réserver un nœud OPCP Core pour un projet OpenStack à l'aide d'une allocation Ironic, et comment le libérer"
+lastUpdated: 2026-09-03
+---
+
+## Objectif
+
+Sur une plateforme **OVHcloud On-Prem Cloud Platform (OPCP)**, les serveurs physiques de votre rack sont enrôlés dans Ironic, le service bare metal d'OpenStack. Déployer un système d'exploitation sur l'un d'eux **ne nécessite aucune réservation** : par défaut, un déploiement puise dans le pool partagé des nœuds `available`, et Ironic choisit indifféremment un nœud correspondant aux caractéristiques demandées.
+
+Une **allocation** répond à un autre besoin : **garantir qu'un nœud ne sera utilisé que par un projet donné**. Créer une allocation consiste à demander à Ironic « trouve-moi un nœud correspondant à ces caractéristiques (classe de ressource, traits) et réserve-le pour ce projet ». Une fois l'allocation à l'état `active`, le nœud sort du pool dans lequel un déploiement peut puiser : aucune autre allocation ne peut s'en emparer, et il n'est plus retenu par le déploiement d'un autre projet. C'est ce qui vous permet de dédier un profil matériel précis à un projet, ou de mettre de la capacité de côté en amont d'un déploiement.
+
+Une allocation est donc une **réservation**, et non un déploiement. Le nœud reste dans l'état de provisionnement `available` et voit simplement ses champs `instance_uuid` et `allocation_uuid` renseignés. L'installation d'un système d'exploitation demeure une opération distincte, réalisée ensuite avec `openstack baremetal node deploy` ou par la création d'une instance, comme décrit dans le guide « [Installer une instance avec le CLI OpenStack](/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli) ».
+
+**Ce guide a pour objectif de vous expliquer comment vérifier qu'un nœud peut être alloué, comment le réserver pour un projet, comment vérifier cette réservation et comment la libérer.**
+
+:::warning
+Ce guide s'applique à **OPCP Core**, c'est-à-dire lorsque vous pilotez la plateforme directement via les API OpenStack et le service Ironic.
+
+Si votre service a été déployé via le **[CloudStore](/guides/hosted-private-cloud/opcp/cloudstore-getting-started)**, n'utilisez pas ces commandes : les ressources sont allouées par le service lui-même lors du déploiement de son contrôleur et de ses applications depuis le catalogue de services, et vous sélectionnez les hôtes cibles depuis l'interface CloudStore. Allouer manuellement un nœud avec Ironic sous un service géré par le CloudStore peut entrer en conflit avec cette orchestration.
+:::
+
+:::info
+Dans OpenStack, un nœud correspond à un serveur physique du rack OPCP.
+
+Dans ce guide, le terme **nœud** désigne donc un serveur physique.
+:::
+
+## Prérequis
+
+- Être administrateur de l'infrastructure [OPCP](https://www.ovhcloud.com/fr/hosted-private-cloud/onprem-cloud-platform/).
+- Disposer d'un **[CLI OpenStack configuré](/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials)** avec les permissions nécessaires (`clouds.yaml` ou variables d'environnement).
+- Avoir parcouru le guide « [Cycle de vie d'un nœud OPCP](/guides/hosted-private-cloud/opcp/node-lifecycle) ».
+- Connaître l'**identifiant du projet OpenStack** auquel le nœud doit être réservé.
+
+## En pratique
+
+### 1. Vérifier quels nœuds peuvent être alloués
+
+Un nœud n'est un candidat valide pour une allocation que si **toutes** les conditions ci-dessous sont remplies. Désigner explicitement un nœud avec `--candidate-node` ne permet d'en contourner **aucune**.
+
+| Champ | Valeur attendue |
+|---|---|
+| `resource_class` | Sur OPCP, les nœuds enrôlés par la chaîne de découverte portent la classe de ressource `discovered` |
+| `provision_state` | `available` |
+| `instance_uuid` | Non renseigné |
+| `maintenance` | `False` |
+| `power_state` | Différent de `None` |
+| `owner` | Égal au propriétaire de l'allocation, lorsque ce champ est renseigné — voir l'étape 5 |
+| `traits` | Un sur-ensemble des traits demandés |
+
+Les **traits** sont les attributs qualitatifs d'un nœud (capacités matérielles, profil matériel). Ils sont attribués automatiquement lors de la découverte, comme décrit dans le guide « [Cycle de vie d'un nœud OPCP](/guides/hosted-private-cloud/opcp/node-lifecycle) », et leurs règles de nommage et de correspondance sont documentées dans la [documentation OpenStack Ironic](https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html).
+
+Pour lister les nœuds réellement allouables à un instant donné :
+
+```bash
+openstack baremetal node list --provision-state available --resource-class discovered \
+  --fields uuid name traits maintenance instance_uuid owner power_state
+```
+
+### 2. Créer une allocation
+
+```bash
+openstack baremetal allocation create \
+  --resource-class discovered \
+  --candidate-node <nom-du-noeud> \
+  --owner <id-du-projet> \
+  --name my-workload-01 \
+  --wait 60
+```
+
+| Option | Description |
+|---|---|
+| `--resource-class` | **Obligatoire**. La classe de ressource du nœud demandé |
+| `--owner` | **Obligatoire**. Le projet auquel le nœud est réservé. Voir l'étape 5 |
+| `--candidate-node` | Répétable et ordonné par préférence. Accepte un nom de nœud ou un UUID. Omettez cette option pour laisser Ironic choisir lui-même un nœud |
+| `--trait` | Répétable, par exemple `--trait CUSTOM_VCF`. Les traits demandés sont combinés par un ET logique |
+| `--name` | Un identifiant utilisable à la place de l'UUID de l'allocation dans toutes les commandes |
+| `--wait [délai]` | Bloque jusqu'à ce que l'allocation atteigne l'état `active` ou `error` |
+
+Une allocation passe de l'état `allocating` à l'un des états suivants :
+
+- `active` : l'allocation a réussi et son champ `node_uuid` est renseigné ;
+- `error` : l'allocation a échoué. Supprimez l'allocation et créez-la de nouveau. Son nom reste réservé jusqu'à sa suppression.
+
+### 3. Lister et afficher les allocations
+
+```bash
+openstack baremetal allocation list --long
+```
+
+```bash
+openstack baremetal allocation show my-workload-01
+```
+
+```bash
+openstack baremetal allocation list --node <nom-du-noeud>
+```
+
+Lorsque l'allocation a réussi, les valeurs suivantes sont retournées :
+
+```bash
+| node_uuid  | cf5dfb7b-3e5f-4189-894b-63b8675cabf1 |
+| state      | active                               |
+| last_error | None                                 |
+```
+
+### 4. Vérifier du côté du nœud
+
+```bash
+openstack baremetal node show <nom-du-noeud> \
+  -f json -c provision_state -c instance_uuid -c allocation_uuid
+```
+
+**Exemple de retour :**
+
+```json
+{
+  "provision_state": "available",
+  "instance_uuid": "f8867871-9c2c-4dae-b0c3-0a50a5359090",
+  "allocation_uuid": "f8867871-9c2c-4dae-b0c3-0a50a5359090"
+}
+```
+
+Les deux UUID sont égaux à l'UUID de l'allocation, et `provision_state` vaut toujours `available`. Il s'agit de l'état attendu après une allocation : le nœud est réservé, mais pas déployé.
+
+Pour obtenir la même information pour tous les nœuds d'une classe de ressource :
+
+```bash
+openstack baremetal node list --resource-class discovered \
+  --fields name provision_state instance_uuid allocation_uuid
+```
+
+### 5. Résolution d'incident : réserver un nœud appartenant à un autre projet
+
+#### 5.1 Ce qu'est le propriétaire d'un nœud
+
+Dans Ironic, chaque nœud porte un champ `owner` qui désigne le projet OpenStack **administrant** le matériel. Ce champ pilote le contrôle d'accès : lorsqu'une requête arrive avec une portée (*scope*) de projet, Ironic ne montre et ne laisse manipuler que les nœuds appartenant à ce projet.
+
+Sur OPCP, les nœuds ne sont **pas** enrôlés à la main. Lorsqu'un serveur est installé et démarré dans le rack, il est découvert et enrôlé automatiquement par le control plane. Cette automatisation s'exécute sous son propre projet OpenStack, et Ironic inscrit l'identifiant du projet demandeur sur le nœud lorsqu'aucun propriétaire n'est fourni explicitement. Par conséquent, un nœud fraîchement découvert appartient au **projet d'administration de la plateforme utilisé par la découverte**, et non au projet dans lequel vous souhaitez exécuter votre charge de travail.
+
+#### 5.2 Pourquoi l'allocation échoue
+
+Une allocation possède également un `owner`. Lorsqu'il est renseigné, Ironic ajoute `owner=<propriétaire de l'allocation>` à la requête qui sélectionne les nœuds candidats. Un nœud appartenant à un autre projet n'est donc jamais candidat, **même lorsqu'il est explicitement désigné avec `--candidate-node`**.
+
+C'est ce qui rend le problème déroutant : avec un token restreint à un projet (*project-scoped*), le champ `owner` de l'allocation est renseigné automatiquement avec l'identifiant de votre projet. Vous demandez donc un nœud que vous voyez bien à l'état `available`, et l'allocation échoue malgré tout, car Ironic recherche des nœuds `available` appartenant à *votre* projet, alors que le nœud appartient encore au projet de découverte.
+
+Quelle que soit la cause réelle, l'allocation échoue toujours avec l'un de ces deux messages, qui ne mentionnent que la classe de ressource :
+
+```bash
+no available nodes match the resource class discovered
+```
+
+```bash
+none of the requested nodes are available and match the resource class discovered
+```
+
+Le premier est retourné lorsqu'aucun nœud candidat n'a été fourni, le second lorsque l'option `--candidate-node` a été utilisée. Les deux signifient la même chose : **la requête de sélection des nœuds candidats n'a rien retourné**.
+
+#### 5.3 Diagnostiquer
+
+Vérifiez chacune des conditions listées à l'étape 1, en commençant par le propriétaire du nœud :
+
+```bash
+openstack baremetal node show <nom-du-noeud> -f value -c owner
+```
+
+Si la valeur retournée n'est pas l'identifiant du projet auquel le nœud est réservé, il s'agit de la cause de l'échec.
+
+#### 5.4 Résoudre
+
+Deux stratégies sont possibles, selon que vous souhaitez ou non affecter **durablement** le nœud à un projet.
+
+**Stratégie 1 — transférer la propriété du nœud au projet cible (recommandé).**
+
+C'est la manière normale de confier un nœud à un projet. En tant qu'administrateur de l'infrastructure, vous transférez la propriété une fois pour toutes, et le projet peut ensuite allouer et déployer sur le nœud de manière autonome :
+
+```bash
+openstack baremetal node set <nom-du-noeud> --owner <id-du-projet>
+```
+
+Créez ensuite l'allocation de nouveau, comme décrit à l'étape 2. Notez que la propriété d'un nœud confère un niveau d'accès élevé à **tous** les membres du projet propriétaire.
+
+**Stratégie 2 — créer l'allocation avec le propriétaire actuel du nœud.**
+
+La propriété du nœud reste inchangée et la réservation est effectuée au nom du projet qui le possède. Cela convient à une réservation administrative ponctuelle, par exemple sur un nœud conservé dans le pool d'administration :
+
+```bash
+openstack baremetal allocation create \
+  --resource-class discovered \
+  --candidate-node <nom-du-noeud> \
+  --owner <id-du-projet-proprietaire-du-noeud> \
+  --name my-workload-01
+```
+
+Cette stratégie nécessite un token vous autorisant à définir un propriétaire arbitraire sur l'allocation. Avec un token restreint à un projet, le champ est forcé à l'identifiant de votre projet et seule la stratégie 1 fonctionne.
+
+### 6. Libérer une allocation
+
+Si le nœud a été déployé, c'est-à-dire si son `provision_state` vaut `active`, commencez par le désinstaller :
+
+```bash
+openstack baremetal node undeploy <nom-du-noeud>
+```
+
+Supprimez ensuite l'allocation afin de libérer la réservation :
+
+```bash
+openstack baremetal allocation delete my-workload-01
+```
+
+Les champs `instance_uuid` et `allocation_uuid` sont vidés et le nœud redevient allouable.
+
+:::warning
+- La suppression d'une allocation ne désinstalle **pas** le nœud. Désinstallez-le toujours au préalable.
+- L'opération est refusée avec une erreur `HTTP 400` ou `HTTP 409` tant que le nœud se trouve dans un état transitoire (`deploying`, `deleting`, `cleaning`). Attendez que la machine à états se stabilise.
+- La désinstallation déclenche le nettoyage automatisé, qui comprend un effacement complet des disques dans la configuration OPCP par défaut. Le retour à l'état `available` prend donc un certain temps.
+:::
+
+## Aller plus loin
+
+- [Cycle de vie d'un nœud OPCP](/guides/hosted-private-cloud/opcp/node-lifecycle)
+- [Consulter l'inventaire des nœuds](/guides/hosted-private-cloud/opcp/how-to-see-node-inventory)
+- [Installer une instance avec le CLI OpenStack](/guides/hosted-private-cloud/opcp/how-to-setup-instance-from-cli)
+- [Documentation OpenStack Ironic - Allocations](https://docs.openstack.org/ironic/latest/user/deploy.html)
+- [Documentation OpenStack Ironic - Multi-tenancy et propriété des nœuds](https://docs.openstack.org/ironic/latest/admin/node-multitenancy.html)
+- [Documentation OpenStack Ironic - Ordonnancement basé sur les traits](https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html)
+
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou consultez la page [Professional Services](/links/professional-services) pour obtenir un devis et faire analyser votre projet par nos experts.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).


### PR DESCRIPTION
docs(opcp): add guide on allocating and de-allocating a node

New guide explaining how to reserve an OPCP Core node so that it is used only by a
given OpenStack project, and how to release it.

- list the conditions a node must meet to be an allocation candidate
- create, inspect and verify an allocation, then release the claim
- explain the `owner` field: discovery enrolls nodes under the platform administration
  project, so an allocation created from another project fails with a message naming
  only the resource class
- scope the guide to OPCP Core: services deployed through the CloudStore allocate their
  resources from the service catalog

Ported from an internal runbook; internal project IDs and node names replaced by
placeholders. Traits and allocations link to the upstream Ironic documentation, as no
OVHcloud guide covers them.

Sidebar entry added under On-Prem Cloud Platform > Getting started, after "Node lifecycle".
EN and FR only.
