### PR TITLE
fix(links): point all community links at the /links/community alias

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/activate-port-firewall-soft-win.mdx
@@ -18,7 +18,7 @@ Um Ihr System optimal zu schützen, verfügt Ihr Windows Server über eine integ
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -35,7 +35,7 @@ Weitere Informationen hierzu finden Sie in unserer Anleitung "[Erste Schritte mi
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
@@ -13,7 +13,7 @@ Wenn Sie feststellen, dass eine Festplatte defekt ist, oder per E-Mail eine Syst
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie verantwortlich sind. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. Zusätzliche Informationen finden Sie im am [Ende dieser Anleitung](#go-further).
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. Zusätzliche Informationen finden Sie im am [Ende dieser Anleitung](#go-further).
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -13,7 +13,7 @@ Rsync (für Fernsynchronisierung) wird unter der GNU GPL vertrieben und ist ein 
 **Diese Anleitung wird Ihnen demonstrieren, wie Dateien mit rsync von einem dedizierten OVHcloud Server auf einen anderen kopiert werden.**
 
 :::warning
-In diesem Tutorial zeigen wir Ihnen die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der OVHcloud Community unter [https://community.ovh.com/en/](https://community.ovh.com/en/) (Englisch). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
+In diesem Tutorial zeigen wir Ihnen die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der OVHcloud Community unter [https://community.ovhcloud.com/](/links/community) (Englisch). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -35,7 +35,7 @@ Mit der Einrichtung eines Webservers und verwandter Software kann Ihr Cloud Serv
 :::warning
 In diesem Tutorial erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchzuführenden Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen.
 
-Bei Schwierigkeiten kontaktieren Sie bitte einen spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
+Bei Schwierigkeiten kontaktieren Sie bitte einen spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Ihre Fragen in der [OVHcloud Community](/links/community). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing.mdx
@@ -27,7 +27,7 @@ IP-Aliasing ist eine spezielle Konfiguration im Netzwerk Ihres Servers, mit der 
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/replacing-lost-ssh-key-pair.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/replacing-lost-ssh-key-pair.mdx
@@ -21,7 +21,7 @@ Sie können sich jedoch weiterhin über den [OVHcloud Rescue-Modus](/guides/bare
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ Lesen Sie ggf. auch unsere Anleitung zu den ersten Schritten für Ihren Dienst:
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -34,7 +34,7 @@ Der Rescue-Modus stellt einen permanenten Zugriff auf Ihre Daten bereit, auch we
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Wir stellen Ihnen dieses Tutorial zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+Wir stellen Ihnen dieses Tutorial zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 
 :::
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -18,7 +18,7 @@ Wenn Sie Ihren Dedicated Server bestellen, können Sie eine Distribution oder ei
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Datenzugriff auf Ihre Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 :::
 
 

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ Das Kommunikationsprotokoll SSH (Secure Shell) ist die bevorzugte Methode zum Au
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie verantwortlich sind. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. Zusätzliche Informationen finden Sie im am [Ende dieser Anleitung](#gofurther).
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. Zusätzliche Informationen finden Sie im am [Ende dieser Anleitung](#gofurther).
 :::
 
 ## Voraussetzungen

--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Es gibt verschiedene Optionen zum Übertragen von Dateien zwischen einem lokalen
 :::warning
 In diesem Tutorial erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Möglicherweise müssen Sie bestimmte Anweisungen an das Betriebssystem Ihres lokalen Systems oder Ihres Servers anpassen.
 
-Wir empfehlen Ihnen, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten.
+Wir empfehlen Ihnen, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten.
 
 :::
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -13,7 +13,7 @@ Mit dem *cloud-init* Modul können Sie Ihre [Public Cloud Instanz](https://www.o
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Maschinen haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 
 Diese Anleitung betrifft **nur** Instanzen, die auf Linux-Distributionen basieren.
 :::

--- a/docs/de/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
@@ -154,4 +154,4 @@ Folgen Sie anschließend den verbleibenden Schritten, wie in [dieser Anleitung](
 
 ## Weiterführende Informationen
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).
+Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovhcloud.com/](/links/community).

--- a/docs/de/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ Plesk ist ein einfach zu verwendendes Server-Verwaltungsinterface. Sie können e
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Maschinen haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovhcloud.com/community/en) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 :::
 
 

--- a/docs/de/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/de/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus ist ein Monitoring-System und eine Zeitreihendatenbank. Sie können d
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie verantwortlich sind. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie auf Schwierigkeiten stoßen.
+Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Wir empfehlen jedoch, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie auf Schwierigkeiten stoßen.
 :::
 
 

--- a/docs/de/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/de/guides/public-cloud/compute/install-wordpress.mdx
@@ -15,7 +15,7 @@ Dieses Tutorial enthält die Grundschritte für die manuelle Installation von Wo
 :::warning
 In diesem Tutorial erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchzuführenden Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen.
 
-Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovhcloud.com/community/en). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
+Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Ihre Fragen in der [OVHcloud Community](/links/community). Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
 
 :::
 

--- a/docs/de/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/de/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -21,7 +21,7 @@ Sie können sich jedoch weiterhin über den OVHcloud Rescue-Modus mit einem prov
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. 
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung genereller Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie bei der Administration Ihres Systems Hilfe benötigen. 
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/de/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/de/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/de/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/de/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/de/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/de/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/de/guides/public-cloud/network-services/configure-additional-ip.mdx
+++ b/docs/de/guides/public-cloud/network-services/configure-additional-ip.mdx
@@ -29,7 +29,7 @@ Es kann notwendig werden, Additional IPs auf Ihren Instanzen konfigurieren, zum 
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Dienstes haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovhcloud.com/community/en) wenden, um sich mit anderen Benutzern auszutauschen.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Dienstes haben. Sie können sich auch jederzeit an unsere [Community](/links/community) wenden, um sich mit anderen Benutzern auszutauschen.
 
 :::
 

--- a/docs/de/guides/public-cloud/network-services/stormshield-vrack.mdx
+++ b/docs/de/guides/public-cloud/network-services/stormshield-vrack.mdx
@@ -18,7 +18,7 @@ In dieser Anleitung erhalten Sie Schritt-für-Schritt-Anweisungen zum Deployment
 :::warning
 In diesem Tutorial erläutern wir die Verwendung von OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Möglicherweise müssen Sie bestimmte Anweisungen an Ihre Umgebung oder individuelle Bedürfnisse anpassen.
 
-Wir empfehlen, bei Schwierigkeiten bezüglich der Umsetzung einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
+Wir empfehlen, bei Schwierigkeiten bezüglich der Umsetzung einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
 
 :::
 

--- a/docs/de/guides/public-cloud/network-services/ubika-vrack.mdx
+++ b/docs/de/guides/public-cloud/network-services/ubika-vrack.mdx
@@ -16,7 +16,7 @@ Diese Anleitung enthält detaillierte Anweisungen zur Inbetriebnahme und Konfigu
 :::warning
 In diesem Tutorial erläutern wir die Verwendung von OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Möglicherweise müssen Sie bestimmte Anweisungen an Ihre Umgebung oder individuelle Bedürfnisse anpassen.
 
-Wir empfehlen, bei Schwierigkeiten bezüglich der Umsetzung einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
+Wir empfehlen, bei Schwierigkeiten bezüglich der Umsetzung einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
 
 :::
 

--- a/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/de/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ OVHcloud HA-NAS ermöglicht Ihnen die Verwaltung eines über Netzwerk zugänglic
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 
 :::
 

--- a/docs/de/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -21,7 +21,7 @@ CyberDuck ist eine solche Lösung und ist einfach konfigurierbar. Es sind noch w
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben so weit wie möglich unterstützen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/).
+Diese Anleitung soll Sie bei allgemeinen Aufgaben so weit wie möglich unterstützen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der [OVHcloud Community](/links/community).
 
 :::
 

--- a/docs/de/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -26,7 +26,7 @@ Es sind aber auch weitere Interfaces verfügbar und im Internet leicht auffindba
 :::warning
 OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 
-Diese Anleitung soll Sie bei allgemeinen Aufgaben so weit wie möglich unterstützen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/).
+Diese Anleitung soll Sie bei allgemeinen Aufgaben so weit wie möglich unterstützen. Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der [OVHcloud Community](/links/community).
 
 :::
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -16,7 +16,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -12,7 +12,7 @@ This guide provides detailed steps to help you migrate from a third-party S3-com
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/de/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/de/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-android.mdx
@@ -22,7 +22,7 @@ Exchange E-Mail-Accounts können auf verschiedenen, kompatiblen E-Mail-Clients k
 :::warning
 In diesem Tutorial erläutern wir die Verwendung einer oder mehrerer OVHcloud Lösungen mit externen Tools. Die durchgeführten Aktionen werden in einem bestimmten Kontext beschrieben. Denken Sie daran, diese an Ihre Situation anzupassen.
 
-Wir empfehlen Ihnen jedoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden oder Ihre Fragen an die [OVHcloud Community](https://community.ovhcloud.com/community/en) zu richten. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
+Wir empfehlen Ihnen jedoch, sich bei Schwierigkeiten an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für externe Dienstleistungen keine weitergehende Unterstützung anbieten.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/activate-port-firewall-soft-win.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/activate-port-firewall-soft-win.mdx
@@ -13,7 +13,7 @@ To best protect your system, your Windows Server dedicated server has its own bu
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 ## Requirements

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -34,7 +34,7 @@ Be sure to consult our "Getting started" guides as well:
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
@@ -13,7 +13,7 @@ If you notice that a disk is faulty, or receive a notification email about a fau
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to the [OVHcloud community](https://community.ovhcloud.com/community/en) if you encounter any difficulties. You can find more information in the [Go further](#go-further) section of this guide.
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to the [OVHcloud community](/links/community) if you encounter any difficulties. You can find more information in the [Go further](#go-further) section of this guide.
 :::
 
 ## Requirements

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -13,7 +13,7 @@ Distributed under the GNU GPL licence, rysnc (short for “remote synchronisatio
 **This tutorial will show you how to copy data from one OVHcloud dedicated server to another using rsync.**
 
 :::warning
-This guide will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation. If you experience any difficulties carrying out these operations, please get in touch with a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss your issues with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot assist you in this regard.
+This guide will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation. If you experience any difficulties carrying out these operations, please get in touch with a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss your issues with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot assist you in this regard.
 :::
 
 ## Requirements

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -29,7 +29,7 @@ Setting up a web server and related software enables your cloud server to host d
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/mail-sending-optimization.mdx
@@ -13,7 +13,7 @@ In general, anti-spam policies are strict. To ensure that emails reach recipient
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/replacing-lost-ssh-key-pair.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/replacing-lost-ssh-key-pair.mdx
@@ -15,7 +15,7 @@ However, you can still connect to your server via the OVHcloud rescue mode, whic
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovhcloud.com/community/en) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 ## Requirements

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -37,7 +37,7 @@ Be sure to consult our "Getting started" guides as well:
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 :::
 

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -28,7 +28,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 :::warning
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This tutorial is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This tutorial is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 :::
 
 ## Instructions

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ The SSH (Secure Shell) communication protocol is the preferred means of establis
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to the [OVHcloud community](https://community.ovhcloud.com/community/en) if you encounter any difficulties. You can find more information in the [Go further](#gofurther) section of this guide.
+This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to the [OVHcloud community](/links/community) if you encounter any difficulties. You can find more information in the [Go further](#gofurther) section of this guide.
 :::
 
 ## Requirements

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ There a various options to transfer files between a local device and a remote ho
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. This tutorial will illustrate how to use OVHcloud solutions with external tools. You may need to adapt some specific instructions to the operating system of your local device or your server.
 
-We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/changing-the-hostname-of-an-instance.mdx
@@ -13,7 +13,7 @@ With the cloud-init module, you can configure your [Public Cloud instance](https
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 This guide is for instances based on Linux distributions **only**.
 :::

--- a/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ Plesk is an easy-to-use hosting control panel. You can install and use it on OVH
 :::warning
 OVHcloud provides services which you are responsible for. In fact, as we do not have administrative access to these machines, we are not administrators and we cannot provide you with support. This means that it is up to you to manage the software and security daily.
 
-We have provided you with this guide in order to help you with common tasks. However, we advise contacting a specialist provider if you experience any difficulties or doubts about administration, usage or server security. Feel free to visit our [community forum](https://community.ovhcloud.com/community/en) to interact with other users.
+We have provided you with this guide in order to help you with common tasks. However, we advise contacting a specialist provider if you experience any difficulties or doubts about administration, usage or server security. Feel free to visit our [community forum](/links/community) to interact with other users.
 :::
 
 

--- a/docs/en/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/en/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus is a monitoring system and time series database. You can install and 
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/en/guides/public-cloud/compute/install-wordpress.mdx
+++ b/docs/en/guides/public-cloud/compute/install-wordpress.mdx
@@ -16,7 +16,7 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 
 This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 
 :::

--- a/docs/en/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/en/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -15,7 +15,7 @@ However, you can still connect to your instance via the OVHcloud rescue mode, wh
 :::warning
 OVHcloud provides services for which you are responsible with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/en/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/en/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/en/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/en/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/en/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/en/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -14,7 +14,7 @@ The OVHcloud HA-NAS service allows you to manage file storage that can be access
 
 OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovhcloud.com/community/en) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](/links/community) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 
 
 :::

--- a/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pca-cyberduck.mdx
@@ -17,7 +17,7 @@ Other interfaces can be found on the Internet and configuration is similar to th
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/pcs-manage-object-storage-with-cyberduck.mdx
@@ -15,7 +15,7 @@ If you're not familiar with managing storage through command lines, there are so
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -15,7 +15,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -11,7 +11,7 @@ This guide provides detailed steps to help you migrate from a third-party S3<sup
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/en/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/how-to-configure-thunderbird.mdx
@@ -47,7 +47,7 @@ Email Pro accounts can be configured on different compatible email clients. This
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/thunderbird-macos-configuration.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/thunderbird-macos-configuration.mdx
@@ -47,7 +47,7 @@ Email Pro accounts can be configured on different compatible email clients. This
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/windows-10-mailapp-configuration.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/email-pro/windows-10-mailapp-configuration.mdx
@@ -50,7 +50,7 @@ The **New Outlook** has replaced the **Mail** application on Windows since Janua
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/how-to-configure-thunderbird-mac.mdx
@@ -47,7 +47,7 @@ Exchange accounts can be configured on various compatible email clients. This al
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-mac.mdx
@@ -41,7 +41,7 @@ MX Plan email accounts can be configured on different compatible email clients. 
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-thunderbird-windows.mdx
@@ -41,7 +41,7 @@ MX Plan email accounts can be configured on compatible email clients. This allow
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a specialist service provider or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/mx-plan/how-to-configure-windows-10.mdx
@@ -42,7 +42,7 @@ The **New Outlook** replaces the **Mail** application on Windows starting from J
 
 This guide will show you how to use OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 
-If you experience any difficulties carrying out these operations, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or discuss the issue with our [community](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
+If you experience any difficulties carrying out these operations, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or discuss the issue with our [community](/links/community). OVHcloud cannot provide you with technical support in this regard. You can find more information in the [Go further](#go-further) section of this guide.
 
 </details>
 

--- a/docs/en/internal/format-reference.mdx
+++ b/docs/en/internal/format-reference.mdx
@@ -273,7 +273,7 @@ Table with HTML line breaks in cells:
 <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
 
 **External link:**
-[OVHcloud community forum](https://community.ovh.com/)
+[OVHcloud community forum](https://community.ovhcloud.com/)
 
 **Link inside a sentence:**
 To manage your SSH keys, log in to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> and navigate to **My account** > **SSH keys**.
@@ -595,6 +595,5 @@ Back at the outer level after the inner closes.
 
 - [OVHcloud API documentation](/guides/manage-and-operate/api/console-preview)
 - [Managing contacts for your services](/guides/account-and-service-management/account-information/managing-contacts)
-- [OVHcloud community forum](https://community.ovh.com/)
 
 Join our [community of users](/links/community).

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -37,7 +37,7 @@ No olvide consultar también nuestras guías de primeros pasos:
 :::warning
 OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
 
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
+Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
 :::
 
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -18,7 +18,7 @@ Rsync (de *remote syncronization*) es un software libre de sincronización de ar
 **Este tutorial explica cómo copiar los datos de un servidor a otro utilizando rsync.**
 
 :::warning
-Este tutorial explica cómo utilizar una solución de OVHcloud con herramientas externas en un contexto concreto. Deberá adaptar las indicaciones a su caso particular. Si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o que comparta sus dudas con nuestra comunidad en [https://community.ovh.com/en/](https://community.ovh.com/en/). Nosotros no podremos asistirle.
+Este tutorial explica cómo utilizar una solución de OVHcloud con herramientas externas en un contexto concreto. Deberá adaptar las indicaciones a su caso particular. Si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o que comparta sus dudas con nuestra comunidad en [https://community.ovhcloud.com/](/links/community). Nosotros no podremos asistirle.
 :::
 
 ## Requisitos

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -35,7 +35,7 @@ La creación de un servidor web y los programas asociados permiten que su servid
 :::warning
 Este tutorial explica cómo utilizar una solución de OVHcloud con herramientas externas en un contexto concreto. Puede que necesite adaptar las indicaciones a su situación.
 
-Le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/) si tiene problemas o dudas relativos a la administración, el uso o la instalación de servicios en un servidor.
+Le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community) si tiene problemas o dudas relativos a la administración, el uso o la instalación de servicios en un servidor.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ No olvide consultar también nuestras guías de primeros pasos:
 :::warning
 OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
 
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
+Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -34,7 +34,7 @@ El modo de rescate permite acceder a sus datos de forma permanente, aunque el si
 :::warning
 La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
 
-Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la instalación de servicios en un servidor, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/).
+Este tutorial le ayudará a realizar las tareas más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la instalación de servicios en un servidor, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community).
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -18,7 +18,7 @@ Los servidores dedicados no incluyen de forma nativa ningún protocolo de seguri
 :::warning
 OVHcloud le ofrece los servicios que usted es responsable de configurar y gestionar. Usted es responsable de su buen funcionamiento.
 
-Si necesita ayuda, póngase en contacto con un proveedor de servicios especializado o debata el problema con nuestra [comunidad de usuarios](https://community.ovhcloud.com/community/en). OVHcloud no puede ofrecerle soporte técnico.
+Si necesita ayuda, póngase en contacto con un proveedor de servicios especializado o debata el problema con nuestra [comunidad de usuarios](/links/community). OVHcloud no puede ofrecerle soporte técnico.
 :::
 
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ El protocolo de comunicación SSH (Secure Shell) es el medio preferido para esta
 :::warning
 OVHcloud ofrece servicios cuya configuración y gestión son responsabilidad suya. Por lo tanto, es su responsabilidad asegurarse de que funcionen correctamente.
 
-Esta guía está diseñada para ayudarle con las tareas más habituales. No obstante, le recomendamos que, si necesita ayuda, se ponga en contacto con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con la [comunidad de OVHcloud](https://community.ovhcloud.com/community/en). Para más información, consulte la sección [Más información](#gofurther) de esta guía.
+Esta guía está diseñada para ayudarle con las tareas más habituales. No obstante, le recomendamos que, si necesita ayuda, se ponga en contacto con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con la [comunidad de OVHcloud](/links/community). Para más información, consulte la sección [Más información](#gofurther) de esta guía.
 
 :::
 

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Existen diversas opciones para transferir archivos entre un dispositivo local y 
 :::warning
 OVHcloud ofrece servicios cuya configuración y gestión son responsabilidad suya. Este tutorial explica cómo utilizar las soluciones de OVHcloud con herramientas externas. Es posible que tenga que adaptar algunas instrucciones específicas para el sistema operativo de su dispositivo local o servidor.
 
-Le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovhcloud.com/community/en).
+Le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community).
 
 :::
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/es/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
@@ -154,4 +154,4 @@ Siga los pasos restantes como se detalla en [esta guía](/guides/public-cloud/co
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).
+Interactúe con nuestra comunidad de usuarios en [https://community.ovhcloud.com/](/links/community).

--- a/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ Plesk es un panel de control de servidores fácil de usar que puede instalarse e
 :::warning
 La responsabilidad sobre los servicios que OVHcloud pone a su disposición recae íntegramente en usted. Nuestros técnicos no son los administradores de las máquinas, ya que no tienen acceso a ellas. Por lo tanto, la gestión del software y la seguridad le corresponde a usted.
 
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovhcloud.com/community/en) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
+Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community) si tiene problemas o dudas sobre la administración, el uso o la implementación de servicios en un servidor.
 :::
 
 

--- a/docs/es/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/es/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus es un sistema de supervisión y una base de datos de series temporale
 :::warning
 OVHcloud pone a su disposición servicios cuya responsabilidad recae en usted. En efecto, al no tener acceso a estas máquinas, no somos sus administradores y no podremos brindarle asistencia. Por lo tanto, le corresponde a usted gestionar y asegurar el software de estas diariamente.
 
-Pusimos a su disposición esta guía para ayudarle en las tareas habituales. Sin embargo, le recomendamos encarecidamente que acuda a un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) si experimenta dificultades o dudas sobre la administración, el uso o la seguridad de un servidor. No dude en visitar nuestro [foro comunitario](https://community.ovhcloud.com/community/en) para intercambiar opiniones con otros usuarios.
+Pusimos a su disposición esta guía para ayudarle en las tareas habituales. Sin embargo, le recomendamos encarecidamente que acuda a un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) si experimenta dificultades o dudas sobre la administración, el uso o la seguridad de un servidor. No dude en visitar nuestro [foro comunitario](/links/community) para intercambiar opiniones con otros usuarios.
 :::
 
 

--- a/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/es/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -22,7 +22,7 @@ Sin embargo, todavía puede conectarse a su instancia a través del modo de resc
 :::warning
 OVHcloud ofrece servicios cuya configuración y gestión son responsabilidad suya. Por lo tanto, es su responsabilidad asegurarse de que funcionen correctamente.
 
-Esta guía explica las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad de usuarios](https://community.ovhcloud.com/community/en) si tiene algún problema.
+Esta guía explica las tareas más habituales. No obstante, le recomendamos que contacte con un [proveedor de servicios especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad de usuarios](/links/community) si tiene algún problema.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/es/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/es/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/es/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/es/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/es/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/es/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/es/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ El servicio NAS-HA de OVHcloud le permite gestionar un almacenamiento de archivo
 :::warning
 OVHcloud le ofrece una serie de servicios cuya configuración y gestión es responsabilidad suya. Por lo tanto, es su responsabilidad asegurarse de que estos funcionan correctamente.
 
-Esta guía le ayudará a realizar las tareas más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la instalación de servicios en un servidor, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovhcloud.com/community/en).
+Esta guía le ayudará a realizar las tareas más habituales. No obstante, si tiene dificultades o dudas con respecto a la administración, el uso o la instalación de servicios en un servidor, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](/links/community).
 
 :::
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -16,7 +16,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -12,7 +12,7 @@ This guide provides detailed steps to help you migrate from a third-party S3-com
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/es/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/es/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -33,7 +33,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 :::warning
 OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 
-Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](https://community.ovhcloud.com/community/fr) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 :::
 
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/disk-replacement.mdx
@@ -13,7 +13,7 @@ Si vous constatez un défaut de disque ou que notre système vous a envoyé une 
 :::warning
 OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il est donc de votre responsabilité de vous assurer de leur bon fonctionnement.
 
-Ce guide est conçu pour vous aider avec les tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter la [communauté OVHcloud](https://community.ovhcloud.com/community/fr) si vous rencontrez des difficultés. Plus d'informations dans la section [Aller plus loin](#aller-plus-loin) de ce guide.
+Ce guide est conçu pour vous aider avec les tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter la [communauté OVHcloud](/links/community) si vous rencontrez des difficultés. Plus d'informations dans la section [Aller plus loin](#aller-plus-loin) de ce guide.
 :::
 
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -13,7 +13,7 @@ Distribué sous licence GNU GPL, rsync (pour  «remote synchronization» ), est 
 **Ce tutoriel va donc illustrer comment copier des données d’un serveur dédié OVHcloud vers un autre en utilisant rsync.**
 
 :::warning
-Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou à poser vos questions à notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr). OVHcloud ne sera pas en mesure de vous fournir une assistance.
+Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou à poser vos questions à notre [communauté d'utilisateurs](/links/community). OVHcloud ne sera pas en mesure de vous fournir une assistance.
 :::
 
 ## Prérequis

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -29,7 +29,7 @@ La mise en place d'un serveur web et des logiciels associés permet à votre ser
 :::warning
 Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Il vous faudra peut-être adapter les consignes à votre situation.
 
-Nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](https://community.ovhcloud.com/community/fr) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+Nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/pfsense-bridging.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/pfsense-bridging.mdx
@@ -36,7 +36,7 @@ Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVH
 
 :::
 
-Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou d'échanger avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
+Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
 
 ## En pratique
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 :::warning
 OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 
-Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](https://community.ovhcloud.com/community/fr) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -28,7 +28,7 @@ Le mode Rescue permet d'accéder à vos données en permanence, même si le syst
 :::warning
 OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 
-Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](https://community.ovhcloud.com/community/fr) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -17,7 +17,7 @@ Le protocole de communication SSH (Secure Shell) est le moyen privilégié pour 
 :::warning
 OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il est donc de votre responsabilité de vous assurer de leur bon fonctionnement.
 
-Ce guide est conçu pour vous aider avec les tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter la [communauté OVHcloud](https://community.ovhcloud.com/community/fr) si vous rencontrez des difficultés. Plus d'informations dans la section [Aller plus loin](#gofurther) de ce guide.
+Ce guide est conçu pour vous aider avec les tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter la [communauté OVHcloud](/links/community) si vous rencontrez des difficultés. Plus d'informations dans la section [Aller plus loin](#gofurther) de ce guide.
 
 :::
 

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Différentes options existent pour transférer des fichiers entre un périphéri
 :::warning
 OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Ce tutoriel va illustrer comment utiliser les solutions OVHcloud avec des outils externes. Vous devrez peut-être adapter certaines instructions spécifiques au système d'exploitation de votre périphérique local ou de votre serveur.
 
-Nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](https://community.ovhcloud.com/community/fr) si vous rencontrez des difficultés.
+Nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés.
 
 :::
 

--- a/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ Plesk est une interface de gestion de serveurs simple à prendre en main. Vous a
 :::warning
 OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. N'hésitez pas à vous rendre sur notre [forum communautaire](https://community.ovhcloud.com/community/fr) pour échanger avec d'autres utilisateurs.
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. N'hésitez pas à vous rendre sur notre [forum communautaire](/links/community) pour échanger avec d'autres utilisateurs.
 :::
 
 

--- a/docs/fr/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/fr/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus est un système de supervision et une base de données de séries tem
 :::warning
 OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 
-Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. N'hésitez pas à vous rendre sur notre [forum communautaire](https://community.ovhcloud.com/community/fr) pour échanger avec d'autres utilisateurs.
+Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. N'hésitez pas à vous rendre sur notre [forum communautaire](/links/community) pour échanger avec d'autres utilisateurs.
 :::
 
 

--- a/docs/fr/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/fr/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -15,7 +15,7 @@ Cependant, vous pouvez toujours vous connecter à votre instance via le mode res
 :::warning
 OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il est donc de votre responsabilité de vous assurer de leur bon fonctionnement.
 
-Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté d'utilisateurs](https://community.ovhcloud.com/community/fr) si vous rencontrez des problèmes.
+Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté d'utilisateurs](/links/community) si vous rencontrez des problèmes.
 
 :::
 

--- a/docs/fr/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/fr/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ Dans ce tutoriel, nous allons vous montrer comment connecter votre OVHcloud Mana
 :::warning
 OVHcloud fournit des services dont vous êtes responsable de la configuration et de la gestion. Vous êtes donc responsable de leur bon fonctionnement.
 
-Ce tutoriel est conçu pour vous aider autant que possible dans vos tâches courantes. Si vous rencontrez des difficultés pour réaliser ces actions, veuillez contacter un prestataire de services spécialisé et/ou en discuter avec notre communauté d'utilisateurs sur [https://community.ovh.com/fr/](https://community.ovh.com/fr/). OVHcloud ne peut pas vous fournir d'assistance technique à ce sujet.
+Ce tutoriel est conçu pour vous aider autant que possible dans vos tâches courantes. Si vous rencontrez des difficultés pour réaliser ces actions, veuillez contacter un prestataire de services spécialisé et/ou en discuter avec notre communauté d'utilisateurs sur [https://community.ovhcloud.com/](/links/community). OVHcloud ne peut pas vous fournir d'assistance technique à ce sujet.
 
 :::
 

--- a/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/fr/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ Le service NAS-HA OVHcloud vous permet de gérer un stockage de fichiers accessi
 :::warning
 OVHcloud vous offre un certain nombre de services dont la configuration et la gestion vous incombent. Il est donc de votre responsabilité de vous assurer qu’ils fonctionnent correctement.
 
-Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](https://community.ovhcloud.com/community/fr) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 
 :::
 

--- a/docs/fr/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/fr/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -11,7 +11,7 @@ Ce guide fournit des étapes détaillées pour vous aider à migrer d'un fournis
 :::warning
 OVHcloud fournit des services dont vous êtes responsable en ce qui concerne leur configuration et leur gestion. Vous êtes donc responsable de vous assurer qu'ils fonctionnent correctement.
 
-Ce guide est conçu pour vous aider dans les tâches courantes autant que possible. Si vous rencontrez des difficultés pour effectuer ces actions, veuillez contacter un [fournisseur de services spécialisés](https://partner.ovhcloud.com/fr/directory/) et/ou discuter du problème avec notre [communauté d'utilisateurs](https://community.ovhcloud.com/community/fr). OVHcloud ne peut pas vous fournir de support technique à cet égard.
+Ce guide est conçu pour vous aider dans les tâches courantes autant que possible. Si vous rencontrez des difficultés pour effectuer ces actions, veuillez contacter un [fournisseur de services spécialisés](https://partner.ovhcloud.com/fr/directory/) et/ou discuter du problème avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir de support technique à cet égard.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -37,7 +37,7 @@ Non dimenticare di consultare anche le nostre guide di primo passo:
 :::warning
 OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. garantirne il corretto funzionamento è quindi responsabilità dell’utente.
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](https://community.ovh.com/en/).
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](/links/community).
 :::
 
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -18,7 +18,7 @@ Distribuito sotto licenza GNU GPL, rsync (da “remote synchronization”) è un
 **Questa guida ti mostra come utilizzare rsync per copiare dati da un server dedicato OVHcloud a un altro.**
 
 :::warning
-Questa guida contiene informazioni relative all’utilizzo di una o più soluzioni OVHcloud con tool esterni in un contesto ben preciso: adatta le indicazioni fornite alla tua situazione e, in caso di difficoltà o dubbi, rivolgiti a un esperto del settore o alla nostra Community di utenti, disponibile all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud non potrà fornirti assistenza.
+Questa guida contiene informazioni relative all’utilizzo di una o più soluzioni OVHcloud con tool esterni in un contesto ben preciso: adatta le indicazioni fornite alla tua situazione e, in caso di difficoltà o dubbi, rivolgiti a un esperto del settore o alla nostra Community di utenti, disponibile all’indirizzo [https://community.ovhcloud.com/](/links/community). OVHcloud non potrà fornirti assistenza.
 :::
 
 ## Prerequisiti

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -35,7 +35,7 @@ La realizzazione di un server Web e dei software associati permette al tuo serve
 :::warning
 Questa guida ti mostra come utilizzare una o più soluzioni OVHcloud con tool esterni per descrivere le operazioni eseguite in un contesto preciso. Forse dovrai adattare le istruzioni alla tua situazione.
 
-In caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](https://community.ovh.com/en/).
+In caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](/links/community).
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ Non dimenticare di consultare anche le nostre guide di primo passo:
 :::warning
 OVHcloud mette a disposizione i servizi ma non si occupa della loro configurazione e gestione. garantirne il corretto funzionamento è quindi responsabilità dell’utente.
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](https://community.ovh.com/en/).
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](/links/community).
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -34,7 +34,7 @@ La modalità Rescue permette di accedere ai tuoi dati in modo permanente, anche 
 :::warning
 OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
 
-Questa guida ti mostra come eseguire le operazioni necessarie alla gestione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](https://community.ovh.com/en/).
+Questa guida ti mostra come eseguire le operazioni necessarie alla gestione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](/links/community).
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ Il protocollo di comunicazione SSH (Secure Shell) è il mezzo preferito per stab
 :::warning
 OVHcloud fornisce servizi la cui configurazione e gestione sono di vostra responsabilità. È quindi vostra responsabilità assicurarvi che funzionino correttamente.
 
-Questa guida è concepita per aiutarti con le operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o la [community OVHcloud](https://community.ovhcloud.com/community/en). Per maggiori informazioni consulta la sezione [Per saperne di più](#gofurther) di questa guida.
+Questa guida è concepita per aiutarti con le operazioni più frequenti. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o la [community OVHcloud](/links/community). Per maggiori informazioni consulta la sezione [Per saperne di più](#gofurther) di questa guida.
 
 :::
 

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Esistono diverse opzioni per trasferire file tra un dispositivo locale e un host
 :::warning
 OVHcloud fornisce servizi la cui configurazione e gestione sono di vostra responsabilità. Questa guida ti mostra come utilizzare le soluzioni OVHcloud con tool esterni. Potrebbe essere necessario adattare alcune istruzioni specifiche al sistema operativo del dispositivo locale o del server.
 
-In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](https://community.ovhcloud.com/community/en).
+In caso di difficoltà o dubbi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](/links/community).
 
 :::
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/it/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
@@ -154,4 +154,4 @@ Segui gli step rimanenti, come descritto in [questa guida](/guides/public-cloud/
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).
+Contatta la nostra Community di utenti all’indirizzo [https://community.ovhcloud.com/](/links/community).

--- a/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ Plesk è un’interfaccia di gestione server di semplice utilizzo, disponibile a
 :::warning
 OVHcloud mette a disposizione i server, ma non è autorizzata ad accedervi e non si occupa quindi della loro amministrazione. Garantire quotidianamente la gestione software e la sicurezza di queste macchine è quindi responsabilità dell’utente.
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente ad amministrazione e sicurezza, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/). Non esitate a collegarvi alla nostra [community forum](https://community.ovhcloud.com/community/en) per comunicare con altri utenti.
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente ad amministrazione e sicurezza, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/). Non esitate a collegarvi alla nostra [community forum](/links/community) per comunicare con altri utenti.
 :::
 
 

--- a/docs/it/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/it/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus è un sistema di monitoraggio e un database di serie temporali. È po
 :::warning
 OVHcloud mette a disposizione servizi la cui responsabilità è vostra. Essendo noi privi di accesso a tali macchine, non ne siamo gli amministratori e non potremo fornire alcun supporto. È quindi a voi che compete la gestione software e la sicurezza quotidiana.
 
-Mettiamo a disposizione questa guida per accompagnarvi al meglio in attività comuni. Tuttavia, vi consigliamo di contattare un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) in caso di difficoltà o dubbi riguardo all'amministrazione, all'utilizzo o alla sicurezza di un server. Non esitate a visitare il nostro [forum comunitario](https://community.ovhcloud.com/community/en) per interagire con altri utenti.
+Mettiamo a disposizione questa guida per accompagnarvi al meglio in attività comuni. Tuttavia, vi consigliamo di contattare un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) in caso di difficoltà o dubbi riguardo all'amministrazione, all'utilizzo o alla sicurezza di un server. Non esitate a visitare il nostro [forum comunitario](/links/community) per interagire con altri utenti.
 :::
 
 

--- a/docs/it/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/it/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -21,7 +21,7 @@ La modalità Rescue di OVHcloud consente comunque di accedere con una password p
 :::warning
 OVHcloud fornisce servizi la cui configurazione e gestione sono di vostra responsabilità. È quindi vostra responsabilità assicurarvi che funzionino correttamente.
 
-Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di problemi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community di utenti](https://community.ovhcloud.com/community/en).
+Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di problemi, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community di utenti](/links/community).
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/it/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/it/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/it/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/it/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/it/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/it/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/it/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ Il servizio NAS-HA OVHcloud ti permette di gestire uno storage di file accessibi
 :::warning
 OVHcloud offre una serie di servizi di cui è responsabile la configurazione e la gestione. Spetta quindi a te assicurarti che funzionino correttamente.
 
-Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo VPS. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](https://community.ovhcloud.com/community/en).
+Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo VPS. Tuttavia, in caso di difficoltà o dubbi relativi all'amministrazione, all'utilizzo o alla creazione di servizi su un server, ti consigliamo di rivolgerti a un [fornitore specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra community](/links/community).
 
 :::
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -16,7 +16,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -12,7 +12,7 @@ This guide provides detailed steps to help you migrate from a third-party S3-com
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/it/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/it/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -38,7 +38,7 @@ Sprawdź również nasze przewodniki:
 :::warning
 OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
 
-Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](https://community.ovh.com/en/).
+Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](/links/community).
 :::
 
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -13,7 +13,7 @@ Rsync (z ang. “remote synchronization”), dystrybuowany w ramach licencji GNU
 **Ten tutorial wyjaśnia, jak kopiować dane z jednego serwera dedykowanego OVHcloud na inną maszynę przy użyciu rsync.**
 
 :::warning
-Tutorial przedstawia zastosowanie jednego lub kilku rozwiązań OVHcloud w powiązaniu z zewnętrznymi narzędziami i opisuje operacje, jakie należy wykonać w danym przypadku. Wybierz odpowiednie dla Ciebie rozwiązanie. Jeśli napotkasz trudności podczas przeprowadzania tych operacji, skontaktuj się z wyspecjalizowanym dostawcą usług administracyjnych i/lub zadaj pytanie na forum społeczności OVHcloud [https://community.ovh.com/en/](https://community.ovh.com/en/). Niestety OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
+Tutorial przedstawia zastosowanie jednego lub kilku rozwiązań OVHcloud w powiązaniu z zewnętrznymi narzędziami i opisuje operacje, jakie należy wykonać w danym przypadku. Wybierz odpowiednie dla Ciebie rozwiązanie. Jeśli napotkasz trudności podczas przeprowadzania tych operacji, skontaktuj się z wyspecjalizowanym dostawcą usług administracyjnych i/lub zadaj pytanie na forum społeczności OVHcloud [https://community.ovhcloud.com/](/links/community). Niestety OVHcloud nie jest w stanie udzielić Ci wsparcia w tym zakresie.
 :::
 
 ## Wymagania początkowe

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -35,7 +35,7 @@ Uruchomienie serwera www i powiązanych z nim aplikacji pozwala serwerowi cloud 
 :::warning
 Tutorial przedstawia zastosowanie jednego lub kilku rozwiązań OVHcloud w powiązaniu z zewnętrznymi narzędziami i opisuje operacje, jakie należy wykonać w konkretnym przypadku. Być może będziesz musiał dostosować instrukcję do Twojego przypadku.
 
-W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy [wyspecjalizowanego](https://partner.ovhcloud.com/pl/directory/) usługodawcy lub zbliżenie się do [naszej społeczności](https://community.ovh.com/en/).
+W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy [wyspecjalizowanego](https://partner.ovhcloud.com/pl/directory/) usługodawcy lub zbliżenie się do [naszej społeczności](/links/community).
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ Sprawdź również nasze przewodniki:
 :::warning
 OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
 
-Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](https://community.ovh.com/en/).
+Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](/links/community).
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -34,7 +34,7 @@ Tryb Rescue pozwala na stały dostęp do Twoich danych, nawet jeśli system oper
 :::warning
 OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
 
-Celem tego tutoriala jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](https://partner.ovhcloud.com/pl/directory/) lub zbliżenie się do [naszej społeczności](https://community.ovh.com/en/).
+Celem tego tutoriala jest pomoc w jak najlepszym wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](https://partner.ovhcloud.com/pl/directory/) lub zbliżenie się do [naszej społeczności](/links/community).
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -23,7 +23,7 @@ OVHcloud świadczy usługi, za które jesteś odpowiedzialny w związku z ich ko
 - Instalacja LAMP na serwerze dedykowanym (Debian/Ubuntu)
 - [Jak zabezpieczyć Memcached na serwerze dedykowanym](/guides/bare-metal-cloud/dedicated-servers/memcache-secure)
 
->Jeśli napotkasz trudności z przeprowadzeniem tych operacji, skontaktuj się z wyspecjalizowanym dostawcą usług i/lub przedyskutuj problem z naszą społecznością użytkowników na stronie https://community.ovh.com/en/. OVHcloud nie może udzielić Ci wsparcia technicznego w tym zakresie.
+>Jeśli napotkasz trudności z przeprowadzeniem tych operacji, skontaktuj się z wyspecjalizowanym dostawcą usług i/lub przedyskutuj problem z naszą społecznością użytkowników na stronie https://community.ovhcloud.com/. OVHcloud nie może udzielić Ci wsparcia technicznego w tym zakresie.
 >
 
 ## Wymagania początkowe

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ Protokół SSH (Secure Shell) jest preferowanym sposobem nawiązywania szyfrowan
 :::warning
 OVHcloud zapewnia usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Do Twoich obowiązków należy zatem upewnienie się, że działają one prawidłowo.
 
-Ten przewodnik ma na celu pomóc w wykonywaniu typowych zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub skontaktowanie się ze społecznością [OVHcloud](https://community.ovhcloud.com/community/en). Więcej informacji znajduje się w sekcji [Sprawdź również](#gofurther) niniejszego przewodnika.
+Ten przewodnik ma na celu pomóc w wykonywaniu typowych zadań. Niemniej jednak w przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub skontaktowanie się ze społecznością [OVHcloud](/links/community). Więcej informacji znajduje się w sekcji [Sprawdź również](#gofurther) niniejszego przewodnika.
 
 :::
 

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Istnieją różne opcje transferu plików między urządzeniem lokalnym a hostem
 :::warning
 OVHcloud zapewnia usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Tutorial ten wyjaśnia, jak korzystać z rozwiązań OVHcloud przy użyciu narzędzi zewnętrznych. Może być konieczne dostosowanie niektórych instrukcji specyficznych dla systemu operacyjnego Twojego lokalnego urządzenia lub serwera.
 
-W przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](https://community.ovhcloud.com/community/en).
+W przypadku trudności zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](/links/community).
 
 :::
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pl/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
@@ -154,4 +154,4 @@ Następnie wykonaj pozostałe etapy zgodnie z instrukcjami zawartymi w [tym prze
 
 ## Sprawdź również
 
-Dołącz do naszej społeczności użytkowników: [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).
+Dołącz do naszej społeczności użytkowników: [https://community.ovhcloud.com/](/links/community).

--- a/docs/pl/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -14,7 +14,7 @@ Plesk to prosty w użytkowaniu interfejs administracyjny dla serwerów dedykowan
 :::warning
 OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVHcloud nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Zarządzanie oprogramowaniem i wdrażanie środków bezpieczeństwa należy do klienta.
 
-Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz jakiekolwiek trudności lub wątpliwości związane z administrowaniem, użytkowaniem lub dbaniem o bezpieczeństwo serwera, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/). Przyłącz się do [forum społeczności](https://community.ovhcloud.com/community/en) i rozmawiaj z innymi użytkownikami.
+Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz jakiekolwiek trudności lub wątpliwości związane z administrowaniem, użytkowaniem lub dbaniem o bezpieczeństwo serwera, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/). Przyłącz się do [forum społeczności](/links/community) i rozmawiaj z innymi użytkownikami.
 :::
 
 

--- a/docs/pl/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/pl/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus to system monitorowania i baza danych szeregów czasowych. Możesz za
 :::warning
 OVHcloud oferuje usługi, za które odpowiadasz samodzielnie. Faktycznie, ponieważ nie mamy dostępu administracyjnego do tych maszyn, nie jesteśmy administratorami i nie możemy udzielić wsparcia. Oznacza to, że Ty odpowiadasz za zarządzanie oprogramowaniem i bezpieczeństwem na co dzień.
 
-Udostępniliśmy Ci ten przewodnik, aby pomóc Ci w wykonywaniu typowych zadań. Jednak zalecamy kontakt z [specjalistycznym dostawcą](https://partner.ovhcloud.com/pl/directory/), jeśli doświadczysz jakichkolwiek trudności lub wątpliwości dotyczących administracji, użycia lub bezpieczeństwa serwera. Zapraszamy również do odwiedzenia naszego [forum społecznościowego](https://community.ovhcloud.com/community/en), aby porozmawiać z innymi użytkownikami.
+Udostępniliśmy Ci ten przewodnik, aby pomóc Ci w wykonywaniu typowych zadań. Jednak zalecamy kontakt z [specjalistycznym dostawcą](https://partner.ovhcloud.com/pl/directory/), jeśli doświadczysz jakichkolwiek trudności lub wątpliwości dotyczących administracji, użycia lub bezpieczeństwa serwera. Zapraszamy również do odwiedzenia naszego [forum społecznościowego](/links/community), aby porozmawiać z innymi użytkownikami.
 :::
 
 

--- a/docs/pl/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/pl/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -21,7 +21,7 @@ Nadal jednak możesz logować się do Twojej instancji w trybie Rescue OVHcloud,
 :::warning
 OVHcloud zapewnia usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Do Twoich obowiązków należy zatem upewnienie się, że działają one prawidłowo.
 
-Ten przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak w przypadku problemów zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością użytkowników](https://community.ovhcloud.com/community/en).
+Ten przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak w przypadku problemów zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością użytkowników](/links/community).
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/pl/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/pl/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/pl/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/pl/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pl/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/pl/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/pl/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ Usługa NAS-HA OVHcloud pozwala na zarządzanie przestrzenią dyskową plików d
 :::warning
 OVHcloud oferuje szereg usług, których konfiguracja i zarządzanie należy do Ciebie. To Ty musisz upewnić się, że działają poprawnie.
 
-Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](https://partner.ovhcloud.com/pl/directory/) lub zbliżenie się do [naszej społeczności](https://community.ovhcloud.com/community/en).
+Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](https://partner.ovhcloud.com/pl/directory/) lub zbliżenie się do [naszej społeczności](/links/community).
 
 :::
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -16,7 +16,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -12,7 +12,7 @@ This guide provides detailed steps to help you migrate from a third-party S3-com
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pl/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/pl/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/changing-root-password-linux-ds.mdx
@@ -38,7 +38,7 @@ Não se esqueça de consultar também os nossos guias de primeiros passos:
 :::warning
 A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
 
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovh.com/en/).
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](/links/community).
 :::
 
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync.mdx
@@ -18,7 +18,7 @@ Distribuído com uma licença GNU GPL, rsync (“remote synchronization”) é u
 **Este tutorial explica como copiar dados de um servidor dedicado OVHcloud para outro utilizando rsync.**
 
 :::warning
-Este tutorial explica a utilização de uma ou várias soluções da OVHcloud através de ferramentas externas e descreve as operações realizadas num contexto preciso. Deverá adaptá-las consoante a sua situação. Se necessitar de ajuda, recomendamos que entre em contacto com um fornecedor especializado ou que partilhe as suas dúvidas com o resto da comunidade: [https://community.ovh.com/en/](https://community.ovh.com/en/) A OVHcloud não lhe poderá fornecer assistência.
+Este tutorial explica a utilização de uma ou várias soluções da OVHcloud através de ferramentas externas e descreve as operações realizadas num contexto preciso. Deverá adaptá-las consoante a sua situação. Se necessitar de ajuda, recomendamos que entre em contacto com um fornecedor especializado ou que partilhe as suas dúvidas com o resto da comunidade: [https://community.ovhcloud.com/](/links/community) A OVHcloud não lhe poderá fornecer assistência.
 :::
 
 ## Requisitos

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/installing-lamp-debian9-ubuntu18.mdx
@@ -35,7 +35,7 @@ A implementação de um servidor web e dos softwares associados permite ao seu s
 :::warning
 Este tutorial explica a utilização de uma ou várias soluções da OVHcloud com ferramentas externas e descreve as operações realizadas num contexto preciso. Talvez tenha de adaptar as instruções à sua situação.
 
-Recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovh.com/en/) se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor.
+Recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](/links/community) se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/replacing-user-password.mdx
@@ -40,7 +40,7 @@ Não se esqueça de consultar também os nossos guias de primeiros passos:
 :::warning
 A OVHcloud oferece-lhe serviços cuja configuração, gestão e responsabilidade é da sua responsabilidade. Assim, deverá assegurar o seu bom funcionamento.
 
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovh.com/en/).
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](/links/community).
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/restore-bdd-rescue.mdx
@@ -34,7 +34,7 @@ O modo Rescue permite aceder aos seus dados de forma permanente, mesmo que o sis
 :::warning
 A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
 
-Este tutorial tem como objetivo acompanhá-lo o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovh.com/en/).
+Este tutorial tem como objetivo acompanhá-lo o melhor possível em tarefas comuns. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](/links/community).
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/securing-a-dedicated-server.mdx
@@ -18,7 +18,7 @@ Quando encomendar o seu servidor dedicado, pode escolher uma distribuição ou u
 :::warning
 A OVHcloud fornece-lhe serviços pelos quais é responsável em termos de configuração e gestão. Assim, é responsável pelo seu bom funcionamento.
 
-Se encontrar dificuldades para realizar estas ações, contacte um fornecedor de serviços especializado e/ou discuta o problema com a nossa [comunidade de utilizadores](https://community.ovhcloud.com/community/en). A OVHcloud não lhe pode fornecer apoio técnico a este respeito.
+Se encontrar dificuldades para realizar estas ações, contacte um fornecedor de serviços especializado e/ou discuta o problema com a nossa [comunidade de utilizadores](/links/community). A OVHcloud não lhe pode fornecer apoio técnico a este respeito.
 :::
 
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/ssh-introduction.mdx
@@ -15,7 +15,7 @@ O protocolo de comunicação SSH (Secure Shell) é a forma preferida de estabele
 :::warning
 A OVHcloud fornece serviços cuja configuração e gestão são da sua responsabilidade. É da sua responsabilidade assegurar o seu bom funcionamento.
 
-Este manual foi concebido para o ajudar com as tarefas de rotina. Contudo, se encontrar dificuldades, recomendamos que contacte um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [comunidade OVHcloud](https://community.ovhcloud.com/community/en). Para mais informações, consulte [Quer saber mais?](#gofurther) deste guia.
+Este manual foi concebido para o ajudar com as tarefas de rotina. Contudo, se encontrar dificuldades, recomendamos que contacte um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [comunidade OVHcloud](/links/community). Para mais informações, consulte [Quer saber mais?](#gofurther) deste guia.
 
 :::
 

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/transfer-data-via-sftp.mdx
@@ -15,7 +15,7 @@ Existem várias opções para transferir ficheiros entre um dispositivo local e 
 :::warning
 A OVHcloud fornece serviços cuja configuração e gestão são da sua responsabilidade. Este tutorial explica como utilizar as soluções da OVHcloud com ferramentas externas. Talvez seja necessário adaptar algumas instruções específicas ao sistema operativo no dispositivo local ou no servidor.
 
-Recomendamos que entre em contacto com um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou entre em contacto com a [nossa comunidade](https://community.ovhcloud.com/community/en) se encontrar dificuldades.
+Recomendamos que entre em contacto com um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou entre em contacto com a [nossa comunidade](/links/community) se encontrar dificuldades.
 
 :::
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/disaster-recovery-plan-overview.mdx
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/ipsec-interconnection.mdx
@@ -11,7 +11,7 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/prism-element-replication.mdx
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/software-gateway-replacement.mdx
@@ -11,7 +11,7 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](/links/community) if you experience any issues.
 
 :::
 

--- a/docs/pt/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/deploy-a-gpu-instance.mdx
@@ -154,4 +154,4 @@ A seguir, siga os passos restantes, conforme descrito em [este guia](/guides/pub
 
 ## Quer saber mais?
 
-Junte-se à nossa comunidade de utilizadores em [https://community.ovhcloud.com/](https://community.ovhcloud.com/en/).
+Junte-se à nossa comunidade de utilizadores em [https://community.ovhcloud.com/](/links/community).

--- a/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-plesk-on-an-instance.mdx
@@ -13,7 +13,7 @@ O Plesk é uma interface de gestão de servidores simples de utilizar. Pode inst
 :::warning
 A utilização e a gestão dos serviços OVHcloud são da responsabilidade do cliente. Uma vez que não temos acesso a estas máquinas, não podemos administrá-las nem fornecer-lhe assistência. O cliente é o único responsável pela gestão e pela segurança do serviço.
 
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Se encontrar dificuldades ou dúvidas relativamente à administração, à utilização ou à segurança de um servidor, deverá contactar um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/). Não hesite em consultar o nosso [fórum comunitário](https://community.ovhcloud.com/community/en) para trocar informações com outros utilizadores.
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. Se encontrar dificuldades ou dúvidas relativamente à administração, à utilização ou à segurança de um servidor, deverá contactar um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/). Não hesite em consultar o nosso [fórum comunitário](/links/community) para trocar informações com outros utilizadores.
 :::
 
 

--- a/docs/pt/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
+++ b/docs/pt/guides/public-cloud/compute/install-prometheus-agent-on-instance.mdx
@@ -16,7 +16,7 @@ Prometheus é um sistema de supervisão e uma base de dados de séries temporais
 :::warning
 A OVHcloud coloca à sua disposição serviços cuja responsabilidade é sua. De fato, não tendo acesso a estas máquinas, não somos os seus administradores e não poderemos prestar assistência. É, portanto, da sua responsabilidade gerir e assegurar a segurança do software diariamente.
 
-Colocamos à sua disposição este guia para o ajudar no melhor possível com tarefas correntes. No entanto, recomendamos que contacte um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) se tiver dificuldades ou dúvidas em relação à administração, utilização ou segurança de um servidor. Não hesite em visitar o nosso [fórum comunitário](https://community.ovhcloud.com/community/en) para trocar informações com outros utilizadores.
+Colocamos à sua disposição este guia para o ajudar no melhor possível com tarefas correntes. No entanto, recomendamos que contacte um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) se tiver dificuldades ou dúvidas em relação à administração, utilização ou segurança de um servidor. Não hesite em visitar o nosso [fórum comunitário](/links/community) para trocar informações com outros utilizadores.
 :::
 
 

--- a/docs/pt/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
+++ b/docs/pt/guides/public-cloud/compute/replacing-lost-ssh-key-pair.mdx
@@ -21,7 +21,7 @@ No entanto, pode ligar-se à sua instância através do modo rescue da OVHcloud,
 :::warning
 A OVHcloud fornece serviços cuja configuração e gestão são da sua responsabilidade. É da sua responsabilidade assegurar o seu bom funcionamento.
 
-Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar algum problema, recomendamos que contacte um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade de utilizadores](https://community.ovhcloud.com/community/en).
+Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar algum problema, recomendamos que contacte um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade de utilizadores](/links/community).
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
+++ b/docs/pt/guides/public-cloud/databases/grafana-tuto-reverse-proxy.mdx
@@ -18,7 +18,7 @@ Schema concept:
 :::warning
 OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](https://community.ovhcloud.com/community/en) if you experience any issues.
+This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialist service provider or reaching out to [our community](/links/community) if you experience any issues.
 :::
 
 

--- a/docs/pt/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
+++ b/docs/pt/guides/public-cloud/databases/mongodb-tuto-connect-nodejs-to-managed-mongodb.mdx
@@ -11,7 +11,7 @@ In this tutorial, we will use the Node.js platform to build a **real-time chat a
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
+++ b/docs/pt/guides/public-cloud/databases/mysql-tuto-connect-k8s-to-managed-mysql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to connect your OVHcloud Managed 
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-strapi-to-managed-postgresql.mdx
@@ -11,7 +11,7 @@ In this tutorial, we are going to show you how to build a [Strapi](https://strap
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
+++ b/docs/pt/guides/public-cloud/databases/postgresql-tuto-connect-wagtail-to-managed-postgresql.mdx
@@ -13,7 +13,7 @@ In this tutorial, we are going to show you how to install [Wagtail](https://wagt
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud can't provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud can't provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/public-cloud/databases/redis-tuto-wordpress.mdx
+++ b/docs/pt/guides/public-cloud/databases/redis-tuto-wordpress.mdx
@@ -11,7 +11,7 @@ Do you have a CMS website or blog, perhaps powered by WordPress? Learn how to sp
 :::warning
 OVHcloud provides services for which you are responsible for their configuration and management. You are therefore responsible for their proper functioning.
 
-This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This tutorial is designed to help you as much as possible with common tasks. If you are having difficulty performing these actions, please contact a specialized service provider and/or discuss it with our community of users on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 
@@ -22,7 +22,7 @@ For this tutorial we propose to use the WordPress CMS, running on Linux Ubuntu w
 :::warning
 This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 
-If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with [our community](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 Remember to back up your files prior to making any changes.
 :::

--- a/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
+++ b/docs/pt/guides/storage-and-backup/file-storage/ha-nas/nas-nfs.mdx
@@ -13,7 +13,7 @@ O serviço NAS-HA da OVHcloud permite-lhe gerir um armazenamento de ficheiros ac
 :::warning
 A OVHcloud oferece-lhe um certo número de serviços cuja configuração e gestão lhe incumbem. Por isso, é da sua responsabilidade garantir que eles funcionem corretamente.
 
-Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovhcloud.com/community/en).
+Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](/links/community).
 
 :::
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-migration-swift-to-s3.mdx
@@ -16,7 +16,7 @@ This guide provides detailed steps to help you migrate from OVHcloud Swift Objec
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-migration.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-migration.mdx
@@ -12,7 +12,7 @@ This guide provides detailed steps to help you migrate from a third-party S3-com
 
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 
 :::
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-nextcloud.mdx
@@ -13,7 +13,7 @@ Nextcloud is a suite of client-server software for creating and using file hosti
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-owncloud.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-owncloud.mdx
@@ -13,7 +13,7 @@ Owncloud is a suite of client-server software for creating and using file hostin
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-rclone.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-rclone.mdx
@@ -13,7 +13,7 @@ lastUpdated: 2026-03-06
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our [community of users](https://community.ovhcloud.com/community/en). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our [community of users](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-s3cmd.mdx
@@ -13,7 +13,7 @@ S3cmd is a free command line tool and client for managing data in storage spaces
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 

--- a/docs/pt/guides/storage-and-backup/object-storage/s3-veeam.mdx
+++ b/docs/pt/guides/storage-and-backup/object-storage/s3-veeam.mdx
@@ -10,7 +10,7 @@ This guide is intended to show you how to configure Veeam to use your Object Sto
 :::warning
 OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 
-This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovh.com/en/](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+This guide is designed to assist you in common tasks as much as possible. If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community on [https://community.ovhcloud.com/](/links/community). OVHcloud cannot provide you with technical support in this regard.
 :::
 
 


### PR DESCRIPTION
226 community links across 219 files used non-canonical URLs: the dead community.ovh.com domain (179) and the /community/{locale} path suffix (100). All now resolve through the /links/community alias.

Shapes handled:
- 167 plain markdown hrefs -> /links/community
- 58 URL-as-label pairs: label text kept, target relinked. The surrounding prose already names the community, so replacing the label with a noun phrase would read "our community on our community" in all 7 locales.
- 1 bare URL in Polish prose -> bare canonical URL (no link to alias)

internal/format-reference.mdx is the authoring template these spread from. Its "External link:" example keeps a real external URL so the example still demonstrates the right syntax; its "Go further" bullet was an exact duplicate of the line below it and was removed.

Verified: content:lint passes, all 219 files compile via @mdx-js/mdx, no symlinks touched, every changed line mentions community.