### PR TITLE
docs(sd): remove eol operating systems in various configuration guides

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguration eines Additional IP-Blocks in einem vRack
 description: In dieser Anleitung erfahren Sie, wie Sie einen Block öffentlicher IP-Adressen für die Verwendung mit dem vRack konfigurieren.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -389,70 +389,6 @@ ip link set eth1 up
 #### GNU/Linux-Konfigurationen
 
 <Tabs>
-<Tab label="Debian 11">
-**Additional IP konfigurieren**
-
-Öffnen Sie die Netzwerkkonfigurationsdatei in `/etc/network/interfaces.d` mit einem Texteditor Ihrer Wahl. Hier heißt die Datei `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Eine neue IP-Routing-Tabelle erstellen**
-
-Erstellen Sie als Nächstes eine neue IP-Route für das vRack. Fügen Sie eine neue Verkehrsregel hinzu, indem Sie die Datei wie folgt ergänzen:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Die Netzwerkkonfigurationsdatei anpassen**
-
-:::info
-Als Beispiel befindet sich die Netzwerkkonfigurationsdatei, auf die wir verweisen, unter /etc/network/interfaces. Die entsprechende Datei auf Ihrem Server kann sich je nach Betriebssystem an einem anderen Ort befinden.
-
-:::
-
-Passen Sie abschließend die Netzwerkkonfigurationsdatei an, um die neue Verkehrsregel zu berücksichtigen und den vRack-Verkehr über die Netzwerk-Gateway-Adresse **46.105.135.110** zu routen.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Starten Sie den Server neu, um die Änderungen zu übernehmen, oder aktivieren Sie einfach die neue Netzwerkschnittstelle:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux und Rocky Linux (8/9)">
 **Die Datei für die sekundäre Netzwerkschnittstelle erstellen**
 
@@ -581,7 +517,7 @@ Wenden Sie die Konfiguration mit dem folgenden Befehl an:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux und Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux und Rocky Linux (10)">
 Überprüfen Sie zunächst, dass Ihre vRack-Schnittstelle den Status `connected` oder `connecting` hat. In unserem Beispiel heißt die Schnittstelle `eno2`.
 
 ```sh

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguration eines Additional IP-Blocks in einem vRack
 description: In dieser Anleitung erfahren Sie, wie Sie einen Block öffentlicher IP-Adressen für die Verwendung mit dem vRack konfigurieren.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: vRack zwischen Public Cloud und Dedicated Server einrichten
 description: Erfahren Sie hier, wie Sie ein privates Netzwerk zwischen Public Cloud Instanzen und Dedicated Servern einrichten
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -177,34 +177,6 @@ Verwenden Sie diesen Schnittstellennamen, um `NETWORK_INTERFACE` in den folgende
 Als Beispiel verwenden wir den IP-Adressbereich `192.168.0.0/16` (**Subnetzmaske**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Öffnen Sie mit einem Texteditor Ihrer Wahl die Netzwerkkonfigurationsdatei in `/etc/network/interfaces.d` zur Bearbeitung. Hier heißt die Datei `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Fügen Sie die folgenden Zeilen zur vorhandenen Konfiguration hinzu und ersetzen Sie `NETWORK_INTERFACE`, `IP_ADDRESS` und `NETMASK` durch Ihre eigenen Werte:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Beispiel:**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Speichern Sie Ihre Änderungen in der Konfigurationsdatei und schließen Sie den Editor.
-    
-    Starten Sie den Netzwerkdienst neu, um die Konfiguration anzuwenden:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu und Debian 12+">
     Öffnen Sie mit einem Texteditor Ihrer Wahl die Netzwerkkonfigurationsdatei in `/etc/netplan/` zur Bearbeitung. Hier heißt die Datei `50-cloud-init.yaml`.
     
@@ -284,7 +256,7 @@ Speichern Sie Ihre Änderungen in der Konfigurationsdatei und schließen Sie den
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux und Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux und Rocky Linux (10)">
     Nachdem Sie den Namen Ihrer privaten Schnittstelle identifiziert haben, führen Sie den folgenden Befehl aus, um zu überprüfen, ob sie verbunden ist. In unserem Beispiel heißt unsere Schnittstelle `eno2`:
     
     ```bash
@@ -421,91 +393,6 @@ Klicken Sie auf <code className="action">OK</code>, um die Änderungen zu speich
 In diesem Beispiel verwenden wir **10** als VLAN-ID (Tag) und **192.168.0.0/16** als privaten IP-Adressbereich.
 
 <Tabs>
-  <Tab label="Debian 11">
-    Die folgende Konfiguration basiert auf Debian 11 (Bullseye).
-    
-    - Bevor Sie beginnen, stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie die folgenden Befehle aus, um das VLAN-Paket zu installieren:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - Laden Sie dann das Kernel-Modul 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Um zu überprüfen, ob das Modul geladen ist:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Führen Sie den folgenden Befehl aus, um sicherzustellen, dass die Module beim Booten dauerhaft geladen werden:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Rufen Sie die Schnittstellennamen ab und identifizieren Sie die private Schnittstelle:
-    
-    ```sh
-    ip a
-    ```
-    
-    In diesem Beispiel wird die private Netzwerkschnittstelle als `eno2` identifiziert.
-    
-    - Als Nächstes erstellen Sie eine VLAN-Subschnittstelle für die Netzwerkschnittstelle (nicht persistente Konfiguration) und weisen Sie ihr die VLAN-ID zu (taggen Sie sie). In diesem Beispiel ist die VLAN-ID 10.
-    
-    Ersetzen Sie die Werte durch Ihre eigenen.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - Weisen Sie dann der neu erstellten VLAN-Subschnittstelle eine private IP-Adresse zu:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - Aktivieren Sie dann die private Schnittstelle und die VLAN-Subschnittstelle:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Um die Konfiguration persistent zu machen, fügen Sie die folgenden Einträge zur Konfigurationsdatei hinzu:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Übersicht:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Starten Sie das Netzwerk neu, um die Änderungen anzuwenden:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu und Debian 12+">
     Die folgende Konfiguration basiert auf Ubuntu 24.04 (Noble Numbat).
     
@@ -676,7 +563,7 @@ In diesem Beispiel verwenden wir **10** als VLAN-ID (Tag) und **192.168.0.0/16**
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
     Die folgende Konfiguration basiert auf Fedora 43.
     
     - Bevor Sie beginnen, stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie den folgenden Befehl aus, um das Kernel-Modul 8021q zu laden:

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: vRack zwischen Public Cloud und Dedicated Server einrichten
 description: Erfahren Sie hier, wie Sie ein privates Netzwerk zwischen Public Cloud Instanzen und Dedicated Servern einrichten
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mehrere VLANs im vRack auf einem Dedicated Server erstellen
 description: Erstellen und verwalten Sie mehrere VLANs in Ihrem OVHcloud vRack, um den Netzwerkverkehr zwischen Dedicated Servern zu segmentieren.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ Alle Befehle müssen an die jeweils verwendete Distribution angepasst werden. Be
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Stellen Sie zunächst eine SSH-Verbindung zu Ihrem Server her und führen Sie die folgenden Befehle über die Kommandozeile aus, um das VLAN-Paket auf Ihrem Server zu installieren:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    Laden Sie als Nächstes das 8021q Kernel-Modul:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Um zu überprüfen, ob das Modul geladen ist:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Führen Sie den folgenden Befehl aus, um sicherzustellen, dass die Module beim Booten dauerhaft geladen werden:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    Rufen Sie als Nächstes Ihre Schnittstellennamen ab und identifizieren Sie die private Schnittstelle:
-    
-    ```sh
-    ip a
-    ```
-    
-    Erstellen Sie als Nächstes ein VLAN-Tag. Das Tag dient als Kennung, mit der Sie verschiedene VLANs voneinander unterscheiden können:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **In diesem Beispiel:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Verwenden Sie denselben Befehl für jedes VLAN-Tag, das Sie hinzufügen möchten.
-    
-    Geben Sie als Nächstes den privaten IP-Adressbereich im vRack an und taggen Sie ihn mit der Kennung. Verwenden Sie hierzu den folgenden Befehl:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Ändern Sie die Konfiguration Ihrer Netzwerkschnittstelle, um das VLAN-Tag zu integrieren. Öffnen Sie Ihre Konfigurationsdatei für Netzwerkschnittstellen und fügen Sie die folgenden Einträge hinzu:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    Für mehrere konfigurierte VLANs sollte Ihre Netzwerkkonfiguration so aussehen:
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu und Debian 12+">
     Diese Befehle wurden unter Ubuntu 24.04 (Noble Numbat) ausgeführt.
     
@@ -272,7 +200,7 @@ Alle Befehle müssen an die jeweils verwendete Distribution angepasst werden. Be
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux und Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux und Rocky Linux (10)">
     Die folgende Konfiguration basiert auf Fedora 43.
     
     Bevor Sie beginnen, stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie den folgenden Befehl aus, um das 8021q Kernel-Modul zu laden:

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mehrere VLANs im vRack auf einem Dedicated Server erstellen
 description: Erstellen und verwalten Sie mehrere VLANs in Ihrem OVHcloud vRack, um den Netzwerkverkehr zwischen Dedicated Servern zu segmentieren.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -155,8 +155,8 @@ Wählen Sie den Tab für Ihr Betriebssystem.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ und Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 und spätere Versionen
+  <Tab label="Debian 12+ und Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 und spätere Versionen
     
     Standardmäßig befinden sich die Konfigurationsdateien im Verzeichnis `/etc/netplan`.
     

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dedicated Server - IP-Aliasing konfigurieren
 description: Fügen Sie Additional IP-Adressen zu Ihrem OVHcloud Dedicated Server hinzu und konfigurieren Sie diese für Multi-Site- oder Dienst-Hosting.
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -69,126 +69,8 @@ Wählen Sie den Tab für Ihr Betriebssystem.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Standardmäßig befindet sich die Konfigurationsdatei unter `/etc/network/interfaces.d/`. Es wird empfohlen, zunächst eine Sicherungskopie der entsprechenden Konfigurationsdatei zu erstellen.
-    
-    **Schritt 1: Backup erstellen**
-    
-    In unserem Beispiel heißt die Datei `50-cloud-init`, also kopieren wir die Datei `50-cloud-init` mit folgendem Befehl:
-    
-    ```sh
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    Wenn Sie einen Fehler gemacht haben, können Sie mit den folgenden Befehlen zum vorherigen Zustand zurückkehren:
-    
-    ```sh
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **Schritt 2: Konfigurationsdatei bearbeiten**
-    
-    :::info
-    Die Namen der Netzwerkschnittstellen in dieser Anleitung können von den Namen Ihres Systems abweichen. Passen Sie die Einstellungen entsprechend an.
-    :::
-    
-    Sie können nun die Konfigurationsdatei bearbeiten:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Fügen Sie anschließend ein virtuelles Interface oder einen Ethernet-Alias hinzu. In unserem Beispiel heißt das Interface `eth0`, der Alias ist also `eth0:0`. Tun Sie dies für jede Additional IP-Adresse, die Sie konfigurieren möchten.
-    
-    Ändern Sie nicht die bestehenden Zeilen in der Konfigurationsdatei, sondern fügen Sie einfach Ihre Additional IP wie unten beschrieben zu der Datei hinzu und ersetzen Sie `ADDITIONAL_IP/32` sowie das virtuelle Interface (wenn Ihr Server nicht **eth0:0** verwendet) durch Ihre eigenen Werte:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    Sie können Ihre Additional IP auch konfigurieren, indem Sie der Konfigurationsdatei die folgenden Zeilen hinzufügen:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    Bei der oben stehenden Konfiguration wird das virtuelle Interface jedes Mal aktiviert oder deaktiviert, wenn das `eth0` Interface aktiviert oder deaktiviert wird.
-    
-    Wenn Sie zwei Additional IPs konfigurieren müssen, sollte die Datei `/etc/network/interfaces.d/50-cloud-init` wie folgt aussehen:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    Oder:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Konfigurationsbeispiel**</summary>
-
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    Oder
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **Schritt 3: Interface neu starten**
-    
-    Im letzten Schritt starten Sie das Interface neu:
-    
-    ```sh
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 und spätere Versionen, AlmaLinux und Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 und spätere Versionen, AlmaLinux und Rocky Linux (10)
     
     Fedora verwendet nunmehr Schlüsseldateien (*keyfiles*).
     Fedora speicherte zuvor im Verzeichnis `/etc/sysconfig/network-scripts/` Netzwerkprofile im Format ifcfg.<br/>

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dedicated Server - IP-Aliasing konfigurieren
 description: Fügen Sie Additional IP-Adressen zu Ihrem OVHcloud Dedicated Server hinzu und konfigurieren Sie diese für Multi-Site- oder Dienst-Hosting.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -155,8 +155,8 @@ Wählen Sie den Tab für Ihr Betriebssystem.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ und Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 und spätere Versionen
+  <Tab label="Debian 12+ und Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 und spätere Versionen
     
     Standardmäßig befinden sich die Konfigurationsdateien im Verzeichnis `/etc/netplan`.
     

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: IPv6 auf einem Dedicated Server konfigurieren
 description: Erfahren Sie hier, wie Sie IPv6-Adressen auf unserer Infrastruktur konfigurieren
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -116,7 +116,6 @@ Bei einigen Betriebssystemen ist das Hinzufügen von statischen IPv6-Routen in d
 
 <Tabs>
   <Tab label="Debian und seine Derivate (außer Debian 12)">
-    Die folgende Beispielkonfiguration basiert auf Debian 11 (Bullseye).
     
     :::warning
     Es wird ausdrücklich empfohlen, dass Sie vor Befolgen der nachstehenden Schritte die IPv6-Autokonfiguration und die Router-Ankündigung deaktivieren. Fügen Sie hierzu die folgenden Zeilen Ihrer `sysctl.conf`-Datei hinzu, die sich in `/etc/sysctl.conf` befindet:
@@ -236,8 +235,8 @@ Bei einigen Betriebssystemen ist das Hinzufügen von statischen IPv6-Routen in d
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    Die folgende Beispielkonfiguration basiert auf Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    Die folgende Beispielkonfiguration basiert auf Fedora 43.
     
     Fedora verwendet Schlüsseldateien (*keyfiles*).
     

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: IPv6 auf einem Dedicated Server konfigurieren
 description: Erfahren Sie hier, wie Sie IPv6-Adressen auf unserer Infrastruktur konfigurieren
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring an Additional IP block in a vRack
 description: This guide will show you how to configure a block of public IP addresses for use with the vRack.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -379,70 +379,6 @@ ip link set eth1 up
 #### GNU/Linux configurations
 
 <Tabs>
-<Tab label="Debian 11">
-**Configure the Additional IP**
-
-Using a text editor of your choice, open the network configuration file located in `/etc/network/interfaces.d` for editing. Here the file is called `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Create a new IP routing table**
-
-Next, we need to create a new IP route for the vRack. We'll be adding a new traffic rule by amending the file, as shown below:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Amend the network configuration file**
-
-:::info
-For example purposes, the network configuration file we refer to is located in /etc/network/interfaces. The equivalent file on your server may be located somewhere else, depending on your operating system.
-
-:::
-
-Finally, we need to amend the network configuration file to account for the new traffic rule and route the vRack traffic through the network gateway address of **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Now reboot your server to apply the changes or alternatively simply enable the new network interface:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux and Rocky Linux (8/9)">
 **Create the file for the secondary network interface**
 
@@ -571,7 +507,7 @@ Apply the configuration with the following command:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux and Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
 First, verify that your vRack interface is `connected` or `connecting` state. In our example, the interface is called `eno2`.
 
 ```sh

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring an Additional IP block in a vRack
 description: This guide will show you how to configure a block of public IP addresses for use with the vRack.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring the vRack between the Public Cloud and a Dedicated Server
 description: Find out how to configure private networking between a Public Cloud instance and a Dedicated Server
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -177,34 +177,6 @@ Use this interface name to replace `NETWORK_INTERFACE` in the configurations bel
 For example purposes, we will use the IP address range of `192.168.0.0/16` (**Subnet mask**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Using a text editor of your choice, open the network configuration file located in `/etc/network/interfaces.d` for editing. Here the file is called `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Add the following lines to the existing configuration, replace `NETWORK_INTERFACE`, `IP_ADDRESS` and `NETMASK` with your own values:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Example**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Save your changes to the config file and exit the editor.
-    
-    Restart the networking service to apply the configuration:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu & Debian 12+">
     Using a text editor of your choice, open the network configuration file located in `/etc/netplan/` for editing. Here the file is called `50-cloud-init.yaml`.
     
@@ -284,7 +256,7 @@ Save your changes to the config file and exit the editor.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux and Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
     Once you have identified the name of your private interface, run the following command to verify that is it connected. In our example, our interface is called `eno2`:
     
     ```bash 
@@ -421,91 +393,6 @@ Click on <code className="action">OK</code> to save the changes and reboot your 
 In this example, we'll use **10** as the VLAN ID (tag), and **192.168.0.0/16** as the private IP address range.
 
 <Tabs>
-  <Tab label="Debian 11">
-    The configuration below is based on Debian 11 (Bullseye).
-    
-    - Before you begin, establish an SSH connection to your server and run the following commands to install the VLAN package:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - Next, load the 8021q kernel module:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - To verify that the module is loaded:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Run the following command to ensure the modules are permanently loaded at boot:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Retrieve the interface names and identify the private interface:
-    
-    ```sh
-    ip a
-    ```
-    
-    In this example, the private network interface is identified as `eno2`.
-    
-    - Next, create a VLAN subinterface for the network interface (non-persistent configuration) and assign (tag) it the VLAN ID. In this example, the VLAN ID is 10.
-    
-    Replace the values with your own.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - Next, assign a private IP address to the newly created VLAN subinterface:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - Next, activate the private interface and the VLAN subinterface:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - To make the configuration persistent, add the following entries to the configuration file:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Overview:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Restart the network to apply the changes:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu and Debian 12+">
     The configuration below is based on Ubuntu 24.04 (Noble Numbat).
     
@@ -676,7 +563,7 @@ In this example, we'll use **10** as the VLAN ID (tag), and **192.168.0.0/16** a
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
     The configuration below is based on Fedora 43.
     
     - Before you begin, establish an SSH connection to your server and run the following command to load the 8021q kernel module:

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring the vRack between the Public Cloud and a Dedicated Server
 description: Find out how to configure private networking between a Public Cloud instance and a Dedicated Server
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create Multiple vLANs in a vRack on a Dedicated Server
 description: Create and manage multiple vLANs within your OVHcloud vRack to segment network traffic between dedicated servers.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -40,78 +40,6 @@ All commands must be adapted to the distribution used. Please refer to the offic
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    First, establish an SSH connection to your server and run the following commands from the command line to install the VLAN package on your server:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    Next, load the 8021q kernel module:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    To verify that the module is loaded:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Run the following command to ensure the modules are permanently loaded at boot:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    Next, retrieve your interface names and identify the private interface:
-    
-    ```sh
-    ip a
-    ```
-    
-    Next, create a VLAN tag. The tag serves as an identifier, allowing you to differentiate between multiple VLANs:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **In this example:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Use the same command for each VLAN tag you wish to add.
-    
-    Next, declare the private IP address range within the vRack and tag it with the identifier using the following command:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Amend the configuration of your network interface to incorporate the VLAN tag. Open your network interface configuration file and add the following entries:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    For multiple configured VLANs, your network configuration should look like this:
-    
-    <img className="thumbnail" alt="Debian network config file with multiple VLAN entries" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu and Debian 12+">
     These commands were executed under Ubuntu 24.04 (Noble Numbat).
     
@@ -271,7 +199,7 @@ All commands must be adapted to the distribution used. Please refer to the offic
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux and Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
     The configuration below is based on Fedora 43.
     
     Before you begin, establish an SSH connection to your server and run the following command to load the 8021q kernel module:

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create Multiple vLANs in a vRack on a Dedicated Server
 description: Create and manage multiple vLANs within your OVHcloud vRack to segment network traffic between dedicated servers.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure IP Aliasing on a Dedicated Server
 description: Add and configure Additional IP addresses on your OVHcloud dedicated server for multi-site or service hosting.
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -70,126 +70,8 @@ Select the tab corresponding to your operating system.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    By default, the configuration files are located in `/etc/network/interfaces.d/`. We recommend that you start by backing up the relevant configuration file. 
-    
-    **Step 1: Create a backup**
-    
-    In our example, our file is called `50-cloud-init`, so we make a copy of the `50-cloud-init` file using the following command:
-    
-    ```bash
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    In case of a mistake, you will be able to revert the changes, using the commands below:
-    
-    ```bash
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **Step 2: Edit the configuration file**
-    
-    :::info
-    Note that the names of the network interfaces in our examples may differ from your own. Please adjust to your appropriate interface names.
-    :::
-    
-    You can now modify the configuration file:
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Next, you need to add a virtual interface or ethernet alias. In our example, our interface is called `eth0`, so our alias is `eth0:0`. Do this for each additional IP you wish to configure.
-    
-    Do not modify the existing lines in the configuration file, simply add your Additional IP to the file as follows, replacing `ADDITIONAL_IP/32` as well as the virtual interface (if your server is not using **eth0:0**) with your own values:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    Alternatively, you can configure your Additional IP by adding the following lines in the configuration file:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    With the configuration above, the virtual interface is enabled or disabled whenever the `eth0` interface is enabled or disabled.
-    
-    If you have two Additional IPs to configure, the `/etc/network/interfaces.d/50-cloud-init` file should look like this:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    Or like this:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Configuration example**</summary>
-
-    ```console
-     auto eth0
-     iface eth0 inet dhcp
-    
-    auto eth0:0
-     iface eth0:0 inet static
-     address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    Or:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **Step 3: Restart the interface**
-    
-    To restart the interface, use the following command:
-    
-    ```bash
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 and following, AlmaLinux & Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 and following, AlmaLinux & Rocky Linux (10)
     
     Fedora now uses keyfiles. NetworkManager previously stored network profiles in ifcfg format in this directory: `/etc/sysconfig/network-scripts/`. However, the ifcfg format is now deprecated. By default, NetworkManager no longer creates new profiles in this format. The configuration file is now found in `/etc/NetworkManager/system-connections/`.
     

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -146,8 +146,8 @@ Select the tab corresponding to your operating system.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ and Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 and following
+  <Tab label="Debian 12+ and Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 and following
     
     By default, the configuration files are located in the `/etc/netplan` directory. 
     

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure IP Aliasing on a Dedicated Server
 description: Add and configure Additional IP addresses on your OVHcloud dedicated server for multi-site or service hosting.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -146,8 +146,8 @@ Select the tab corresponding to your operating system.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ and Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 and following
+  <Tab label="Debian 12+ and Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 and following
     
     By default, the configuration files are located in the `/etc/netplan` directory. 
     

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring IPv6 on dedicated servers
 description: Find out how to configure IPv6 addresses on our infrastructure
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -112,7 +112,6 @@ With some operating systems, the addition of static IPv6 routes in the original 
 
 <Tabs>
   <Tab label="Debian and derivatives (excluding Debian 12)">
-    The configuration example below is based on Debian 11 (Bullseye).
     
     :::warning
     Before following the steps below, we strongly suggest that you disable IPv6 autoconf and router advertising to prevent known issues. You can do so by adding the following lines to your `sysctl.conf` file, which is located in `/etc/sysctl.conf`:
@@ -232,8 +231,8 @@ With some operating systems, the addition of static IPv6 routes in the original 
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    The configuration example below is based on Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    The configuration example below is based on Fedora 43.
     
     Fedora now uses keyfiles. NetworkManager previously stored network profiles in ifcfg format in this directory: `/etc/sysconfig/network-scripts/`. However, the ifcfg format is now deprecated. By default, NetworkManager no longer creates new profiles in this format. The configuration file is now found in `/etc/NetworkManager/system-connections/`. 
     

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring IPv6 on dedicated servers
 description: Find out how to configure IPv6 addresses on our infrastructure
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un bloque de Additional IP en un vRack
 description: Descubra cómo configurar un bloque de direcciones IP públicas en el vRack.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -389,70 +389,6 @@ ip link set eth1 up
 #### Configuraciones GNU/Linux
 
 <Tabs>
-<Tab label="Debian 11">
-**Configurar la Additional IP**
-
-Abra el archivo de configuración de red ubicado en `/etc/network/interfaces.d` con el editor de texto de su elección. Aquí el archivo se llama `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Crear una nueva tabla de enrutamiento IP**
-
-A continuación, cree una nueva ruta IP para el vRack. Añada una nueva regla de tráfico modificando el archivo como se muestra a continuación:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Modificar el archivo de configuración de red**
-
-:::info
-A modo de ejemplo, el archivo de configuración de red al que hacemos referencia se encuentra en /etc/network/interfaces. El archivo equivalente en su servidor puede estar ubicado en otro lugar, dependiendo de su sistema operativo.
-
-:::
-
-Por último, modifique el archivo de configuración de red para tener en cuenta la nueva regla de tráfico y enrutar el tráfico del vRack a través de la dirección de puerta de enlace de red **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Reinicie el servidor para aplicar los cambios o habilite simplemente la nueva interfaz de red:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux y Rocky Linux (8/9)">
 **Crear el archivo para la interfaz de red secundaria**
 
@@ -581,7 +517,7 @@ Aplique la configuración con el siguiente comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux y Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux y Rocky Linux (10)">
 En primer lugar, compruebe que su interfaz vRack está en estado `connected` o `connecting`. En nuestro ejemplo, la interfaz se llama `eno2`.
 
 ```sh

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar un bloque de Additional IP en un vRack
 description: Descubra cómo configurar un bloque de direcciones IP públicas en el vRack.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el vRack entre Public Cloud y un servidor dedicado
 description: Cómo configurar una red privada entre una instancia de Public Cloud y un servidor dedicado
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -177,34 +177,6 @@ Use este nombre de interfaz para reemplazar `NETWORK_INTERFACE` en las siguiente
 A modo de ejemplo, utilizaremos el rango de direcciones IP `192.168.0.0/16` (**Máscara de subred**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Con un editor de texto de su elección, abra el archivo de configuración de red ubicado en `/etc/network/interfaces.d` para editarlo. Aquí el archivo se llama `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Añada las siguientes líneas a la configuración existente, reemplazando `NETWORK_INTERFACE`, `IP_ADDRESS` y `NETMASK` con sus propios valores:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Ejemplo:**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Guarde los cambios en el archivo de configuración y cierre el editor.
-    
-    Reinicie el servicio de red para aplicar la configuración:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu y Debian 12+">
     Con un editor de texto de su elección, abra el archivo de configuración de red ubicado en `/etc/netplan/` para editarlo. Aquí el archivo se llama `50-cloud-init.yaml`.
     
@@ -284,7 +256,7 @@ Guarde los cambios en el archivo de configuración y cierre el editor.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux y Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux y Rocky Linux (10)">
     Una vez que haya identificado el nombre de su interfaz privada, ejecute el siguiente comando para verificar que esté conectada. En nuestro ejemplo, nuestra interfaz se llama `eno2`:
     
     ```bash
@@ -421,91 +393,6 @@ Haga clic en <code className="action">Aceptar</code> para guardar los cambios y 
 En este ejemplo, utilizaremos **10** como VLAN ID (etiqueta) y **192.168.0.0/16** como rango de direcciones IP privadas.
 
 <Tabs>
-  <Tab label="Debian 11">
-    La configuración siguiente se basa en Debian 11 (Bullseye).
-    
-    - Antes de comenzar, establezca una conexión SSH a su servidor y ejecute los siguientes comandos para instalar el paquete VLAN:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - A continuación, cargue el módulo del kernel 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Para verificar que el módulo esté cargado:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Ejecute el siguiente comando para asegurarse de que los módulos se carguen permanentemente al arrancar:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Obtenga los nombres de las interfaces e identifique la interfaz privada:
-    
-    ```sh
-    ip a
-    ```
-    
-    En este ejemplo, la interfaz de red privada se identifica como `eno2`.
-    
-    - A continuación, cree una subinterfaz VLAN para la interfaz de red (configuración no persistente) y asígnele (etiquete) el VLAN ID.
-    
-    Reemplace los valores con los suyos.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - A continuación, asigne una dirección IP privada a la subinterfaz VLAN recién creada:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - A continuación, active la interfaz privada y la subinterfaz VLAN:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Para hacer la configuración persistente, añada las siguientes entradas al archivo de configuración:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Resumen:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Reinicie la red para aplicar los cambios:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu y Debian 12+">
     La configuración siguiente se basa en Ubuntu 24.04 (Noble Numbat).
     
@@ -676,7 +563,7 @@ En este ejemplo, utilizaremos **10** como VLAN ID (etiqueta) y **192.168.0.0/16*
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux y Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux y Rocky Linux (10)">
     La configuración siguiente se basa en Fedora 43.
     
     - Antes de comenzar, establezca una conexión SSH a su servidor y ejecute el siguiente comando para cargar el módulo del kernel 8021q:

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el vRack entre Public Cloud y un servidor dedicado
 description: Cómo configurar una red privada entre una instancia de Public Cloud y un servidor dedicado
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear varias VLAN en el vRack en un servidor dedicado
 description: Cree y gestione varias VLAN en su vRack de OVHcloud para segmentar el tráfico de red entre servidores dedicados.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ Todos los comandos deben adaptarse a la distribución utilizada. En caso de duda
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    En primer lugar, establezca una conexión SSH con su servidor y ejecute los siguientes comandos desde la línea de comandos para instalar el paquete VLAN en su servidor:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    A continuación, cargue el módulo del núcleo 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Para verificar que el módulo está cargado:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Ejecute el siguiente comando para asegurarse de que los módulos se cargan permanentemente en el arranque:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    A continuación, obtenga los nombres de sus interfaces e identifique la interfaz privada:
-    
-    ```sh
-    ip a
-    ```
-    
-    A continuación, cree una etiqueta VLAN. La etiqueta sirve como identificador, lo que le permite distinguir varias VLAN:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **En este ejemplo:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Utilice el mismo comando para cada etiqueta VLAN que desee añadir.
-    
-    A continuación, declare el rango de direcciones IP privadas dentro del vRack y etiquételo con el identificador utilizando el siguiente comando:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Modifique la configuración de su interfaz de red para incorporar la etiqueta VLAN. Abra su archivo de configuración de interfaz de red y añada las siguientes entradas:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    Para varias VLAN configuradas, su configuración de red debería verse así:
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu y Debian 12+">
     Estos comandos se ejecutaron bajo Ubuntu 24.04 (Noble Numbat).
     
@@ -272,7 +200,7 @@ Todos los comandos deben adaptarse a la distribución utilizada. En caso de duda
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux y Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux y Rocky Linux (10)">
     La configuración a continuación se basa en Fedora 43.
     
     Antes de empezar, establezca una conexión SSH con su servidor y ejecute el siguiente comando para cargar el módulo del núcleo 8021q:

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Crear varias VLAN en el vRack en un servidor dedicado
 description: Cree y gestione varias VLAN en su vRack de OVHcloud para segmentar el tráfico de red entre servidores dedicados.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -147,8 +147,8 @@ Seleccione la pestaña correspondiente a su sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ y Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 y versiones posteriores
+  <Tab label="Debian 12+ y Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 y versiones posteriores
     
     Por defecto, los ficheros de configuración se encuentran en el directorio `/etc/netplan`.
     

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el IP aliasing en un servidor dedicado
 description: Añada y configure direcciones Additional IP en su servidor dedicado OVHcloud para un alojamiento multisitio o multiservicio
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -62,126 +62,8 @@ Seleccione la pestaña correspondiente a su sistema operativo.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Por defecto, el fichero de configuración se encuentra en `/etc/network/interfaces.d/`. Se recomienda realizar una copia de seguridad del archivo de configuración correspondiente.
-    
-    **1. Crear una copia de seguridad del archivo de configuración**
-    
-    En nuestro ejemplo, nuestro archivo se llama `50-cloud-init`, por lo que copiamos el archivo `50-cloud-init` utilizando el siguiente comando:
-    
-    ```sh
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    Si comete algún error, puede volver atrás con los siguientes comandos:
-    
-    ```sh
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **2. Editar el archivo de configuración**
-    
-    :::info
-    Los nombres de las interfaces de red de esta guía pueden ser diferentes de los suyos. Por favor, adapte las operaciones en consecuencia.
-    :::
-    
-    Ya puede editar el archivo.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    A continuación, debe agregar una interfaz virtual o un alias Ethernet. En nuestro ejemplo, nuestra interfaz se llama `eth0`, por lo que nuestro alias es `eth0:0`. Haga esto para cada dirección Additional IP que quiera configurar.
-    
-    No modifique las líneas existentes en el archivo de configuración, simplemente añada su Additional IP al archivo como se indica a continuación, sustituyendo `ADDITIONAL_IP/32` y la interfaz virtual (si su servidor no utiliza **eth0:0**) por sus propios valores:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    También puede configurar su Additional IP añadiendo las siguientes líneas al fichero de configuración:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    Con la configuración anterior, la interfaz virtual se activa o desactiva cada vez que la interfaz «eth0» se activa o desactiva.
-    
-    Si tiene que configurar dos direcciones Additional IP, el archivo `/etc/network/interfaces.d/50-cloud-init` debe tener el siguiente aspecto:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    O como esto:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Ejemplo**</summary>
-
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    O bien:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **3. Reiniciar la interfaz**
-    
-    Por último, reinicie la interfaz con el siguiente comando:
-    
-    ```sh
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 y versiones posteriores, AlmaLinux y Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 y versiones posteriores, AlmaLinux y Rocky Linux (10)
     
     Fedora ahora utiliza archivos clave (*keyfiles*).
     Fedora solía utilizar perfiles de red almacenados por NetworkManager en formato ifcfg en el directorio `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar el IP aliasing en un servidor dedicado
 description: Añada y configure direcciones Additional IP en su servidor dedicado OVHcloud para un alojamiento multisitio o multiservicio
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -147,8 +147,8 @@ Seleccione la pestaña correspondiente a su sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ y Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 y versiones posteriores
+  <Tab label="Debian 12+ y Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 y versiones posteriores
     
     Por defecto, los ficheros de configuración se encuentran en el directorio `/etc/netplan`.
     

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar IPv6 en un servidor dedicado
 description: Descubra cómo configurar direcciones IPv6 en nuestra infraestructura
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -117,7 +117,6 @@ Algunos sistemas operativos requieren que se añadan por defecto rutas IPv6 est�
 
 <Tabs>
   <Tab label="Debian y sus derivados (excepto Debian 12)">
-    El ejemplo de configuración que se muestra a continuación se basa en Debian 11 (Bullseye).
     
     :::warning
     Antes de seguir los pasos que se indican a continuación, es muy recomendable que deshabilite la autoconfiguración IPv6 y el «router advertising» para prevenir problemas conocidos. Para ello, debe añadir las siguientes líneas a su archivo `sysctl.conf` que se encuentra en `/etc/sysctl.conf`:
@@ -238,8 +237,8 @@ Algunos sistemas operativos requieren que se añadan por defecto rutas IPv6 est�
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    El ejemplo de configuración siguiente se basa en Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    El ejemplo de configuración siguiente se basa en Fedora 43.
     
     Fedora ahora utiliza archivos clave (*keyfiles*).
     Fedora solía utilizar perfiles de red almacenados por NetworkManager en formato ifcfg en el directorio `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar IPv6 en un servidor dedicado
 description: Descubra cómo configurar direcciones IPv6 en nuestra infraestructura
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un bloc Additional IP dans le vRack
 description: "Découvrez comment configurer un bloc d'adresses IP publiques dans le vRack"
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -394,70 +394,6 @@ ip link set eth1 up
 #### Configurations GNU/Linux
 
 <Tabs>
-<Tab label="Debian 11">
-**Configurer l'Additional IP**
-
-Ouvrez le fichier de configuration réseau situé dans `/etc/network/interfaces.d` avec un éditeur de texte de votre choix. Ici, le fichier s'appelle `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Créer une nouvelle table de routage IP**
-
-Ensuite, créez une nouvelle route IP pour le vRack. Ajoutez une nouvelle règle de trafic en modifiant le fichier comme indiqué ci-dessous :
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Modifier le fichier de configuration réseau**
-
-:::info
-À titre d'exemple, le fichier de configuration réseau auquel nous faisons référence se trouve dans /etc/network/interfaces. En fonction du système d'exploitation utilisé, le fichier équivalent peut être situé ailleurs.
-
-:::
-
-Pour finir, modifiez le fichier de configuration réseau pour prendre en compte la nouvelle règle de trafic et acheminer le trafic vRack via l'adresse de passerelle réseau **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Redémarrez le serveur pour appliquer les modifications ou activez simplement la nouvelle interface réseau :
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux et Rocky Linux (8/9)">
 **Créer le fichier pour l'interface réseau secondaire**
 
@@ -586,7 +522,7 @@ Appliquez la configuration avec la commande suivante :
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux et Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux et Rocky Linux (10)">
 Vérifiez d'abord que votre interface vRack est à l'état `connected` ou `connecting`. Dans notre exemple, l'interface s'appelle `eno2`.
 
 ```sh

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer un bloc Additional IP dans le vRack
 description: "Découvrez comment configurer un bloc d'adresses IP publiques dans le vRack"
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer le vRack entre Public Cloud et un serveur dédié
 description: Découvrez comment configurer un réseau privé entre une instance Public Cloud et un serveur dédié.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -177,34 +177,6 @@ Utilisez ce nom d'interface pour remplacer `NETWORK_INTERFACE` dans les configur
 À titre d'exemple, nous utiliserons la plage d'adresses IP `192.168.0.0/16` (**masque de sous-réseau** : `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Dans un éditeur de texte, ouvrez le fichier de configuration réseau situé dans `/etc/network/interfaces.d` pour le modifier. Ici, le fichier s'appelle `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Ajoutez les lignes suivantes à la configuration existante, remplacez `NETWORK_INTERFACE`, `IP_ADDRESS` et `NETMASK` par vos propres valeurs :
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Exemple :**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Enregistrez vos modifications dans le fichier de configuration et quittez l'éditeur.
-    
-    Redémarrez le service réseau pour appliquer la configuration :
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu et Debian 12+">
     A l'aide de l'éditeur de texte de votre choix, ouvrez le fichier de configuration réseau se trouvant dans `/etc/netplan/` afin de l'éditer. Ici, le fichier s'appelle `50-cloud-init.yaml`.
     
@@ -284,7 +256,7 @@ Enregistrez vos modifications dans le fichier de configuration et quittez l'édi
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux et Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux et Rocky Linux (10)">
     Une fois que vous avez identifié le nom de votre interface privée, lancez la commande suivante pour vérifiez qu'elle est bien connectée. Dans notre exemple, notre interface est appelée `eno2` :
     
     ```bash 
@@ -421,91 +393,6 @@ Cliquez sur <code className="action">OK</code> pour sauvegarder les modification
 Dans cet exemple, nous utiliserons **10** comme identifiant (balise) VLAN et **192.168.0.0/16** comme plage d'adresses IP privées.
 
 <Tabs>
-  <Tab label="Debian 11">
-    La configuration ci-dessous est basée sur Debian 11 (Bullseye).
-    
-    - Avant de commencer, établissez une connexion SSH vers votre serveur et exécutez les commandes suivantes pour installer le paquet VLAN :
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - Ensuite, chargez le module noyau 8021q :
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Pour vérifier que le module est chargé :
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Exécutez la commande suivante pour vous assurer que les modules sont chargés de manière permanente au démarrage :
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Récupérez les noms des interfaces et identifiez l'interface privée :
-    
-    ```sh
-    ip a
-    ```
-    
-    Dans cet exemple, l'interface réseau privée s'appelle `eno2`.
-    
-    - Ensuite, créez une sous-interface VLAN pour l'interface réseau (configuration non persistante) et attribuez-lui (taguez) le VLAN ID. Dans cet exemple, le VLAN ID est 10.
-    
-    Remplacez les valeurs par les vôtres.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - Ensuite, attribuez une adresse IP privée à la nouvelle sous-interface VLAN :
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - Ensuite, activez l'interface privée et la sous-interface VLAN :
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Pour rendre la configuration persistante, ajoutez les entrées suivantes au fichier de configuration :
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Aperçu :
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Redémarrez le réseau pour appliquer les modifications :
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu et Debian 12+">
     La configuration ci-dessous est basée sur Ubuntu 24.04 (Noble Numbat).
     
@@ -675,7 +562,7 @@ Dans cet exemple, nous utiliserons **10** comme identifiant (balise) VLAN et **1
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
     La configuration ci-dessous est basée sur Fedora 43.
     
     - Avant de commencer, établissez une connexion SSH vers votre serveur et exécutez la commande suivante pour charger le module noyau 8021q :

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer le vRack entre Public Cloud et un serveur dédié
 description: Découvrez comment configurer un réseau privé entre une instance Public Cloud et un serveur dédié.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer plusieurs VLAN dans le vRack sur un serveur dédié
 description: Créez et gérez plusieurs VLAN dans votre vRack OVHcloud pour segmenter le trafic réseau entre serveurs dédiés
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ Toutes les commandes sont à adapter en fonction de la distribution utilisée. N
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Tout d'abord, établissez une connexion SSH vers votre serveur et exécutez les commandes suivantes depuis la ligne de commande pour installer le paquet VLAN sur votre serveur :
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    Ensuite, chargez le module noyau 8021q :
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Pour vérifier que le module est chargé :
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Exécutez la commande suivante pour vous assurer que les modules sont chargés de manière permanente au démarrage :
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    Ensuite, récupérez les noms de vos interfaces et identifiez l'interface privée :
-    
-    ```sh
-    ip a
-    ```
-    
-    Ensuite, créez une balise VLAN. La balise sert d'identifiant, vous permettant de distinguer plusieurs VLAN :
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **Dans cet exemple :**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Utilisez la même commande pour chaque balise VLAN que vous souhaitez ajouter.
-    
-    Ensuite, déclarez la plage d'adresses IP privée dans le vRack et étiquetez-la avec l'identifiant en utilisant la commande suivante :
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Modifiez la configuration de votre interface réseau pour y intégrer la balise VLAN. Ouvrez votre fichier de configuration d'interface réseau et ajoutez les entrées suivantes :
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    Pour plusieurs VLAN configurés, votre configuration réseau devrait ressembler à ceci :
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu et Debian 12+">
     Ces commandes ont été exécutées sous Ubuntu 24.04 (Noble Numbat).
     
@@ -272,7 +200,7 @@ Toutes les commandes sont à adapter en fonction de la distribution utilisée. N
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux et Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux et Rocky Linux (10)">
     La configuration ci-dessous est basée sur Fedora 43.
     
     Avant de commencer, établissez une connexion SSH vers votre serveur et exécutez la commande suivante pour charger le module noyau 8021q :

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Créer plusieurs VLAN dans le vRack sur un serveur dédié
 description: Créez et gérez plusieurs VLAN dans votre vRack OVHcloud pour segmenter le trafic réseau entre serveurs dédiés
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -156,8 +156,8 @@ Sélectionnez l'onglet correspondant à votre système d'exploitation.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ et Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 et versions suivantes
+  <Tab label="Debian 12+ et Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 et versions suivantes
     
     Par défaut, les fichiers de configuration sont situés dans le répertoire `/etc/netplan`.
     

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurer l'IP aliasing sur un serveur dédié"
 description: Ajoutez et configurez des adresses Additional IP sur votre serveur dédié OVHcloud pour un hébergement multi-sites ou multi-services
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -71,126 +71,8 @@ Sélectionnez l'onglet correspondant à votre système d'exploitation.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Par défaut, le fichier de configuration est situé dans `/etc/network/interfaces.d/`. Il est recommandé de commencer par sauvegarder le fichier de configuration correspondant.
-    
-    **Étape 1 : créer une sauvegarde**
-    
-    Dans notre exemple, notre fichier s'appelle `50-cloud-init`, nous copions donc le fichier `50-cloud-init` en utilisant la commande suivante :
-    
-    ```bash
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    En cas d'erreur, vous pourrez alors revenir en arrière grâce aux commandes ci-dessous :
-    
-    ```bash
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **Étape 2 : éditer le fichier de configuration**
-    
-    :::info
-    Les noms donnés aux interfaces réseau dans ce guide peuvent différer des vôtres. Veuillez adapter les manipulations en conséquence.
-    :::
-    
-    Vous pouvez désormais modifier le fichier de configuration :
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Vous devez ensuite ajouter une interface virtuelle ou un alias ethernet. Dans notre exemple, notre interface s'appelle `eth0`, donc notre alias est `eth0:0`. Faites ceci pour chaque adresse Additional IP que vous souhaitez configurer.
-    
-    Ne modifiez pas les lignes existantes dans le fichier de configuration, ajoutez simplement votre Additional IP au fichier comme indiqué ci-dessous, en remplaçant `ADDITIONAL_IP/32` ainsi que l'interface virtuelle (si votre serveur n'utilise pas **eth0:0**) par vos propres valeurs :
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    Vous pouvez également configurer votre Additional IP en ajoutant les lignes suivantes dans le fichier de configuration :
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    Avec la configuration ci-dessus, l'interface virtuelle est activée ou désactivée chaque fois que l'interface `eth0` est activée ou désactivée.
-    
-    Si vous avez deux Additional IP à configurer, le fichier `/etc/network/interfaces.d/50-cloud-init` doit ressembler à ceci :
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    Ou à cela :
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Exemple de configuration**</summary>
-
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    Ou :
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **Étape 3 : redémarrer l’interface**
-    
-    Pour redémarrer l'interface, utilisez la commande suivante :
-    
-    ```bash
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 et versions ultérieures, AlmaLinux et Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 et versions ultérieures, AlmaLinux et Rocky Linux (10)
     
     Fedora utilise dorénavant des fichiers clés (*keyfiles*).
     Fedora utilisait auparavant des profils réseau stockés par NetworkManager au format ifcfg dans le répertoire `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurer l'IP aliasing sur un serveur dédié"
 description: Ajoutez et configurez des adresses Additional IP sur votre serveur dédié OVHcloud pour un hébergement multi-sites ou multi-services
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -156,8 +156,8 @@ Sélectionnez l'onglet correspondant à votre système d'exploitation.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ et Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 et versions suivantes
+  <Tab label="Debian 12+ et Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 et versions suivantes
     
     Par défaut, les fichiers de configuration sont situés dans le répertoire `/etc/netplan`.
     

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer une adresse IPv6 principale sur un serveur dédié
 description: Découvrez comment configurer des adresses IPv6 sur notre infrastructure.
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -116,7 +116,6 @@ Avec certains systèmes d'exploitation, l'ajout de routes IPv6 statiques dans le
 
 <Tabs>
   <Tab label="Debian et ses dérivés (à l'exception de Debian 12)">
-    L'exemple de configuration ci-dessous est basé sur Debian 11 (Bullseye).
     
     :::warning
     Avant de suivre les étapes ci-dessous, nous vous recommandons fortement de désactiver l’autoconf IPv6 et l’annonce de routage afin d’éviter des problèmes déjà connus. Vous pouvez le faire en ajoutant les lignes suivantes à votre fichier `sysctl.conf`, fichier se trouvant dans `/etc/sysctl.conf` :
@@ -236,8 +235,8 @@ Avec certains systèmes d'exploitation, l'ajout de routes IPv6 statiques dans le
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    L'exemple de configuration ci-dessous est basé sur Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    L'exemple de configuration ci-dessous est basé sur Fedora 43.
     
     Fedora utilise dorénavant des fichiers clés (*keyfiles*).
     Fedora utilisait auparavant des profils réseau stockés par NetworkManager au format ifcfg dans le répertoire `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurer une adresse IPv6 principale sur un serveur dédié
 description: Découvrez comment configurer des adresses IPv6 sur notre infrastructure.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un blocco Additional IP in un vRack
 description: Scopri come configurare un blocco di indirizzi IP pubblici nel vRack.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -389,70 +389,6 @@ ip link set eth1 up
 #### Configurazioni GNU/Linux
 
 <Tabs>
-<Tab label="Debian 11">
-**Configurare l'Additional IP**
-
-Aprire il file di configurazione di rete situato in `/etc/network/interfaces.d` con un editor di testo a scelta. Qui il file si chiama `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Creare una nuova tabella di routing IP**
-
-Successivamente, creare una nuova route IP per il vRack. Aggiungere una nuova regola di traffico modificando il file come mostrato di seguito:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Modificare il file di configurazione di rete**
-
-:::info
-A titolo di esempio, il file di configurazione di rete a cui facciamo riferimento si trova in /etc/network/interfaces. Il file equivalente sul server potrebbe trovarsi altrove, a seconda del sistema operativo.
-
-:::
-
-Infine, modificare il file di configurazione di rete per tenere conto della nuova regola di traffico e instradare il traffico del vRack attraverso l'indirizzo del gateway di rete **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Riavviare il server per applicare le modifiche oppure abilitare semplicemente la nuova interfaccia di rete:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
 **Creare il file per l'interfaccia di rete secondaria**
 
@@ -581,7 +517,7 @@ Applicare la configurazione con il seguente comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux e Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
 Per prima cosa, verificare che l'interfaccia vRack sia nello stato `connected` o `connecting`. Nel nostro esempio, l'interfaccia si chiama `eno2`.
 
 ```sh

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un blocco Additional IP in un vRack
 description: Scopri come configurare un blocco di indirizzi IP pubblici nel vRack.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurare la vRack tra un'istanza Public Cloud e un server dedicato"
 description: "Scopri come configurare una rete privata tra un'istanza Public Cloud e un server dedicato"
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -177,34 +177,6 @@ Utilizza questo nome di interfaccia per sostituire `NETWORK_INTERFACE` nelle con
 A titolo di esempio, utilizzeremo l'intervallo di indirizzi IP `192.168.0.0/16` (**Subnet mask**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Utilizzando un editor di testo di tua scelta, apri il file di configurazione di rete situato in `/etc/network/interfaces.d` per modificarlo. Qui il file è chiamato `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Aggiungi le seguenti righe alla configurazione esistente, sostituisci `NETWORK_INTERFACE`, `IP_ADDRESS` e `NETMASK` con i tuoi valori:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Esempio:**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Salva le modifiche nel file di configurazione ed esci dall'editor.
-    
-    Riavvia il servizio di rete per applicare la configurazione:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     Utilizzando un editor di testo di tua scelta, apri il file di configurazione di rete situato in `/etc/netplan/` per modificarlo. Qui il file è chiamato `50-cloud-init.yaml`.
     
@@ -284,7 +256,7 @@ Salva le modifiche nel file di configurazione ed esci dall'editor.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux e Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
     Una volta identificato il nome dell'interfaccia privata, esegui il seguente comando per verificare che sia connessa. Nel nostro esempio, la nostra interfaccia è chiamata `eno2`:
     
     ```bash
@@ -421,91 +393,6 @@ Clicca su <code className="action">OK</code> per salvare le modifiche e riavvia 
 In questo esempio, utilizzeremo **10** come VLAN ID (tag) e **192.168.0.0/16** come intervallo di indirizzi IP privati.
 
 <Tabs>
-  <Tab label="Debian 11">
-    La configurazione seguente è basata su Debian 11 (Bullseye).
-    
-    - Prima di iniziare, stabilisci una connessione SSH al tuo server ed esegui i seguenti comandi per installare il pacchetto VLAN:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - Successivamente, carica il modulo kernel 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Per verificare che il modulo sia caricato:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Esegui il seguente comando per assicurarti che i moduli vengano caricati permanentemente all'avvio:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Recupera i nomi delle interfacce e identifica l'interfaccia privata:
-    
-    ```sh
-    ip a
-    ```
-    
-    In questo esempio, l'interfaccia di rete privata è identificata come `eno2`.
-    
-    - Successivamente, crea una sotto-interfaccia VLAN per l'interfaccia di rete (configurazione non persistente) e assegna (tagga) il VLAN ID. In questo esempio, il VLAN ID è 10.
-    
-    Sostituisci i valori con i tuoi.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - Successivamente, assegna un indirizzo IP privato alla sotto-interfaccia VLAN appena creata:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - Successivamente, attiva l'interfaccia privata e la sotto-interfaccia VLAN:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Per rendere la configurazione persistente, aggiungi le seguenti voci al file di configurazione:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Panoramica:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Riavvia la rete per applicare le modifiche:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     La configurazione seguente è basata su Ubuntu 24.04 (Noble Numbat).
     
@@ -676,7 +563,7 @@ In questo esempio, utilizzeremo **10** come VLAN ID (tag) e **192.168.0.0/16** c
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux e Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
     La configurazione seguente è basata su Fedora 43.
     
     - Prima di iniziare, stabilisci una connessione SSH al tuo server ed esegui il seguente comando per caricare il modulo kernel 8021q:

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurare la vRack tra un'istanza Public Cloud e un server dedicato"
 description: "Scopri come configurare una rete privata tra un'istanza Public Cloud e un server dedicato"
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare più VLAN nella vRack su un server dedicato
 description: Crea e gestisci più VLAN nella tua vRack OVHcloud per segmentare il traffico di rete tra server dedicati.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ A titolo di esempio, utilizzeremo **eno2** come interfaccia di rete, **10** e **
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Per prima cosa, stabilisci una connessione SSH al tuo server ed esegui i seguenti comandi dalla riga di comando per installare il pacchetto VLAN sul tuo server:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    Successivamente, carica il modulo kernel 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Per verificare che il modulo sia caricato:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Esegui il seguente comando per assicurarti che i moduli siano caricati permanentemente all'avvio:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    Successivamente, recupera i nomi delle tue interfacce e identifica l'interfaccia privata:
-    
-    ```sh
-    ip a
-    ```
-    
-    Successivamente, crea un tag VLAN. Il tag funge da identificatore, permettendoti di distinguere tra diverse VLAN:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **In questo esempio:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Utilizza lo stesso comando per ogni tag VLAN che desideri aggiungere.
-    
-    Successivamente, dichiara il range di indirizzi IP privati all'interno della vRack e taggalo con l'identificatore utilizzando il seguente comando:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Modifica la configurazione dell'interfaccia di rete per incorporare il tag VLAN. Apri il file di configurazione dell'interfaccia di rete e aggiungi le seguenti voci:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    Per più VLAN configurate, la tua configurazione di rete dovrebbe apparire così:
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     Questi comandi sono stati eseguiti su Ubuntu 24.04 (Noble Numbat).
     
@@ -272,7 +200,7 @@ A titolo di esempio, utilizzeremo **eno2** come interfaccia di rete, **10** e **
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux e Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
     La configurazione seguente è basata su Fedora 43.
     
     Prima di iniziare, stabilisci una connessione SSH al tuo server ed esegui il seguente comando per caricare il modulo kernel 8021q:

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Creare più VLAN nella vRack su un server dedicato
 description: Crea e gestisci più VLAN nella tua vRack OVHcloud per segmentare il traffico di rete tra server dedicati.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -154,8 +154,8 @@ Seleziona la scheda corrispondente al tuo sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ e Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 e versioni successive
+  <Tab label="Debian 12+ e Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 e versioni successive
     
     Per impostazione predefinita, i file di configurazione si trovano nella directory `/etc/netplan`.
     

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurare l'IP aliasing su un server dedicato"
 description: Aggiungi e configura indirizzi Additional IP sul tuo server dedicato OVHcloud per un hosting multi-sito o multi-servizio
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -69,126 +69,8 @@ Seleziona la scheda corrispondente al tuo sistema operativo.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Per impostazione predefinita, il file di configurazione si trova in `/etc/network/interfaces.d/`. È consigliabile iniziare effettuando il backup del file di configurazione corrispondente.
-    
-    **Step 1: crea un backup**
-    
-    Nel nostro esempio, il nostro file si chiama `50-cloud-init`, quindi copiamo il file `50-cloud-init` utilizzando il seguente comando:
-    
-    ```sh
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    In caso di errore, è possibile annullare l’operazione eseguendo questi comandi:
-    
-    ```sh
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **Step 2: modifica il file di configurazione**
-    
-    :::info
-    I nomi forniti alle interfacce di rete in questa guida potrebbero essere diversi dai tuoi. Adattare le operazioni di conseguenza.
-    :::
-    
-    Ora è possibile modificare il file sorgente:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    È quindi necessario aggiungere un'interfaccia virtuale o un alias ethernet. Nel nostro esempio, la nostra interfaccia si chiama `eth0`, quindi il nostro alias è `eth0:0`. Ripeti questa operazione per ogni indirizzo Additional IP da configurare.
-    
-    Non modificare le linee esistenti nel file di configurazione, è sufficiente aggiungere l’Additional IP al file come indicato qui di seguito, sostituendo `ADDITIONAL_IP/32` e l’interfaccia virtuale (se il server non utilizza **eth0:0**) con i tuoi valori:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    È inoltre possibile configurare l’Additional IP aggiungendo le righe seguenti al file di configurazione:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    Con la configurazione di cui sopra, l’interfaccia virtuale viene attivata o disattivata ogni volta che l’interfaccia `eth0` viene attivata o disattivata.
-    
-    Per configurare due Additional IP, il file `/etc/network/interfaces.d/50-cloud-init` deve essere di questo tipo:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    O così:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Esempio di configurazione**</summary>
-
-    ```console
-     auto eth0
-     iface eth0 inet dhcp
-    
-    auto eth0:0
-     iface eth0:0 inet static
-     address 203.0.113.1
-     netmask 255.255.255.255
-    ```
-    
-    O così:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **Step 3: riavvia l’interfaccia**
-    
-    Per riavviare l’interfaccia esegui il comando:
-    
-    ```sh
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 e versioni successive. AlmaLinux e Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 e versioni successive. AlmaLinux e Rocky Linux (10)
     
     Da questo momento, Fedora utilizza file chiave (*keyfiles*).
     In precedenza Fedora utilizzava profili di rete memorizzati da NetworkManager in formato ifcfg nella directory `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configurare l'IP aliasing su un server dedicato"
 description: Aggiungi e configura indirizzi Additional IP sul tuo server dedicato OVHcloud per un hosting multi-sito o multi-servizio
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -154,8 +154,8 @@ Seleziona la scheda corrispondente al tuo sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ e Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 e versioni successive
+  <Tab label="Debian 12+ e Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 e versioni successive
     
     Per impostazione predefinita, i file di configurazione si trovano nella directory `/etc/netplan`.
     

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare IPv6 su un server dedicato
 description: Scopri come configurare indirizzi IPv6 sulla nostra infrastruttura
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -116,7 +116,6 @@ Alcuni sistemi operativi richiedono l'aggiunta di rotte IPv6 statiche al file di
 
 <Tabs>
   <Tab label="Debian e i suoi derivati (ad eccezione di Debian 12)">
-    La configurazione di esempio qui sotto è basata su Debian 11 (Bullseye).
     
     :::warning
     Prima di seguire i passaggi qui indicati, consigliamo vivamente di disabilitare l’auto-configurazione dell’IPv6 e gli annunci del router per non incorrere in problemi noti. Puoi farlo aggiungendo le righe che seguono al tuo file `sysctl.conf`, che trovi in `/etc/sysctl.conf`:
@@ -236,8 +235,8 @@ Alcuni sistemi operativi richiedono l'aggiunta di rotte IPv6 statiche al file di
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    La configurazione di esempio qui sotto è basata su Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    La configurazione di esempio qui sotto è basata su Fedora 43.
     
     Fedora ora utilizza i file chiave (*keyfiles*).
     In precedenza Fedora utilizzava i profili di rete archiviati da NetworkManager in formato ifcfg nella directory `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare IPv6 su un server dedicato
 description: Scopri come configurare indirizzi IPv6 sulla nostra infrastruttura
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja bloku Additional IP w sieci vRack
 description: Ten przewodnik pokazuje, jak skonfigurować blok publicznych adresów IP do użytku z siecią vRack.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -389,70 +389,6 @@ ip link set eth1 up
 #### Konfiguracje GNU/Linux
 
 <Tabs>
-<Tab label="Debian 11">
-**Konfiguracja Additional IP**
-
-Otwórz plik konfiguracji sieci znajdujący się w `/etc/network/interfaces.d` za pomocą wybranego edytora tekstu. Tutaj plik nazywa się `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Tworzenie nowej tabeli routingu IP**
-
-Następnie utwórz nową trasę IP dla sieci vRack. Dodaj nową regułę ruchu, modyfikując plik w następujący sposób:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Modyfikacja pliku konfiguracji sieci**
-
-:::info
-Dla celów przykładowych plik konfiguracji sieci, do którego się odwołujemy, znajduje się w /etc/network/interfaces. Odpowiedni plik na Twoim serwerze może znajdować się w innym miejscu, w zależności od systemu operacyjnego.
-
-:::
-
-Na koniec zmodyfikuj plik konfiguracji sieci, aby uwzględnić nową regułę ruchu i skierować ruch vRack przez adres bramki sieciowej **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Uruchom ponownie serwer, aby zastosować zmiany, lub włącz po prostu nowy interfejs sieciowy:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux i Rocky Linux (8/9)">
 **Tworzenie pliku dla dodatkowego interfejsu sieciowego**
 
@@ -581,7 +517,7 @@ Zastosuj konfigurację za pomocą następującego polecenia:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux i Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux i Rocky Linux (10)">
 Najpierw sprawdź, czy interfejs vRack ma status `connected` lub `connecting`. W naszym przykładzie interfejs nazywa się `eno2`.
 
 ```sh

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja bloku Additional IP w sieci vRack
 description: Ten przewodnik pokazuje, jak skonfigurować blok publicznych adresów IP do użytku z siecią vRack.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja sieci vRack między Public Cloud a serwerem dedykowanym
 description: Dowiedz się, jak skonfigurować prywatną sieć między instancją Public Cloud a serwerem dedykowanym
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -178,34 +178,6 @@ Użyj tej nazwy interfejsu, aby zastąpić `NETWORK_INTERFACE` w poniższych kon
 Na przykład użyjemy zakresu adresów IP `192.168.0.0/16` (**Maska podsieci**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Za pomocą wybranego edytora tekstu otwórz plik konfiguracyjny sieci znajdujący się w `/etc/network/interfaces.d`, aby go edytować. Tutaj plik nazywa się `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Dodaj następujące wiersze do istniejącej konfiguracji, zastępując `NETWORK_INTERFACE`, `IP_ADDRESS` i `NETMASK` swoimi wartościami:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Przykład:**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Zapisz zmiany w pliku konfiguracyjnym i zamknij edytor.
-    
-    Uruchom ponownie usługę sieciową, aby zastosować konfigurację:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu i Debian 12+">
     Za pomocą wybranego edytora tekstu otwórz plik konfiguracyjny sieci znajdujący się w `/etc/netplan/`, aby go edytować. Tutaj plik nazywa się `50-cloud-init.yaml`.
     
@@ -285,7 +257,7 @@ Zapisz zmiany w pliku konfiguracyjnym i zamknij edytor.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux i Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux i Rocky Linux (10)">
     Po zidentyfikowaniu nazwy interfejsu prywatnego uruchom następujące polecenie, aby sprawdzić, czy jest on podłączony. W naszym przykładzie nasz interfejs nazywa się `eno2`:
     
     ```bash
@@ -422,91 +394,6 @@ Kliknij na <code className="action">OK</code>, aby zapisać zmiany i uruchom pon
 W tym przykładzie użyjemy **10** jako identyfikatora VLAN (tag) oraz **192.168.0.0/16** jako zakresu prywatnych adresów IP.
 
 <Tabs>
-  <Tab label="Debian 11">
-    Poniższa konfiguracja jest oparta na Debian 11 (Bullseye).
-    
-    - Przed rozpoczęciem nawiąż połączenie SSH z serwerem i uruchom następujące polecenia, aby zainstalować pakiet VLAN:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - Następnie załaduj moduł jądra 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Aby sprawdzić, czy moduł jest załadowany:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Uruchom następujące polecenie, aby zapewnić trwałe ładowanie modułów podczas rozruchu:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Pobierz nazwy interfejsów i zidentyfikuj interfejs prywatny:
-    
-    ```sh
-    ip a
-    ```
-    
-    W tym przykładzie interfejs sieci prywatnej jest identyfikowany jako `eno2`.
-    
-    - Następnie utwórz podinterfejs VLAN dla interfejsu sieciowego (konfiguracja nietrwała) i przypisz (oznacz) mu identyfikator VLAN. W tym przykładzie identyfikator VLAN to 10.
-    
-    Zastąp wartości swoimi własnymi.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - Następnie przypisz prywatny adres IP do nowo utworzonego podinterfejsu VLAN:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - Następnie aktywuj interfejs prywatny i podinterfejs VLAN:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Aby konfiguracja była trwała, dodaj następujące wpisy do pliku konfiguracyjnego:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Przegląd:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Uruchom ponownie sieć, aby zastosować zmiany:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu i Debian 12+">
     Poniższa konfiguracja jest oparta na Ubuntu 24.04 (Noble Numbat).
     
@@ -677,7 +564,7 @@ W tym przykładzie użyjemy **10** jako identyfikatora VLAN (tag) oraz **192.168
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux i Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux i Rocky Linux (10)">
     Poniższa konfiguracja jest oparta na Fedora 43.
     
     - Przed rozpoczęciem nawiąż połączenie SSH z serwerem i uruchom następujące polecenie, aby załadować moduł jądra 8021q:

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja sieci vRack między Public Cloud a serwerem dedykowanym
 description: Dowiedz się, jak skonfigurować prywatną sieć między instancją Public Cloud a serwerem dedykowanym
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie wielu sieci VLAN w sieci vRack na serwerze dedykowanym
 description: Twórz i zarządzaj wieloma sieciami VLAN w sieci OVHcloud vRack, aby segmentować ruch sieciowy między serwerami dedykowanymi.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ Wszystkie polecenia należy dostosować do używanej dystrybucji. W przypadku w�
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Najpierw nawiąż połączenie SSH z serwerem i uruchom następujące polecenia z wiersza poleceń, aby zainstalować pakiet VLAN na serwerze:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    Następnie załaduj moduł jądra 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Aby sprawdzić, czy moduł został załadowany:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Uruchom następujące polecenie, aby moduły były ładowane automatycznie przy starcie systemu:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    Następnie pobierz nazwy interfejsów i zidentyfikuj interfejs prywatny:
-    
-    ```sh
-    ip a
-    ```
-    
-    Następnie utwórz tag VLAN. Tag jest identyfikatorem umożliwiającym rozróżnienie kilku sieci VLAN:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **W tym przykładzie:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Użyj tego samego polecenia dla każdego tagu VLAN, który chcesz dodać.
-    
-    Następnie określ zakres adresów IP w sieci vRack i oznacz go identyfikatorem, używając następującego polecenia:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Zmodyfikuj konfigurację interfejsu sieciowego, aby uwzględnić tag VLAN. Otwórz plik konfiguracyjny interfejsu sieciowego i dodaj następujące wpisy:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    W przypadku kilku skonfigurowanych sieci VLAN Twoja konfiguracja sieciowa powinna wyglądać następująco:
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu i Debian 12+">
     Te polecenia zostały wykonane w Ubuntu 24.04 (Noble Numbat).
     
@@ -272,7 +200,7 @@ Wszystkie polecenia należy dostosować do używanej dystrybucji. W przypadku w�
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux i Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux i Rocky Linux (10)">
     Poniższa konfiguracja jest oparta na Fedora 43.
     
     Przed rozpoczęciem nawiąż połączenie SSH z serwerem i uruchom następujące polecenie, aby załadować moduł jądra 8021q:

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tworzenie wielu sieci VLAN w sieci vRack na serwerze dedykowanym
 description: Twórz i zarządzaj wieloma sieciami VLAN w sieci OVHcloud vRack, aby segmentować ruch sieciowy między serwerami dedykowanymi.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -154,8 +154,8 @@ Wybierz zakładkę odpowiadającą Twojemu systemowi operacyjnemu.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ i Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 i kolejne wersje
+  <Tab label="Debian 12+ i Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 i kolejne wersje
     
     Domyślnie pliki konfiguracyjne znajdują się w katalogu `/etc/netplan`.
     

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja Additional IP jako aliasu IP na serwerze dedykowanym
 description: Skonfiguruj Additional IP jako alias na serwerze dedykowanym OVHcloud z systemem Linux, Windows lub Plesk.
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -69,127 +69,8 @@ Wybierz zakładkę odpowiadającą Twojemu systemowi operacyjnemu.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Domyślnie plik konfiguracyjny znajduje się w katalogu `/etc/network/interfaces.d/`. Zaleca się, aby najpierw wykonać kopię zapasową odpowiedniego pliku konfiguracyjnego.
-    
-    **Krok 1: tworzenie kopii zapasowej**
-    
-    W naszym przykładzie nasz plik nosi nazwę `50-cloud-init`, dlatego kopiujemy plik `50-cloud-init` za pomocą następującego polecenia:
-    
-    ```sh
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    W przypadku błędu będziesz mógł wrócić do poprzedniej wersji za pomocą poniższych poleceń:
-    
-    ```sh
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **Krok 2: modyfikacja pliku konfiguracyjnego**
-    
-    :::info
-    Nazwy interfejsów sieciowych podane w tym przewodniku mogą różnić się od Twoich. Prosimy o odpowiednie dostosowanie sposobu postępowania.
-    :::
-    
-    Teraz można zmodyfikować plik konfiguracyjny:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Następnie dodaj wirtualny interfejs lub alias ethernet. W naszym przykładzie nasz interfejs nosi nazwę `eth0`, więc nasz alias to `eth0:0`. Zrób to dla każdego adresu Additional IP, który chcesz skonfigurować.
-    
-    Nie zmieniaj istniejących linii w pliku konfiguracyjnym, dodaj Additional IP do pliku, jak pokazano poniżej, zastępując `ADDITIONAL_IP/32` oraz wirtualny interfejs (jeśli Twój serwer nie używa **eth0:0**) własnymi wartościami:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    Możesz również skonfigurować Additional IP, dodając następujące wiersze poleceń w pliku konfiguracyjnym:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    W przypadku powyższej konfiguracji wirtualny interfejs jest aktywowany lub dezaktywowany za każdym razem, gdy interfejs `eth0` jest włączony lub wyłączony.
-    
-    Jeśli masz do skonfigurowania dwa adresy Additional IP, plik `/etc/network/interfaces.d/50-cloud-init` musi wyglądać w taki sposób:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    Lub tak:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    
-    <details>
-    <summary>**Przykład konfiguracji**</summary>
-
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    Lub:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **Krok 3: restart interfejsu**
-    
-    Pozostaje tylko zrestartować interfejs:
-    
-    ```sh
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 i kolejne wersje, AlmaLinux i Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 i kolejne wersje, AlmaLinux i Rocky Linux (10)
     
     Fedora korzysta teraz z kluczowych plików (*keyfiles*).
     Fedora korzystała wcześniej z profili sieci przechowywanych przez NetworkManager w formacie ifcfg w katalogu `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja Additional IP jako aliasu IP na serwerze dedykowanym
 description: Skonfiguruj Additional IP jako alias na serwerze dedykowanym OVHcloud z systemem Linux, Windows lub Plesk.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -154,8 +154,8 @@ Wybierz zakładkę odpowiadającą Twojemu systemowi operacyjnemu.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ i Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 i kolejne wersje
+  <Tab label="Debian 12+ i Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 i kolejne wersje
     
     Domyślnie pliki konfiguracyjne znajdują się w katalogu `/etc/netplan`.
     

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfigurowanie adresu IPv6 na serwerach dedykowanych
 description: Dowiedz się, jak skonfigurować adresy IPv6 w infrastrukturze OVHcloud
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -116,7 +116,6 @@ Niektóre systemy operacyjne wymagają domyślnego dodania statycznych tras IPv6
 
 <Tabs>
   <Tab label="Debian i jego pochodne (z wyjątkiem Debian 12)">
-    Poniższy przykład konfiguracji opiera się na dystrybucji Debian 11 (Bullseye).
     
     :::warning
     Przed wykonaniem poniższych kroków zalecamy wyłączenie narzędzi autoconf IPv6 i anonsowania routera, aby zapobiec wystąpieniu znanych problemów. W tym celu należy dodać następujące wiersze do pliku `sysctl.conf`, który znajduje się w katalogu `/etc/sysctl.conf`:
@@ -236,8 +235,8 @@ Niektóre systemy operacyjne wymagają domyślnego dodania statycznych tras IPv6
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    Poniższy przykład konfiguracji oparty jest na Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    Poniższy przykład konfiguracji oparty jest na Fedora 43.
     
     Fedora używa teraz plików kluczy (*keyfiles*).
     Fedora wcześniej używała profili sieciowych przechowywanych przez NetworkManager w formacie ifcfg w katalogu `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfigurowanie adresu IPv6 na serwerach dedykowanych
 description: Dowiedz się, jak skonfigurować adresy IPv6 w infrastrukturze OVHcloud
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um bloco de Additional IP num vRack
 description: Saiba como configurar um bloco de endereços IP públicos num vRack.
-lastUpdated: 2026-05-28
+lastUpdated: 2026-09-04
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -389,70 +389,6 @@ ip link set eth1 up
 #### Configurações GNU/Linux
 
 <Tabs>
-<Tab label="Debian 11">
-**Configurar o Additional IP**
-
-Abra o ficheiro de configuração de rede situado em `/etc/network/interfaces.d` com um editor de texto à sua escolha. Aqui, o ficheiro chama-se `50-cloud-init`.
-
-```sh
-/etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-**Criar uma nova tabela de routing IP**
-
-Em seguida, crie uma nova rota IP para o vRack. Adicione uma nova regra de tráfego modificando o ficheiro como indicado abaixo:
-
-```sh
-sudo nano /etc/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-**Modificar o ficheiro de configuração de rede**
-
-:::info
-A título de exemplo, o ficheiro de configuração de rede ao qual nos referimos encontra-se em /etc/network/interfaces. O ficheiro equivalente no seu servidor pode estar noutro local, dependendo do sistema operativo.
-
-:::
-
-Por último, modifique o ficheiro de configuração de rede para ter em conta a nova regra de tráfego e encaminhar o tráfego do vRack através do endereço do gateway de rede **46.105.135.110**.
-
-```sh
-sudo nano /etc/network/interfaces.d/50-cloud-init
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
-Reinicie o servidor para aplicar as alterações ou ative simplesmente a nova interface de rede:
-
-```sh
-ip link set eth1 up
-```
-</Tab>
 <Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
 **Criar o ficheiro para a interface de rede secundária**
 
@@ -581,7 +517,7 @@ Aplique a configuração com o seguinte comando:
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora, AlmaLinux e Rocky Linux (10)">
+<Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
 Em primeiro lugar, verifique que a sua interface vRack está no estado `connected` ou `connecting`. No nosso exemplo, a interface chama-se `eno2`.
 
 ```sh

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar um bloco de Additional IP num vRack
 description: Saiba como configurar um bloco de endereços IP públicos num vRack.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o vRack entre o Public Cloud e um servidor dedicado
 description: Saiba como configurar uma rede privada entre uma instância Public Cloud e um servidor dedicado
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -178,34 +178,6 @@ Utilize este nome de interface para substituir `NETWORK_INTERFACE` nas configura
 A título de exemplo, utilizaremos o intervalo de endereços IP `192.168.0.0/16` (**máscara de sub-rede**: `255.255.0.0`).
 
 <Tabs>
-  <Tab label="Debian 11">
-    Utilizando um editor de texto à sua escolha, abra o ficheiro de configuração de rede localizado em `/etc/network/interfaces.d` para edição. Aqui, o ficheiro chama-se `50-cloud-init`.
-    
-    ```bash
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    Adicione as seguintes linhas à configuração existente, substitua `NETWORK_INTERFACE`, `IP_ADDRESS` e `NETMASK` pelos seus próprios valores:
-    
-    ```console
-    auto NETWORK_INTERFACE
-    iface NETWORK_INTERFACE inet static
-       address IP_ADDRESS
-       netmask NETMASK
-    ```
-    
-    **Exemplo:**
-    
-    <img className="thumbnail" alt="debian config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/debian_configuration.png" loading="lazy" />
-
-Guarde as alterações no ficheiro de configuração e saia do editor.
-    
-    Reinicie o serviço de rede para aplicar a configuração:
-    
-    ```bash
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     Utilizando um editor de texto à sua escolha, abra o ficheiro de configuração de rede localizado em `/etc/netplan/` para edição. Aqui, o ficheiro chama-se `50-cloud-init.yaml`.
     
@@ -285,7 +257,7 @@ Guarde as alterações no ficheiro de configuração e saia do editor.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux e Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
     Depois de ter identificado o nome da sua interface privada, execute o seguinte comando para verificar se está ligada. No nosso exemplo, a nossa interface chama-se `eno2`:
     
     ```bash
@@ -422,91 +394,6 @@ Clique em <code className="action">OK</code> para guardar as alterações e rein
 Neste exemplo, vamos utilizar **10** como identificador (tag) VLAN e **192.168.0.0/16** como intervalo de endereços IP privados.
 
 <Tabs>
-  <Tab label="Debian 11">
-    A configuração abaixo baseia-se em Debian 11 (Bullseye).
-    
-    - Antes de começar, estabeleça uma ligação SSH ao seu servidor e execute os seguintes comandos para instalar o pacote VLAN:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    - De seguida, carregue o módulo kernel 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    - Para verificar se o módulo está carregado:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    - Execute o seguinte comando para garantir que os módulos são carregados permanentemente no arranque:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    - Obtenha os nomes das interfaces e identifique a interface privada:
-    
-    ```sh
-    ip a
-    ```
-    
-    Neste exemplo, a interface de rede privada é identificada como `eno2`.
-    
-    - De seguida, crie uma subinterface VLAN para a interface de rede (configuração não persistente) e atribua (marque) o VLAN ID. Neste exemplo, o VLAN ID é 10.
-    
-    Substitua os valores pelos seus próprios.
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    - De seguida, atribua um endereço IP privado à subinterface VLAN recém-criada:
-    
-    ```sh
-    sudo ip addr add 192.168.0.14/16 dev eno2.10
-    ```
-    
-    - De seguida, ative a interface privada e a subinterface VLAN:
-    
-    ```sh
-    sudo ip link set dev eno2 up
-    sudo ip link set dev eno2.10 up
-    ```
-    
-    - Para tornar a configuração persistente, adicione as seguintes entradas ao ficheiro de configuração:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    ```console
-    auto eno2.10
-    iface eno2.10 inet static
-       address 192.168.0.14
-       netmask 255.255.0.0
-       broadcast 192.168.255.255
-       vlan-raw-device eno2
-    ```
-    
-    - Vista geral:
-    
-    <img className="thumbnail" alt="config" src="/images/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server/config_debian.png" loading="lazy" />
-    
-    - Reinicie a rede para aplicar as alterações:
-    
-    ```sh
-    sudo systemctl restart networking
-    ```
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     A configuração abaixo baseia-se em Ubuntu 24.04 (Noble Numbat).
     
@@ -677,7 +564,7 @@ Neste exemplo, vamos utilizar **10** como identificador (tag) VLAN e **192.168.0
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
     A configuração abaixo baseia-se em Fedora 43.
     
     - Antes de começar, estabeleça uma ligação SSH ao seu servidor e execute o seguinte comando para carregar o módulo kernel 8021q:

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o vRack entre o Public Cloud e um servidor dedicado
 description: Saiba como configurar uma rede privada entre uma instância Public Cloud e um servidor dedicado
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar várias VLAN na vRack num servidor dedicado
 description: Crie e faça a gestão de várias VLAN na sua vRack OVHcloud para segmentar o tráfego de rede entre servidores dedicados.
-lastUpdated: 2026-02-20
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -41,78 +41,6 @@ Todos os comandos devem ser adaptados em função da distribuição utilizada. N
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Primeiro, deve estabelecer uma ligação SSH ao seu servidor e executar os seguintes comandos a partir da linha de comandos para instalar o pacote VLAN no seu servidor:
-    
-    ```sh
-    sudo apt update
-    sudo apt install vlan
-    ```
-    
-    De seguida, carregue o módulo kernel 8021q:
-    
-    ```sh
-    sudo modprobe 8021q
-    ```
-    
-    Para verificar se o módulo está carregado:
-    
-    ```sh
-    user@server:~$ lsmod | grep 8021q
-    8021q                  40960  0
-    garp                   16384  1 8021q
-    mrp                    20480  1 8021q
-    ```
-    
-    Execute o seguinte comando para garantir que os módulos são carregados permanentemente no arranque:
-    
-    ```sh
-    sudo su -c 'echo "8021q" >> /etc/modules'
-    ```
-    
-    De seguida, recupere os nomes das suas interfaces e identifique a interface privada:
-    
-    ```sh
-    ip a
-    ```
-    
-    Em seguida, crie uma etiqueta VLAN. A etiqueta serve de identificador, permitindo-lhe distinguir várias VLAN:
-    
-    ```sh
-    sudo ip link add link <parent-interface> name <vlan-identifier> type vlan id <ID>
-    ```
-    
-    **Neste exemplo:**
-    
-    ```sh
-    sudo ip link add link eno2 name eno2.10 type vlan id 10
-    ```
-    
-    Utilize o mesmo comando para cada etiqueta VLAN que pretende adicionar.
-    
-    Em seguida, declare o intervalo de endereços de IP privado no vRack e identifique-o com o identificador utilizando o seguinte comando:
-    
-    ```sh
-    sudo ip addr add 192.168.0.10/16 dev eno2.10
-    ```
-    
-    Altere a configuração da sua interface de rede para incorporar a etiqueta VLAN. Abra o ficheiro de configuração da interface de rede e adicione as seguintes entradas:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    
-    auto eno2.10
-    iface eno2.10 inet static
-    address 192.168.0.10
-    netmask 255.255.0.0
-    broadcast 192.168.255.255
-    vlan-raw-device eno2
-    ```
-    
-    Para várias VLAN configuradas, a sua configuração de rede deve ser semelhante a esta:
-    
-    <img className="thumbnail" alt="debian VLAN" src="/images/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack/multiple_vlan_debian.png" loading="lazy" />
-  </Tab>
   <Tab label="Ubuntu e Debian 12+">
     Estes comandos foram executados com Ubuntu 24.04 (Noble Numbat).
     
@@ -272,7 +200,7 @@ Todos os comandos devem ser adaptados em função da distribuição utilizada. N
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux e Rocky Linux (10)">
+  <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
     A configuração abaixo é baseada em Fedora 43.
     
     Antes de começar, estabeleça uma ligação SSH ao seu servidor e execute o seguinte comando para carregar o módulo kernel 8021q:

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Criar várias VLAN na vRack num servidor dedicado
 description: Crie e faça a gestão de várias VLAN na sua vRack OVHcloud para segmentar o tráfego de rede entre servidores dedicados.
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o IP aliasing num servidor dedicado
 description: Adicione e configure endereços Additional IP no seu servidor dedicado OVHcloud para um alojamento multi-sites ou multi-serviços
-lastUpdated: 2025-12-04
+lastUpdated: 2026-09-04
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -69,126 +69,8 @@ Selecione o separador correspondente ao seu sistema operativo.
 
 
 <Tabs>
-  <Tab label="Debian 11">
-    Debian 11
-    
-    Por predefinição, o ficheiro de configuração está situado em `/etc/network/interfaces.d/`. Recomendamos começar por realizar uma cópia de segurança do ficheiro de configuração correspondente.
-    
-    **1 - Fazer cópia do ficheiro de configuração (*source file*)**
-    
-    No nosso exemplo, o nosso ficheiro chama-se `50-cloud-init`, pelo que copiamos o ficheiro `50-cloud-init` utilizando o seguinte comando:
-    
-    ```sh
-    sudo cp /etc/network/interfaces.d/50-cloud-init /etc/network/interfaces.d/50-cloud-init.bak
-    ```
-    
-    Em caso de erro, poderá então reverter a operação através dos seguintes comandos:
-    
-    ```bash
-    sudo rm -f /etc/network/interfaces.d/50-cloud-init
-    sudo cp /etc/network/interfaces.d/50-cloud-init.bak /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    **2 - Editar o ficheiro de configuração**
-    
-    :::info
-    Os nomes das interfaces de rede indicados neste manual podem ser diferentes dos seus. Adapte as operações em conformidade.
-    :::
-    
-    Já pode modificar o ficheiro de configuração:
-    
-    ```sh
-    sudo nano /etc/network/interfaces.d/50-cloud-init
-    ```
-    
-    De seguida, deverá adicionar uma interface virtual ou um alias ethernet. No nosso exemplo, a nossa interface chama-se `eth0`, pelo que o nosso alias é `eth0:0`. Faça isso para cada endereço Additional IP que deseja configurar.
-    
-    Não modifique as linhas existentes no ficheiro de configuração. Adicione simplesmente o seu Additional IP ao ficheiro como indicado abaixo, substituindo `ADDITIONAL_IP/32` assim como a interface virtual (se o seu servidor não utilizar **eth0:0**) pelos seus próprios valores:
-    
-    ```console
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP
-    netmask 255.255.255.255
-    ```
-    
-    Também pode configurar o seu Additional IP adicionando as seguintes linhas ao ficheiro de configuração:
-    
-    ```console
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP netmask 255.255.255.255 broadcast ADDITIONAL_IP
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-    
-    Com a configuração acima, a interface virtual é ativada ou desativada sempre que a interface `eth0` é ativada ou desativada.
-    
-    Se tem dois Additional IP a configurar, o ficheiro `/etc/network/interfaces.d/50-cloud-init` deve ter o seguinte formato:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address ADDITIONAL_IP1
-    netmask 255.255.255.255
-    
-    auto eth0:1
-    iface eth0:1 inet static
-    address ADDITIONAL_IP2
-    netmask 255.255.255.255
-    ```
-    
-    Ou assim:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 ADDITIONAL_IP1 netmask 255.255.255.255 broadcast ADDITIONAL_IP1
-    pre-down /sbin/ifconfig eth0:0 down
-    
-    # IP 2
-    post-up /sbin/ifconfig eth0:1 ADDITIONAL_IP2 netmask 255.255.255.255 broadcast ADDITIONAL_IP2
-    pre-down /sbin/ifconfig eth0:1 down
-    ```
-    
-    <details>
-    <summary>**Exemplo de configuração**</summary>
-
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    auto eth0:0
-    iface eth0:0 inet static
-    address 203.0.113.1
-    netmask 255.255.255.255
-    ```
-    
-    Ou:
-    
-    ```console
-    auto eth0
-    iface eth0 inet dhcp
-    
-    # IP 1
-    post-up /sbin/ifconfig eth0:0 203.0.113.1 netmask 255.255.255.255 broadcast 203.0.113.1
-    pre-down /sbin/ifconfig eth0:0 down
-    ```
-
-    </details>
-    
-    **3 - Reiniciar a interface de rede**
-    
-    Agora, execute este comando para reiniciar a interface:
-    
-    ```sh
-    sudo /etc/init.d/networking restart
-    ```
-  </Tab>
-  <Tab label="Fedora 42+ / AlmaLinux (10) / Rocky Linux (10)">
-    Fedora 42 e versões posteriores, AlmaLinux e Rocky Linux (10)
+  <Tab label="Fedora 43+ / AlmaLinux (10) / Rocky Linux (10)">
+    Fedora 43 e versões posteriores, AlmaLinux e Rocky Linux (10)
     
     Fedora utiliza agora ficheiros chave (*keyfiles*).
     Fedora utilizava anteriormente perfis de rede armazenados pela NetworkManager no formato ifcfg no diretório `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -154,8 +154,8 @@ Selecione o separador correspondente ao seu sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ e Ubuntu 20.04+">
-    Debian 12, Ubuntu 20.04 e versões seguintes
+  <Tab label="Debian 12+ e Ubuntu 22.04+">
+    Debian 12, Ubuntu 22.04 e versões seguintes
     
     Por predefinição, os ficheiros de configuração estão localizados no diretório `/etc/netplan`.
     

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar o IP aliasing num servidor dedicado
 description: Adicione e configure endereços Additional IP no seu servidor dedicado OVHcloud para um alojamento multi-sites ou multi-serviços
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -154,8 +154,8 @@ Selecione o separador correspondente ao seu sistema operativo.
     sudo systemctl restart NetworkManager
     ```
   </Tab>
-  <Tab label="Debian 12+ e Ubuntu 22.04+">
-    Debian 12, Ubuntu 22.04 e versões seguintes
+  <Tab label="Debian 12+ e Ubuntu 20.04+">
+    Debian 12, Ubuntu 20.04 e versões seguintes
     
     Por predefinição, os ficheiros de configuração estão localizados no diretório `/etc/netplan`.
     

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar IPv6 em servidores dedicados
 description: Saiba como configurar endereços IPv6 na nossa infraestrutura
-lastUpdated: 2026-06-18
+lastUpdated: 2026-09-04
 ---
 
 import Api from '@components/Api';
@@ -116,7 +116,6 @@ Alguns sistemas operativos exigem que as rotas IPv6 estáticas sejam adicionadas
 
 <Tabs>
   <Tab label="Debian e seus derivados (exceto Debian 12)">
-    O exemplo de configuração abaixo é baseado em Debian 11 (Bullseye).
     
     :::warning
     Antes de seguir os próximos passos, recomendamos que desative a autoconfiguração de IPv6 e o router advertising para evitar certos problemas. Pode fazê-lo acrescentando as seguintes linhas ao ficheiro `sysctl.conf`, localizado em `/etc/sysctl.conf`:
@@ -236,8 +235,8 @@ Alguns sistemas operativos exigem que as rotas IPv6 estáticas sejam adicionadas
     sudo /etc/init.d/networking restart
     ```
   </Tab>
-  <Tab label="Fedora 42+, AlmaLinux & Rocky Linux (10)">
-    O exemplo de configuração abaixo é baseado no Fedora 42.
+  <Tab label="Fedora 43+, AlmaLinux & Rocky Linux (10)">
+    O exemplo de configuração abaixo é baseado no Fedora 43.
     
     O Fedora utiliza agora ficheiros principais (*keyfiles*).
     O Fedora utilizava anteriormente perfis de rede armazenados pelo NetworkManager no formato ifcfg no diretório `/etc/sysconfig/network-scripts/`.<br/>

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/network-ipv6.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurar IPv6 em servidores dedicados
 description: Saiba como configurar endereços IPv6 na nossa infraestrutura
-lastUpdated: 2026-09-04
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';


### PR DESCRIPTION
- Remove Debian 11 and Fedora 42 in a few dedicated server guides as we no longer offer them.