### PR TITLE
docs(VoIP): document the unsupported Softcall installation on Linux via Wine

### DIFF
--- a/docs/fr/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall.mdx
+++ b/docs/fr/guides/web-cloud/phone-and-fax/voip/installer-configurer-softcall.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installer et configurer Softcall
 description: Découvrez comment installer et configurer Softcall afin de profiter de la solution Softphone
-lastUpdated: 2025-04-28
+lastUpdated: 2026-09-07
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -10,31 +10,35 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 Le Softphone est une solution qui transforme votre ordinateur, smartphone ou tablette en un téléphone virtuel, vous permettant d'utiliser votre ligne SIP (**S**ession **I**nitiation **P**rotocol) n'importe où et à tout moment. Grâce à notre application [Softcall](https://labs.ovhcloud.com/en/softphone-beta/), facilement téléchargeable sur les plateformes Android, iOS, macOS et Windows, vous pouvez accéder à toutes les fonctionnalités de votre ligne téléphonique professionnelle sans être attaché à un téléphone de bureau traditionnel. Que vous soyez en déplacement ou que vous travailliez à distance, Softcall garantit que votre ligne SIP reste aussi mobile et flexible que nécessaire.
 
-**Découvrez comment installer et configurer Softcall sur les plateformes Android, iOS, macOS et Windows.**
+Softcall n'est pas disponible nativement sous Linux. Son application de bureau Windows peut toutefois être installée à l'aide de Wine. Cette installation n'est pas couverte par notre support technique.
+
+**Découvrez comment installer et configurer Softcall sur les plateformes Android, iOS, macOS et Windows, ainsi que sous Linux à l'aide de Wine.**
 
 ## Prérequis
 
 - Disposer d'une [ligne SIP OVHcloud](https://www.ovhcloud.com/fr/phone/voip/).
 - Si votre ligne est rattachée à un téléphone fourni par OVHcloud, celui-ci ne pourra plus être utilisé dès lors que Softcall est activé.
-- Si votre connexion est derrière un pare-feu, vous devez y autoriser la plage d'adresses IP suivante : `5.196.180.0/27`.
+- Si votre connexion est derrière un pare-feu, vous devez y autoriser la plage d'adresses IP suivante : `5.196.180.0/27`.
 
 {/* CP-NAV-START:telecom-voip-fax */}
 ---
 
 ### Accès à l'espace client OVHcloud
 
-- **Lien direct :** <ManagerLink to="/#/telecom/telephony">VoIP & Fax</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Télécom</code> > <code className="action">VoIP & Fax</code> > Sélectionnez votre groupe de téléphonie
+- **Lien direct :** <ManagerLink to="/#/telecom/telephony">VoIP & Fax</ManagerLink>
+- **Pour accéder à vos services :** <code className="action">Télécom</code> > <code className="action">VoIP & Fax</code> > Sélectionnez votre groupe de téléphonie
 
 ---
 {/* CP-NAV-END:telecom-voip-fax */}
 
 :::info
-Si Softcall est désactivé et que vous souhaitez réutiliser votre téléphone OVHcloud, vous devez procéder à un dépannage Plug & Phone (pour plus de détails, consultez notre guide [Dépanner son téléphone OVHcloud](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel)). Pour les autres types d'appareils, il est nécessaire de réinitialiser le mot de passe SIP et de le renseigner à nouveau dans les paramètres de l'appareil.
+Si Softcall est désactivé et que vous souhaitez réutiliser votre téléphone OVHcloud, vous devez procéder à un dépannage Plug & Phone (pour plus de détails, consultez notre guide « [Dépanner son téléphone OVHcloud](/guides/web-cloud/phone-and-fax/voip/troubleshoot-fix-control-panel) »). Pour les autres types d'appareils, il est nécessaire de réinitialiser le mot de passe SIP et de le renseigner à nouveau dans les paramètres de l'appareil.
 
 :::
 
 ## En pratique
+
+[[fragment:support-scope]]
 
 ### Installer Softcall
 
@@ -44,21 +48,49 @@ Cliquez sur l'onglet <code className="action">Services</code> puis sur la ligne 
 
 Après avoir sélectionné l'onglet <code className="action">Softphone</code>, cliquez sur l'interrupteur pour utiliser la ligne SIP sur l'ensemble de vos applications Softcall.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/toggle_activation_sip.png" loading="lazy" />
+<img className="thumbnail" alt="Interrupteur d'activation du Softphone sur la ligne SIP dans l'espace client" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/toggle_activation_sip.png" loading="lazy" />
 
 #### Télécharger et installer Softcall
 
 Cliquez sur <code className="action">Liens de téléchargements</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/download_softcall_manager_button.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton Liens de téléchargements de Softcall dans l'espace client OVHcloud" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/download_softcall_manager_button.png" loading="lazy" />
 
-Vous disposez de trois options pour télécharger l'application Softcall :
+Vous disposez de trois options pour télécharger l'application Softcall :
 
-- Option 1 : via un store d'applications (Apple App Store, Google Play Store, Microsoft Store).
-- Option 2 : via le QR code.
-- Option 3 : via le lien de téléchargement.
+- Option 1 : via un store d'applications (Apple App Store, Google Play Store, Microsoft Store).
+- Option 2 : via le QR code.
+- Option 3 : via le lien de téléchargement.
 
 Une fois l'application Softcall téléchargée, installez-la sur votre appareil.
+
+#### Installation sous Linux avec Wine (sans support OVHcloud)
+
+:::warning
+Linux ne fait pas partie des systèmes d'exploitation pris en charge par Softcall. La procédure ci-dessous repose sur [Wine](https://gitlab.winehq.org/wine/wine/-/wikis/Download), une couche de compatibilité tierce permettant d'exécuter des applications Windows sous Linux. Elle est fournie à titre informatif.
+
+Même si l'installation reste techniquement possible, OVHcloud n'assure aucun support sur la mise en place ni sur le fonctionnement de Softcall sous Linux. Aucune demande d'assistance ne pourra être traitée à ce sujet et le fonctionnement de l'application n'est pas garanti.
+:::
+
+Vérifiez au préalable que Wine est installé sur votre distribution. Pour cela, consultez la [page de téléchargement de Wine](https://gitlab.winehq.org/wine/wine/-/wikis/Download) et suivez les instructions correspondant à votre système d'exploitation. L'utilitaire [Winetricks](https://github.com/Winetricks/winetricks) permet en complément de gérer vos préfixes Wine depuis une interface graphique.
+
+Téléchargez ensuite l'installateur Windows de Softcall en suivant l'option 3 de la section « [Télécharger et installer Softcall](#télécharger-et-installer-softcall) ». Vous obtenez un fichier nommé `softcallsetup.exe`.
+
+Lancez cet installateur avec Wine depuis un terminal, en adaptant le chemin vers le fichier téléchargé :
+
+```bash
+wine ~/Téléchargements/softcallsetup.exe
+```
+
+Vous pouvez également passer par l'interface graphique de Winetricks : sélectionnez le préfixe Wine à utiliser (`~/.wine` par défaut). Si un avertissement signale l'utilisation d'un préfixe Wine 64 bits, cliquez sur <code className="action">Ok</code> pour poursuivre.
+
+Choisissez ensuite l'action <code className="action">Exécuter un exécutable arbitraire (.exe/.msi/.msu)</code>, puis sélectionnez le fichier `softcallsetup.exe`.
+
+Le programme d'installation Windows de Softcall s'ouvre. Cliquez sur <code className="action">Suivant</code> à chaque étape de l'assistant, en conservant le dossier d'installation proposé (`C:\Program Files\Softcall`, environ 680 Mo d'espace disque requis).
+
+À la fin de l'installation, laissez l'option <code className="action">Lancer Softcall</code> cochée, puis cliquez sur <code className="action">Fermer</code>.
+
+Softcall démarre et affiche son écran de configuration. Poursuivez avec les étapes décrites dans les sections « [Obtenir le code de configuration](#obtenir-le-code-de-configuration) » et « [Configurer l'application de bureau (Windows et macOS)](#configurer-lapplication-de-bureau-windows-et-macos) ».
 
 ### Configurer Softcall
 
@@ -66,11 +98,11 @@ Une fois l'application Softcall téléchargée, installez-la sur votre appareil.
 
 Dans la section <code className="action">Configurer la ligne</code>, cliquez sur <code className="action">Obtenir un code de configuration</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/get_configuration_code_button.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton Obtenir un code de configuration dans la section Configurer la ligne" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/get_configuration_code_button.png" loading="lazy" />
 
 Dans la fenêtre qui s'ouvre, cliquez sur le bouton <code className="action">Générer un code de configuration</code>. Si vous souhaitez recevoir également le code de configuration par e-mail (facultatif), entrez votre adresse e-mail dans le champ concerné.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/configuration_code_popup.png" loading="lazy" />
+<img className="thumbnail" alt="Fenêtre de génération du code de configuration avec le champ d'adresse e-mail" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/configuration_code_popup.png" loading="lazy" />
 
 Dans la nouvelle fenêtre, retrouvez le code de configuration et le QR code.
 
@@ -78,14 +110,14 @@ Dans la nouvelle fenêtre, retrouvez le code de configuration et le QR code.
 
 Cliquez sur l'icône de l'application Softcall. Au premier démarrage, vous êtes dirigé vers l'écran <code className="action">Assistant</code>.
 
-*Cliquez sur l'onglet correspondant à votre système d'exploitation mobile :*
+*Cliquez sur l'onglet correspondant à votre système d'exploitation mobile :*
 
 <Tabs>
   <Tab label="Android">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_ios_android.png" loading="lazy" />
+    <img className="thumbnail" alt="Écran Assistant de l'application mobile Softcall pour saisir le code de configuration" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_ios_android.png" loading="lazy" />
   </Tab>
   <Tab label="iOS">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_ios_android.png" loading="lazy" />
+    <img className="thumbnail" alt="Écran Assistant de l'application mobile Softcall pour saisir le code de configuration" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_ios_android.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -97,20 +129,20 @@ Votre compte Softcall est désormais configuré. Dans le menu principal de Softc
 
 Cliquez sur l'icône de l'application Softcall. Au premier démarrage, vous êtes dirigé vers l'écran <code className="action">Assistant</code>.
 
-*Cliquez sur l'onglet correspondant à votre système d'exploitation :*
+*Cliquez sur l'onglet correspondant à votre système d'exploitation :*
 
 <Tabs>
   <Tab label="Windows">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_windows_macos.png" loading="lazy" />
+    <img className="thumbnail" alt="Écran Assistant de l'application de bureau Softcall pour saisir le code de configuration" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_windows_macos.png" loading="lazy" />
   </Tab>
   <Tab label="macOS">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_windows_macos.png" loading="lazy" />
+    <img className="thumbnail" alt="Écran Assistant de l'application de bureau Softcall pour saisir le code de configuration" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/assistant_windows_macos.png" loading="lazy" />
   </Tab>
 </Tabs>
 
 Dans l'écran <code className="action">Assistant</code> de l'application Softcall, utilisez le code de configuration récupéré précédemment, puis cliquez sur <code className="action">Télécharger</code>. Un message de confirmation s'affiche.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/confirm_dl_config_windows.png" loading="lazy" />
+<img className="thumbnail" alt="Message de confirmation du téléchargement de la configuration dans Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/confirm_dl_config_windows.png" loading="lazy" />
 
 Cliquez sur <code className="action">Confirmer</code> pour redémarrer l'application Softcall afin de prendre en compte la configuration de votre compte Softcall.
 
@@ -126,10 +158,10 @@ Dans le menu principal en bas de l'écran, cliquez sur l'icône représentant un
 
 <Tabs>
   <Tab label="Android">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_android.jpg" loading="lazy" />
+    <img className="thumbnail" alt="Menu inférieur de l'application mobile Softcall avec l'icône du clavier numérique" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_android.jpg" loading="lazy" />
   </Tab>
   <Tab label="iOS">
-    <img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_ios.png" loading="lazy" />
+    <img className="thumbnail" alt="Menu inférieur de Softcall sous iOS avec l'icône du clavier numérique" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_ios.png" loading="lazy" />
   </Tab>
 </Tabs>
 
@@ -139,13 +171,13 @@ Entrez le numéro de votre contact et cliquez sur l'icône représentant un tél
 
 Pour passer un appel téléphonique, entrez le numéro dans le champ en haut de l'interface, ou cliquez sur l'icône représentant un clavier numérique pour taper le numéro. Cliquez sur l'icône représentant un téléphone pour passer l'appel.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_number.png" loading="lazy" />
+<img className="thumbnail" alt="Champ de saisie du numéro à appeler en haut de l'interface Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_number.png" loading="lazy" />
 
 Dans le menu principal à gauche de l'interface, cliquez sur l'icône représentant un téléphone pour accéder à votre historique d'appels.
 
 #### Gérer les contacts
 
-Dans le menu principal à gauche de l'interface, cliquez sur l'icône des contacts. Sur l'écran qui s'affiche, vous pouvez :
+Dans le menu principal à gauche de l'interface, cliquez sur l'icône des contacts. Sur l'écran qui s'affiche, vous pouvez :
 
 - Accéder à vos contacts
 - Rechercher un contact
@@ -159,12 +191,12 @@ Cette fonctionnalité permet de supprimer votre compte Softcall uniquement sur v
 
 :::
 
-Effectuez les actions suivantes pour supprimer votre compte Softcall de votre appareil :
+Effectuez les actions suivantes pour supprimer votre compte Softcall de votre appareil :
 
 - Dans le menu principal, cliquez sur <code className="action">Options</code>.
 - Cliquez sur le numéro du compte Softcall que vous voulez supprimer.
 - Cliquez sur <code className="action">Supprimer le compte</code>.
-- Un message de confirmation s'affiche : cliquez sur <code className="action">Supprimer</code> pour confirmer la suppression locale de votre compte Softcall.
+- Un message de confirmation s'affiche : cliquez sur <code className="action">Supprimer</code> pour confirmer la suppression locale de votre compte Softcall.
 
 ### Fonctionnalités Softcall avancées
 
@@ -176,7 +208,7 @@ Effectuez les actions suivantes pour supprimer votre compte Softcall de votre ap
 
 Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à droite de l'interface de Softcall.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/voicemail_button.png" loading="lazy" />
+<img className="thumbnail" alt="Icône d'accès à la messagerie vocale dans l'interface de bureau Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/voicemail_button.png" loading="lazy" />
 
 </details>
 
@@ -186,11 +218,11 @@ Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à 
 
 Dans le menu latéral de l'interface de Softcall, cliquez sur l'icône représentant un téléphone.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_history_button.png" loading="lazy" />
+<img className="thumbnail" alt="Icône de l'historique des appels dans le menu latéral de Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_history_button.png" loading="lazy" />
 
 En haut à droite de l'écran, cliquez sur le bouton représentant un téléphone pour appeler le dernier numéro avec lequel vous avez été en contact.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bis_number.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton de rappel du dernier numéro composé dans l'historique des appels" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bis_number.png" loading="lazy" />
 
 </details>
 
@@ -198,28 +230,28 @@ En haut à droite de l'écran, cliquez sur le bouton représentant un téléphon
 
 <summary>Effectuer un transfert d'appel à l'aveugle</summary>
 
-Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
+Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
 
 - Le transfert est effectué directement, sans préalablement contacter le nouveau destinataire de l'appel.
 - Votre correspondant en cours n'est pas mis en attente lors du transfert.
 
-Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
+Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 - En haut à gauche de l'interface, cliquez sur l'icône représentant un téléphone.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_main_interface.png" loading="lazy" />
+<img className="thumbnail" alt="Interface de Softcall pendant un appel en cours avec le correspondant affiché" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_main_interface.png" loading="lazy" />
 
 - Juste à droite du numéro de votre correspondant en cours, cliquez sur les trois points (<code className="action">⋮</code>). Dans le menu qui s'affiche, choisissez <code className="action">Transférer l'appel</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_menu_blind_transfer.png" loading="lazy" />
+<img className="thumbnail" alt="Menu d'appel en cours ouvert sur l'option Transférer l'appel" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_menu_blind_transfer.png" loading="lazy" />
 
 - Sur l'écran qui s'affiche, tapez le numéro du destinataire à qui vous souhaitez transférer l'appel. Cliquez sur le bouton à droite du numéro (représentant une flèche) pour transférer l'appel.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/blind_call_transfer_form.png" loading="lazy" />
+<img className="thumbnail" alt="Champ de saisie du numéro du destinataire du transfert d'appel" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/blind_call_transfer_form.png" loading="lazy" />
 
 - Lorsque le destinataire du transfert décroche, l'appel avec votre correspondant en cours se termine.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/end_of_call.png" loading="lazy" />
+<img className="thumbnail" alt="Écran Fin d'appel indiquant que le correspondant a raccroché" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/end_of_call.png" loading="lazy" />
 
 </details>
 
@@ -227,32 +259,32 @@ Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 <summary>Effectuer un transfert d'appel accompagné</summary>
 
-Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
+Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
 
 - Vous contactez le nouveau destinataire pour obtenir son accord avant de valider le transfert.
 - Votre correspondant est mis en attente avant d'effectuer le transfert.
 
-Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
+Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 - En haut à gauche de l'interface, cliquez sur l'icône représentant un téléphone.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_main_interface.png" loading="lazy" />
+<img className="thumbnail" alt="Interface de Softcall pendant un appel en cours avec le correspondant affiché" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_main_interface.png" loading="lazy" />
 
 - Juste à droite du numéro de votre correspondant en cours, cliquez sur les trois points (<code className="action">⋮</code>). Dans le menu qui s'affiche, choisissez <code className="action">Consultation avant transfert</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_menu_attended_transfer.png" loading="lazy" />
+<img className="thumbnail" alt="Menu d'appel en cours ouvert sur l'option Consultation avant transfert" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/call_in_progress_menu_attended_transfer.png" loading="lazy" />
 
 - Sur l'écran qui s'affiche, tapez le numéro du destinataire à qui vous souhaitez transférer l'appel. Cliquez sur le bouton à droite du numéro (représentant une flèche) pour l'appeler.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/blind_call_transfer_form.png" loading="lazy" />
+<img className="thumbnail" alt="Champ de saisie du numéro du destinataire du transfert d'appel" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/blind_call_transfer_form.png" loading="lazy" />
 
 - Votre correspondant en cours est mis en attente. Lorsque le destinataire du transfert décroche, cliquez sur l'icône représentant un téléphone, en haut à gauche de l'interface. Dans le menu latéral de gauche, les numéros de vos correspondants en attente et en cours s'affichent. Cliquez sur les trois points (<code className="action">⋮</code>) à droite du numéro de votre correspondant en cours, puis choisissez <code className="action">Valider le transfert</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/validate_transfer.png" loading="lazy" />
+<img className="thumbnail" alt="Bouton de validation du transfert supervisé pendant un appel en cours" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/validate_transfer.png" loading="lazy" />
 
 - Une fois le transfert validé, les appels avec vos deux correspondants sont terminés.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/end_of_call.png" loading="lazy" />
+<img className="thumbnail" alt="Écran Fin d'appel indiquant que le correspondant a raccroché" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/end_of_call.png" loading="lazy" />
 
 </details>
 
@@ -260,12 +292,12 @@ Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 <summary>Rapporter un incident à nos équipes</summary>
 
-Si vous rencontrez un problème avec l'application Softcall (bug, erreur, etc.), nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
+Si vous rencontrez un problème avec l'application Softcall (bug, erreur, etc.), nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
 
 1. En bas à gauche de l'interface de Softcall, cliquez sur l'icône des paramètres (représentée par une roue crantée), puis sur <code className="action">Préférences</code>.
 1. Sur l'écran qui s'affiche, rendez-vous dans l'onglet <code className="action">Avancés</code>.
 1. Cliquez sur le bouton <code className="action">Envoyer les traces</code>.
-1. Un lien est alors généré. Sélectionnez ce lien, copiez-le puis envoyez-le par e-mail à l'adresse suivante : [bug@softcall.app](mailto:bug@softcall.app)
+1. Un lien est alors généré. Sélectionnez ce lien, copiez-le puis envoyez-le par e-mail à l'adresse suivante : [bug@softcall.app](mailto:bug@softcall.app).
 
 </details>
 
@@ -277,7 +309,7 @@ Si vous rencontrez un problème avec l'application Softcall (bug, erreur, etc.),
 
 Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à droite de l'interface de Softcall.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_voicemail.jpg" loading="lazy" />
+<img className="thumbnail" alt="Icône d'accès à la messagerie vocale dans l'application mobile Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_voicemail.jpg" loading="lazy" />
 
 </details>
 
@@ -285,15 +317,15 @@ Pour appeler votre messagerie vocale, cliquez sur l'icône suivante, en haut à 
 
 <summary>Utiliser le mode bis</summary>
 
-Pour appeler le dernier numéro avec lequel vous avez été en contact, suivez les étapes ci-dessous :
+Pour appeler le dernier numéro avec lequel vous avez été en contact, suivez les étapes ci-dessous :
 
-- Cliquez sur l'icône suivante (en bas à droite de l'interface) pour afficher le clavier numérique :
+- Cliquez sur l'icône suivante (en bas à droite de l'interface) pour afficher le clavier numérique :
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_android.jpg" loading="lazy" />
+<img className="thumbnail" alt="Menu inférieur de l'application mobile Softcall avec l'icône du clavier numérique" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/bottom_menu_android.jpg" loading="lazy" />
 
-- Cliquez sur le bouton représentant un téléphone :
+- Cliquez sur le bouton représentant un téléphone :
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_button_call.jpg" loading="lazy" />
+<img className="thumbnail" alt="Bouton d'appel du clavier numérique dans l'application mobile Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_button_call.jpg" loading="lazy" />
 
 - Le dernier numéro appelé s'affiche. Appuyez à nouveau sur le même bouton pour l'appeler.
 
@@ -303,24 +335,24 @@ Pour appeler le dernier numéro avec lequel vous avez été en contact, suivez l
 
 <summary>Effectuer un transfert d'appel à l'aveugle</summary>
 
-Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
+Lorsque vous transférez un appel téléphonique à l'aveugle, cela signifie que :
 
 - Le transfert est effectué directement, sans préalablement contacter le nouveau destinataire de l'appel.
 - Votre correspondant en cours n'est pas mis en attente lors du transfert.
 
-Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
+Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 - Lorsque vous êtes en ligne avec votre correspondant, cliquez en bas à droite de l'interface sur les trois points (<code className="action">...</code>).
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_interface.jpg" loading="lazy" />
+<img className="thumbnail" alt="Interface de l'application mobile Softcall pendant un appel en cours" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_interface.jpg" loading="lazy" />
 
 - Dans le menu qui s'ouvre, cliquez sur <code className="action">Transférer l'appel</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_transfer_call.jpg" loading="lazy" />
+<img className="thumbnail" alt="Menu mobile de Softcall ouvert sur l'option Transférer l'appel" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_transfer_call.jpg" loading="lazy" />
 
 - Sur l'écran qui s'affiche, tapez le numéro du destinataire à qui vous souhaitez transférer l'appel. Cliquez sur le bouton en bas à droite de l'écran (représentant un téléphone) pour transférer l'appel.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_keyboard_transfer.jpg" loading="lazy" />
+<img className="thumbnail" alt="Clavier numérique mobile pour saisir le numéro du destinataire du transfert" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_keyboard_transfer.jpg" loading="lazy" />
 
 - Lorsque le destinataire du transfert décroche, l'appel avec votre correspondant en cours se termine.
 
@@ -330,28 +362,28 @@ Pour effectuer un transfert d'appel à l'aveugle, suivez ces étapes :
 
 <summary>Effectuer un transfert d'appel accompagné</summary>
 
-Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
+Lorsque vous effectuez un transfert d'appel accompagné, cela signifie que :
 
 - Vous contactez le nouveau destinataire pour obtenir son accord avant de valider le transfert.
 - Votre correspondant est mis en attente avant d'effectuer le transfert.
 
-Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
+Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 - Lorsque vous êtes en ligne avec votre correspondant, cliquez en bas à droite de l'interface sur les trois points (<code className="action">...</code>).
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_interface.jpg" loading="lazy" />
+<img className="thumbnail" alt="Interface de l'application mobile Softcall pendant un appel en cours" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_interface.jpg" loading="lazy" />
 
 - Dans le menu qui s'affiche, cliquez sur <code className="action">Nouvel appel</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_menu_new_call.jpg" loading="lazy" />
+<img className="thumbnail" alt="Menu mobile de Softcall ouvert sur l'option Nouvel appel" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_menu_new_call.jpg" loading="lazy" />
 
 - Sur l'écran qui s'affiche, tapez le numéro du destinataire à qui vous souhaitez transférer l'appel. Cliquez sur le bouton en bas à droite de l'interface (représentant un téléphone) pour l'appeler.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_keyboard_transfer.jpg" loading="lazy" />
+<img className="thumbnail" alt="Clavier numérique mobile pour saisir le numéro du destinataire du transfert" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_keyboard_transfer.jpg" loading="lazy" />
 
 - Votre correspondant en cours est mis en attente. Lorsque le destinataire du transfert décroche, cliquez sur les trois points (<code className="action">...</code>) en bas à droite de l'interface. Dans le menu qui s'affiche, cliquez sur <code className="action">Transfert supervisé</code> pour effectuer le transfert.
 
-<img className="thumbnail" alt="Install Softcalls" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_attended_transfer.jpg" loading="lazy" />
+<img className="thumbnail" alt="Bouton de transfert de l'appel supervisé dans l'application mobile Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_call_in_progress_attended_transfer.jpg" loading="lazy" />
 
 - Une fois le transfert validé, les appels avec vos deux correspondants sont terminés.
 
@@ -361,13 +393,13 @@ Pour effectuer un transfert d'appel accompagné, suivez ces étapes :
 
 <summary>Rapporter un incident à nos équipes</summary>
 
-Si vous rencontrez un problème dans l'application Softcall (bug, erreur, etc.), nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
+Si vous rencontrez un problème dans l'application Softcall (bug, erreur, etc.), nous vous recommandons d'envoyer un rapport d'erreurs à nos équipes en suivant ces étapes :
 
 Composez le numéro `#1234#`.
 
 Dans le menu qui s'affiche, cliquez sur <code className="action">Activer les traces</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_enable_debugging.jpg" loading="lazy" />
+<img className="thumbnail" alt="Option Activer les traces dans les paramètres de l'application mobile Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_enable_debugging.jpg" loading="lazy" />
 
 Reproduisez les actions qui provoquent l'anomalie.
 
@@ -375,7 +407,7 @@ Composez à nouveau le numéro `#1234#`.
 
 Dans le menu qui s'affiche, cliquez sur <code className="action">Envoyer les traces</code>.
 
-<img className="thumbnail" alt="Install Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_submit_logs.jpg" loading="lazy" />
+<img className="thumbnail" alt="Option Envoyer les traces dans les paramètres de l'application mobile Softcall" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/mobile_submit_logs.jpg" loading="lazy" />
 
 Sur l'écran qui s'affiche, choisissez votre client de messagerie. Le destinataire et le lien du rapport de bug sont pré-remplis dans l'e-mail.
 Envoyez l'e-mail pour transmettre ce rapport à notre équipe en charge du produit Softcall.
@@ -405,14 +437,14 @@ Dirigez-vous dans la section <code className="action">Ajouter un logo</code>.
 
 Cliquez sur le bouton <code className="action">Drag and drop a file or select a file</code>. La photo que vous venez de charger s'affiche en-dessous de la mention `Attached file(s)` (`OVHcloud_logo.png` dans l'exemple ci-dessous).
 
-<img className="thumbnail" alt="Install Softcalls" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/add_logo_manager.png" loading="lazy" />
+<img className="thumbnail" alt="Section Ajouter un logo avec le fichier chargé et le bouton Appliquer un logo" src="/images/web-cloud/phone-and-fax/voip/installer-configurer-softcall/add_logo_manager.png" loading="lazy" />
 
 :::warning
-Respectez les critères suivants pour la photo à charger :
+Respectez les critères suivants pour la photo à charger :
 
 - Format `png`, `jpeg` ou `jpg`.
 - Poids inférieur à 1 MB.
-- Dimensions maximales : 512 x 512 pixels.
+- Dimensions maximales : 512 x 512 pixels.
 
 :::
 


### PR DESCRIPTION
Add a section under "Installer Softcall" describing how to run the Windows desktop installer with Wine/Winetricks, with an explicit warning that OVHcloud provides no support for this setup. Mention the Linux case in the objective and insert the shared support-scope fragment.

Proofreading pass on the whole guide: French descriptive alt text on the 37 images, non-breaking spaces before double punctuation, chevrons on guide and section citations, action-button syntax for the Winetricks menu entry and the installer checkbox, missing final period.