### PR TITLE
docs(fragments): Repair-sweep generic support-scope residuals

### DIFF
--- a/docs/de/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
+++ b/docs/de/guides/bare-metal-cloud/virtual-private-servers/understand-vps-control-panel.mdx
@@ -162,6 +162,7 @@ Dieser Abschnitt stellt die wichtigsten Informationen zur Abrechnung Ihres Diens
 ### VPS-Funktionen im Tab "Start"
 
 [[fragment:support-scope]]
+
 #### Neustart Ihres VPS <a name="rebootvps"></a>
 
 Ein Neustart kann erforderlich sein, um Konfigurationsaktualisierungen anzuwenden oder ein Problem zu beheben. Falls möglich, führen Sie einen "Software-Neustart" über die grafische Benutzeroberfläche des Servers (Windows, Plesk etc.) oder über den folgenden Befehl durch:

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation 
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Drupal](https://www.drupal.org/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [Herausgeber von Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Hier finden Sie alle Elemente, um das Content Management System (CMS) Joomla! in
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von Joomla!](https://www.joomla.org/) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [Herausgeber von Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Hier finden Sie alle Elemente, um das Content Management System (CMS) PrestaShop
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den [Herausgeber von PrestaShop](https://www.prestashop.com/en/support) zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [Herausgeber von PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation 
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/de/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation 
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 :::tip
 Um Ihr CMS **automatisch** in Ihrem <ManagerLink to="/">OVHcloud Kundencenter</ManagerLink> zu installieren, lesen Sie unsere Anleitung zur [Installation Ihrer Website mit 1-Klick-Modulen](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/de/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Es gibt mehrere Möglichkeiten, das Administratorpasswort Ihres CMS anzupassen:
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen dieses Tutorial zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) oder den Herausgeber des CMS zu kontaktieren, wenn Sie bei der Administration Ihrer Dienste Hilfe benötigen.
-:::
-
 ### Administratorpasswort per automatischer E-Mail ändern ("Passwort vergessen") <a name="via-email"></a>
 
 Sie haben noch Zugriff auf Ihre E-Mails und das Login-Interface? Diese Methode ist am schnellsten, da der Zugriff auf die Einstellungen des CMS oder der Umweg über phpMyAdmin vermieden wird.

--- a/docs/de/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -15,10 +15,6 @@ Auf Ihrem OVHcloud Webhosting können Sie Skripte verwenden, um bestimmte Operat
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 ## Voraussetzungen
 
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting) in Ihrem Kunden-Account.

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ Mit der automatisierten Sperrung werden Sie auch vor möglichen rechtlichen Kons
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [OVHcloud Community](/links/community) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 ## Voraussetzungen
 
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting).

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-fix-500-internal-server-error.mdx
@@ -17,10 +17,6 @@ Diese Fehler können auch durch Updates entstehen, die **automatisch** von Kompo
 
 [[fragment:support-scope]]
 
-:::warning
-Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) und/oder stellen Ihre Fragen in der [OVHcloud Community](/links/community) (Englisch). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 ## Voraussetzungen
 
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting) in Ihrem Kunden-Account.

--- a/docs/de/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -54,10 +54,6 @@ Darüber hinaus wird die Performance der Hosting-Infrastruktur von OVHcloud perm
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten, sofern die **Ausfälle nicht auf Ebene der Hosting-Infrastruktur verursacht werden**.
-:::
-
 :::tip
 Wir empfehlen Ihnen, die Ergebnisse Ihrer Diagnosen festzuhalten, während Sie dieser Anleitung folgen. Diese Daten werden für Verbesserungsmaßnahmen nützlich sein, unabhängig von der Ursache der Langsamkeit.
 

--- a/docs/de/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Wenn Sie Ihre Website ohne Visual Studio Code verwalten möchten, können Sie de
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen dieses Tutorial zur Verfügung, um Sie bestmöglich bei gängigen Aufgaben zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Anbieter](/links/partner) oder den Herausgeber von [Visual Studio Code IDE](https://code.visualstudio.com/) zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [Visual Studio Code IDE](https://code.visualstudio.com/).
 :::
 
 ### SFTP-Erweiterung für Visual Studio Code installieren

--- a/docs/de/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ Sie sind für Backups von auf Webhostings gehosteten Websites alleine verantwort
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/).
 :::
 
 **Dieses Tutorial erklärt, wie Sie Ihre WordPress Website und deren Datenbank sichern.**

