### PR TITLE
docs(domains): extend the Anycast DNS guides to the CA and APAC zones

### DIFF
--- a/docs/de/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: DNS Anycast für Ihren Domainnamen deaktivieren
 description: Erfahren Sie, wie Sie die für Ihren Domainnamen abonnierte DNS Anycast Option über Ihr OVHcloud Kundencenter kündigen
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/de/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/de/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: DNS Anycast für Ihren Domainnamen aktivieren
 description: Erfahren Sie, wie Sie mit der DNS Anycast Option Ihrer Domain den Zugriff auf Ihre Webdienste beschleunigen können
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/en/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: How to disable Anycast DNS for your domain name
 description: Find out how to cancel the Anycast DNS option subscribed for your domain name from your OVHcloud Control Panel
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/en/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/en/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: How to enable Anycast DNS for your domain name
 description: Find out how to speed up access to your web services with the DNS resolution speed offered by your domain name's Anycast DNS option
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Desactivar los DNS Anycast para su dominio
 description: Descubra cómo dar de baja la opción DNS Anycast contratada para su nombre de dominio desde su área de cliente de OVHcloud
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/es/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/es/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Activar los DNS Anycast para su dominio
 description: Descubra cómo acelerar el acceso a sus servicios web gracias a la velocidad de resolución DNS que ofrece la opción DNS Anycast de su dominio
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Désactiver les DNS Anycast pour votre nom de domaine
 description: "Découvrez comment résilier l’option DNS Anycast souscrite pour votre nom de domaine depuis votre espace client OVHcloud"
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/fr/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/fr/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Activer les DNS Anycast pour votre nom de domaine
 description: "Découvrez comment accélérer l’accès à vos services web grâce à la vitesse de résolution DNS offerte par l’option DNS Anycast de votre nom de domaine"
-lastUpdated: 2026-07-31
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Disattivare i DNS Anycast per il tuo dominio
 description: "Questa guida ti mostra come disattivare l'opzione DNS Anycast sottoscritta per il tuo nome di dominio dal tuo Spazio Cliente OVHcloud"
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/it/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/it/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Attivare i DNS Anycast per il tuo dominio
 description: "Questa guida ti mostra accelerare l'accesso ai tuoi servizi Web grazie alla velocità di risoluzione DNS offerta dall'opzione DNS Anycast del tuo dominio"
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pl/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Wyłączenie DNS Anycast dla Twojej domeny
 description: Dowiedz się, jak zrezygnować z opcji DNS Anycast wykupionej dla Twojej nazwy domeny z poziomu Panelu klienta OVHcloud
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pl/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/pl/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Włączenie DNS Anycast dla Twojej domeny
 description: Dowiedz się, jak przyspieszyć dostęp do usług WWW dzięki prędkości odczytu DNS oferowanej przez opcję DNS Anycast dla Twojej domeny
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/web-cloud/domains/dns-anycast-disable.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-anycast-disable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Desativar os DNS Anycast para o seu nome de domínio
 description: Saiba como rescindir a opção DNS Anycast subscrita para o seu nome de domínio a partir da sua Área de Cliente OVHcloud
-lastUpdated: 2026-08-25
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';

--- a/docs/pt/guides/web-cloud/domains/dns-anycast-enable.mdx
+++ b/docs/pt/guides/web-cloud/domains/dns-anycast-enable.mdx
@@ -1,8 +1,8 @@
 ---
 title: Ativar os DNS Anycast para o seu nome de domínio
 description: Saiba como acelerar o acesso aos seus serviços web graças à velocidade de resolução DNS oferecida pela opção DNS Anycast do seu domínio
-lastUpdated: 2025-06-18
-availableIn: [eu]
+lastUpdated: 2026-09-09
+availableIn: [eu, ca, apac]
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';


### PR DESCRIPTION
The two Anycast DNS guides were gated to `availableIn: [eu]`, so readers in Canada and APAC were told the option does not exist in their zone. It does.

Checked against three independent sources:

- Order catalog (/order/catalog/public/domain): the `dnsanycast` addon of the `DNS` family is offered on the same 942 extension plans in every subsidiary.
- Commercial pages: en-ca, fr-ca, en-sg, en-au, asia and en-in all return a localised product page with those prices and a live order funnel.
- Manager codebase: the domain/anycast and dns-zone/new modules carry no subsidiary or region gating at all.