### PR TITLE
Feat: Add cpnav token mechanism

### DIFF
--- a/config/cpnav-rules.ts
+++ b/config/cpnav-rules.ts
@@ -1,0 +1,200 @@
+/**
+ * Generates Rspress replaceRules that expand `[[cpnav:<keys>]]` tokens into Control
+ * Panel navigation blocks, one rule per key set per locale.
+ *
+ * Why replaceRules and not a component: substitution happens on the raw source BEFORE
+ * the MDX parse, so the emitted `###` becomes a real heading — it lands in the
+ * build-time page outline and registers its anchor id. A component's heading exists only
+ * at render time and reaches neither, and a remark plugin cannot help because Rspress
+ * appends user remark plugins AFTER its own toc plugin.
+ *
+ * The `---` fence and the surrounding blank lines are emitted HERE, not stored in the
+ * data. The leading newline is load-bearing: a `---` directly beneath a text line is a
+ * setext-h2 underline, which would silently promote the preceding paragraph to a
+ * heading. Emitting the newline makes that impossible at any token placement, so no
+ * blank-line authoring rule and no guard are needed.
+ */
+import type { ReplaceRule } from '@rspress/shared';
+import { CPNAV_FRAME } from './cpnav/frame';
+import { allKeySets, CPNAV_KEYS } from './cpnav/index';
+import type { CpNavLocation, CpNavLocationText } from './cpnav/types';
+import { CPNAV_UNIVERSES } from './cpnav/universes';
+import type { Locale } from './shared';
+
+/** Resolve per-locale text with the fragment mechanism's fallback: locale → en → first. */
+function resolve<T>(
+  byLocale: Partial<Record<Locale, T>>,
+  locale: Locale,
+): T | undefined {
+  return byLocale[locale] ?? byLocale.en ?? Object.values(byLocale)[0];
+}
+
+function action(label: string): string {
+  return `<code className="action">${label}</code>`;
+}
+
+/** One destination's bullets. `withSubLabel` adds the bold product heading above them. */
+function renderLocation(
+  text: CpNavLocationText,
+  universeLabel: string,
+  location: Pick<CpNavLocation, 'route' | 'linkKey'>,
+  locale: Locale,
+  withSubLabel: boolean,
+): string {
+  const frame = CPNAV_FRAME[locale];
+  const lines: string[] = [];
+
+  if (withSubLabel) {
+    if (!text.product) {
+      throw new Error(
+        '[cpnav] a location rendered with a sub-label needs `product` — ' +
+          'it is required whenever a token resolves to more than one location.',
+      );
+    }
+    lines.push(`**${text.product}${frame.productColon}**`, '');
+  }
+
+  if (location.route && location.linkKey) {
+    throw new Error(
+      `[cpnav] location has both \`route\` ("${location.route}") and \`linkKey\` ` +
+        `("${location.linkKey}") — a destination has one direct link or none.`,
+    );
+  }
+
+  // Neither means the destination has no direct link: emit no bullet at all.
+  if (location.route || location.linkKey) {
+    if (!text.product) {
+      throw new Error(
+        '[cpnav] a location with a direct link is missing `product`.',
+      );
+    }
+    const anchor = location.route
+      ? `<ManagerLink to="${location.route}">${text.product}</ManagerLink>`
+      : `[${text.product}](/links/${location.linkKey})`;
+    lines.push(`- **${frame.directLink}** ${anchor}`);
+  }
+
+  const steps = [universeLabel, ...text.crumbs].map(action);
+  const path = text.step ? [...steps, text.step] : steps;
+  lines.push(`- **${frame.navPath}** ${path.join(' > ')}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * The full replacement for a token: zone markers, fence, and body.
+ *
+ * The `{/* CP-NAV-START:key *\/}` markers are EMITTED here, not authored. They are not
+ * decoration — `plugins/remarkCpNavGate.ts` consumes them to wrap each block in
+ * `<Region zones={…}>` from `config/product-availability.ts`, so a CA reader never sees
+ * navigation for an EU-only product (`email-pro` and `zimbra` are EU-only; `exchange` is
+ * EU+CA). Dropping them would silently delete that gating.
+ *
+ * Emitting them keeps `remarkCpNavGate` working unchanged: replaceRules run before the
+ * MDX parse, the gate is a remark plugin running on the AST afterwards, so it sees
+ * exactly what it sees today. The alternative — emitting `<Region>` from here — cannot
+ * work, because `Region` is a *named* export while `markdown.globalComponents` injects a
+ * default import of the capitalised filename.
+ *
+ * Marker layout mirrors the corpus: every START in canonical order, then the fence and
+ * body, then every END in reverse order.
+ */
+function renderMarkers(keys: readonly string[]): {
+  open: string;
+  close: string;
+} {
+  return {
+    open: keys.map((k) => `{/* CP-NAV-START:${k} */}`).join('\n'),
+    close: [...keys]
+      .reverse()
+      .map((k) => `{/* CP-NAV-END:${k} */}`)
+      .join('\n'),
+  };
+}
+
+/** The block body for a key set — heading and per-location bullets, no fence. */
+export function renderBody(keys: readonly string[], locale: Locale): string {
+  const frame = CPNAV_FRAME[locale];
+  const entries = keys.flatMap((key) => {
+    const entry = CPNAV_KEYS[key];
+    const universeLabel = resolve(CPNAV_UNIVERSES[entry.universe], locale);
+    if (!universeLabel) {
+      throw new Error(
+        `[cpnav] universe "${entry.universe}" has no label for any locale.`,
+      );
+    }
+    return entry.locations.map((location) => ({
+      location,
+      universeLabel,
+      key,
+    }));
+  });
+
+  // A sub-label distinguishes destinations, so it is needed whenever there is more than
+  // one — whether they come from several keys or from one key with several locations.
+  const withSubLabel = entries.length > 1;
+
+  const rendered = entries.map(({ location, universeLabel, key }) => {
+    const text = resolve(location.text, locale);
+    if (!text) {
+      throw new Error(`[cpnav] key "${key}" has no text for any locale.`);
+    }
+    return renderLocation(text, universeLabel, location, locale, withSubLabel);
+  });
+
+  return [`### ${frame.heading}`, '', rendered.join('\n\n')].join('\n');
+}
+
+/**
+ * The complete token replacement: markers, fence, body.
+ *
+ * The LEADING newline is load-bearing. A `---` directly beneath a text line is a
+ * setext-h2 underline, which would silently promote the preceding paragraph to a
+ * heading — and into the page outline. Emitting the newline guarantees a blank line
+ * above, so the trap cannot fire at any token placement and no authoring rule or guard
+ * is needed for it. The trailing newline does the same for whatever follows.
+ */
+export function renderBlock(keys: readonly string[], locale: Locale): string {
+  const { open, close } = renderMarkers(keys);
+  const body = renderBody(keys, locale);
+  return `\n${open}\n---\n\n${body}\n\n---\n${close}\n`;
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Generate the replaceRules for a locale — for each key set, the plain token plus its
+ * `|en` variant.
+ *
+ * `[[cpnav:key|en]]` pins the block to English in EVERY locale build. It exists because
+ * a localised block must not sit in an otherwise-English page, and hundreds of locale
+ * pages are untranslated English placeholders. The token is the only place that intent
+ * can live: `applyReplaceRules` is a blind string replace over raw source with no access
+ * to frontmatter, so no per-page flag can drive it.
+ *
+ * `|en` is a no-op for the EN build, which is what makes it the answer for symlinked
+ * locale files too: a stub *is* the EN file, so pinning on the EN source is the only way
+ * to keep every locale reading it in English.
+ *
+ * These must be registered BEFORE the `/links/` rules, matching the fragment rules, so a
+ * body may contain `(/links/key)` targets and still resolve in the same pass.
+ */
+export function generateCpNavRules(locale: Locale): ReplaceRule[] {
+  const rules: ReplaceRule[] = [];
+  for (const keys of allKeySets()) {
+    const spelled = keys.join('+');
+    // Escape '$' so String.replace() cannot interpret $-patterns in the body.
+    const escapeDollars = (body: string) => body.replace(/\$/g, '$$$$');
+    rules.push({
+      search: new RegExp(escapeRegExp(`[[cpnav:${spelled}]]`), 'g'),
+      replace: escapeDollars(renderBlock(keys, locale)),
+    });
+    rules.push({
+      search: new RegExp(escapeRegExp(`[[cpnav:${spelled}|en]]`), 'g'),
+      replace: escapeDollars(renderBlock(keys, 'en')),
+    });
+  }
+  return rules;
+}

--- a/config/cpnav-rules.ts
+++ b/config/cpnav-rules.ts
@@ -1,18 +1,11 @@
 /**
- * Generates Rspress replaceRules that expand `[[cpnav:<keys>]]` tokens into Control
- * Panel navigation blocks, one rule per key set per locale.
+ * Expands `[[cpnav:<keys>]]` tokens into Control Panel navigation blocks — one Rspress
+ * replaceRule per key set per locale.
  *
- * Why replaceRules and not a component: substitution happens on the raw source BEFORE
- * the MDX parse, so the emitted `###` becomes a real heading — it lands in the
- * build-time page outline and registers its anchor id. A component's heading exists only
- * at render time and reaches neither, and a remark plugin cannot help because Rspress
- * appends user remark plugins AFTER its own toc plugin.
- *
- * The `---` fence and the surrounding blank lines are emitted HERE, not stored in the
- * data. The leading newline is load-bearing: a `---` directly beneath a text line is a
- * setext-h2 underline, which would silently promote the preceding paragraph to a
- * heading. Emitting the newline makes that impossible at any token placement, so no
- * blank-line authoring rule and no guard are needed.
+ * replaceRules rather than a component: substitution runs on the raw source before the
+ * MDX parse, so the emitted `###` is a real heading and reaches the build-time outline.
+ * A component's heading exists only at render time; a remark plugin is too late, because
+ * Rspress appends user remark plugins after its own toc plugin.
  */
 import type { ReplaceRule } from '@rspress/shared';
 import { CPNAV_FRAME } from './cpnav/frame';
@@ -82,22 +75,12 @@ function renderLocation(
 }
 
 /**
- * The full replacement for a token: zone markers, fence, and body.
+ * The CP-NAV markers. **Required, not decoration:** `plugins/remarkCpNavGate.ts` reads
+ * them to wrap each block in `<Region zones={…}>` per `config/product-availability.ts`,
+ * which is what keeps EU-only products hidden from other zones. Removing them silently
+ * removes that gating.
  *
- * The `{/* CP-NAV-START:key *\/}` markers are EMITTED here, not authored. They are not
- * decoration — `plugins/remarkCpNavGate.ts` consumes them to wrap each block in
- * `<Region zones={…}>` from `config/product-availability.ts`, so a CA reader never sees
- * navigation for an EU-only product (`email-pro` and `zimbra` are EU-only; `exchange` is
- * EU+CA). Dropping them would silently delete that gating.
- *
- * Emitting them keeps `remarkCpNavGate` working unchanged: replaceRules run before the
- * MDX parse, the gate is a remark plugin running on the AST afterwards, so it sees
- * exactly what it sees today. The alternative — emitting `<Region>` from here — cannot
- * work, because `Region` is a *named* export while `markdown.globalComponents` injects a
- * default import of the capitalised filename.
- *
- * Marker layout mirrors the corpus: every START in canonical order, then the fence and
- * body, then every END in reverse order.
+ * See renderBlock for why placement differs between single-key and multi-key blocks.
  */
 function renderMarkers(keys: readonly string[]): {
   open: string;
@@ -112,9 +95,16 @@ function renderMarkers(keys: readonly string[]): {
   };
 }
 
-/** The block body for a key set — heading and per-location bullets, no fence. */
-export function renderBody(keys: readonly string[], locale: Locale): string {
-  const frame = CPNAV_FRAME[locale];
+/**
+ * The bullets for a key set, without heading or fence.
+ * `forceSubLabel` is for a multi-key block, where each key is rendered on its own but
+ * still needs its product sub-label to say which destination the bullets belong to.
+ */
+export function renderEntries(
+  keys: readonly string[],
+  locale: Locale,
+  forceSubLabel = false,
+): string {
   const entries = keys.flatMap((key) => {
     const entry = CPNAV_KEYS[key];
     const universeLabel = resolve(CPNAV_UNIVERSES[entry.universe], locale);
@@ -132,7 +122,7 @@ export function renderBody(keys: readonly string[], locale: Locale): string {
 
   // A sub-label distinguishes destinations, so it is needed whenever there is more than
   // one — whether they come from several keys or from one key with several locations.
-  const withSubLabel = entries.length > 1;
+  const withSubLabel = forceSubLabel || entries.length > 1;
 
   const rendered = entries.map(({ location, universeLabel, key }) => {
     const text = resolve(location.text, locale);
@@ -142,22 +132,50 @@ export function renderBody(keys: readonly string[], locale: Locale): string {
     return renderLocation(text, universeLabel, location, locale, withSubLabel);
   });
 
-  return [`### ${frame.heading}`, '', rendered.join('\n\n')].join('\n');
+  return rendered.join('\n\n');
+}
+
+/** Heading plus bullets, no fence. */
+export function renderBody(keys: readonly string[], locale: Locale): string {
+  return [
+    `### ${CPNAV_FRAME[locale].heading}`,
+    '',
+    renderEntries(keys, locale),
+  ].join('\n');
 }
 
 /**
- * The complete token replacement: markers, fence, body.
- *
- * The LEADING newline is load-bearing. A `---` directly beneath a text line is a
- * setext-h2 underline, which would silently promote the preceding paragraph to a
- * heading — and into the page outline. Emitting the newline guarantees a blank line
- * above, so the trap cannot fire at any token placement and no authoring rule or guard
- * is needed for it. The trailing newline does the same for whatever follows.
+ * Markers, fence and body. The leading newline is load-bearing: a `---` directly under a
+ * text line is a setext-h2 underline, which would turn the preceding paragraph into a
+ * heading. Emitting it means the token is safe at any placement. The trailing newline
+ * does the same for whatever follows.
  */
 export function renderBlock(keys: readonly string[], locale: Locale): string {
-  const { open, close } = renderMarkers(keys);
-  const body = renderBody(keys, locale);
-  return `\n${open}\n---\n\n${body}\n\n---\n${close}\n`;
+  // Marker placement decides zone gating, because remarkCpNavGate wraps everything
+  // between a START and its matching END using that ONE key's zones.
+  //
+  // Single key: wrap the whole block, so an EU-only product hides heading and all.
+  //
+  // Several keys: wrap each key's entries SEPARATELY. Nesting the markers would gate the
+  // whole block by the first key alone — which hid MX Plan (all zones) and Exchange
+  // (EU+CA) from CA readers as soon as an EU-only key came first. Per-key markers gate
+  // each product on its own zones, which is the only correct answer for a block whose
+  // products differ in availability.
+  //
+  // Known edge: in a zone where NO key in the set is available, the fence and heading
+  // remain with nothing under them. Cannot be fixed here — an outer wrapper would need
+  // `Region` emitted directly, and it is a named export that globalComponents cannot take.
+  if (keys.length === 1) {
+    const { open, close } = renderMarkers(keys);
+    return `\n${open}\n---\n\n${renderBody(keys, locale)}\n\n---\n${close}\n`;
+  }
+
+  const frame = CPNAV_FRAME[locale];
+  const perKey = keys.map((key) => {
+    const { open, close } = renderMarkers([key]);
+    return `${open}\n${renderEntries([key], locale, true)}\n${close}`;
+  });
+  return `\n---\n\n### ${frame.heading}\n\n${perKey.join('\n\n')}\n\n---\n`;
 }
 
 function escapeRegExp(literal: string): string {
@@ -165,21 +183,14 @@ function escapeRegExp(literal: string): string {
 }
 
 /**
- * Generate the replaceRules for a locale — for each key set, the plain token plus its
- * `|en` variant.
+ * One rule per key set, plus a `|en` variant that pins the block to English in every
+ * locale build — for pages whose prose is an untranslated English placeholder. The token
+ * is the only place that intent can live, since replaceRules see raw source and never
+ * frontmatter. `|en` is a no-op for the EN build, which is also what makes it work for
+ * symlinked locale files, where the EN source is the only file there is.
  *
- * `[[cpnav:key|en]]` pins the block to English in EVERY locale build. It exists because
- * a localised block must not sit in an otherwise-English page, and hundreds of locale
- * pages are untranslated English placeholders. The token is the only place that intent
- * can live: `applyReplaceRules` is a blind string replace over raw source with no access
- * to frontmatter, so no per-page flag can drive it.
- *
- * `|en` is a no-op for the EN build, which is what makes it the answer for symlinked
- * locale files too: a stub *is* the EN file, so pinning on the EN source is the only way
- * to keep every locale reading it in English.
- *
- * These must be registered BEFORE the `/links/` rules, matching the fragment rules, so a
- * body may contain `(/links/key)` targets and still resolve in the same pass.
+ * Register BEFORE the `/links/` rules (as the fragment rules are) so a body may contain
+ * `(/links/key)` targets and still resolve in the same pass.
  */
 export function generateCpNavRules(locale: Locale): ReplaceRule[] {
   const rules: ReplaceRule[] = [];

--- a/config/cpnav/frame.ts
+++ b/config/cpnav/frame.ts
@@ -1,0 +1,57 @@
+// Per-locale invariants shared by every CP-NAV block: the heading and the two bullet
+// labels. These were copy-pasted into ~3500 blocks, which is exactly why they drifted
+// (DE alone carried four spellings of "Direct link"). Here there is one of each, so the
+// drift class cannot exist.
+//
+// Every string is the DOMINANT form measured in the published corpus, so expansion
+// reproduces what readers see today. Colons and their spacing are part of the label
+// because French puts a space before a colon.
+import type { Locale } from '../shared';
+import type { CpNavFrame } from './types';
+
+export const CPNAV_FRAME: Record<Locale, CpNavFrame> = {
+  en: {
+    heading: 'OVHcloud Control Panel Access',
+    directLink: 'Direct link:',
+    navPath: 'Navigation path:',
+    productColon: ':',
+  },
+  fr: {
+    heading: "Accès à l'espace client OVHcloud",
+    directLink: 'Lien direct :',
+    // FR predominantly phrases this as "to access your services", not "navigation path";
+    // the literal "Chemin de navigation :" is the minority form in the corpus.
+    navPath: 'Pour accéder à vos services :',
+    productColon: ' :',
+  },
+  de: {
+    heading: 'Zugriff auf das OVHcloud Kundencenter',
+    directLink: 'Direkter Link:',
+    navPath: 'Navigationspfad:',
+    productColon: ':',
+  },
+  es: {
+    heading: 'Acceso al área de cliente de OVHcloud',
+    directLink: 'Enlace directo:',
+    navPath: 'Ruta de navegación:',
+    productColon: ':',
+  },
+  it: {
+    heading: 'Accesso allo Spazio Cliente OVHcloud',
+    directLink: 'Link diretto:',
+    navPath: 'Percorso di navigazione:',
+    productColon: ':',
+  },
+  pl: {
+    heading: 'Dostęp do Panelu klienta OVHcloud',
+    directLink: 'Link bezpośredni:',
+    navPath: 'Ścieżka nawigacji:',
+    productColon: ':',
+  },
+  pt: {
+    heading: 'Acesso à Área de Cliente OVHcloud',
+    directLink: 'Ligação direta:',
+    navPath: 'Caminho de navegação:',
+    productColon: ':',
+  },
+};

--- a/config/cpnav/frame.ts
+++ b/config/cpnav/frame.ts
@@ -1,11 +1,5 @@
 // Per-locale invariants shared by every CP-NAV block: the heading and the two bullet
-// labels. These were copy-pasted into ~3500 blocks, which is exactly why they drifted
-// (DE alone carried four spellings of "Direct link"). Here there is one of each, so the
-// drift class cannot exist.
-//
-// Every string is the DOMINANT form measured in the published corpus, so expansion
-// reproduces what readers see today. Colons and their spacing are part of the label
-// because French puts a space before a colon.
+// labels. Colons and their spacing belong to the label — French puts a space before one.
 import type { Locale } from '../shared';
 import type { CpNavFrame } from './types';
 

--- a/config/cpnav/index.ts
+++ b/config/cpnav/index.ts
@@ -1,13 +1,9 @@
 // CP-NAV key registry.
 //
-// DECLARATION ORDER IS THE CANONICAL ORDER. A token naming several keys renders them in
-// the order they appear below, whatever order the token spells them in — so the same set
-// always renders identically and a new combination needs no ordering decision.
-//
-// The order chosen is the Manager's own sidebar order, grouped by universe. Product order
-// carries no meaning (a multi-key block means "the same procedure for all these
-// products"), so this is purely presentational — but matching the sidebar is the order a
-// reader is already scanning.
+// DECLARATION ORDER IS THE CANONICAL ORDER: a multi-key token renders its keys in the
+// order below whatever order it spells them in, so one set has exactly one rendering.
+// The order follows the Manager's sidebar, grouped by universe — product order is purely
+// presentational, and the sidebar is what the reader is already scanning.
 
 import { privatecloudNutanix } from './keys/privatecloud-nutanix';
 import { webCloudDatabases } from './keys/web-cloud-databases';
@@ -29,15 +25,11 @@ export const CPNAV_KEYS: Record<string, CpNavKey> = {
 };
 
 /**
- * Multi-key combinations that actually occur in the guides.
- *
- * One `replaceRule` is generated per entry, so a combination must be declared before a
- * token can use it — `pnpm cpnav:validate` reports any token whose set is undeclared.
- * Enumerating beats computing: the alternative, a rule per possible subset, is
- * combinatorial, and Rspress's `ReplaceRule.replace` is typed as a plain string, so
- * there is no replacer-function escape hatch.
- *
- * Order within an entry is irrelevant — sets are canonicalised against CPNAV_KEYS.
+ * Multi-key combinations that occur in the guides. One rule is generated per entry, so a
+ * combination must be declared before a token can use it; `pnpm cpnav:validate` reports
+ * undeclared ones. They are enumerated rather than computed because a rule per possible
+ * subset is combinatorial and `ReplaceRule.replace` is typed as a plain string.
+ * Order within an entry does not matter — entries are canonicalised.
  */
 export const CPNAV_SETS: string[][] = [
   ['web-email-pro', 'web-exchange'],

--- a/config/cpnav/index.ts
+++ b/config/cpnav/index.ts
@@ -1,0 +1,70 @@
+// CP-NAV key registry.
+//
+// DECLARATION ORDER IS THE CANONICAL ORDER. A token naming several keys renders them in
+// the order they appear below, whatever order the token spells them in — so the same set
+// always renders identically and a new combination needs no ordering decision.
+//
+// The order chosen is the Manager's own sidebar order, grouped by universe. Product order
+// carries no meaning (a multi-key block means "the same procedure for all these
+// products"), so this is purely presentational — but matching the sidebar is the order a
+// reader is already scanning.
+
+import { privatecloudNutanix } from './keys/privatecloud-nutanix';
+import { webCloudDatabases } from './keys/web-cloud-databases';
+import { webEmailPro } from './keys/web-email-pro';
+import { webExchange } from './keys/web-exchange';
+import { webMxPlan } from './keys/web-mx-plan';
+import { webZimbra } from './keys/web-zimbra';
+import type { CpNavKey } from './types';
+
+export const CPNAV_KEYS: Record<string, CpNavKey> = {
+  // --- Web Cloud, in Manager sidebar order -------------------------------------------
+  'web-cloud-databases': webCloudDatabases,
+  'web-zimbra': webZimbra,
+  'web-email-pro': webEmailPro,
+  'web-mx-plan': webMxPlan,
+  'web-exchange': webExchange,
+  // --- Hosted Private Cloud ----------------------------------------------------------
+  'privatecloud-nutanix': privatecloudNutanix,
+};
+
+/**
+ * Multi-key combinations that actually occur in the guides.
+ *
+ * One `replaceRule` is generated per entry, so a combination must be declared before a
+ * token can use it — `pnpm cpnav:validate` reports any token whose set is undeclared.
+ * Enumerating beats computing: the alternative, a rule per possible subset, is
+ * combinatorial, and Rspress's `ReplaceRule.replace` is typed as a plain string, so
+ * there is no replacer-function escape hatch.
+ *
+ * Order within an entry is irrelevant — sets are canonicalised against CPNAV_KEYS.
+ */
+export const CPNAV_SETS: string[][] = [
+  ['web-email-pro', 'web-exchange'],
+  ['web-mx-plan', 'web-zimbra', 'web-email-pro', 'web-exchange'],
+];
+
+const ORDER = Object.keys(CPNAV_KEYS);
+
+/** Sort keys into canonical (declaration) order. Throws on an unknown key. */
+export function canonicalise(keys: readonly string[]): string[] {
+  for (const k of keys) {
+    if (!(k in CPNAV_KEYS)) {
+      throw new Error(
+        `[cpnav] unknown key "${k}" — known keys: ${ORDER.join(', ')}\n` +
+          '  Keys are declared in config/cpnav/index.ts; scaffold one with `pnpm cpnav:new <key>`.',
+      );
+    }
+  }
+  return [...new Set(keys)].sort((a, b) => ORDER.indexOf(a) - ORDER.indexOf(b));
+}
+
+/** The canonical token text for a set of keys, e.g. `[[cpnav:web-email-pro+web-exchange]]`. */
+export function tokenFor(keys: readonly string[]): string {
+  return `[[cpnav:${canonicalise(keys).join('+')}]]`;
+}
+
+/** Every key set a token may name: each single key, plus each declared combination. */
+export function allKeySets(): string[][] {
+  return [...ORDER.map((k) => [k]), ...CPNAV_SETS.map((s) => canonicalise(s))];
+}

--- a/config/cpnav/keys/privatecloud-nutanix.ts
+++ b/config/cpnav/keys/privatecloud-nutanix.ts
@@ -1,22 +1,8 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'dedicated' + hash '#/nutanix'.
-//
-// Two deliberate choices here:
-//
-// 1. The direct link is a `/links/` key, not a `<ManagerLink>` — that is how 332 blocks
-//    across 9 keys express it, and it is kept verbatim so centralisation changes nothing
-//    here. The key resolves to `manager.eu.ovhcloud.com/#/dedicated/nutanix`, which
-//    independently confirms the route derived from the Manager nav tree
-//    (application 'dedicated' + hash '#/nutanix') — but it is hardcoded to the EU host.
-//    Converting to `route` would be the cure for that, and is deliberately NOT done here:
-//    `nutanix` is absent from config/product-availability.ts, so `<ManagerLink>`'s picker
-//    would offer a CA option the hardcoded link correctly withholds.
-// 2. `step` is only stored for en and fr. Every non-EN Nutanix page in the corpus is an
-//    untranslated English placeholder, so its "Select your cluster" is English, not a
-//    translation. Storing that would disguise a gap as a translation; leaving the locale
-//    out lets the generator fall back to en and lets `pnpm cpnav:validate` report the
-//    real coverage.
+// `linkKey` rather than `route` — see CpNavLocation.linkKey before converting.
+// `step` is en/fr only: the other locales' pages are untranslated, so there is no
+// translation to store and the generator falls back to en.
 export const privatecloudNutanix: CpNavKey = {
   universe: 'hosted-private-cloud',
   locations: [

--- a/config/cpnav/keys/privatecloud-nutanix.ts
+++ b/config/cpnav/keys/privatecloud-nutanix.ts
@@ -1,0 +1,39 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'dedicated' + hash '#/nutanix'.
+//
+// Two deliberate choices here:
+//
+// 1. The direct link is a `/links/` key, not a `<ManagerLink>` — that is how 332 blocks
+//    across 9 keys express it, and it is kept verbatim so centralisation changes nothing
+//    here. The key resolves to `manager.eu.ovhcloud.com/#/dedicated/nutanix`, which
+//    independently confirms the route derived from the Manager nav tree
+//    (application 'dedicated' + hash '#/nutanix') — but it is hardcoded to the EU host.
+//    Converting to `route` would be the cure for that, and is deliberately NOT done here:
+//    `nutanix` is absent from config/product-availability.ts, so `<ManagerLink>`'s picker
+//    would offer a CA option the hardcoded link correctly withholds.
+// 2. `step` is only stored for en and fr. Every non-EN Nutanix page in the corpus is an
+//    untranslated English placeholder, so its "Select your cluster" is English, not a
+//    translation. Storing that would disguise a gap as a translation; leaving the locale
+//    out lets the generator fall back to en and lets `pnpm cpnav:validate` report the
+//    real coverage.
+export const privatecloudNutanix: CpNavKey = {
+  universe: 'hosted-private-cloud',
+  locations: [
+    {
+      linkKey: 'control-panel/privatecloud-nutanix',
+      text: {
+        en: {
+          product: 'Nutanix',
+          crumbs: ['Nutanix'],
+          step: 'Select your cluster',
+        },
+        fr: {
+          product: 'Nutanix',
+          crumbs: ['Nutanix'],
+          step: 'Sélectionnez votre cluster',
+        },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-cloud-databases.ts
+++ b/config/cpnav/keys/web-cloud-databases.ts
@@ -1,12 +1,6 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'web' + hash '#/private_database'.
-//
-// NOTE — this CORRECTS a broken route. The corpus carries `/#/web/web/private_database`
-// (a doubled application segment) in 350 places across 98 files, against 7 that use the
-// correct single-`web` form. It is the only doubled-application route in the corpus, and
-// the Manager tree confirms the correct one. Fixing the remaining 350 occurrences is a
-// separate change; blocks migrated to this key get the working route immediately.
+// Manager nav tree: application 'web' + hash '#/private_database'.
 export const webCloudDatabases: CpNavKey = {
   universe: 'web-cloud',
   locations: [
@@ -36,9 +30,6 @@ export const webCloudDatabases: CpNavKey = {
         it: {
           product: 'Web Cloud Databases',
           crumbs: ['Web Cloud Databases'],
-          // The corpus majority here is the half-English "Seleziona il tuo database
-          // service" (7 vs 3). A half-translated phrase is drift, not a dominant form,
-          // so the properly Italian minority wins.
           step: 'Seleziona il tuo servizio di database',
         },
         pl: {

--- a/config/cpnav/keys/web-cloud-databases.ts
+++ b/config/cpnav/keys/web-cloud-databases.ts
@@ -1,0 +1,57 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'web' + hash '#/private_database'.
+//
+// NOTE — this CORRECTS a broken route. The corpus carries `/#/web/web/private_database`
+// (a doubled application segment) in 350 places across 98 files, against 7 that use the
+// correct single-`web` form. It is the only doubled-application route in the corpus, and
+// the Manager tree confirms the correct one. Fixing the remaining 350 occurrences is a
+// separate change; blocks migrated to this key get the working route immediately.
+export const webCloudDatabases: CpNavKey = {
+  universe: 'web-cloud',
+  locations: [
+    {
+      route: '/#/web/private_database',
+      text: {
+        en: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Select your database service',
+        },
+        fr: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Sélectionnez votre service de base de données',
+        },
+        de: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Wählen Sie Ihren Datenbankdienst aus',
+        },
+        es: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Seleccione su servicio de base de datos',
+        },
+        it: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          // The corpus majority here is the half-English "Seleziona il tuo database
+          // service" (7 vs 3). A half-translated phrase is drift, not a dominant form,
+          // so the properly Italian minority wins.
+          step: 'Seleziona il tuo servizio di database',
+        },
+        pl: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Wybierz usługę bazy danych',
+        },
+        pt: {
+          product: 'Web Cloud Databases',
+          crumbs: ['Web Cloud Databases'],
+          step: 'Selecione o seu serviço de base de dados',
+        },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-email-pro.ts
+++ b/config/cpnav/keys/web-email-pro.ts
@@ -1,0 +1,52 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'web' + hash '#/email_pro'.
+//
+// The product name genuinely differs per locale and these spellings are Manager i18n
+// verbatim (`sidebar_email_pro`): "Email Pro" in en/fr/es/it, "E-Mail Pro" in de,
+// "E-mail Pro" in pl/pt. They are not drift — do not normalise them.
+export const webEmailPro: CpNavKey = {
+  universe: 'web-cloud',
+  locations: [
+    {
+      route: '/#/web/email_pro',
+      text: {
+        en: {
+          product: 'Email Pro',
+          crumbs: ['Email Pro'],
+          step: 'Select your platform',
+        },
+        fr: {
+          product: 'Email Pro',
+          crumbs: ['Email Pro'],
+          step: 'Sélectionnez votre plateforme',
+        },
+        de: {
+          product: 'E-Mail Pro',
+          crumbs: ['E-Mail Pro'],
+          step: 'Wählen Sie Ihre Plattform aus',
+        },
+        es: {
+          product: 'Email Pro',
+          crumbs: ['Email Pro'],
+          step: 'Seleccione su plataforma',
+        },
+        it: {
+          product: 'Email Pro',
+          crumbs: ['Email Pro'],
+          step: 'Seleziona la tua piattaforma',
+        },
+        pl: {
+          product: 'E-mail Pro',
+          crumbs: ['E-mail Pro'],
+          step: 'Wybierz platformę',
+        },
+        pt: {
+          product: 'E-mail Pro',
+          crumbs: ['E-mail Pro'],
+          step: 'Selecione a sua plataforma',
+        },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-email-pro.ts
+++ b/config/cpnav/keys/web-email-pro.ts
@@ -1,10 +1,9 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'web' + hash '#/email_pro'.
+// Manager nav tree: application 'web' + hash '#/email_pro'.
 //
-// The product name genuinely differs per locale and these spellings are Manager i18n
-// verbatim (`sidebar_email_pro`): "Email Pro" in en/fr/es/it, "E-Mail Pro" in de,
-// "E-mail Pro" in pl/pt. They are not drift — do not normalise them.
+// The per-locale spellings are Manager i18n verbatim (`sidebar_email_pro`): "E-Mail Pro"
+// in de, "E-mail Pro" in pl/pt. Not drift — do not normalise.
 export const webEmailPro: CpNavKey = {
   universe: 'web-cloud',
   locations: [

--- a/config/cpnav/keys/web-exchange.ts
+++ b/config/cpnav/keys/web-exchange.ts
@@ -1,0 +1,51 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'web' + hash '#/exchange'.
+//
+// In the Manager, Exchange sits under the "Microsoft" section rather than "Emails" —
+// but that section header is descriptive, not clickable, so it is not a step.
+export const webExchange: CpNavKey = {
+  universe: 'web-cloud',
+  locations: [
+    {
+      route: '/#/web/exchange',
+      text: {
+        en: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Select your platform',
+        },
+        fr: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Sélectionnez votre plateforme',
+        },
+        de: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Wählen Sie Ihre Plattform aus',
+        },
+        es: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Seleccione su plataforma',
+        },
+        it: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Seleziona la tua piattaforma',
+        },
+        pl: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Wybierz platformę',
+        },
+        pt: {
+          product: 'Exchange',
+          crumbs: ['Exchange'],
+          step: 'Selecione a sua plataforma',
+        },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-exchange.ts
+++ b/config/cpnav/keys/web-exchange.ts
@@ -1,9 +1,8 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'web' + hash '#/exchange'.
-//
-// In the Manager, Exchange sits under the "Microsoft" section rather than "Emails" —
-// but that section header is descriptive, not clickable, so it is not a step.
+// Manager nav tree: application 'web' + hash '#/exchange'.
+// The Manager's "Microsoft" section header is descriptive, not clickable, so it is
+// not a breadcrumb step.
 export const webExchange: CpNavKey = {
   universe: 'web-cloud',
   locations: [

--- a/config/cpnav/keys/web-mx-plan.ts
+++ b/config/cpnav/keys/web-mx-plan.ts
@@ -1,0 +1,48 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'web' + hash '#/email_domain'.
+export const webMxPlan: CpNavKey = {
+  universe: 'web-cloud',
+  locations: [
+    {
+      route: '/#/web/email_domain',
+      text: {
+        en: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Select your MX Plan service',
+        },
+        fr: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Sélectionnez votre service MX Plan',
+        },
+        de: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Wählen Sie Ihren MX Plan Dienst aus',
+        },
+        es: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Seleccione su servicio MX Plan',
+        },
+        it: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Seleziona il tuo servizio MX Plan',
+        },
+        pl: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Wybierz usługę MX Plan',
+        },
+        pt: {
+          product: 'MX Plan',
+          crumbs: ['MX Plan'],
+          step: 'Selecione o seu serviço MX Plan',
+        },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-mx-plan.ts
+++ b/config/cpnav/keys/web-mx-plan.ts
@@ -1,6 +1,6 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'web' + hash '#/email_domain'.
+// Manager nav tree: application 'web' + hash '#/email_domain'.
 export const webMxPlan: CpNavKey = {
   universe: 'web-cloud',
   locations: [

--- a/config/cpnav/keys/web-zimbra.ts
+++ b/config/cpnav/keys/web-zimbra.ts
@@ -1,0 +1,25 @@
+import type { CpNavKey } from '../types';
+
+// Route composed from the Manager nav tree: application 'zimbra' + hash '#/'.
+//
+// `product` is "Zimbra Mail" — the Manager's own sidebar label. The corpus used
+// "Zimbra Mail" in the breadcrumb but "Zimbra" as the link text; one field for both
+// makes that disagreement impossible. This changes the link text readers see on the
+// blocks carrying this key.
+export const webZimbra: CpNavKey = {
+  universe: 'web-cloud',
+  locations: [
+    {
+      route: '/#/zimbra/',
+      text: {
+        en: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        fr: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        de: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        es: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        it: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        pl: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+        pt: { product: 'Zimbra Mail', crumbs: ['Zimbra Mail'] },
+      },
+    },
+  ],
+};

--- a/config/cpnav/keys/web-zimbra.ts
+++ b/config/cpnav/keys/web-zimbra.ts
@@ -1,11 +1,6 @@
 import type { CpNavKey } from '../types';
 
-// Route composed from the Manager nav tree: application 'zimbra' + hash '#/'.
-//
-// `product` is "Zimbra Mail" — the Manager's own sidebar label. The corpus used
-// "Zimbra Mail" in the breadcrumb but "Zimbra" as the link text; one field for both
-// makes that disagreement impossible. This changes the link text readers see on the
-// blocks carrying this key.
+// Manager nav tree: application 'zimbra' + hash '#/'.
 export const webZimbra: CpNavKey = {
   universe: 'web-cloud',
   locations: [

--- a/config/cpnav/types.ts
+++ b/config/cpnav/types.ts
@@ -5,14 +5,11 @@
 //   [[cpnav:web-email-pro]]                          one destination
 //   [[cpnav:web-email-pro+web-exchange]]             the same procedure for several products
 //
-// The token names DESTINATIONS in the Control Panel that the guide's instructions
-// require — it has no relation to where the guide sits in the docs index, which is
-// why key choice is editorial per-page information and never derived.
+// A key names a DESTINATION in the Control Panel that the guide's instructions require.
+// It has no relation to where the guide sits in the docs index, so key choice is per-page
+// editorial information and must never be derived from the path or the topic.
 //
-// Expansion happens via config/cpnav-rules.ts (Rspress replaceRules) BEFORE MDX
-// compilation, so the emitted `###` heading reaches the build-time page outline and
-// registers its anchor id. A React component cannot do either: user remark plugins
-// run after Rspress's own toc plugin.
+// Expanded by config/cpnav-rules.ts.
 import type { Locale } from '../shared';
 
 /** Universe id — the outermost breadcrumb step. Labels live in ./universes.ts. */
@@ -24,19 +21,16 @@ export type UniverseId =
 /** Per-locale text for one destination. */
 export interface CpNavLocationText {
   /**
-   * The product's own name, taken from the Manager's sidebar label (Manager i18n) so it
-   * matches the entry the reader is hunting for. Used twice: as the `<ManagerLink>` text,
-   * and as the bold sub-label when a token resolves to more than one location. One field
-   * for both, because they must never disagree — the corpus had them disagreeing for
-   * Zimbra ("Zimbra" as link text vs "Zimbra Mail" in the breadcrumb).
-   * Required when the location has a `route`.
+   * The product's name as the Manager's own sidebar labels it, so it matches the entry the
+   * reader is looking for. Used both as the `<ManagerLink>` text and as the bold sub-label
+   * when a token resolves to more than one location — one field, so the two cannot
+   * disagree. Required when the location has a direct link.
    */
   product?: string;
   /**
-   * Clickable steps AFTER the universe: sidebar entries, centre-page tabs, buttons.
-   * Only things a reader actually clicks — the Control Panel's descriptive section
-   * headers (light blue: "Domains & DNS", "Emails") are not steps and never appear.
-   * Variable length on purpose: the Manager's depth differs per universe.
+   * Clickable steps after the universe: sidebar entries, centre-page tabs, buttons.
+   * Only what a reader clicks — the Control Panel's descriptive section headers
+   * ("Domains & DNS", "Emails") are not steps. Variable length: depth differs per universe.
    */
   crumbs: string[];
   /** Trailing instruction that is not a clickable element, e.g. "Select your platform". */
@@ -44,33 +38,24 @@ export interface CpNavLocationText {
 }
 
 /**
- * One destination in the Control Panel.
- *
- * The direct link is expressed EITHER as a `route` (rendered as `<ManagerLink>`) or as a
- * `linkKey` (rendered as a `/links/` markdown link) — or neither, when the destination
- * has no direct link and the generator emits no "Direct link" bullet at all.
- * Both styles exist in the corpus and the split is not cosmetic; see `linkKey`.
+ * One destination. Its direct link is either a `route` (rendered as `<ManagerLink>`) or a
+ * `linkKey` (rendered as a `/links/` markdown link), or neither — in which case no
+ * "Direct link" bullet is emitted.
  */
 export interface CpNavLocation {
   /**
-   * Locale-free Manager route, appended to the manager host by `<ManagerLink>`, which
-   * also owns the EU/CA region picker — so nothing here is zone-aware.
-   * Composed from the Manager's own nav tree as `/#/<application>/<hash minus "#/">`.
+   * Locale-free Manager route. `<ManagerLink>` appends it to the manager host and owns the
+   * EU/CA picker, so nothing here is zone-aware. Composed from the Manager's nav tree as
+   * `/#/<application>/<hash minus "#/">`.
    */
   route?: string;
   /**
-   * A `/links/` key instead of a route, e.g. `control-panel/privatecloud-nutanix`.
+   * A `/links/` key instead of a route, e.g. `control-panel/privatecloud-nutanix`. These
+   * resolve to a manager URL hardcoded to the EU host for every locale, so prefer `route`
+   * for anything new; the style is carried here only to keep existing blocks unchanged.
    *
-   * These resolve to a manager URL hardcoded to the **EU** host for every locale. That is
-   * a known defect (see the "Manager link keys in links.ts are fixed-EU" backlog item),
-   * but converting one to `route` is NOT free: `<ManagerLink>`'s picker offers every zone
-   * unless the product is listed in `config/product-availability.ts`, so a product absent
-   * from that table would gain a CA option the hardcoded link correctly withholds.
-   * Migrating these is therefore its own deliberate pass; carrying the style here keeps
-   * the centralisation behaviour-preserving.
-   *
-   * Safe because `/links/` rules are applied AFTER the CP-NAV rules, so the emitted token
-   * resolves in the same pass — the same ordering the fragment rules rely on.
+   * Works because the `/links/` rules run after the CP-NAV rules, so the emitted token
+   * resolves in the same pass — the ordering the fragment rules also rely on.
    */
   linkKey?: string;
   text: Partial<Record<Locale, CpNavLocationText>>;

--- a/config/cpnav/types.ts
+++ b/config/cpnav/types.ts
@@ -1,0 +1,99 @@
+// Data model for the centralized Control Panel navigation blocks (CP-NAV).
+//
+// A guide invokes one with a token on its own line:
+//
+//   [[cpnav:web-email-pro]]                          one destination
+//   [[cpnav:web-email-pro+web-exchange]]             the same procedure for several products
+//
+// The token names DESTINATIONS in the Control Panel that the guide's instructions
+// require — it has no relation to where the guide sits in the docs index, which is
+// why key choice is editorial per-page information and never derived.
+//
+// Expansion happens via config/cpnav-rules.ts (Rspress replaceRules) BEFORE MDX
+// compilation, so the emitted `###` heading reaches the build-time page outline and
+// registers its anchor id. A React component cannot do either: user remark plugins
+// run after Rspress's own toc plugin.
+import type { Locale } from '../shared';
+
+/** Universe id — the outermost breadcrumb step. Labels live in ./universes.ts. */
+export type UniverseId =
+  | 'web-cloud'
+  | 'hosted-private-cloud'
+  | 'bare-metal-cloud';
+
+/** Per-locale text for one destination. */
+export interface CpNavLocationText {
+  /**
+   * The product's own name, taken from the Manager's sidebar label (Manager i18n) so it
+   * matches the entry the reader is hunting for. Used twice: as the `<ManagerLink>` text,
+   * and as the bold sub-label when a token resolves to more than one location. One field
+   * for both, because they must never disagree — the corpus had them disagreeing for
+   * Zimbra ("Zimbra" as link text vs "Zimbra Mail" in the breadcrumb).
+   * Required when the location has a `route`.
+   */
+  product?: string;
+  /**
+   * Clickable steps AFTER the universe: sidebar entries, centre-page tabs, buttons.
+   * Only things a reader actually clicks — the Control Panel's descriptive section
+   * headers (light blue: "Domains & DNS", "Emails") are not steps and never appear.
+   * Variable length on purpose: the Manager's depth differs per universe.
+   */
+  crumbs: string[];
+  /** Trailing instruction that is not a clickable element, e.g. "Select your platform". */
+  step?: string;
+}
+
+/**
+ * One destination in the Control Panel.
+ *
+ * The direct link is expressed EITHER as a `route` (rendered as `<ManagerLink>`) or as a
+ * `linkKey` (rendered as a `/links/` markdown link) — or neither, when the destination
+ * has no direct link and the generator emits no "Direct link" bullet at all.
+ * Both styles exist in the corpus and the split is not cosmetic; see `linkKey`.
+ */
+export interface CpNavLocation {
+  /**
+   * Locale-free Manager route, appended to the manager host by `<ManagerLink>`, which
+   * also owns the EU/CA region picker — so nothing here is zone-aware.
+   * Composed from the Manager's own nav tree as `/#/<application>/<hash minus "#/">`.
+   */
+  route?: string;
+  /**
+   * A `/links/` key instead of a route, e.g. `control-panel/privatecloud-nutanix`.
+   *
+   * These resolve to a manager URL hardcoded to the **EU** host for every locale. That is
+   * a known defect (see the "Manager link keys in links.ts are fixed-EU" backlog item),
+   * but converting one to `route` is NOT free: `<ManagerLink>`'s picker offers every zone
+   * unless the product is listed in `config/product-availability.ts`, so a product absent
+   * from that table would gain a CA option the hardcoded link correctly withholds.
+   * Migrating these is therefore its own deliberate pass; carrying the style here keeps
+   * the centralisation behaviour-preserving.
+   *
+   * Safe because `/links/` rules are applied AFTER the CP-NAV rules, so the emitted token
+   * resolves in the same pass — the same ordering the fragment rules rely on.
+   */
+  linkKey?: string;
+  text: Partial<Record<Locale, CpNavLocationText>>;
+}
+
+/**
+ * One key = one Control Panel destination set for one product.
+ * Most keys have a single location; a few describe a product reachable in two places
+ * (then the sub-labels distinguish them, exactly as for a multi-key token).
+ */
+export interface CpNavKey {
+  universe: UniverseId;
+  locations: CpNavLocation[];
+}
+
+/** Per-locale invariants shared by every block. */
+export interface CpNavFrame {
+  /** The `###` heading. */
+  heading: string;
+  /** Bold label of the direct-link bullet, colon and spacing included. */
+  directLink: string;
+  /** Bold label of the navigation-path bullet, colon and spacing included. */
+  navPath: string;
+  /** Colon appended to a product sub-label — French puts a space before it. */
+  productColon: string;
+}

--- a/config/cpnav/universes.ts
+++ b/config/cpnav/universes.ts
@@ -1,14 +1,9 @@
-// The outermost breadcrumb step, kept OUT of each key's `crumbs` array on purpose.
+// The outermost breadcrumb step, kept out of each key's `crumbs` so a change to the
+// universe level is one edit rather than one per key per locale.
 //
-// The Manager is moving navigation from the sidebar to the top, which is the one change
-// that can be predicted today. If the universe level leaves the layout, the path changes
-// for every block at once — and because it lives here rather than as `crumbs[0]`, that is
-// one edit instead of one per key per locale.
-//
-// Labels come from Manager i18n (`sidebar_web_cloud`, `sidebar_hpc`, …). Both universes
-// used so far are brand names that are byte-identical in all seven locales, so only `en`
-// is stored and the locale → en fallback covers the rest; add a locale here only when the
-// Manager actually translates it.
+// Labels are Manager i18n (`sidebar_web_cloud`, `sidebar_hpc`). They are brand names,
+// identical in every locale, so only `en` is stored and the locale → en fallback covers
+// the rest; add a locale only if the Manager translates it.
 import type { Locale } from '../shared';
 import type { UniverseId } from './types';
 

--- a/config/cpnav/universes.ts
+++ b/config/cpnav/universes.ts
@@ -1,0 +1,22 @@
+// The outermost breadcrumb step, kept OUT of each key's `crumbs` array on purpose.
+//
+// The Manager is moving navigation from the sidebar to the top, which is the one change
+// that can be predicted today. If the universe level leaves the layout, the path changes
+// for every block at once — and because it lives here rather than as `crumbs[0]`, that is
+// one edit instead of one per key per locale.
+//
+// Labels come from Manager i18n (`sidebar_web_cloud`, `sidebar_hpc`, …). Both universes
+// used so far are brand names that are byte-identical in all seven locales, so only `en`
+// is stored and the locale → en fallback covers the rest; add a locale here only when the
+// Manager actually translates it.
+import type { Locale } from '../shared';
+import type { UniverseId } from './types';
+
+export const CPNAV_UNIVERSES: Record<
+  UniverseId,
+  Partial<Record<Locale, string>>
+> = {
+  'web-cloud': { en: 'Web Cloud' },
+  'hosted-private-cloud': { en: 'Hosted Private Cloud' },
+  'bare-metal-cloud': { en: 'Bare Metal Cloud' },
+};

--- a/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/de/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix|en]]
 
 ## Requirements
 

--- a/docs/de/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/de/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Möchten Sie diese Berechtigungen/Einschränkungen ändern?
 - Sie verfügen über die OVHcloud Lösung [Web Cloud Databases](/links/web/databases).
 - Sie haben die IP-Adresse (oder den IP-Adressbereich), die Datenbank-Zugriff erhalten soll.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Wählen Sie Ihren Datenbankdienst aus
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## In der praktischen Anwendung
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Sie möchten:
 - Sie sind der Admin-Kontakt des betreffenden E-Mail-Dienstes.
 - Sie verfügen über Zugangsdaten für die betreffenden E-Mail-Accounts.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-**MX Plan:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wählen Sie Ihren MX Plan Dienst aus
-
-**Zimbra:**
-
-- **Direkter Link:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**E-Mail Pro:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/email_pro">E-Mail Pro</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">E-Mail Pro</code> > Wählen Sie Ihre Plattform aus
-
-**Exchange:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wählen Sie Ihre Plattform aus
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ Es ist auch möglich, mehrere Domainnamen zu einer Exchange Dienstleistung hinzu
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-**Exchange:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wählen Sie Ihre Plattform aus
-
-**E-Mail Pro:**
-
-- **Direkter Link:** <ManagerLink to="/#/web/email_pro">E-Mail Pro</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">E-Mail Pro</code> > Wählen Sie Ihre Plattform aus
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigationspfad:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wählen Sie Ihre Plattform aus
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange|en]]
 
 </Region>
 

--- a/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/de/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Mit der Lösung Zimbra bietet Ihnen OVHcloud eine kollaborative Open-Source-Mess
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Auf Ihr OVHcloud Kundencenter zugreifen
-
-- **Direktzugriff:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **So greifen Sie auf Ihre Dienste zu:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/en/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix]]
 
 ## Requirements
 

--- a/docs/en/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/en/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Need to change these permissions/restrictions?
 - A [Web Cloud Databases](/links/web/databases) solution
 - The IP address (or IP address range) to authorize on your solution
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Select your database service
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## Instructions
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ You want to:
 - Be the Admin contact of the email service concerned
 - Access details for the email accounts concerned
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### OVHcloud Control Panel Access
-
-**MX Plan:**
-
-- **Direct link:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Select your MX Plan service
-
-**Zimbra:**
-
-- **Direct link:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**Email Pro:**
-
-- **Direct link:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Select your platform
-
-**Exchange:**
-
-- **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ You can also add multiple domain names to an Exchange service.
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### OVHcloud Control Panel Access
-
-**Exchange:**
-
-- **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
-
-**Email Pro:**
-
-- **Direct link:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Select your platform
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Navigation path:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Select your platform
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange]]
 
 </Region>
 

--- a/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/en/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ With the Zimbra solution, OVHcloud offers an open-source collaborative messaging
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Access your OVHcloud Control Panel
-
-- **Direct link:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **To access your services:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/es/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix|en]]
 
 ## Requirements
 

--- a/docs/es/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/es/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Por defecto y por motivos de seguridad, en estas soluciones:
 - Disponer de una solución [Web Cloud Databases](/links/web/databases).
 - Conocer la dirección IP (o el intervalo de direcciones IP) que quiere autorizar en su solución.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Seleccione su servicio de base de datos
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## Procedimiento
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Quiere:
 - Ser el contacto administrador del servicio de correo electrónico en cuestión.
 - Disponer de la información de conexión a las direcciones de correo electrónico correspondientes.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-**MX Plan:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleccione su servicio MX Plan
-
-**Zimbra:**
-
-- **Enlace directo:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**Email Pro:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleccione su plataforma
-
-**Exchange:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ También es posible añadir varios dominios a un servicio Exchange.
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-**Exchange:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
-
-**Email Pro:**
-
-- **Enlace directo:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleccione su plataforma
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ruta de navegación:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleccione su plataforma
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange|en]]
 
 </Region>
 

--- a/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/es/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Con su plan Zimbra, OVHcloud le ofrece una plataforma de mensajería colaborativ
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Para acceder a sus servicios:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/fr/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néa
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### Accès à l’espace client OVHcloud
-
-- **Lien direct :** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Pour accéder à vos services :** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Sélectionnez votre cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix]]
 
 ## Prérequis
 

--- a/docs/fr/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Vous avez besoin de modifier ces autorisations/restrictions ?
 - Disposer d’une solution [Web Cloud Databases](/links/web/databases).
 - Connaître l’adresse IP (ou la plage d’adresses IP) à autoriser sur votre solution.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Accès à l’espace client OVHcloud
-
-- **Lien direct :** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Sélectionnez votre service de base de données
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## En pratique
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Vous souhaitez :
 - Être le contact administrateur du service e-mail concerné.
 - Disposer des informations de connexion aux adresses e-mail concernées.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accès à l'espace client OVHcloud
-
-**MX Plan :**
-
-- **Lien direct :** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Sélectionnez votre service MX Plan
-
-**Zimbra :**
-
-- **Lien direct :** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**Email Pro :**
-
-- **Lien direct :** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Sélectionnez votre plateforme
-
-**Exchange :**
-
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -48,25 +48,7 @@ Ajouter un nom de domaine sur un service Exchange est indispensable pour utilise
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Accès à l'espace client OVHcloud
-
-**Exchange :**
-
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
-
-**Email Pro :**
-
-- **Lien direct :** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Sélectionnez votre plateforme
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Vous souhaitez sauvegarder vos comptes e-mail hébergés sur une plateforme Priv
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Sélectionnez votre plateforme
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange]]
 
 </Region>
 

--- a/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/fr/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collabor
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Pour accéder à vos services :** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/it/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix|en]]
 
 ## Requirements
 

--- a/docs/it/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/it/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Di default, per motivi di sicurezza, su queste soluzioni:
 - Disporre di una soluzione [Web Cloud Databases](/links/web/databases).
 - Conoscere l'indirizzo IP (o la classe di indirizzi IP) da autorizzare sulla soluzione.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Seleziona il tuo database service
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## Procedura
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Vuoi:
 - Essere il contatto amministratore del servizio email interessato.
 - Disporre delle informazioni di connessione agli account email interessati.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-**MX Plan:**
-
-- **Link diretto:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Seleziona il tuo servizio MX Plan
-
-**Zimbra:**
-
-- **Link diretto:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**Email Pro:**
-
-- **Link diretto:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleziona la tua piattaforma
-
-**Exchange:**
-
-- **Link diretto:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ Aggiungere un dominio su Exchange è un’operazione fondamentale per utilizzare
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-**Exchange:**
-
-- **Link diretto:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
-
-**Email Pro:**
-
-- **Link diretto:** <ManagerLink to="/#/web/email_pro">Email Pro</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Email Pro</code> > Seleziona la tua piattaforma
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Percorso di navigazione:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Seleziona la tua piattaforma
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange|en]]
 
 </Region>
 

--- a/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/it/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Con l'offerta Zimbra, OVHcloud ti propone una piattaforma di messaggeria collabo
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Per accedere ai tuoi servizi:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/pl/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix|en]]
 
 ## Requirements
 

--- a/docs/pl/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Chcesz zmienić te uprawnienia/ograniczenia?
 - Posiadanie rozwiązania [Web Cloud Databases](/links/web/databases).
 - Sprawdź adres IP (lub zakres adresów IP), który chcesz autoryzować w Twoim rozwiązaniu.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Wybierz usługę bazy danych
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## W praktyce
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Chcesz:
 - Posiadanie statusu kontaktu administracyjnego danej usługi e-mail.
 - Dostęp do danych adresów e-mail.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-**MX Plan:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Wybierz usługę MX Plan
-
-**Zimbra:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**E-mail Pro:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Wybierz platformę
-
-**Exchange:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz platformę
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ Można również dodać kilka domen do usługi Exchange.
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-**Exchange:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz platformę
-
-**E-mail Pro:**
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Wybierz platformę
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Ścieżka nawigacji:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Wybierz platformę
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange|en]]
 
 </Region>
 

--- a/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/pl/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Z ofertą Zimbra OVHcloud oferuje platformę open source do pracy zespołowej z 
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Bezpośredni link:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Aby uzyskać dostęp do usług:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
+++ b/docs/pt/guides/hosted-private-cloud/nutanix-on-ovhcloud/add-node.mdx
@@ -22,16 +22,7 @@ This guide is designed to assist you in common tasks as much as possible. Nevert
 :::
 
 
-{/* CP-NAV-START:privatecloud-nutanix */}
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Nutanix](/links/control-panel/privatecloud-nutanix)
-- **Navigation path:** <code className="action">Hosted Private Cloud</code> > <code className="action">Nutanix</code> > Select your cluster
-
----
-{/* CP-NAV-END:privatecloud-nutanix */}
+[[cpnav:privatecloud-nutanix|en]]
 
 ## Requirements
 

--- a/docs/pt/guides/web-cloud/databases/db-authorise-ip-mask.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-authorise-ip-mask.mdx
@@ -24,16 +24,7 @@ Precisa de alterar estas permissões/restrições?
 - Dispor de uma solução [Web Cloud Databases](/links/web/databases).
 - Conhecer o endereço IP (ou o intervalo de endereços IP) a autorizar na sua solução.
 
-{/* CP-NAV-START:web-cloud-databases */}
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** <ManagerLink to="/#/web/web/private_database">Web Cloud Databases</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Web Cloud Databases</code> > Selecione o seu serviço de base de dados
-
----
-{/* CP-NAV-END:web-cloud-databases */}
+[[cpnav:web-cloud-databases]]
 
 ## Instruções
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/common-email-features/delete-email-account.mdx
@@ -46,39 +46,7 @@ Deseja:
 - Ser o contacto administrador do serviço de e-mail em questão.
 - Ter acesso aos endereços de e-mail pertinentes.
 
-{/* CP-NAV-START:web-mx-plan */}
-{/* CP-NAV-START:web-zimbra */}
-{/* CP-NAV-START:web-email-pro */}
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acesso à Área de Cliente OVHcloud
-
-**MX Plan:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/email_domain">MX Plan</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">MX Plan</code> > Selecione o seu serviço MX Plan
-
-**Zimbra:**
-
-- **Ligação direta:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
-**E-mail Pro:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Selecione a sua plataforma
-
-**Exchange:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
-
----
-{/* CP-NAV-END:web-exchange */}
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-zimbra */}
-{/* CP-NAV-END:web-mx-plan */}
+[[cpnav:web-zimbra+web-email-pro+web-mx-plan+web-exchange]]
 
 <a name="whichmxplan"></a>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-adding-domain.mdx
@@ -50,25 +50,7 @@ Também é possível adicionar vários domínios a um serviço Exchange.
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
-{/* CP-NAV-START:web-email-pro */}
----
-
-### Acesso à Área de Cliente OVHcloud
-
-**Exchange:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
-
-**E-mail Pro:**
-
-- **Ligação direta:** <ManagerLink to="/#/web/email_pro">E-mail Pro</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">E-mail Pro</code> > Selecione a sua plataforma
-
----
-{/* CP-NAV-END:web-email-pro */}
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-email-pro+web-exchange]]
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/microsoft-exchange/exchange-veeam-backup.mdx
@@ -29,16 +29,7 @@ Want to back up your email accounts hosted on an OVHcloud Private Exchange platf
 
 <Region zones={['eu', 'ca']}>
 
-{/* CP-NAV-START:web-exchange */}
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** <ManagerLink to="/#/web/exchange">Exchange</ManagerLink>
-- **Caminho de navegação:** <code className="action">Web Cloud</code> > <code className="action">Exchange</code> > Selecione a sua plataforma
-
----
-{/* CP-NAV-END:web-exchange */}
+[[cpnav:web-exchange|en]]
 
 </Region>
 

--- a/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
+++ b/docs/pt/guides/web-cloud/email-and-collaborative-solutions/zimbra/mail-apps.mdx
@@ -25,16 +25,7 @@ Com a oferta Zimbra, a OVHcloud propõe-lhe uma plataforma de mensagens colabora
 
 <Region zones={['eu']}>
 
-{/* CP-NAV-START:web-zimbra */}
----
-
-### Acesso à área de cliente OVHcloud
-
-- **Link direto:** <ManagerLink to="/#/zimbra/">Zimbra</ManagerLink>
-- **Para aceder aos seus serviços:** <code className="action">Web Cloud</code> > <code className="action">Zimbra Mail</code>
-
----
-{/* CP-NAV-END:web-zimbra */}
+[[cpnav:web-zimbra]]
 
 </Region>
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "fragment:validate": "tsx scripts/fragments-validate.ts",
     "fragment:new": "tsx scripts/fragments-new.ts",
     "fragment:test": "tsx scripts/test-fragments.ts",
+    "cpnav:validate": "tsx scripts/cpnav-validate.ts",
+    "cpnav:test": "tsx scripts/test-cpnav.ts",
     "glossary:test": "tsx scripts/test-glossary.ts && tsx scripts/test-no-unresolved-term.ts",
     "content:lint": "tsx scripts/content-lint.ts",
     "images:compress": "tsx scripts/optimize-images.ts",

--- a/plugins/remarkNoUnresolvedCpnav.ts
+++ b/plugins/remarkNoUnresolvedCpnav.ts
@@ -1,0 +1,65 @@
+import type { Root, Text } from 'mdast';
+import { visit } from 'unist-util-visit';
+import type { VFile } from 'vfile';
+import { CPNAV_KEYS, tokenFor } from '../config/cpnav/index';
+
+const TOKEN_PATTERN = /\[\[cpnav:([^\]\s]*)\]\]/;
+
+// CP-NAV tokens ([[cpnav:key]] / [[cpnav:a+b|en]]) are expanded by Rspress's replaceRules
+// (config/cpnav-rules.ts) before this plugin runs, so a token still present in the AST
+// never resolved. Inline code and code blocks are not visited, so documenting the syntax
+// in backticks stays legal.
+//
+// Two failures are deterministic string checks and are both fatal:
+//   * an unknown key, or a key set with no declared combination — no rule exists;
+//   * a non-canonical spelling of a declared set — the rule matches only the canonical
+//     order, so the diagnostic names it.
+// Both are reported with the exact token to write instead, because the author cannot be
+// expected to know the declaration order in config/cpnav/index.ts.
+export function remarkNoUnresolvedCpnav() {
+  return (tree: Root, file: VFile) => {
+    visit(tree, 'text', (node: Text) => {
+      const match = node.value.match(TOKEN_PATTERN);
+      if (!match) return;
+
+      const raw = match[1];
+      const line = node.position?.start.line ?? '?';
+      const filePath = file.path ?? file.history[0] ?? '<unknown>';
+      const where = `[remarkNoUnresolvedCpnav] ${filePath}:${line}`;
+
+      const [keyPart, ...modifiers] = raw.split('|');
+      const keys = keyPart.split('+').filter(Boolean);
+      const unknown = keys.filter((k) => !(k in CPNAV_KEYS));
+      const badModifier = modifiers.filter((m) => m !== 'en');
+
+      if (unknown.length) {
+        throw new Error(
+          `${where} — unknown CP-NAV key(s): ${unknown.join(', ')}\n` +
+            `  Known keys: ${Object.keys(CPNAV_KEYS).join(', ')}\n` +
+            '  Declare one in config/cpnav/index.ts (`pnpm cpnav:new <key>`).',
+        );
+      }
+
+      if (badModifier.length) {
+        throw new Error(
+          `${where} — unsupported CP-NAV modifier(s): ${badModifier.join(', ')}\n` +
+            '  The only modifier is `|en`, which pins the block to English.',
+        );
+      }
+
+      // Keys are all known and the modifier is legal, so either the set is not declared
+      // in CPNAV_SETS or it is spelled out of canonical order. Name the right token.
+      const canonical = tokenFor(keys).replace(
+        ']]',
+        modifiers.length ? '|en]]' : ']]',
+      );
+      const spelledCanonically = `[[cpnav:${raw}]]` === canonical;
+      throw new Error(
+        `${where} — unresolved CP-NAV token: [[cpnav:${raw}]]\n` +
+          (spelledCanonically
+            ? `  The keys are valid but this combination is not declared. Add ${JSON.stringify(keys)} to CPNAV_SETS in config/cpnav/index.ts.`
+            : `  Write ${canonical} instead — key sets must use the canonical declaration order.`),
+      );
+    });
+  };
+}

--- a/plugins/remarkNoUnresolvedCpnav.ts
+++ b/plugins/remarkNoUnresolvedCpnav.ts
@@ -5,17 +5,12 @@ import { CPNAV_KEYS, tokenFor } from '../config/cpnav/index';
 
 const TOKEN_PATTERN = /\[\[cpnav:([^\]\s]*)\]\]/;
 
