### PR TITLE
docs(ldp): remove the outdated IAM availability notice on Logs Data Platform

### DIFF
--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: IAM for Logs Data Platform - Migration and Breaking Changes
 description: Important changes introduced by the IAM migration
-lastUpdated: 2026-09-08
+lastUpdated: 2025-10-16
 ---
 
 ## Objective

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -24,9 +24,9 @@ IAM stands for **Identity and Access Management**. It is a system of policies an
 - **Convenience**: IAM simplifies user management as it is unified across all OVHcloud products, allowing individuals to access all their products with one set of credentials.
 - **Flexibility**: IAM allows you to create sophisticated policies for sharing resources in a robust way.
 
-### IAM Migration for Logs Data Platform
+### IAM availability
 
-The IAM Migration for Logs Data Platform took place on 17 September 2025. A scheduled maintenance enabled IAM for all Logs Data Platform customers, introducing new features and allowing full migration to IAM.
+Since 17 September 2025, IAM has been enabled for all Logs Data Platform customers, introducing new features and allowing full migration to IAM.
 
 ### Breaking Changes
 

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -1,16 +1,8 @@
 ---
 title: IAM for Logs Data Platform - Migration and Breaking Changes
-description: Important changes to be aware of before the IAM migration
-lastUpdated: 2025-10-16
+description: Important changes introduced by the IAM migration
+lastUpdated: 2026-09-08
 ---
-
-:::info
-
-IAM for Logs Data Platform will be available starting **17th September 2025**.
-The content of this documentation should be read to prepare this migration.
-
-:::
-
 
 ## Objective
 
@@ -34,7 +26,7 @@ IAM stands for **Identity and Access Management**. It is a system of policies an
 
 ### IAM Migration for Logs Data Platform
 
-The IAM Migration for Logs Data Platform is scheduled for 17 September 2025. A scheduled maintenance will enable IAM for all Logs Data Platform customers, introducing new features and allowing full migration to IAM.
+The IAM Migration for Logs Data Platform took place on 17 September 2025. A scheduled maintenance enabled IAM for all Logs Data Platform customers, introducing new features and allowing full migration to IAM.
 
 ### Breaking Changes
 

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: IAM for Logs Data Platform - Presentation and FAQ
 description: A presentation on how IAM works with Logs Data Platform
-lastUpdated: 2026-09-08
+lastUpdated: 2025-10-16
 ---
 
 import Api from '@components/Api';

--- a/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
+++ b/docs/en/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
@@ -1,18 +1,10 @@
 ---
 title: IAM for Logs Data Platform - Presentation and FAQ
 description: A presentation on how IAM works with Logs Data Platform
-lastUpdated: 2025-10-16
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';
-
-
-:::info
-
-IAM for Logs Data Platform will be available starting **17th September 2025**.
-The content of this documentation will be valid from this date.
-
-:::
 
 
 ## Objective

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: IAM pour Logs Data Platform - Migration et changements majeurs
 description: Les changements importants introduits par la migration IAM
-lastUpdated: 2026-09-08
+lastUpdated: 2025-10-16
 ---
 
 ## Objectif

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -24,9 +24,9 @@ IAM signifie **Identity and Access Management** (gestion des identités et des a
 - **Confort d'utilisation** : l'IAM simplifie la gestion des utilisateurs puisqu'elle est unifiée sur tous les produits OVHcloud, permettant à chacun d'accéder à tous ses produits avec un seul jeu d'identifiants.
 - **Flexibilité** : l'IAM vous permet de créer des politiques sophistiquées pour partager des ressources de manière robuste.
 
-### Migration IAM pour Logs Data Platform
+### Disponibilité de l'IAM
 
-La migration IAM pour Logs Data Platform a eu lieu le 17 septembre 2025. Une maintenance planifiée a activé l'IAM pour tous les clients de Logs Data Platform, introduisant de nouvelles fonctionnalités et permettant une migration complète vers l'IAM.
+Depuis le 17 septembre 2025, l'IAM est activé pour tous les clients de Logs Data Platform, ce qui introduit de nouvelles fonctionnalités et permet une migration complète vers l'IAM.
 
 ### Changements majeurs
 

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-migration.mdx
@@ -1,16 +1,8 @@
 ---
 title: IAM pour Logs Data Platform - Migration et changements majeurs
-description: Les changements importants à connaître avant la migration IAM
-lastUpdated: 2025-10-16
+description: Les changements importants introduits par la migration IAM
+lastUpdated: 2026-09-08
 ---
-
-:::info
-
-L'IAM pour Logs Data Platform sera disponible à partir du **17 septembre 2025**.
-Le contenu de cette documentation doit être lu pour préparer cette migration.
-
-:::
-
 
 ## Objectif
 
@@ -34,7 +26,7 @@ IAM signifie **Identity and Access Management** (gestion des identités et des a
 
 ### Migration IAM pour Logs Data Platform
 
-La migration IAM pour Logs Data Platform est prévue pour le 17 septembre 2025. Une maintenance planifiée activera l'IAM pour tous les clients de Logs Data Platform, introduisant de nouvelles fonctionnalités et permettant une migration complète vers l'IAM.
+La migration IAM pour Logs Data Platform a eu lieu le 17 septembre 2025. Une maintenance planifiée a activé l'IAM pour tous les clients de Logs Data Platform, introduisant de nouvelles fonctionnalités et permettant une migration complète vers l'IAM.
 
 ### Changements majeurs
 

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: IAM pour Logs Data Platform - Présentation et FAQ
 description: Une présentation du fonctionnement de l'IAM avec Logs Data Platform
-lastUpdated: 2026-09-08
+lastUpdated: 2025-10-16
 ---
 
 import Api from '@components/Api';

--- a/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
+++ b/docs/fr/guides/manage-and-operate/observability/logs-data-platform/iam-presentation-faq.mdx
@@ -1,18 +1,10 @@
 ---
 title: IAM pour Logs Data Platform - Présentation et FAQ
 description: Une présentation du fonctionnement de l'IAM avec Logs Data Platform
-lastUpdated: 2025-10-16
+lastUpdated: 2026-09-08
 ---
 
 import Api from '@components/Api';
-
-
-:::info
-
-L'IAM pour Logs Data Platform sera disponible à partir du **17 septembre 2025**.
-Le contenu de cette documentation sera valable à compter de cette date.
-
-:::
 
 
 ## Objectif


### PR DESCRIPTION
Both IAM guides still announced IAM as available from 17 September 2025, a year after the fact. The notices are gone and the migration date now reads in the past tense.