### PR TITLE
docs(account): add 72h transmission delay to e-invoicing FAQ

### DIFF
--- a/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
+++ b/docs/fr/guides/account-and-service-management/managing-billing-payments-and-services/faq-electronic-invoicing.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ sur la facturation électronique OVHcloud
 description: Retrouvez les questions les plus fréquemment posées sur la réforme de la facturation électronique et la réception de vos factures OVHcloud
-lastUpdated: 2026-08-27
+lastUpdated: 2026-09-04
 ---
 
 <Banner kind="siret-fr" />
@@ -89,6 +89,8 @@ Pour savoir comment y accéder, consultez le guide « [Gérer mes factures OVHc
 <details>
 
 <summary>Pourquoi ma facture n'apparaît-elle pas dans ma plateforme ?</summary>
+
+**La transmission des factures sur les plateformes peut nécessiter jusqu'à 72 heures après la finalisation des commandes.**
 
 Une facture est générée uniquement lorsque votre commande est **finalisée**. Nous vous invitons à vérifier le statut de vos commandes depuis votre espace client en vous aidant du guide « [Gérer mes commandes OVHcloud](/guides/account-and-service-management/managing-billing-payments-and-services/ovh-orders) ».
 


### PR DESCRIPTION
Clarify in the "Pourquoi ma facture n'apparait-elle pas dans ma plateforme ?" entry that invoice transmission to the platforms can take up to 72 hours after an order is finalised.