--- a/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ In dieser Anleitung erfahren Sie, wie Sie bestimmte Funktionen Ihres Webhostings
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/).
 :::
 
 **Dieses Tutorial erklärt, wie Sie Ihr WordPress mit .htaccess-Dateien absichern.**

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP bietet mehrere Erweiterungen zum Sichern Ihrer Websites an.
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [den Herausgeber des Plugins MainWP](https://mainwp.com/support/).
 :::
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ Die Kundenbindung ist entscheidend für die Entwicklung Ihres Unternehmens. Ob S
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [den Herausgeber des Plugins MainWP](https://mainwp.com/support/).
 :::
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ In dieser Anleitung haben wir uns für das Plugin MainWP entschieden. Es gibt we
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [den Herausgeber des Plugins MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Die Sicherheit Ihrer Websites aufrechtzuerhalten, ist entscheidend für die Entw
 
 [[fragment:support-scope]]
 
-:::warning
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Sie bei gängigen Aufgaben bestmöglich zu unterstützen. Wir empfehlen Ihnen dennoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) oder an [den Herausgeber des Plugins MainWP](https://mainwp.com/support/) zu wenden. Wir können Ihnen hierbei keine Unterstützung bieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [den Herausgeber des Plugins MainWP](https://mainwp.com/support/).
 :::
 
 ## In der praktischen Anwendung

--- a/docs/de/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-website-to-vps.mdx
@@ -22,10 +22,6 @@ Ihre Website entwickelt sich weiter, und der Ressourcenverbrauch wird immer stä
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 ### Schritt 1 - Sicherung der Dateien und der Datenbank Ihrer Website <a name="step1"></a>
 
 Der erste Schritt ist, alle Dateien Ihrer Website zu sichern, in der Regel über das **F**ile **T**ransfer **P**rotocol (**FTP**) sowie die dazugehörige Datenbank.

--- a/docs/de/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ In dieser Anleitung erfahren Sie Schritt für Schritt, wie Sie Ihre WordPress We
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/).
 :::
 
 **Diese Anleitung erklärt, wie Sie Ihre WordPress Website und zugehörige Dienste zu OVHcloud migrieren.**

--- a/docs/de/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ In dieser Anleitung erfahren Sie Schritt für Schritt, wie Sie Ihre Xara Website
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder die [offizielle Website von Xara Web Designer](https://www.xara.com/de/webdesigner-plus/) zu besuchen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [offizielle Website von Xara Web Designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Diese Anleitung erklärt, wie Sie Ihre Xara Website und zugehörige Dienste zu OVHcloud migrieren.**

--- a/docs/de/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -18,10 +18,6 @@ Möglicherweise wird in Ihrem Webbrowser die Fehlerseite "**Seite nicht installi
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
-:::
-
 
 ## Voraussetzungen
 

--- a/docs/de/guides/web-cloud/web-hosting/sql-database-export.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-database-export.mdx
@@ -51,10 +51,6 @@ Folgen Sie dieser Anleitung nun entsprechend der von Ihnen ausgewählten Backup-
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
-:::
-
 ### Backup mit dem OVHcloud Backup-Tool exportieren
 
 Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.

--- a/docs/de/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/sql-recovering-deleted-db-backup.mdx
@@ -16,10 +16,6 @@ Die meisten unserer [Webhosting](/links/web/hosting) Angebote beinhalten Datenba
 
 [[fragment:support-scope]]
 
-:::warning
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen zur API-Verwendung keine weitergehende technische Unterstützung anbieten.
-:::
-
 ## Voraussetzungen
 
 - Sie verfügen über ein aktives [OVHcloud Webhosting](/links/web/hosting) Angebot mit mindestens einer OVHcloud Shared-Datenbank.

--- a/docs/de/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -18,12 +18,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) ist auf Ihrem lokalen Gerät installiert.
 - Sie verfügen über Grundkenntnisse des [SSH-Protokolls und seiner Verwendung](/guides/bare-metal-cloud/dedicated-servers/ssh-introduction).
 
-:::warning
-In diesem Tutorial erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Möglicherweise müssen Sie bestimmte Anweisungen an das Betriebssystem Ihres lokalen Systems oder Ihres Servers anpassen.
-
-Wir empfehlen Ihnen, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](/links/partner) zu wenden oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten.
-
-:::
+[[fragment:support-scope]]
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/de/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Mithilfe dieser Anleitung können Sie Ihre ersten Inhalte erstellen, organisiere
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/).
 :::
 
 **Dieses Tutorial erklärt, wie Sie eine Website mit dem CMS WordPress erstellen.**

--- a/docs/de/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/de/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Dieses Tutorial erklärt, wie Sie einen Onlineshop mit der Open-Source-Anwendung
 
 [[fragment:support-scope]]
 