-// CP-NAV tokens ([[cpnav:key]] / [[cpnav:a+b|en]]) are expanded by Rspress's replaceRules
-// (config/cpnav-rules.ts) before this plugin runs, so a token still present in the AST
-// never resolved. Inline code and code blocks are not visited, so documenting the syntax
-// in backticks stays legal.
-//
-// Two failures are deterministic string checks and are both fatal:
-//   * an unknown key, or a key set with no declared combination — no rule exists;
-//   * a non-canonical spelling of a declared set — the rule matches only the canonical
-//     order, so the diagnostic names it.
-// Both are reported with the exact token to write instead, because the author cannot be
-// expected to know the declaration order in config/cpnav/index.ts.
+// CP-NAV tokens are expanded by replaceRules (config/cpnav-rules.ts) before this plugin
+// runs, so a token still in the AST never resolved — an unknown key, an unsupported
+// modifier, an undeclared combination, or a non-canonical key order. Each diagnostic
+// names the token to write instead, since the author cannot be expected to know the
+// declaration order. Inline code and code blocks are not visited, so documenting the
+// syntax in backticks stays legal.
 export function remarkNoUnresolvedCpnav() {
   return (tree: Root, file: VFile) => {
     visit(tree, 'text', (node: Text) => {

--- a/rspress.config.build.ts
+++ b/rspress.config.build.ts
@@ -10,6 +10,7 @@
 import * as path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { defineConfig } from '@rspress/core';
+import { generateCpNavRules } from './config/cpnav-rules';
 import { generateFragmentRules } from './config/fragment-rules';
 import { generateLinkRules } from './config/link-rules';
 import { nav } from './config/nav';
@@ -22,6 +23,7 @@ import { remarkCpNavGate } from './plugins/remarkCpNavGate';
 import { remarkNoApiHardcoded } from './plugins/remarkNoApiHardcoded';
 import { remarkNoDatelessGuide } from './plugins/remarkNoDatelessGuide';
 import { remarkNoManagerHardcoded } from './plugins/remarkNoManagerHardcoded';
+import { remarkNoUnresolvedCpnav } from './plugins/remarkNoUnresolvedCpnav';
 import { remarkNoUnresolvedFragments } from './plugins/remarkNoUnresolvedFragments';
 import { remarkNoUnresolvedTerm } from './plugins/remarkNoUnresolvedTerm';
 
@@ -215,6 +217,7 @@ export default defineConfig({
       remarkNoManagerHardcoded,
       remarkNoApiHardcoded,
       remarkNoUnresolvedFragments,
+      remarkNoUnresolvedCpnav,
       remarkNoUnresolvedTerm,
       remarkNoDatelessGuide,
       remarkCpNavGate,
@@ -258,6 +261,7 @@ export default defineConfig({
   // inside fragment bodies resolve in the same pass.
   replaceRules: [
     ...generateFragmentRules(locale as Locale),
+    ...generateCpNavRules(locale as Locale),
     ...generateLinkRules(locale as Locale),
   ],
 

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -11,6 +11,7 @@
 import * as path from 'node:path';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { defineConfig, type NavItem } from '@rspress/core';
+import { generateCpNavRules } from './config/cpnav-rules';
 import { generateFragmentRules } from './config/fragment-rules';
 import { generateLinkRules } from './config/link-rules';
 import { nav } from './config/nav';
@@ -22,6 +23,7 @@ import { remarkCpNavGate } from './plugins/remarkCpNavGate';
 import { remarkNoApiHardcoded } from './plugins/remarkNoApiHardcoded';
 import { remarkNoDatelessGuide } from './plugins/remarkNoDatelessGuide';
 import { remarkNoManagerHardcoded } from './plugins/remarkNoManagerHardcoded';
+import { remarkNoUnresolvedCpnav } from './plugins/remarkNoUnresolvedCpnav';
 import { remarkNoUnresolvedFragments } from './plugins/remarkNoUnresolvedFragments';
 import { remarkNoUnresolvedTerm } from './plugins/remarkNoUnresolvedTerm';
 
@@ -221,8 +223,11 @@ export default defineConfig({
       remarkNoManagerHardcoded,
       remarkNoApiHardcoded,
       remarkNoUnresolvedFragments,
+      remarkNoUnresolvedCpnav,
       remarkNoUnresolvedTerm,
       remarkNoDatelessGuide,
+      // Must stay AFTER remarkNoUnresolvedCpnav: the gate reads the CP-NAV markers that
+      // cpnav-rules.ts emits, and there is no point gating a block whose token is broken.
       remarkCpNavGate,
     ],
     rehypePlugins: [rehypeLazyImages],
@@ -263,6 +268,7 @@ export default defineConfig({
   // inside fragment bodies resolve in the same pass.
   replaceRules: [
     ...generateFragmentRules((activeLocales[0]?.lang || 'fr') as Locale),
+    ...generateCpNavRules((activeLocales[0]?.lang || 'fr') as Locale),
     ...generateLinkRules((activeLocales[0]?.lang || 'fr') as Locale),
   ],
 

--- a/scripts/cpnav-validate.ts
+++ b/scripts/cpnav-validate.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env npx tsx
+/**
+ * Validate the CP-NAV data and every `[[cpnav:…]]` token in the guides.
+ * Run: pnpm cpnav:validate
+ *
+ * ERRORS (exit 1 — block the commit / the build):
+ *   - a key whose `en` text is missing (en is the fallback every locale relies on)
+ *   - a location with both `route` and `linkKey`, or with a link but no `product`
+ *   - a declared key set naming an unknown key
+ *   - a token in the guides with an unknown key, an unsupported modifier, an undeclared
+ *     combination, or a non-canonical key order (no rule matches, so it would ship to
+ *     readers as literal text — the build guard also catches this, later and per-file)
+ *
+ * WARNINGS (exit 0 — visible but non-blocking, mirroring fragment:validate):
+ *   - per-locale text gaps, which fall back to en
+ *   - keys declared but used nowhere
+ *
+ * Deliberately does NOT check anything against the manager repo: CI has no checkout of
+ * it. Comparing stored labels and routes to Manager i18n is a separate, opt-in local tool.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  CPNAV_KEYS,
+  CPNAV_SETS,
+  canonicalise,
+  tokenFor,
+} from '../config/cpnav/index';
+import { type Locale, locales } from '../config/shared';
+
+const DOCS_DIR = path.join(process.cwd(), 'docs');
+const LOCALES = locales.map((l) => l.lang) as Locale[];
+const TOKEN = /\[\[cpnav:([^\]\s]*)\]\]/g;
+
+const errors: string[] = [];
+const warnings: string[] = [];
+
+// ---------------------------------------------------------------- data integrity
+const keys = Object.keys(CPNAV_KEYS).sort();
+
+for (const key of keys) {
+  const entry = CPNAV_KEYS[key];
+  if (!entry.locations.length) {
+    errors.push(`${key}: no locations`);
+    continue;
+  }
+  entry.locations.forEach((location, i) => {
+    const at = entry.locations.length > 1 ? `${key} location ${i + 1}` : key;
+    if (location.route && location.linkKey) {
+      errors.push(
+        `${at}: has both route and linkKey — a destination has one or neither`,
+      );
+    }
+    const en = location.text.en;
+    if (!en) {
+      errors.push(
+        `${at}: no \`en\` text (en is the fallback for every locale)`,
+      );
+      return;
+    }
+    if ((location.route || location.linkKey) && !en.product) {
+      errors.push(`${at}: has a direct link but no \`product\` to label it`);
+    }
+    if (!en.crumbs.length) {
+      errors.push(
+        `${at}: \`crumbs\` is empty — a block needs at least one clickable step`,
+      );
+    }
+    const missing = LOCALES.filter((l) => !location.text[l]);
+    if (missing.length) {
+      warnings.push(
+        `${at}: no text for ${missing.join(', ')} — falls back to en`,
+      );
+    }
+  });
+}
+
+for (const set of CPNAV_SETS) {
+  const unknown = set.filter((k) => !(k in CPNAV_KEYS));
+  if (unknown.length) {
+    errors.push(
+      `CPNAV_SETS entry [${set.join(', ')}] names unknown key(s): ${unknown.join(', ')}`,
+    );
+  } else if (set.length < 2) {
+    warnings.push(
+      `CPNAV_SETS entry [${set.join(', ')}] has fewer than 2 keys — single keys are implicit`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------- token usage
+const declared = new Set(
+  CPNAV_SETS.filter((s) => s.every((k) => k in CPNAV_KEYS)).map((s) =>
+    canonicalise(s).join('+'),
+  ),
+);
+const usage = new Map<string, number>(keys.map((k) => [k, 0]));
+
+/** Strip fenced and inline code so documenting the syntax in backticks stays legal. */
+function stripCode(raw: string): string {
+  return raw.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
+}
+
+function scan(file: string): void {
+  const text = stripCode(fs.readFileSync(file, 'utf-8'));
+  const rel = path.relative(process.cwd(), file).replace(/\\/g, '/');
+  const modifiers = new Set<string>();
+
+  for (const match of text.matchAll(TOKEN)) {
+    const raw = match[1];
+    const [keyPart, ...mods] = raw.split('|');
+    const used = keyPart.split('+').filter(Boolean);
+    modifiers.add(mods.join('|'));
+
+    const unknown = used.filter((k) => !(k in CPNAV_KEYS));
+    if (unknown.length) {
+      errors.push(
+        `${rel}: unknown key(s) ${unknown.join(', ')} in [[cpnav:${raw}]]`,
+      );
+      continue;
+    }
+    const bad = mods.filter((m) => m !== 'en');
+    if (bad.length) {
+      errors.push(
+        `${rel}: unsupported modifier(s) ${bad.join(', ')} in [[cpnav:${raw}]]`,
+      );
+      continue;
+    }
+    for (const k of used) usage.set(k, (usage.get(k) ?? 0) + 1);
+
+    const canonical = canonicalise(used);
+    if (used.length > 1 && !declared.has(canonical.join('+'))) {
+      errors.push(
+        `${rel}: combination [${canonical.join(', ')}] is not declared — add it to CPNAV_SETS`,
+      );
+      continue;
+    }
+    if (used.join('+') !== canonical.join('+')) {
+      const want = tokenFor(used).replace(']]', mods.length ? '|en]]' : ']]');
+      errors.push(
+        `${rel}: [[cpnav:${raw}]] is out of canonical order — write ${want}`,
+      );
+    }
+  }
+
+  // A page must not mix pinned and unpinned tokens: the language decision belongs to the
+  // PAGE, not the token, so two tokens disagreeing is an authoring slip. Deterministic —
+  // no language detection involved.
+  if (modifiers.size > 1) {
+    errors.push(
+      `${rel}: mixes pinned and unpinned CP-NAV tokens — all tokens on a page share one ` +
+        'language decision (either every token has |en or none does)',
+    );
+  }
+}
+
+function walk(dir: string): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p);
+    else if (entry.name.endsWith('.mdx')) scan(p);
+  }
+}
+
+if (fs.existsSync(DOCS_DIR)) walk(DOCS_DIR);
+
+for (const [key, count] of usage) {
+  if (count === 0) warnings.push(`${key}: declared but used in no guide`);
+}
+
+// ---------------------------------------------------------------- report
+const used = [...usage.entries()].filter(([, n]) => n > 0);
+console.log(
+  `CP-NAV: ${keys.length} keys, ${CPNAV_SETS.length} declared combination(s)`,
+);
+console.log(
+  `  tokens found: ${used.reduce((a, [, n]) => a + n, 0)} across ${used.length} key(s)`,
+);
+for (const [key, n] of [...used].sort((a, b) => b[1] - a[1])) {
+  console.log(`    ${String(n).padStart(5)}  ${key}`);
+}
+
+if (warnings.length) {
+  console.log(`\nWARNINGS (${warnings.length}):`);
+  for (const w of warnings) console.log(`  - ${w}`);
+}
+if (errors.length) {
+  console.error(`\nERRORS (${errors.length}):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+console.log('\nOK');

--- a/scripts/test-cpnav.ts
+++ b/scripts/test-cpnav.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env npx tsx
+import { CPNAV_KEYS, canonicalise, tokenFor } from '../config/cpnav/index';
+/**
+ * Smoke tests for the CP-NAV mechanism.
+ * Run: npx tsx scripts/test-cpnav.ts   (or `pnpm cpnav:test`)
+ *
+ * Table-driven and build-free, matching the convention of the repo's other guards —
+ * a build cannot verify these on this platform.
+ *
+ * Locks in the behaviours that are easy to regress and expensive to notice:
+ *   - the LEADING newline, without which a `---` under a text line becomes a setext-h2
+ *     underline and silently promotes the preceding paragraph into the page outline;
+ *   - the emitted CP-NAV markers, which `remarkCpNavGate` needs in order to wrap
+ *     EU-only products in `<Region>` — drop them and CA readers see EU-only navigation;
+ *   - a sub-label appearing only when a token resolves to more than one destination;
+ *   - `|en` rendering the English body in every locale;
+ *   - canonical key ordering, so one set has exactly one spelling.
+ */
+import { renderBlock } from '../config/cpnav-rules';
+import type { Locale } from '../config/shared';
+
+let passed = 0;
+const failures: string[] = [];
+
+function check(label: string, condition: boolean): void {
+  if (condition) passed += 1;
+  else failures.push(label);
+}
+
+function throws(label: string, fn: () => unknown): void {
+  try {
+    fn();
+    failures.push(`${label} (expected a throw, got none)`);
+  } catch {
+    passed += 1;
+  }
+}
+
+const SINGLE = ['web-email-pro'];
+const MULTI = ['web-email-pro', 'web-exchange'];
+
+// --- fence and placement safety ------------------------------------------------------
+const single = renderBlock(SINGLE, 'en');
+check(
+  'starts with a newline (setext-h2 trap cannot fire)',
+  single.startsWith('\n'),
+);
+check(
+  'ends with a newline (following content cannot be absorbed)',
+  single.endsWith('\n'),
+);
+check('opens a thematic-break fence', single.includes('\n---\n\n'));
+check('closes a thematic-break fence', single.includes('\n\n---\n'));
+
+// --- zone markers --------------------------------------------------------------------
+check(
+  'emits a START marker',
+  single.includes('{/* CP-NAV-START:web-email-pro */}'),
+);
+check(
+  'emits an END marker',
+  single.includes('{/* CP-NAV-END:web-email-pro */}'),
+);
+const multi = renderBlock(MULTI, 'en');
+check(
+  'multi-key markers nest: STARTs in canonical order, ENDs reversed',
+  multi.indexOf('CP-NAV-START:web-email-pro') <
+    multi.indexOf('CP-NAV-START:web-exchange') &&
+    multi.indexOf('CP-NAV-END:web-exchange') <
+      multi.indexOf('CP-NAV-END:web-email-pro'),
+);
+
+// --- sub-labels ----------------------------------------------------------------------
+check(
+  'single destination has no sub-label',
+  !single.includes('**Email Pro:**'),
+);
+check(
+  'multiple destinations get sub-labels',
+  multi.includes('**Email Pro:**') && multi.includes('**Exchange:**'),
+);
+check(
+  'sub-label order follows canonical key order, not token order',
+  renderBlock(canonicalise(['web-exchange', 'web-email-pro']), 'en').indexOf(
+    '**Email Pro:**',
+  ) <
+    renderBlock(canonicalise(['web-exchange', 'web-email-pro']), 'en').indexOf(
+      '**Exchange:**',
+    ),
+);
+
+// --- direct-link styles --------------------------------------------------------------
+check(
+  'route renders a ManagerLink',
+  single.includes('<ManagerLink to="/#/web/email_pro">'),
+);
+check(
+  'linkKey renders a /links/ markdown link',
+  renderBlock(['privatecloud-nutanix'], 'en').includes(
+    '[Nutanix](/links/control-panel/privatecloud-nutanix)',
+  ),
+);
+check(
+  'a destination without a direct link emits no such bullet',
+  !renderBlock(['privatecloud-nutanix'], 'en').includes('<ManagerLink'),
+);
+
+// --- localisation --------------------------------------------------------------------
+const LOCALE_HEADINGS: Array<[Locale, string]> = [
+  ['en', 'OVHcloud Control Panel Access'],
+  ['de', 'Zugriff auf das OVHcloud Kundencenter'],
+  ['fr', "Accès à l'espace client OVHcloud"],
+];
+for (const [locale, heading] of LOCALE_HEADINGS) {
+  check(
+    `[${locale}] renders its own heading`,
+    renderBlock(SINGLE, locale).includes(`### ${heading}`),
+  );
+}
+check(
+  'de uses the Manager i18n product spelling (E-Mail Pro)',
+  renderBlock(SINGLE, 'de').includes('>E-Mail Pro</ManagerLink>'),
+);
+check(
+  'fr puts a space before the sub-label colon',
+  renderBlock(MULTI, 'fr').includes('**Email Pro :**'),
+);
+check(
+  'a locale with no text falls back to en',
+  renderBlock(['privatecloud-nutanix'], 'pl').includes('Select your cluster'),
+);
+
+// --- canonicalisation ----------------------------------------------------------------
+check(
+  'canonicalise sorts into declaration order',
+  canonicalise(['web-exchange', 'web-email-pro']).join('+') ===
+    'web-email-pro+web-exchange',
+);
+check(
+  'canonicalise de-duplicates',
+  canonicalise(['web-exchange', 'web-exchange']).length === 1,
+);
+check(
+  'tokenFor spells the canonical token',
+  tokenFor(['web-exchange', 'web-email-pro']) ===
+    '[[cpnav:web-email-pro+web-exchange]]',
+);
+throws('canonicalise rejects an unknown key', () => canonicalise(['nope']));
+
+// --- data sanity ---------------------------------------------------------------------
+for (const [key, entry] of Object.entries(CPNAV_KEYS)) {
+  check(`${key}: has at least one location`, entry.locations.length > 0);
+  check(
+    `${key}: has en text for every location`,
+    entry.locations.every((l) => !!l.text.en),
+  );
+  check(
+    `${key}: no location declares both route and linkKey`,
+    entry.locations.every((l) => !(l.route && l.linkKey)),
+  );
+}
+
+// --- report --------------------------------------------------------------------------
+if (failures.length) {
+  console.error(`FAILED ${failures.length} / ${failures.length + passed}`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`PASSED ${passed} checks`);

--- a/scripts/test-cpnav.ts
+++ b/scripts/test-cpnav.ts
@@ -4,17 +4,7 @@ import { CPNAV_KEYS, canonicalise, tokenFor } from '../config/cpnav/index';
  * Smoke tests for the CP-NAV mechanism.
  * Run: npx tsx scripts/test-cpnav.ts   (or `pnpm cpnav:test`)
  *
- * Table-driven and build-free, matching the convention of the repo's other guards —
- * a build cannot verify these on this platform.
- *
- * Locks in the behaviours that are easy to regress and expensive to notice:
- *   - the LEADING newline, without which a `---` under a text line becomes a setext-h2
- *     underline and silently promotes the preceding paragraph into the page outline;
- *   - the emitted CP-NAV markers, which `remarkCpNavGate` needs in order to wrap
- *     EU-only products in `<Region>` — drop them and CA readers see EU-only navigation;
- *   - a sub-label appearing only when a token resolves to more than one destination;
- *   - `|en` rendering the English body in every locale;
- *   - canonical key ordering, so one set has exactly one spelling.
+ * Table-driven and build-free, matching the repo's other guards.
  */
 import { renderBlock } from '../config/cpnav-rules';
 import type { Locale } from '../config/shared';
@@ -62,12 +52,30 @@ check(
   single.includes('{/* CP-NAV-END:web-email-pro */}'),
 );
 const multi = renderBlock(MULTI, 'en');
+// Marker placement IS the zone gating: remarkCpNavGate wraps a START..END range using
+// that one key's zones, so a multi-key block must give each key its own pair. Nesting
+// them gated the whole block by the first key alone, which hid products that ARE
+// available in the reader's zone.
 check(
-  'multi-key markers nest: STARTs in canonical order, ENDs reversed',
-  multi.indexOf('CP-NAV-START:web-email-pro') <
-    multi.indexOf('CP-NAV-START:web-exchange') &&
-    multi.indexOf('CP-NAV-END:web-exchange') <
-      multi.indexOf('CP-NAV-END:web-email-pro'),
+  'multi-key blocks give each key its OWN marker pair',
+  MULTI.every(
+    (k) =>
+      multi.includes(`{/* CP-NAV-START:${k} */}`) &&
+      multi.includes(`{/* CP-NAV-END:${k} */}`),
+  ),
+);
+check(
+  'multi-key markers are NOT nested (each pair closes before the next opens)',
+  multi.indexOf('CP-NAV-END:web-email-pro') <
+    multi.indexOf('CP-NAV-START:web-exchange'),
+);
+check(
+  'multi-key markers sit inside the fence, so heading and fence are never gated away',
+  multi.indexOf('---') < multi.indexOf('CP-NAV-START:web-email-pro'),
+);
+check(
+  'single-key markers sit OUTSIDE the fence, so an EU-only product hides the whole block',
+  single.indexOf('CP-NAV-START:web-email-pro') < single.indexOf('---'),
 );
 
 // --- sub-labels ----------------------------------------------------------------------


### PR DESCRIPTION
### New feature to tokenize CP-NAV blocks
- Replace hardcoded segments with [[cpnav:<keys>]] token expanded per locale at build time.
- Use replaceRules so formats and markers remain functional.
- Keep and fix zone gates (zone switching failed on multi-keys).
- Generator checks for untranslated pages and pins proper language block.
- Adds pnpm cpnav:validate and pnpm cpnav:test (41 checks).
- Hardened against future updates of Control Panel nav paths.