### PR TITLE
fix(opcp): fix keycloak client audience mapping docs

### DIFF
--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -71,7 +71,7 @@ openstack-cli
 6\. **Add an audience mapper** (from OPCP version 3.0.5 onwards)
 
 :::info
-As of OPCP version **3.0.5**, you must add an audience mapper to the client so that the issued tokens include the `keystone` audience. Without this mapper, authentication against Keystone fails.
+As of OPCP version **3.0.5**, you must add an audience mapper to the client so that the issued tokens include the `keystone-default` audience. Without this mapper, authentication against Keystone fails.
 :::
 
 - From the `Client Scopes` tab, select the `[your-client-id]-dedicated` scope again.
@@ -81,7 +81,7 @@ As of OPCP version **3.0.5**, you must add an audience mapper to the client so t
    | Field | Value |
    |--------|--------|
    | **Name** | `keystone-audience` |
-   | **Included Client Audience** | `keystone` |
+   | **Included Client Audience** | `keystone-default` |
    | **Included Custom Audience** | *(leave empty)* |
 
 - Click on <code className="action">Save</code>.

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to use the APIs and obtain the credentials
 description: Discover the steps required to configure Keycloak and the OpenStack CLI to allow authentication via Keycloak
-lastUpdated: 2026-07-24
+lastUpdated: 2026-09-09
 ---
 
 ## Objective

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Comment utiliser les API et obtenir les informations d'identification"
 description: Découvrez les étapes nécessaires pour configurer Keycloak et le CLI OpenStack afin de permettre l’authentification via Keycloak
-lastUpdated: 2026-07-24
+lastUpdated: 2026-09-09
 ---
 
 ## Objectif

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-use-api-and-get-credentials.mdx
@@ -71,7 +71,7 @@ Un client **Keycloak dédié** est nécessaire pour permettre à la CLI OpenStac
 6\. **Ajout d’un mapper d’audience** (à partir de la version 3.0.5 d’OPCP)
 
 :::info
-Depuis la version **3.0.5** d’OPCP, vous devez ajouter un mapper d’audience au client afin que les tokens émis incluent l’audience `keystone`. Sans ce mapper, l’authentification auprès de Keystone échoue.
+Depuis la version **3.0.5** d’OPCP, vous devez ajouter un mapper d’audience au client afin que les tokens émis incluent l’audience `keystone-default`. Sans ce mapper, l’authentification auprès de Keystone échoue.
 :::
 
 - Depuis l’onglet `Client Scopes`, sélectionnez de nouveau la portée `[votre-client-id]-dedicated`.
@@ -81,7 +81,7 @@ Depuis la version **3.0.5** d’OPCP, vous devez ajouter un mapper d’audience 
    | Champ | Valeur |
    |--------|--------|
    | **Name** | `keystone-audience` |
-   | **Included Client Audience** | `keystone` |
+   | **Included Client Audience** | `keystone-default` |
    | **Included Custom Audience** | *(laisser vide)* |
 
 - Cliquez sur <code className="action">Enregistrer</code>.


### PR DESCRIPTION
The documentation for configuring API access via keycloak was wrong at the point where the audience for the client was selected.