-:::warning
-Dieses Tutorial soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der [WordPress Community](https://wordpress.com/support/) oder dem [Herausgeber von WooCommerce](https://woocommerce.com/) zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+:::info
+Falls Sie Hilfe brauchen, kontaktieren Sie [WordPress Community](https://wordpress.org/support/) oder [Herausgeber von WooCommerce](https://woocommerce.com/).
 :::
 
 ## Voraussetzungen

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ This tutorial will help you install Drupal CMS (Content Management System) manua
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Drupal support](https://www.drupal.org/support) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [Drupal support](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ This tutorial will help you install Joomla! CMS (Content Management System) manu
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [Joomla! support](https://www.joomla.org/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [Joomla! support](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ This tutorial will help you install PrestaShop CMS (Content Management System) m
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [PrestaShop support](https://www.prestashop.com/en/support) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [PrestaShop support](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ This tutorial will help you install the WordPress CMS (Content Management System
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [WordPress support](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/en/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you.
-:::
-
 :::tip
 To install your CMS **automatically** from your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>, please refer to our documentation on [installing a 1-click module](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/en/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ There are several ways of changing the admin password for your CMS, depending on
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you.
-:::
-
 ### Change your admin password via automatic email (forgotten password) <a name="via-email"></a>
 
 Do you still have access to your emails and the login interface? This method is the fastest, by avoiding accessing the CMS settings or passing through phpMyAdmin.

--- a/docs/en/guides/web-cloud/web-hosting/cron-tasks.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/cron-tasks.mdx
@@ -15,10 +15,6 @@ On your OVHcloud web hosting, you can use scripts to automate certain operations
 
 [[fragment:support-scope]]
 
-:::warning
-This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
-:::
-
 ## Requirements
 
 - An [OVHcloud web hosting plan](/links/web/hosting)

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ This device also legally protects you from actions resulting from a possible hac
 
 [[fragment:support-scope]]
 
-:::warning
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
-:::
-
 ## Requirements
 
 - An [OVHcloud web hosting plan](/links/web/hosting)

--- a/docs/en/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -55,10 +55,6 @@ Furthermore, the performance of OVHcloud shared hosting infrastructures is monit
 
 [[fragment:support-scope]]
 
-:::warning
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the OVHcloud community if you encounter any difficulties. We will not be able to assist you with issues **not caused by the relevant hosting infrastructure itself**.
-:::
-
 :::tip
 We recommend noting your diagnostic results as you progress in this guide. This data will prove useful for resolving your issue, whatever the cause of the slowness.
 

--- a/docs/en/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ If you want to administer your website remotely without using Visual Studio Code
 
 [[fragment:support-scope]]
 
-:::warning
-We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/).
 :::
 
 ### Install the SFTP extension for Visual Studio Code

--- a/docs/en/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ On a web hosting plan, you are responsible for your website's backups. Although 
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [WordPress support](https://wordpress.org/support/).
 :::
 
 **This tutorial explains how to back up the content of your WordPress website and its database.**

--- a/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ This tutorial will show you how to configure certain features of your web hostin
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [WordPress support](https://wordpress.org/support/).
 :::
 
 **This tutorial explains how to secure your WordPress with one or more .htaccess files.**

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP offers several extensions for backing up your websites.
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the publisher of the MainWP plugin](https://mainwp.com/support/).
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ Retaining customers is vital to your company's development. Whether you have one
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the publisher of the MainWP plugin](https://mainwp.com/support/).
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ In this guide, we have chosen the MainWP plugin. Other similar solutions exist, 
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the publisher of the MainWP plugin](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Maintaining the security of your websites is crucial for the development of your
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the MainWP plugin](https://mainwp.com/support/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the publisher of the MainWP plugin](https://mainwp.com/support/).
 :::
 
 ## Instructions

--- a/docs/en/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ This tutorial will show you step by step how to migrate your WordPress website a
 
 [[fragment:support-scope]]
 
-:::warning
-We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or [the WordPress CMS editor](https://wordpress.com/support/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [the WordPress CMS editor](https://wordpress.org/support/).
 :::
 
 **Find out how to migrate your WordPress website and associated services to OVHcloud.**

--- a/docs/en/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ This tutorial will show you step by step how to migrate your Xara website and al
 
 [[fragment:support-scope]]
 
-:::warning
-We offer this tutorial to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the [official website of Xara Web designer](https://www.xara.com/webdesigner-plus/) if you experience any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [official website of Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Find out how to migrate your Xara website and associated services to OVHcloud.**

--- a/docs/en/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/multisites-website-not-installed.mdx
@@ -17,10 +17,6 @@ You may see the error page "**Site not installed**" displayed on your web browse
 
 [[fragment:support-scope]]
 
-:::warning
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you.
-:::
-
 ## Requirements
 
 - An [OVHcloud web hosting plan](/links/web/hosting)

--- a/docs/en/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial will illustrate how to use OVHcloud solutions with external tools. You may need to adapt some specific instructions to the operating system of your local device or your server.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/en/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ This tutorial will help you create your first content, organise it, put it onlin
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [WordPress support](https://wordpress.org/support/).
 :::
 
 **This tutorial explains how to create a website with WordPress CMS.**

--- a/docs/en/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/en/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ This tutorial explains how to create an online store with the open-source plugin
 
 [[fragment:support-scope]]
 
-:::warning
-This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the [WordPress support](https://wordpress.com/support/) or [the publisher of WooCommerce](https://woocommerce.com/) if you encounter any difficulties. We will not be able to assist you.
+:::info
+If you experience any difficulties, contact [WordPress support](https://wordpress.org/support/) or [the publisher of WooCommerce](https://woocommerce.com/).
 :::
 
 ## Requirements

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Aquí encontrará todos los elementos necesarios para instalar manualmente el CM
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Drupal](https://www.drupal.org/support). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Aquí encontrará todos los elementos necesarios para instalar manualmente el CM
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS Joomla!](https://www.joomla.org/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Aquí encontrará todos los elementos necesarios para instalar manualmente el CM
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS PrestaShop](https://www.prestashop.com/en/support). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Este tutorial le ayudará a instalar manualmente el CMS (Content Management Syst
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/es/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Esta guía explica cómo instalar manualmente un CMS (del inglés content manage
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle.
-:::
-
 :::tip
 Para instalar su CMS **automáticamente** desde su <ManagerLink to="/">área de cliente de OVHcloud</ManagerLink>, consulte nuestra documentación sobre la instalación de un módulo en un clic](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/es/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Existen diversas formas de cambiar la contraseña de administrador del CMS en fu
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el editor del CMS que haya elegido instalar. Nosotros no podremos asistirle.
-:::
-
 ### Cambiar la contraseña del administrador por correo electrónico automático (olvidado) <a name="via-email"></a>
 
 ¿Todavía tiene acceso a su correo electrónico y a la interfaz de conexión? Este método es el más rápido, ya que evita tener acceso a los parámetros del CMS o utilizar phpMyAdmin.

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ Tras la detección de un funcionamiento sospechoso, nuestros robots de seguridad
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) y/o con nuestra [comunidad de usuarios](/links/community). Nosotros no podremos asistirle.
-:::
-
 ## Requisitos
 
 - Tener contratado un plan de [hosting](/links/web/hosting) de OVHcloud.

--- a/docs/es/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -54,10 +54,6 @@ Por otro lado, el rendimiento de la infraestructura de alojamientos compartidos 
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición esta guía para ayudarle a realizar las tareas más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner). Nosotros no podremos asistirle. **Siempre que la infraestructura en la que está alojado su plan de hosting no sea válida**.
-:::
-
 :::tip
 Le recomendamos que anote sus resultados de diagnóstico a medida que avance en esta guía. En efecto, estos resultados serán muy útiles para la resolución de su situación, independientemente del origen de la lentitud.
 :::

--- a/docs/es/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Si desea administrar su sitio web de forma remota sin utilizar Visual Studio Cod
 
 [[fragment:support-scope]]
 
-:::warning
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del IDE de Visual Studio Code](https://code.visualstudio.com/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [editor del IDE de Visual Studio Code](https://code.visualstudio.com/).
 :::
 
 ### Instalar la extensión SFTP para Visual Studio Code

--- a/docs/es/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ En un alojamiento web compartido, usted es responsable de las copias de segurida
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra cómo guardar copia de seguridad del contenido de su sitio web WordPress y su base de datos.**

--- a/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ Este tutorial explica cómo configurar algunas funcionalidades de su alojamiento
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o [el editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra cómo proteger su WordPress con uno o más archivos htaccess.**

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP ofrece varias extensiones que permiten guardar copias de seguridad de sus
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
+:::info
+Si necesita ayuda, contacte con [el editor del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedimiento

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ Fidelizar a los clientes es esencial para el desarrollo de su empresa. Tanto si 
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
+:::info
+Si necesita ayuda, contacte con [el editor del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedimiento

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ En esta guía hemos elegido el plugin MainWP. Existen otras soluciones similares
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
+:::info
+Si necesita ayuda, contacte con [el editor del plugin MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Mantener la seguridad de sus sitios web es crucial para el desarrollo de su marc
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del plugin MainWP](https://mainwp.com/support/) si tiene alguna dificultad, ya que no podremos prestarle asistencia.
+:::info
+Si necesita ayuda, contacte con [el editor del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedimiento

--- a/docs/es/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Este tutorial explica paso a paso cómo migrar un sitio web WordPress y todos su
 
 [[fragment:support-scope]]
 
-:::warning
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [editor del CMS WordPress](https://wordpress.com/es/support/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra cómo migrar su sitio web WordPress y los servicios asociados a OVHcloud.**

--- a/docs/es/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Este tutorial explica paso a paso cómo migrar un sitio web Xara y todos sus ser
 
 [[fragment:support-scope]]
 
-:::warning
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con el [sitio oficial de Xara Web designer](https://www.xara.com/webdesigner-plus/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [sitio oficial de Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Descubra cómo migrar su sitio web Xara y los servicios asociados a OVHcloud.**

--- a/docs/es/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 [[fragment:support-scope]]
 
-:::warning
-Este tutorial explica cómo utilizar las soluciones de OVHcloud con herramientas externas. Es posible que tenga que adaptar algunas instrucciones específicas para el sistema operativo de su estación de trabajo local o servidor.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/es/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Este tutorial le permitirá crear sus primeros contenidos, organizarlos, publica
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [el editor del CMS WordPress](https://wordpress.com/support/). Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra cómo crear un sitio web con el CMS WordPress.**

--- a/docs/es/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/es/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Esta guía explica cómo crear una tienda online con la extensión open source *
 
 [[fragment:support-scope]]
 
-:::warning
-Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](/links/partner), [el editor del CMS WordPress](https://wordpress.com/support/) o con [el editor de WooCommerce](https://woocommerce.com/) si tiene alguna dificultad. Nosotros no podremos asistirle.
+:::info
+Si necesita ayuda, contacte con [el editor del CMS WordPress](https://wordpress.org/support/) o [el editor de WooCommerce](https://woocommerce.com/).
 :::
 
 ## Requisitos

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Vous trouverez ici tous les éléments pour installer manuellement le CMS (Conte
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Drupal](https://www.drupal.org/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Vous trouverez ici tous les éléments pour installer manuellement le CMS (Conte
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS Joomla!](https://www.joomla.org/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Vous trouverez ici tous les éléments pour installer manuellement le CMS (Conte
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS PrestaShop](https://www.prestashop.com/en/support) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement le CMS (Cont
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l’éditeur du CMS que vous aurez choisi d’installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
-:::
-
 :::tip
 Pour installer votre CMS **automatiquement** depuis votre <ManagerLink to="/">espace client OVHcloud</ManagerLink>, consultez notre documentation sur l’[installation d’un module « en un clic »](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/fr/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Plusieurs méthodes existent pour modifier le mot de passe administrateur de vot
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, si vous éprouvez des difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à l’éditeur du CMS que vous aurez choisi d’installer. En effet, nous ne serons pas en mesure de vous fournir une assistance.
-:::
-
 ### Modifier son mot de passe administrateur via l’e-mail automatique (mot de passe oublié) <a name="via-email"></a>
 
 Vous avez encore accès à vos e-mails et à l’interface de connexion ? Cette méthode est la plus rapide en évitant d’accéder aux paramètres du CMS ou de passer par phpMyAdmin.

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ Suite à la détection d’un fonctionnement suspect, nos robots de sécurité p
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d’échanger avec notre [communauté d’utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
-:::
-
 ## Prérequis
 
 - Disposer d’une [offre d’hébergement web](/links/web/hosting) OVHcloud.

--- a/docs/fr/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -54,10 +54,6 @@ Par ailleurs, les performances de l’infrastructure d’hébergements mutualis�
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance **dès lors que l’infrastructure où votre offre d’hébergement mutualisé est présente n’est pas en cause**.
-:::
-
 :::tip
 Nous vous conseillons de noter vos résultats de diagnostic au fur et à mesure de votre avancée dans ce guide. En effet, ces résultats s’avèreront très utiles pour la résolution de votre situation, quelle que soit l’origine de la lenteur.
 

--- a/docs/fr/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Si vous souhaitez administrer votre site web à distance sans utiliser Visual St
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur de l’IDE Visual Studio Code](https://code.visualstudio.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur de l’IDE Visual Studio Code](https://code.visualstudio.com/).
 :::
 
 ### Installer l’extension SFTP pour Visual Studio Code

--- a/docs/fr/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ Sur un hébergement web mutualisé, vous êtes responsable des sauvegardes de vo
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Découvrez comment sauvegarder le contenu de votre site WordPress et sa base de données.**

--- a/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ Ce tutoriel vous explique comment configurer certaines fonctionnalités de votre
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Découvrez comment sécuriser votre WordPress avec un ou plusieurs fichiers htaccess.**

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP propose plusieurs extensions permettant de sauvegarder vos sites web.
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ La fidélisation de vos clients est primordiale pour le développement de votre 
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ Dans ce guide, nous avons choisi le plugin MainWP. D’autres solutions analogue
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du plugin MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Maintenir la sécurité de vos sites web est crucial pour le développement de v
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du plugin MainWP](https://mainwp.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## En pratique

--- a/docs/fr/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Ce tutoriel vous explique pas à pas comment migrer votre site web WordPress et 
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Découvrez comment migrer votre site web WordPress et ses services associés vers OVHcloud.**

--- a/docs/fr/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Ce tutoriel vous explique pas à pas comment migrer votre site web Xara et tous 
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou au [site officiel de Xara Web designer](https://www.xara.com/webdesigner-plus/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [site officiel de Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Découvrez comment migrer votre site web Xara et ses services associés vers OVHcloud.**

--- a/docs/fr/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 [[fragment:support-scope]]
 
-:::warning
-Ce tutoriel va illustrer comment utiliser les solutions OVHcloud avec des outils externes. Vous devrez peut-être adapter certaines instructions spécifiques au système d’exploitation de votre poste de travail local ou de votre serveur.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/fr/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Ce tutoriel va vous permettre de créer vos premiers contenus, les organiser, le
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou à [l’éditeur du CMS WordPress](https://wordpress.com/support/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Découvrez comment créer un site web avec le CMS WordPress.**

--- a/docs/fr/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/fr/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Découvrez comment créer une boutique en ligne avec l’extension open source *
 
 [[fragment:support-scope]]
 
-:::warning
-Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner), à [l’éditeur du CMS WordPress](https://wordpress.com/fr/support/) ou à [l’éditeur de WooCommerce](https://woocommerce.com/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance.
+:::info
+Si vous éprouvez des difficultés, contactez [l’éditeur du CMS WordPress](https://wordpress.org/support/) ou [l’éditeur de WooCommerce](https://woocommerce.com/).
 :::
 
 ## Prérequis

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Qui trovi tutti gli elementi per installare manualmente il CMS (Content Manageme
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Drupal](https://www.drupal.org/support). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Qui trovi tutti gli elementi per installare manualmente il CMS (Content Manageme
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [amministratore del CMS Joomla!](https://www.joomla.org/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Qui trovi tutti gli elementi per installare manualmente il CMS (Content Manageme
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o [amministratore del CMS PrestaShop](https://www.prestashop.com/en/support). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Questa guida ti mostra come installare manualmente il CMS (Content Management Sy
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [l'amministratore del CMS WordPress](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/it/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Questa guida ti mostra come installare manualmente un CMS (Content Management Sy
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza.
-:::
-
 :::tip
 Per installare il tuo CMS **automaticamente** dal tuo <ManagerLink to="/">Spazio Cliente OVHcloud</ManagerLink>, consulta la nostra guida sull'[installazione di un modulo "in un click"](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/it/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Esistono diversi metodi per modificare la password amministratore del CMS in bas
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o all'amministratore del CMS che hai scelto di installare. OVHcloud non potrà fornirti alcuna assistenza.
-:::
-
 ### Modificare la password amministratore tramite l'email automatica (password dimenticata) <a name="via-email"></a>
 
 Hai ancora accesso alle tue email e all'interfaccia di connessione? Questo metodo è il più rapido ed evita di accedere alle impostazioni del CMS o di utilizzare phpMyAdmin.

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ In seguito al rilevamento di un funzionamento sospetto, i nostri sistemi di sicu
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) e/o di contattare la nostra [Community di utenti](/links/community). OVHcloud non potrà fornirti alcuna assistenza.
-:::
-
 ## Prerequisiti
 
 - Disporre di una [soluzione di hosting Web](/links/web/hosting) OVHcloud

--- a/docs/it/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -54,10 +54,6 @@ Inoltre, le prestazioni dell'infrastruttura di hosting condivisi OVHcloud sono m
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner). OVHcloud non sarà infatti in grado di fornirti assistenza **se l'infrastruttura in cui è presente la tua offerta di hosting condiviso non è interessata**.
-:::
-
 :::tip
 Ti consigliamo di registrare i risultati della diagnostica in base ai tuoi progressi in questa guida. In effetti, questi risultati si riveleranno molto utili per la risoluzione della sua situazione, qualunque sia la causa della lentezza.
 

--- a/docs/it/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Per gestire il sito Web in remoto senza utilizzare Visual Studio Code, installa 
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l'editor dell'IDE Visual Studio Code](https://code.visualstudio.com/). OVHcloud non sarà infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editor dell'IDE Visual Studio Code](https://code.visualstudio.com/).
 :::
 
 ### Installare l'estensione SFTP per Visual Studio Code

--- a/docs/it/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ Su un hosting Web condiviso, sei responsabile dei backup del tuo sito Web. Anche
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Questa guida ti mostra come salvare il contenuto del tuo sito WordPress e del suo database.**

--- a/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ Questa guida ti mostra come configurare alcune funzionalità del tuo hosting Web
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a uno [specialista del settore](/links/partner) o [l'amministratore del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [l'amministratore del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Questa guida ti mostra come proteggere il tuo WordPress con uno o più file htaccess.**

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP propone diverse estensioni che permettono di effettuare il backup dei tuo
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editore del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedura

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ La fidelizzazione dei clienti è essenziale per lo sviluppo della tua azienda. C
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editore del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedura

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ In questa guida abbiamo scelto il plugin MainWP. Esistono altre soluzioni simili
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editore del plugin MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Mantenere la sicurezza dei tuoi siti web è fondamentale per lo sviluppo del tuo
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per aiutarti nelle operazioni più comuni. Ti consigliamo tuttavia di contattare un [fornitore specializzato](/links/partner) o [l'editore del plugin MainWP](https://mainwp.com/support/) in caso di difficoltà: non saremo infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editore del plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Procedura

--- a/docs/it/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Questa guida ti mostra come migrare passo per passo il sito Web WordPress e tutt
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [l'editor del CMS WordPress](https://wordpress.com/it/support/). OVHcloud non sarà infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [l'editor del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Questa guida ti mostra come migrare il tuo sito Web WordPress e i servizi associati in OVHcloud.**

--- a/docs/it/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Questa guida ti mostra come migrare passo per passo il sito Web Xara e tutti i s
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider specializzato](/links/partner) o [sito ufficiale di Xara Web designer](https://www.xara.com/webdesigner-plus/). OVHcloud non sarà infatti in grado di fornirti assistenza.
+:::info
+In caso di difficoltà, contatta [sito ufficiale di Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Questa guida ti mostra come migrare il tuo sito Web Xara e i servizi associati in OVHcloud.**

--- a/docs/it/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 [[fragment:support-scope]]
 
-:::warning
-Questa guida ti mostra come utilizzare le soluzioni OVHcloud con tool esterni. Potrebbe essere necessario adattare alcune istruzioni specifiche al sistema operativo della workstation locale o del server.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/it/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Questa guida ti mostra come creare i tuoi primi contenuti, organizzarli, metterl
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [fornitore specializzato](/links/partner) o [amministratore del CMS WordPress](https://wordpress.com/support/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Questa guida ti mostra come creare un sito Web con CMS WordPress.**

--- a/docs/it/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/it/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Scopri come creare un negozio online con l'estensione open source **WooCommerce*
 
 [[fragment:support-scope]]
 
-:::warning
-Mettiamo a tua disposizione questo tutorial per supportarti nelle operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a [uno specialista del settore](/links/partner), [amministratore del CMS WordPress](https://wordpress.com/support/) o [amministratore delegato di WooCommerce](https://woocommerce.com/). OVHcloud non potrà fornirti alcuna assistenza.
+:::info
+In caso di difficoltà, contatta [amministratore del CMS WordPress](https://wordpress.org/support/) o [amministratore delegato di WooCommerce](https://woocommerce.com/).
 :::
 
 ## Prerequisiti

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Tutaj znajdziesz wszystkie elementy, które pozwolą Ci ręcznie zainstalować C
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [producenta CMS Drupal](https://www.drupal.org/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [producenta CMS Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Znajdziesz tutaj wszystkie elementy do ręcznego zainstalowania systemu CMS (Con
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS Joomla!](https://www.joomla.org/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Tutaj znajdziesz wszystkie elementy do ręcznego zainstalowania systemu CMS (Con
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS PrestaShop](https://www.prestashop.com/en/support). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Tutorial ten pomoże Ci ręcznie zainstalować CMS (Content Management System) W
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Tutorial ten pomoże Ci ręcznie zainstalować CMS (Content Management System), 
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
-:::
-
 :::tip
 Aby zainstalować CMS **automatycznie** z poziomu <ManagerLink to="/">Panelu klienta OVHcloud</ManagerLink>, zapoznaj się z naszą dokumentacją dotyczącą [instalacji modułu "jednym kliknięciem"](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/pl/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Istnieje kilka metod zmiany hasła administratora CMS w zależności od Twojego 
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego webmastera](/links/partner) lub producenta systemu CMS, który wybrałeś. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
-:::
-
 ### Zmiana hasła administratora za pomocą automatycznego konta e-mail (zapomniane hasło) <a name="via-email"></a>
 
 Nadal masz dostęp do poczty e-mail i do interfejsu logowania? Jest to najszybsza metoda, która eliminuje dostęp do ustawień CMS czy phpMyAdmin.

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ Po wykryciu podejrzanego działania nasze roboty związane z bezpieczeństwem mo
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) i/lub kontakt z [społecznością użytkowników](/links/community). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
-:::
-
 ## Wymagania początkowe
 
 - Posiadanie [hostingu](/links/web/hosting) OVHcloud

--- a/docs/pl/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -59,10 +59,6 @@ Niniejszy przewodnik zostanie wkrótce zaktualizowany. W razie jakichkolwiek tru
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twojej ręce niniejszy przewodnik, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Niestety nie będziemy w stanie udzielić Ci wsparcia **w przypadku, gdy infrastruktura, na której hostowana jest Twoja oferta hostingu współdzielonego, nie jest istotna**.
-:::
-
 :::tip
 W tym przewodniku zalecamy zapoznanie się z wynikami diagnostyki. Wyniki te będą bardzo przydatne w rozwiązywaniu Twojej sytuacji, niezależnie od źródła powolnego tempa.
 

--- a/docs/pl/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Jeśli chcesz zdalnie zarządzać swoją witryną internetową bez użycia Visua
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [Visual Studio Code](https://code.visualstudio.com/) IDE. Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [Visual Studio Code](https://code.visualstudio.com/).
 :::
 
 ### Zainstaluj rozszerzenie SFTP dla Visual Studio Code

--- a/docs/pl/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ Na hostingu możesz zarządzać kopiami zapasowymi Twojej strony WWW. Nawet jeś
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Dowiedz się, jak zapisać zawartość strony WordPress i jej bazy danych.**

--- a/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ Tutorial wyjaśnia, jak skonfigurować niektóre funkcjonalności hostingu za po
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Dowiedz się, jak zabezpieczyć moduł WordPress korzystając z jednego lub kilku plików htaccess.**

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ MainWP oferuje kilka rozszerzeń umożliwiających tworzenie kopii zapasowych st
 
 [[fragment:support-scope]]
 
-:::warning
-Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
+:::info
+W przypadku trudności skontaktuj się z [wydawcy wtyczki MainWP](https://mainwp.com/support/).
 :::
 
 ## W praktyce

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ Utrzymanie klientów jest kluczowe dla rozwoju Twojej firmy. Niezależnie od teg
 
 [[fragment:support-scope]]
 
-:::warning
-Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
+:::info
+W przypadku trudności skontaktuj się z [wydawcy wtyczki MainWP](https://mainwp.com/support/).
 :::
 
 ## W praktyce

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ W tym przewodniku wybraliśmy wtyczkę MainWP. Istnieją inne podobne rozwiązan
 
 [[fragment:support-scope]]
 
-:::warning
-Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
+:::info
+W przypadku trudności skontaktuj się z [wydawcy wtyczki MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Utrzymanie bezpieczeństwa stron jest kluczowe dla rozwoju Twojej marki. Optymal
 
 [[fragment:support-scope]]
 
-:::warning
-Udostępniamy Ci ten przewodnik, aby pomóc Ci w wykonaniu typowych zadań. Zalecamy jednak skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [wydawcy wtyczki MainWP](https://mainwp.com/support/), jeśli napotkasz trudności. Nie będziemy bowiem w stanie udzielić Ci wsparcia.
+:::info
+W przypadku trudności skontaktuj się z [wydawcy wtyczki MainWP](https://mainwp.com/support/).
 :::
 
 ## W praktyce

--- a/docs/pl/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Tutorial ten krok po kroku wyjaśnia, jak migrować Twoją stronę WWW WordPress
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Dowiedz się, jak przenieść Twoją stronę WWW WordPress i powiązane z nią usługi do OVHcloud.**

--- a/docs/pl/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Tutorial ten krok po kroku wyjaśnia, jak migrować Twoją stronę WWW Xara i ws
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy w Twoje ręce tutorial, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego dostawcy](/links/partner) lub [oficjalna strona Xara Web designer](https://www.xara.com/webdesigner-plus/). Niestety firma OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [oficjalna strona Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Dowiedz się, jak przenieść Twoją stronę WWW Xara i powiązane z nią usługi do OVHcloud.**

--- a/docs/pl/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 [[fragment:support-scope]]
 
-:::warning
-Tutorial ten wyjaśnia, jak korzystać z rozwiązań OVHcloud przy użyciu narzędzi zewnętrznych. Może być konieczne dostosowanie niektórych instrukcji specyficznych dla systemu operacyjnego lokalnego komputera lub serwera.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/pl/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Tutorial ten pozwoli Ci na tworzenie pierwszych treści, ich organizację, umies
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub [edytora CMS WordPress](https://wordpress.com/support/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Dowiedz się, jak utworzyć stronę WWW przy użyciu CMS WordPress.**

--- a/docs/pl/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/pl/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Dowiedz się, jak utworzyć sklep internetowy z rozszerzeniem open source **WooC
 
 [[fragment:support-scope]]
 
-:::warning
-Oddajemy do Twojej dyspozycji niniejszy tutorial, którego celem jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner), [edytora CMS WordPress](https://wordpress.com/support/) lub [edytora WooCommerce](https://woocommerce.com/). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+:::info
+W przypadku trudności skontaktuj się z [edytora CMS WordPress](https://wordpress.org/support/) lub [edytora WooCommerce](https://woocommerce.com/).
 :::
 
 ## Wymagania początkowe

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-drupal.mdx
@@ -11,8 +11,8 @@ Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Cont
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Drupal](https://www.drupal.org/support). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS Drupal](https://www.drupal.org/support).
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-joomla.mdx
@@ -11,8 +11,8 @@ Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Cont
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS Joomla!](https://www.joomla.org/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS Joomla!](https://www.joomla.org/).
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-prestashop.mdx
@@ -11,8 +11,8 @@ Aqui, poderá encontrar todos os elementos para instalar manualmente o CMS (Cont
 
 [[fragment:support-scope]]
 
-:::warning
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS PrestaShop](https://www.prestashop.com/en/support). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS PrestaShop](https://www.prestashop.com/en/support).
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation-wordpress.mdx
@@ -11,8 +11,8 @@ Este tutorial tem como objetivo ajudá-lo a instalar manualmente o CMS (Content 
 
 [[fragment:support-scope]]
 
-:::warning
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/).
 :::
 
 :::tip

--- a/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-manual-installation.mdx
@@ -14,10 +14,6 @@ Este tutorial tem como objetivo ajudá-lo a instalar manualmente um CMS (Content
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica.
-:::
-
 :::tip
 Para instalar o seu CMS **automaticamente** a partir do seu <ManagerLink to="/">Área de Cliente OVHcloud</ManagerLink>, consulte o nosso manual sobre a [instalação de um módulo "num clique"](/guides/web-cloud/web-hosting/cms-install-1-click-modules).
 

--- a/docs/pt/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/cms-update-password-admin.mdx
@@ -39,10 +39,6 @@ Existem vários métodos para alterar a palavra-passe de administrador do seu CM
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao editor do CMS. Não poderemos proporcionar-lhe assistência técnica.
-:::
-
 ### Alterar a palavra-passe de administrador através do e-mail automático (palavra-passe esquecida) <a name="via-email"></a>
 
 Ainda tem acesso aos e-mails e à interface de ligação? Este método é o mais rápido, evitando aceder aos parâmetros do CMS ou passar pelo phpMyAdmin.

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-403-forbidden.mdx
@@ -35,10 +35,6 @@ Após a deteção de um funcionamento suspeito, os nossos robôs de segurança p
 
 [[fragment:support-scope]]
 
-:::warning
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) e/ou que troque informações com a nossa [comunidade de utilizadores](/links/community). Não poderemos proporcionar-lhe assistência técnica.
-:::
-
 ## Requisitos
 
 - Ter um [serviço de alojamento web](/links/web/hosting) OVHcloud.

--- a/docs/pt/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/diagnostic-slownesses.mdx
@@ -59,10 +59,6 @@ Este guia será atualizado em breve. Em caso de dificuldades, consulte a versão
 
 [[fragment:support-scope]]
 
-:::warning
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner). De facto, não poderemos fornecer-lhe assistência **a partir do momento em que a infraestrutura em que o seu alojamento partilhado está presente não esteja em causa**.
-:::
-
 :::tip
 Recomendamos que registe os resultados de diagnóstico à medida que avançamos neste manual. De facto, estes resultados revelar-se-ão muito úteis para a resolução da sua situação, independentemente da origem da lentidão.
 

--- a/docs/pt/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/handle-sftp-connexion-vscode.mdx
@@ -37,8 +37,8 @@ Se pretender administrar o seu website remotamente sem utilizar o Visual Studio 
 
 [[fragment:support-scope]]
 
-:::warning
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do IDE Visual Studio Code](https://code.visualstudio.com/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do IDE Visual Studio Code](https://code.visualstudio.com/).
 :::
 
 ### Instalar a extensão SFTP para o Visual Studio Code

--- a/docs/pt/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/how-to-backup-your-wordpress.mdx
@@ -14,8 +14,8 @@ Num alojamento web partilhado, é responsável pelos backups do seu website. Mes
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra como guardar o conteúdo do seu site WordPress e a sua base de dados.**

--- a/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/htaccess-how-to-protect-wordpress.mdx
@@ -13,8 +13,8 @@ Este tutorial explica-lhe como configurar certas funcionalidades do seu alojamen
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra como proteger o seu WordPress com um ou vários ficheiros htaccess.**

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-backup.mdx
@@ -25,8 +25,8 @@ O MainWP disponibiliza várias extensões que permitem efetuar backups dos seus 
 
 [[fragment:support-scope]]
 
-:::warning
-Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
+:::info
+Se encontrar dificuldades, contacte [o editor do plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Instruções

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-client-management.mdx
@@ -18,8 +18,8 @@ Fidelizar os clientes é essencial para o desenvolvimento da sua empresa. Quer t
 
 [[fragment:support-scope]]
 
-:::warning
-Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
+:::info
+Se encontrar dificuldades, contacte [o editor do plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Instruções

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-general.mdx
@@ -28,8 +28,8 @@ Neste guia escolhemos o plugin MainWP. Existem outras soluções semelhantes, pe
 
 [[fragment:support-scope]]
 
-:::warning
-Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
+:::info
+Se encontrar dificuldades, contacte [o editor do plugin MainWP](https://mainwp.com/support/).
 :::
 
 {/* CP-NAV-START:web-hosting */}

--- a/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/mainwp-security.mdx
@@ -18,8 +18,8 @@ Manter a segurança dos seus sites é fundamental para o desenvolvimento da sua 
 
 [[fragment:support-scope]]
 
-:::warning
-Disponibilizamos-lhe este tutorial para o ajudar nas tarefas mais comuns. No entanto, recomendamos que contacte um [prestador especializado](/links/partner) ou [o editor do plugin MainWP](https://mainwp.com/support/) em caso de dificuldade, dado que não lhe poderemos prestar assistência.
+:::info
+Se encontrar dificuldades, contacte [o editor do plugin MainWP](https://mainwp.com/support/).
 :::
 
 ## Instruções

--- a/docs/pt/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/migrate-wordpress-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Este tutorial explica passo a passo como migrar o seu website WordPress e todos 
 
 [[fragment:support-scope]]
 
-:::warning
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra como migrar o seu website WordPress e os seus serviços associados para a OVHcloud.**

--- a/docs/pt/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/migrate-xara-website-to-ovh.mdx
@@ -11,8 +11,8 @@ Este tutorial explica passo a passo como migrar o seu website Xara e todos os se
 
 [[fragment:support-scope]]
 
-:::warning
-Nós disponibilizamos-lhe este tutorial a fim de o acompanhar nas tarefas mais comuns. Contudo, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou a [site oficial do Xara Web designer](https://www.xara.com/webdesigner-plus/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [site oficial do Xara Web designer](https://www.xara.com/webdesigner-plus/).
 :::
 
 **Descubra como migrar o seu website Xara e os seus serviços associados para a OVHcloud.**

--- a/docs/pt/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/ssh-using-putty-on-windows.mdx
@@ -20,10 +20,6 @@ O [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html) é um 
 
 [[fragment:support-scope]]
 
-:::warning
-Este tutorial explica como utilizar as soluções da OVHcloud com ferramentas externas. Poderá ser necessário adaptar algumas instruções específicas ao sistema operativo da estação de trabalho local ou do servidor.
-:::
-
 
 {/* CP-NAV-START:web-hosting */}
 ---

--- a/docs/pt/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/wordpress-first-steps.mdx
@@ -11,8 +11,8 @@ Este tutorial vai permitir-lhe criar os seus primeiros conteúdos, organizá-los
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou ao [editor do CMS WordPress](https://wordpress.com/support/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/).
 :::
 
 **Descubra como criar um website com o CMS WordPress.**

--- a/docs/pt/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
+++ b/docs/pt/guides/web-cloud/web-hosting/wordpress-woocommerce-first-steps.mdx
@@ -11,8 +11,8 @@ Saiba como criar uma loja online com a extensão open source **WooCommerce** com
 
 [[fragment:support-scope]]
 
-:::warning
-Colocamos à sua disposição este tutorial para o acompanhar o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades, recomendamos que recorra a um [fornecedor especializado](/links/partner), ao [editor do CMS WordPress](https://wordpress.com/support/) ou ao [editor do WooCommerce](https://woocommerce.com/). Não poderemos proporcionar-lhe assistência técnica.
+:::info
+Se encontrar dificuldades, contacte [editor do CMS WordPress](https://wordpress.org/support/) ou [editor do WooCommerce](https://woocommerce.com/).
 :::
 
 ## Requisitos


### PR DESCRIPTION
Web Cloud support-scope fragment replacement sweep follow-up:
- Remove residual warning blocks not caught by the sweep
- Apply full sweep rules, leave only specific info blocks in page body