### PR TITLE
docs(sd): update guide - configuring an IP block in a vRack

### DIFF
--- a/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/de/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguration eines Additional IP-Blocks in einem vRack
-description: In dieser Anleitung erfahren Sie, wie Sie einen Block öffentlicher IP-Adressen für die Verwendung mit dem vRack konfigurieren.
-lastUpdated: 2026-09-08
+description: In dieser Anleitung erfahren Sie, wie Sie einen Block öffentlicher IP-Adressen für die Verwendung mit dem vRack konfigurieren
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -54,7 +54,7 @@ Dieser Artikel befasst sich mit der Konfiguration von Additional IP über ein vR
 {/* CP-NAV-END:network-vrack */}
 
 :::warning
-Diese Funktion kann auf Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) nicht verfügbar oder eingeschränkt sein.
+Diese Funktion kann auf Servern der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) nicht verfügbar oder eingeschränkt sein.
 
 Weitere Informationen finden Sie auf unserer [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
 
@@ -66,7 +66,7 @@ Weitere Informationen finden Sie auf unserer [Vergleichsseite](https://eco.ovhcl
 :::info
 Als Beispiel verwenden wir einen IP-Block von 46.105.135.96/28 und eth1 für die sekundäre Netzwerkschnittstelle, die dem vRack gewidmet ist.
 
-Als Beispiel befindet sich die Netzwerkkonfigurationsdatei, auf die wir verweisen, unter `/etc/network/interfaces`. Die entsprechende Datei auf Ihrem Server kann sich je nach Betriebssystem an einem anderen Ort befinden. Der Dateiinhalt kann ebenfalls abweichen. Bei Schwierigkeiten konsultieren Sie bitte die offizielle Dokumentation Ihrer Distribution.
+Die Netzwerkkonfigurationsdatei, auf die wir uns beziehen, befindet sich unter `/etc/network/interfaces`. Die entsprechende Datei auf Ihrem Server kann sich je nach Betriebssystem an einem anderen Ort befinden. Der Dateiinhalt kann ebenfalls abweichen. Bei Schwierigkeiten konsultieren Sie bitte die offizielle Dokumentation Ihrer Distribution.
 
 :::
 
@@ -76,7 +76,7 @@ Als Beispiel befindet sich die Netzwerkkonfigurationsdatei, auf die wir verweise
 :::warning
 Sobald ein IP-Block zum vRack hinzugefügt wird, ist er nicht mehr mit einem physischen Server verbunden.
 
-Dieses Setup ermöglicht es Ihnen, IPs desselben Blocks auf mehreren Servern zu konfigurieren, vorausgesetzt, dass sich alle Server im selben vRack wie der IP-Block befinden. Der IP-Block muss mindestens 2 nutzbare IPs oder mehr haben, damit dies möglich ist.
+Dieses Setup ermöglicht es Ihnen, IPs desselben Blocks auf mehreren Servern zu konfigurieren, vorausgesetzt, dass sich alle diese Server im selben vRack wie der IP-Block befinden. Der IP-Block muss dafür mindestens 2 nutzbare IPs oder mehr haben.
 
 :::
 
@@ -87,9 +87,9 @@ Wählen Sie Ihr vRack aus der Liste aus, um die Liste der berechtigten Dienste a
 
 ### Öffentliche IP-Bandbreite im vRack verwalten
 
-Standardmäßig profitieren Additional IP-Blöcke, die über ein vRack geroutet werden, von einer Standard-Öffentlichbandbreite von 5 Gbps in Europa/Kanada/USA und 100 Mbps in APAC-Regionen. Eine detaillierte Übersicht der Verfügbarkeit finden Sie in den öffentlichen Routing-Optionen auf unserer [vRack-Produktseite](https://www.ovhcloud.com/de/network/vrack/).
+Standardmäßig profitieren Additional IP-Blöcke, die über ein vRack geroutet werden, von einer öffentlichen Standardbandbreite von 5 Gbps in Europa/Kanada/USA und 100 Mbps in APAC-Regionen. Eine detaillierte Übersicht der Verfügbarkeit finden Sie in den öffentlichen Routing-Optionen auf unserer [vRack-Produktseite](https://www.ovhcloud.com/de/network/vrack/).
 
-Mit wachsenden Infrastrukturanforderungen benötigen Nutzer möglicherweise eine größere Bandbreite zur Unterstützung von hochfrequentierten öffentlich ausgerichteten Diensten, für die OVHcloud kostenpflichtige Bandbreitenoptionen bereitstellt. Es ist wichtig zu beachten, dass Bandbreitenoptionen **pro vRack und pro Region** angewendet werden. Da Additional IP-Adressen an eine Region gebunden sind, wirkt sich jede Bandbreitenänderung auf alle IP-Adressen (sowohl IPv4 als auch IPv6) aus, die zum spezifischen vRack in dieser bestimmten Region geroutet werden.
+Mit wachsenden Infrastrukturanforderungen benötigen Nutzer unter Umständen eine größere Bandbreite zur Unterstützung von stark frequentierten, öffentlich ausgerichteten Diensten, wofür OVHcloud kostenpflichtige Bandbreitenoptionen bereitstellt. Bandbreitenoptionen werden **pro vRack und pro Region** angewendet. Da Additional IP-Adressen an eine Region gebunden sind, wirkt sich jede Bandbreitenänderung auf alle IP-Adressen (sowohl IPv4 als auch IPv6) aus, die innerhalb dieser Region zum jeweiligen vRack geroutet werden.
 
 <details>
 
@@ -98,29 +98,29 @@ Mit wachsenden Infrastrukturanforderungen benötigen Nutzer möglicherweise eine
 
 #### Öffentliche Bandbreite bei einer Additional IP-Bestellung auswählen
 
-Die Standard-Öffentlichbandbreite kann geändert werden, wenn Sie einen neuen Additional IP-Block mit einem vRack-Netzwerk als Backend bestellen.
+Sie können die öffentliche Standardbandbreite ändern, wenn Sie einen neuen Additional IP-Block mit einem vRack-Netzwerk als Backend bestellen.
 
 So bestellen Sie einen neuen Additional IP-Block:
 
 - Öffnen Sie den Bereich <code className="action">Network</code> in der linken Seitenleiste.
 - Wählen Sie <code className="action">Öffentliche IP-Adressen</code>.
-- Klicken Sie auf die Schaltfläche <code className="action">IPs bestellen</code> nahe der Oberseite der Seite.
+- Klicken Sie auf die Schaltfläche <code className="action">IPs bestellen</code> am oberen Rand der Seite.
 - Wählen Sie die IP-Version und dann das vRack aus, an das Sie Ihre Additional IP anhängen möchten.
-- Wählen Sie die Region, in der Ihre Additional IP sein soll.
-- Wählen Sie die öffentliche Bandbreite, die Sie für Ihr vRack in dieser spezifischen Region anwenden möchten.
-- Füllen Sie die übrigen Optionen nach Bedarf aus und führen Sie dann Ihre Bestellung durch.
+- Wählen Sie die Region, in der sich Ihre Additional IP befinden soll.
+- Wählen Sie die öffentliche Bandbreite aus, die Sie für Ihr vRack in dieser spezifischen Region anwenden möchten.
+- Füllen Sie die übrigen Optionen nach Bedarf aus und schließen Sie anschließend Ihre Bestellung ab.
 
 </details>
 
 
 <details>
 
-<summary>Von der vRack-Verwaltungsseite</summary>
+<summary>Über die vRack-Verwaltungsseite</summary>
 
 
 #### Öffentliche vRack-Bandbreite auf der Verwaltungsseite ändern
 
-Für Additional IP-Blöcke, die bereits an ein vRack angehängt sind, kann die Bandbreite direkt über die Dienstkonfigurationsseite verwaltet werden.
+Für Additional IP-Blöcke, die bereits an ein vRack angehängt sind, können Sie die Bandbreite direkt über die Dienstkonfigurationsseite verwalten.
 
 So greifen Sie auf die Verwaltungsoberfläche zu:
 
@@ -128,19 +128,19 @@ So greifen Sie auf die Verwaltungsoberfläche zu:
 
 Die Verwaltungsseite ist in zwei Tabs unterteilt:
 
-- **All attached services**: Derzeit leitet es zur klassischen vRack-Verwaltungsseite weiter. In Kürze werden dort alle Produkte (Server, Cloud-Projekte usw.), die derzeit mit dem vRack verknüpft sind, auf neue Weise aufgelistet.
-- **Public IP Routing**: Verwaltet die öffentlichen IP-Routing-Optionen Ihres vRack, einschließlich der öffentlichen Bandbreite.
+- **All attached services**: Derzeit leitet dieser Tab zur klassischen vRack-Verwaltungsseite weiter. Bald werden dort alle Produkte (Server, Cloud-Projekte usw.), die derzeit mit dem vRack verknüpft sind, auf neue Weise aufgelistet.
+- **Public IP routing**: Verwaltet die öffentlichen IP-Routing-Optionen Ihres vRack, einschließlich der öffentlichen Bandbreite.
 
 So ändern Sie die öffentliche Bandbreite:
 
-- Navigieren Sie zum Tab <code className="action">Public IP Routing</code>.
-- Die Oberfläche zeigt individuelle Verwaltungsfenster für jede Region (z. B. `eu-west-par`) an, die mit dem vRack verknüpft ist, und listet alle IP-Adressen auf, die mit dieser spezifischen Region verbunden sind.
+- Navigieren Sie zum Tab <code className="action">Public IP routing</code>.
+- Die Oberfläche zeigt für jede mit dem vRack verknüpfte Region (z. B. `eu-west-par`) ein eigenes Verwaltungsfenster an, das alle dieser spezifischen Region zugeordneten IP-Adressen auflistet.
 - Klicken Sie im Fenster für die betreffende Region auf die Schaltfläche <code className="action">Bandbreite ändern</code>.
-- Wählen Sie die gewünschte Bandbreitenoption im Panel, das auf der rechten Seite erscheint, und klicken Sie dann auf <code className="action">Zur Bestellung</code>, um die Bestellung zu bestätigen.
+- Wählen Sie die gewünschte Bandbreitenoption im Panel aus, das auf der rechten Seite erscheint, und klicken Sie dann auf <code className="action">Zur Bestellung</code>, um die Bestellung zu bestätigen.
 - Nach der Zahlung sollte die ausgewählte Bandbreite nach einigen Minuten für Ihr vRack in der gewählten Region verfügbar sein.
 
 :::info
-Die Gebühren für den ersten Monat werden anteilig auf der Grundlage der verbleibenden Tage berechnet, wobei der volle Tarif im nächsten Abrechnungszyklus gilt.
+Die Gebühren für den ersten Monat werden anteilig auf Grundlage der verbleibenden Tage berechnet, wobei ab dem nächsten Abrechnungszyklus der volle Tarif gilt.
 
 :::
 
@@ -152,7 +152,7 @@ Das ausgewählte Bandbreiten-Upgrade gilt für alle IP-Adressen in dieser Region
 
 ### 3-AZ Failover-Prioritäten verwalten
 
-Einige OVHcloud-Regionen erstrecken sich über drei Availability Zones (AZs), die in physisch unabhängigen Standorten innerhalb derselben Region gehostet werden. Wenn eine solche Region am Public-IP-Routing Ihres vRacks beteiligt ist, wird sie im OVHcloud Kundencenter durch ein **3-AZ**-Badge neben dem Regionsnamen im Tab <code className="action">Public IP Routing</code> gekennzeichnet.
+Einige OVHcloud-Regionen erstrecken sich über drei Availability Zones (AZs), die an physisch unabhängigen Standorten innerhalb derselben Region gehostet werden. Wenn eine solche Region am Public-IP-Routing Ihres vRacks beteiligt ist, wird sie im OVHcloud Kundencenter durch ein **3-AZ**-Badge neben dem Regionsnamen im Tab <code className="action">Public IP routing</code> gekennzeichnet.
 
 :::info
 Wenn eine Region in den 3-AZ-Modus übergegangen ist, während Sie bereits IPs über das vRack in dieser Region geroutet hatten, bleiben diese IPs im 1-AZ-Modus und profitieren nicht automatisch von der 3-AZ-Routing-Konfiguration.
@@ -172,9 +172,9 @@ Um den 3-AZ-Modus für IP-Blöcke zu aktivieren, die in solchen Regionen über d
 
 #### Funktionsweise und Verwaltung der Prioritäten
 
-Wenn ein vRack erstmals mit einer 3-AZ-Region verknüpft wird, weist OVHcloud seinen Availability Zones eine zufällige Prioritätenreihenfolge zu. Die Zonen **Primary**, **Secondary** und **Last resort** werden in dieser Reihenfolge auf der entsprechenden Regionskachel im Tab <code className="action">Public IP Routing</code> innerhalb des Unterabschnitts `3-AZ failover priorities` angezeigt, direkt über der Schaltfläche <code className="action">Konfigurieren</code>.
+Wenn ein vRack erstmals mit einer 3-AZ-Region verknüpft wird, weist OVHcloud dessen Availability Zones eine zufällige Prioritätenreihenfolge zu. Die Zonen **Primary**, **Secondary** und **Last resort** werden in dieser Reihenfolge auf der entsprechenden Regionskachel im Tab <code className="action">Public IP routing</code> innerhalb des Unterabschnitts `3-AZ failover priorities` angezeigt, direkt über der Schaltfläche <code className="action">Konfigurieren</code>.
 
-Sie können diese zufällige Zuweisung jederzeit überschreiben, beispielsweise um die Failover-Prioritäten am AZ-Layout der weiteren mit Ihrer Infrastruktur verbundenen Komponenten auszurichten.
+Sie können diese zufällige Zuweisung jederzeit überschreiben, beispielsweise um die Failover-Prioritäten am AZ-Layout weiterer mit Ihrer Infrastruktur verbundener Komponenten auszurichten.
 
 <details>
 
@@ -186,13 +186,13 @@ So passen Sie die Failover-Prioritäten einer 3-AZ-Region an:
 - Öffnen Sie <code className="action">Network</code> in der linken Seitenleiste Ihres Kundencenters.
 - Wählen Sie <code className="action">Privates vRack Netzwerk</code> aus.
 - Klicken Sie in der Spalte "Public IP & bandwidth" auf die Schaltfläche <code className="action">Verwalten</code> für das entsprechende vRack.
-- Öffnen Sie den Tab <code className="action">Public IP Routing</code>.
-- Suchen Sie die Kachel der 3-AZ-Region, die Sie konfigurieren möchten, anschließend den Unterabschnitt `3-AZ failover priorities`, und klicken Sie auf <code className="action">Konfigurieren</code>.
-- Weisen Sie im erscheinenden Panel jede Availability Zone einem der drei Slots zu: **Primary Zone**, **Secondary Zone** und **Last resort Zone**.
+- Öffnen Sie den Tab <code className="action">Public IP routing</code>.
+- Suchen Sie die Kachel der 3-AZ-Region, die Sie konfigurieren möchten, dann den Unterabschnitt `3-AZ failover priorities`, und klicken Sie auf <code className="action">Konfigurieren</code>.
+- Weisen Sie im daraufhin geöffneten Panel jede Availability Zone einem der drei Slots zu: **Primary Zone**, **Secondary Zone** und **Last resort Zone**.
 - Bestätigen Sie Ihre Auswahl.
 
 :::info
-Prioritätsänderungen gelten für alle Additional-IP-Blöcke, die für das ausgewählte vRack in die entsprechende 3-AZ-Region geroutet werden, unabhängig von ihrer IP-Version.
+Prioritätsänderungen gelten unabhängig von ihrer IP-Version für alle Additional IP-Blöcke, die für das ausgewählte vRack in die entsprechende 3-AZ-Region geroutet werden.
 
 :::
 
@@ -202,11 +202,11 @@ Prioritätsänderungen gelten für alle Additional-IP-Blöcke, die für das ausg
 
 ### Eine nutzbare IP-Adresse konfigurieren
 
-Für vRack-Zwecke sind die erste, vorletzte und letzte Adresse in einem IP-Block immer für die Netzwerkadresse, das Netzwerk-Gateway und den Netzwerk-Broadcast reserviert. Das bedeutet, dass die erste nutzbare Adresse die zweite Adresse im Block ist, wie unten gezeigt:
+Für vRack-Zwecke sind die erste, vorletzte und letzte Adresse eines jeden IP-Blocks immer für die Netzwerkadresse, das Netzwerk-Gateway und den Netzwerk-Broadcast reserviert. Das bedeutet, dass die erste nutzbare Adresse die zweite Adresse im Block ist, wie unten gezeigt:
 
 ```sh
-46.105.135.96   # Reserviert: Netzwerkadresse
-46.105.135.97   # Erste nutzbare IP
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,12 +218,12 @@ Für vRack-Zwecke sind die erste, vorletzte und letzte Adresse in einem IP-Block
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109  # Letzte nutzbare IP
-46.105.135.110  # Reserviert: Netzwerk-Gateway
-46.105.135.111  # Reserviert: Netzwerk-Broadcast
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Um die erste nutzbare IP-Adresse zu konfigurieren, müssen wir die Netzwerkkonfigurationsdatei bearbeiten, wie unten gezeigt. In diesem Beispiel müssen wir eine Subnetzmaske von *255.255.255.240* verwenden.
+Um die erste nutzbare IP-Adresse zu konfigurieren, müssen wir die Netzwerkkonfigurationsdatei wie unten gezeigt bearbeiten. In diesem Beispiel müssen wir eine Subnetzmaske von **255.255.255.240** verwenden.
 
 :::info
 Die in unserem Beispiel verwendete Subnetzmaske ist für unseren IP-Block geeignet. Ihre Subnetzmaske kann je nach Größe Ihres Blocks abweichen. Beim Kauf Ihres IP-Blocks erhalten Sie eine E-Mail, die Ihnen mitteilt, welche Subnetzmaske Sie verwenden müssen.
@@ -233,66 +233,12 @@ Die in unserem Beispiel verwendete Subnetzmaske ist für unseren IP-Block geeign
 
 ### Das Paket `iproute2` herunterladen
 
-```sh
-/etc/network/interfaces
+Laden Sie vor Beginn **iproute2** herunter und installieren Sie es. Dabei handelt es sich um ein Paket zur manuellen Konfiguration des IP-Routings. Dieses Paket ist möglicherweise bereits auf Ihrem Server verfügbar — ist dies der Fall, überspringen Sie diesen Schritt und fahren Sie mit dem nächsten fort.
 
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-### Eine neue IP-Routing-Tabelle erstellen
-
-Zunächst müssen wir iproute2 herunterladen und installieren, ein Paket, das es uns ermöglicht, das IP-Routing auf dem Server manuell zu konfigurieren.
-
-Stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie den folgenden Befehl über die Befehlszeile aus. Damit wird iproute2 heruntergeladen und installiert.
+Stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie den folgenden Befehl über die Befehlszeile aus. Dadurch werden iproute2 heruntergeladen und installiert.
 
 ```sh
-# apt-get install iproute2
-```
-
-Als nächstes müssen wir eine neue IP-Route für das vRack erstellen. Wir fügen eine neue Verkehrsregel hinzu, indem wir die Datei wie folgt ergänzen:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reservierte Werte
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# lokal
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Die Netzwerkkonfigurationsdatei anpassen
-
-:::info
-Als Beispiel befindet sich die Netzwerkkonfigurationsdatei, auf die wir verweisen, unter /etc/network/interfaces. Die entsprechende Datei auf Ihrem Server kann sich je nach Betriebssystem an einem anderen Ort befinden.
-
-:::
-
-
-Schließlich müssen wir die Netzwerkkonfigurationsdatei anpassen, um die neue Verkehrsregel zu berücksichtigen und den vRack-Verkehr über die Netzwerk-Gateway-Adresse **46.105.135.110** zu routen.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -301,98 +247,13 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Die Datei für die sekundäre Netzwerkschnittstelle erstellen
-
-Zunächst können wir die Konfiguration der primären Netzwerkschnittstelle kopieren und nach unseren Bedürfnissen anpassen:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Dann öffnen wir die neue Datei:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Und wir definieren die IP-Einstellungen:
-```sh
-# Automatisch beim Instanzstart durch cloud-init erstellt, nicht bearbeiten.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Eine neue IP-Routing-Tabelle erstellen
-
-Als nächstes müssen wir eine neue IP-Route für das vRack erstellen. Wir fügen eine neue Verkehrsregel hinzu, indem wir die Datei wie folgt ergänzen:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reservierte Werte
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# lokal
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Als nächstes erstellen wir die Datei, die zum Anwenden der neuen Regeln benötigt wird:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-Und fügen den folgenden Inhalt ein (denken Sie daran, unsere Variablen durch Ihre eigenen Werte zu ersetzen):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Die Netzwerkkonfigurationsdatei anpassen
-
-Schließlich müssen wir die Netzwerkkonfigurationsdatei anpassen, um die neue Verkehrsregel zu berücksichtigen und den vRack-Verkehr über die Netzwerk-Gateway-Adresse **46.105.135.110** zu routen.
-
-Dazu bearbeiten wir die folgende Datei, um persistente und statische Routen hinzuzufügen:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Stellen Sie eine SSH-Verbindung zu Ihrem Server her und führen Sie den folgenden Befehl aus, um iproute2 herunterzuladen und zu installieren:
-
-```sh
-sudo apt-get install iproute2
-```
-
-Starten Sie nun Ihren Server neu, um die Änderungen zu übernehmen, oder aktivieren Sie alternativ einfach die neue Netzwerkschnittstelle:
-
-```sh
-ip link set eth1 up
-```
-
 #### GNU/Linux-Konfigurationen
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux und Rocky Linux (8/9)">
+<Tab label="AlmaLinux und Rocky Linux (8/9)">
 **Die Datei für die sekundäre Netzwerkschnittstelle erstellen**
 
-Kopieren Sie die Konfiguration der primären Netzwerkschnittstelle und passen Sie sie nach Bedarf an:
+Kopieren Sie zunächst die Konfiguration der primären Netzwerkschnittstelle und passen Sie sie nach Bedarf an:
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
@@ -423,7 +284,7 @@ ARP=yes
 
 **Eine neue IP-Routing-Tabelle erstellen**
 
-Erstellen Sie als Nächstes eine neue IP-Route für das vRack. Fügen Sie eine neue Verkehrsregel hinzu, indem Sie die Datei wie folgt ergänzen:
+Als Nächstes müssen wir eine neue IP-Route für das vRack erstellen. Wir fügen eine neue Verkehrsregel hinzu, indem wir die Datei wie folgt ergänzen:
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -441,13 +302,13 @@ sudo nano /etc/iproute2/rt_tables
 1 vrack
 ```
 
-Erstellen Sie dann die Datei, die zum Anwenden der neuen Regeln benötigt wird:
+Erstellen Sie als Nächstes die Datei, die zum Anwenden der neuen Regeln benötigt wird:
 
 ```sh
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Fügen Sie den folgenden Inhalt ein (denken Sie daran, die Variablen durch Ihre eigenen Werte zu ersetzen):
+Und fügen Sie den folgenden Inhalt ein (denken Sie daran, unsere Variablen durch Ihre eigenen Werte zu ersetzen):
 
 ```sh
 from 46.105.135.96/28 table vrack
@@ -456,7 +317,7 @@ to 46.105.135.96/28 table vrack
 
 **Die Netzwerkkonfigurationsdatei anpassen**
 
-Passen Sie abschließend die Netzwerkkonfigurationsdatei an, um die neue Verkehrsregel zu berücksichtigen und den vRack-Verkehr über die Netzwerk-Gateway-Adresse **46.105.135.110** zu routen.
+Abschließend müssen wir die Netzwerkkonfigurationsdatei anpassen, um die neue Verkehrsregel zu berücksichtigen und den vRack-Verkehr über die Netzwerk-Gateway-Adresse **46.105.135.110** zu routen.
 
 Bearbeiten Sie die folgende Datei, um persistente und statische Routen hinzuzufügen:
 
@@ -464,51 +325,64 @@ Bearbeiten Sie die folgende Datei, um persistente und statische Routen hinzuzuf�
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Fügen Sie den folgenden Inhalt ein (denken Sie daran, die Variablen durch Ihre eigenen Werte zu ersetzen):
+Fügen Sie den folgenden Inhalt ein (denken Sie daran, unsere Variablen durch Ihre eigenen Werte zu ersetzen):
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Starten Sie den Server neu, um die Änderungen zu übernehmen, oder aktivieren Sie einfach die neue Netzwerkschnittstelle:
+Starten Sie nun Ihren Server neu, um die Änderungen zu übernehmen, oder aktivieren Sie einfach die neue Netzwerkschnittstelle:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="Ubuntu und Debian 12+">
+<Tab label="Ubuntu & Debian 12+">
+
 - Additional IP konfigurieren
 
-Öffnen Sie die Netzwerkkonfigurationsdatei in `/etc/netplan` mit einem Texteditor Ihrer Wahl. Hier heißt die Datei `50-cloud-init.yaml`.
+Öffnen Sie mit einem Texteditor Ihrer Wahl die Netzwerkkonfigurationsdatei unter `/etc/netplan`. Hier heißt die Datei `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Definieren Sie die IP-Einstellungen mit den folgenden Variablen:
+- Definieren Sie die IP-Einstellungen mit den folgenden Variablen und fügen Sie diese zu Ihrer bestehenden Konfiguration hinzu:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Standardmäßig verwendet der für Ihre Additional IP bestimmte Datenverkehr möglicherweise nicht die vRack-Schnittstelle für den Rückweg. Dies kann zu asymmetrischem Routing führen, wodurch manche Netzwerke den Datenverkehr ablehnen könnten. Die Route `table: 1` sorgt in Kombination mit der unten stehenden Regel `routing-policy` dafür, dass Antworten von der Additional IP über die vRack-Schnittstelle zurückgeroutet werden. Die ID `1` wird hier verwendet, um mit den anderen Tabs dieser Anleitung übereinzustimmen; Sie können auch eine beliebige andere Zahl verwenden, solange Sie sie konsistent einsetzen.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Beispiel**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
 Wenden Sie die Konfiguration mit dem folgenden Befehl an:
@@ -518,7 +392,7 @@ sudo netplan apply
 ```
 </Tab>
 <Tab label="Fedora 43+, AlmaLinux und Rocky Linux (10)">
-Überprüfen Sie zunächst, dass Ihre vRack-Schnittstelle den Status `connected` oder `connecting` hat. In unserem Beispiel heißt die Schnittstelle `eno2`.
+Überprüfen Sie zunächst den Namen Ihrer vRack-Schnittstelle. In unserem Beispiel heißt die Schnittstelle `eno2`:
 
 ```sh
 nmcli device status
@@ -526,14 +400,15 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Ermitteln Sie dann den Namen der Konfigurationsdatei in `/etc/NetworkManager/system-connections`. Hier heißt die Datei `vRack.nmconnection`.
+Wenn Ihre vRack-Schnittstelle bereits den Status `connected` oder `connecting` hat, können Sie mit dem Hinzufügen der IP fortfahren.
+
+In unserem Beispiel lautet der Status `disconnected`, daher erstellen wir sie mit dem folgenden Befehl. Wir haben sie `vRack` genannt, um sie von den anderen Schnittstellen zu unterscheiden.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
 Konfigurieren Sie Ihre Additional IP mithilfe des `nmcli`-Handlers. Ersetzen Sie `vRack` und andere Parameter durch Ihre eigenen Werte.
@@ -541,64 +416,71 @@ Konfigurieren Sie Ihre Additional IP mithilfe des `nmcli`-Handlers. Ersetzen Sie
 - IP hinzufügen
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Gateway hinzufügen
+- Verhindern, dass die vRack-Verbindung zur Standardroute wird
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
-- Konfiguration von **auto** auf **manual** ändern:
+- Ändern Sie die Konfiguration von **auto** auf **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Konfiguration persistent machen
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Eine neue IP-Routing-Tabelle erstellen**
+:::info
+Standardmäßig verwendet der für Ihre vRack-IP bestimmte Datenverkehr möglicherweise nicht die vRack-Schnittstelle für den Rückweg. Dies kann zu asymmetrischem Routing führen, wodurch manche Netzwerke den Datenverkehr ablehnen könnten. Die folgenden Schritte konfigurieren eine separate Routing-Tabelle für den vRack-Datenverkehr und stellen sicher, dass Antworten von der vRack-IP über die vRack-Schnittstelle zurückgeroutet werden.
+:::
 
-Erstellen Sie als Nächstes eine neue IP-Route für das vRack. Fügen Sie eine neue Verkehrsregel (`1 vrack`) hinzu, indem Sie die Datei wie folgt ergänzen:
+- vRack-Routing-Tabelle erstellen
 
+In unserem Beispiel verwenden wir 1 als ID, Sie können aber auch eine beliebige andere Zahl verwenden. Die folgenden Befehle referenzieren die Tabelle über ihre ID (`table=1`); der Name `vrack` dient lediglich der besseren Lesbarkeit, zum Beispiel bei `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Route hinzufügen
+- Datenverkehr dieser Verbindung über die vRack-Tabelle routen
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Route über das Gateway hinzufügen
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 In unserem Beispiel
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Starten Sie Ihr Netzwerk mit folgendem Befehl neu:
+- Regel hinzufügen, damit der vRack-Verkehr diese Tabelle verwendet
+
+Dieser Schritt weist Ihren Server erst tatsächlich an, Tabelle 1 für alles zu verwenden, was von Ihrer vRack-IP gesendet wird. Ohne ihn würden die soeben hinzugefügten Routen ignoriert.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Wenden Sie die Änderungen an:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>
@@ -608,7 +490,7 @@ sudo systemctl restart NetworkManager
 
 #### Schritt 1: Die sekundäre Netzwerkschnittstelle prüfen und konfigurieren
 
-Prüfen Sie die Informationen der neuen Netzwerkschnittstelle:
+Prüfen Sie zunächst die Informationen der neuen Netzwerkschnittstelle:
 
 <img className="thumbnail" alt="Prüfung der sekundären Netzwerkschnittstelle" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
 
@@ -634,13 +516,13 @@ Deaktivieren Sie zunächst die Schnittstelle.
 
 <img className="thumbnail" alt="Netzwerk deaktivieren" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-6.png" loading="lazy" />
 
-Aktivieren Sie sie dann wieder.
+Aktivieren Sie sie anschließend wieder.
 
 <img className="thumbnail" alt="Netzwerk aktivieren" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-7.png" loading="lazy" />
 
 ### Fehlersuche
 
-Wenn Sie keine Verbindung von Ihrer VM oder Ihrem Server zum privaten Netzwerk herstellen können, erstellen Sie ein Support-Ticket über Ihr Kundencenter mit folgenden Angaben:
+Wenn Sie keine Verbindung von Ihrer VM oder Ihrem Server zum privaten Netzwerk herstellen können, senden Sie uns bitte ein Ticket über Ihr Kundencenter mit folgenden Angaben:
 
 - Quell-IP und Ziel-IP
 - Ergebnis von `ifconfig -a` oder `ipconfig /all` auf beiden Servern oder VMs (Netzwerkkonfiguration)

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -241,145 +241,16 @@ Establish an SSH connection to your server and run the following command from th
 # apt-get install iproute2
 ```
 
-Next, we need to create a new IP route for the vRack. We'll be adding a new traffic rule by amending the file, as shown below:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Amend the network configuration file
-
-:::info
-For example purposes, the network configuration file we refer to is located in /etc/network/interfaces. The equivalent file on your server may be located somewhere else, depending on your operating system.
-
-:::
-
-
-Finally, we need to amend the network configuration file to account for the new traffic rule and route the vRack traffic through the network gateway address of **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
-```
-
 **Fedora**
 
 ```sh
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Create the file for the secondary network interface
-
-First we can copy and use the configuration being used for the primary network interface and adjust it as per our needs:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Then we access to the new file:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-And we define the IP settings:
-```sh
-# Created by cloud-init on instance boot automatically, do not edit.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Create a new IP routing table
-
-Next, we need to create a new IP route for the vRack. We'll be adding a new traffic rule by amending the file, as shown below:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Next, create the  file needed to apply the new rules:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-And paste the following content (please remember to replace our variables with your own values):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Amend the network configuration file
-
-Finally, we need to amend the network configuration file to account for the new traffic rule and route the vRack traffic through the network gateway address of **46.105.135.110**.
-
-We can achieve it by editing the following file in order to add persistent and static routes:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Paste the following content (please remember to replace our variables with your own values):
-
-```sh
-46.105.135.96/28 dev eth1 table vrack
-default via 46.105.135.110 dev eth1 table vrack
-```
-
-Now reboot your server to apply the changes or alternatively enable simply the new network interface:
-
-```sh
-ip link set eth1 up
-```
-
 #### GNU/Linux configurations
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux and Rocky Linux (8/9)">
+<Tab label="AlmaLinux and Rocky Linux (8/9)">
 **Create the file for the secondary network interface**
 
 First, copy the primary network interface configuration and adjust it as needed:
@@ -477,28 +348,40 @@ Using a text editor of your choice, open the network configuration file located 
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Define the IP settings with the following variables:
+- Define the IP settings with the following variables and add them to your existing configuration:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+By default, traffic destined for your Additional IP may not use the vRack interface for the return path. This can cause asymmetric routing, and some networks may reject the traffic. The `table: 1` route combined with the `routing-policy` rule below ensures that responses from the Additional IP are routed back through the vRack interface. The ID `1` is used here to match the other tabs in this guide; feel free to use any number of your choice, as long as it's used consistently.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Example**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
 Apply the configuration with the following command:
@@ -508,7 +391,7 @@ sudo netplan apply
 ```
 </Tab>
 <Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
-First, verify that your vRack interface is `connected` or `connecting` state. In our example, the interface is called `eno2`.
+First, verify the name of your vRack interface. In our example, the interface is called `eno2`:
 
 ```sh
 nmcli device status
@@ -516,14 +399,15 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Next, retrieve the name of the configuration file located in `/etc/NetworkManager/system-connections` for editing. Here the file is called `vRack.nmconnection`.
+If your vRack interface is already `connected` or in `connecting` state, you can proceed with adding the IP.
+
+In our example, the state is `disconnected`, so we create it with the following command. We named it `vRack` but feel free to use any name of your choice:
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
 Using the `nmcli` handler, configure your Additional IP. Replace `vRack` and other parameters with your own values.
@@ -531,13 +415,13 @@ Using the `nmcli` handler, configure your Additional IP. Replace `vRack` and oth
 - Add the IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack IPv4.addresses 46.105.135.97/28
 ```
 
-- Add the Gateway
+- Set the vRack to not be the default route
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
 - Change the configuration from **auto** to **manual**:
@@ -549,46 +433,53 @@ sudo nmcli connection modify vRack IPv4.method manual
 - Make the configuration persistent
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Create a new IP routing table**
+:::info
+By default, traffic destined for your vRack IP may not use the vRack interface for the return path. This can cause asymmetric routing, and some networks may reject the traffic. The steps below configure a separate routing table for vRack traffic, ensuring that responses from the vRack IP are routed back through the vRack interface.
+:::
 
-Next, we need to create a new IP route for the vRack. We'll be adding a new traffic rule (`1 vrack`) by amending the file, as shown below:
+- Create the vRack routing table
 
+In our example, we use 1 as the ID but feel free to use any number of your choice. The commands below reference the table by its ID (`table=1`); the name `vrack` is just so you can read it more easily later, for example with `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Add the route
+- Set the connection for the configured IP to pass through the vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Add the route through the gateway
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 In our example
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Restart your network with the following command:
+- Add a rule so vRack traffic uses this table
+
+This is the step that actually tells your server to use table 1 for anything sent from your vRack IP. Without it, the routes you just added would be ignored.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Apply the changes:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>

--- a/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/en/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring an Additional IP block in a vRack
-description: This guide will show you how to configure a block of public IP addresses for use with the vRack.
-lastUpdated: 2026-09-08
+description: This guide will show you how to configure a block of public IP addresses for use with the vRack
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -21,7 +21,7 @@ vRack supports both IPv4 and IPv6 public routing with Additional IP address bloc
 
 
 :::info
-This article is focusing on Additional IP configuration over a vRack network. If you look for guidance on Additional IP configuration together with primary IP (on public network interface), read the following articles:
+This article focuses on Additional IP configuration over a vRack network. If you are looking for guidance on Additional IP configuration together with primary IP (on public network interface), read the following articles:
 
 - IPv4:
     - [Configuring IP aliasing on dedicated servers](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
@@ -66,7 +66,7 @@ Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for 
 :::info
 For example purposes we'll be using an IP block of 46.105.135.96/28 and eth1 for the secondary network interface, which is dedicated to the vRack.
 
-Also for example purposes, the network configuration file we refer to is located in `/etc/network/interfaces`. The equivalent file on your server may be located somewhere else, depending on your operating system. The file content may also be different. If you encounter any difficulties, please refer to the official documentation for your distribution.
+The network configuration file we refer to is located in `/etc/network/interfaces`. The equivalent file on your server may be located somewhere else, depending on your operating system. The file content may also be different. If you encounter any difficulties, please refer to the official documentation for your distribution.
 
 :::
 
@@ -87,9 +87,9 @@ Select your vRack from the list to display the list of eligible services. Click 
 
 ### Managing public IP bandwidth on vRack
 
-By default, Additional IP blocks routed via a vRack benefit from a standard public bandwidth of 5 Gbps in Europe/Canada/US and 100 Mbps in APAC regions. For a detailed overview of availability, please refer to public routing options on our [vRack product page](https://www.ovhcloud.com/en-gb/network/vrack/). 
+By default, Additional IP blocks routed via a vRack benefit from a standard public bandwidth of 5 Gbps in Europe/Canada/US and 100 Mbps in APAC regions. For a detailed overview of availability, see the public routing options on our [vRack product page](https://www.ovhcloud.com/en-gb/network/vrack/). 
 
-As infrastructure requirements scale, users may require broader bandwidth to support high-traffic public-oriented services, for which OVHcloud provides paid bandwidth options. It is important to note that bandwidth options are applied **per-vRack and per-region**. Since Additional IP addresses are tied to a region, any bandwidth modification will affect all IP addresses (both IPv4 and IPv6) routed to the specific vRack within that particular region.
+As infrastructure requirements scale, users may require broader bandwidth to support high-traffic public-oriented services, for which OVHcloud provides paid bandwidth options. Bandwidth options are applied **per-vRack and per-region**. Since Additional IP addresses are tied to a region, any bandwidth modification will affect all IP addresses (both IPv4 and IPv6) routed to the specific vRack within that region.
 
 <details>
 
@@ -98,7 +98,7 @@ As infrastructure requirements scale, users may require broader bandwidth to sup
 
 #### Choosing public bandwidth during an Additional IP order
 
-The default public bandwidth can be changed when ordering a new Additional IP block with a vRack network as the backend.
+You can change the default public bandwidth when ordering a new Additional IP block with a vRack network as the backend.
 
 To order a new Additional IP block:
 
@@ -120,7 +120,7 @@ To order a new Additional IP block:
 
 #### Modifying vRack public bandwidth on management page
 
-For Additional IP blocks already attached to a vRack, bandwidth can be managed directly through the service configuration page.
+For Additional IP blocks already attached to a vRack, you can manage bandwidth directly through the service configuration page.
 
 To access the management interface:
 
@@ -202,7 +202,7 @@ Priority changes apply to all Additional IP blocks routed to the corresponding 3
 
 ### Configure a usable IP address
 
-For vRack purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first useable address is the second address in the block, as shown below:
+For vRack purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```sh
 46.105.135.96   Reserved: Network address
@@ -238,7 +238,7 @@ Before you begin, download and install **iproute2**, a package for manual IP rou
 Establish an SSH connection to your server and run the following command from the command line. This will download and install iproute2.
 
 ```sh
-# apt-get install iproute2
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -332,13 +332,14 @@ Paste the following content (please remember to replace our variables with your 
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Now reboot your server to apply the changes or alternatively simply enable the new network interface:
+Now reboot your server to apply the changes, or simply enable the new network interface:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
 <Tab label="Ubuntu & Debian 12+">
+
 - Configure the Additional IP
 
 Using a text editor of your choice, open the network configuration file located in `/etc/netplan` for editing. Here the file is called `50-cloud-init.yaml`.
@@ -404,7 +405,7 @@ eno2             ethernet  disconnected            --
 
 If your vRack interface is already `connected` or in `connecting` state, you can proceed with adding the IP.
 
-In our example, the state is `disconnected`, so we create it with the following command. We named it `vRack` but feel free to use any name of your choice:
+In our example, the state is `disconnected`, so we create it with the following command. We named it `vRack` to distinguish it from the other interfaces.
 
 ```sh
 sudo nmcli connection add type ethernet ifname eno2 con-name vRack
@@ -415,10 +416,10 @@ Using the `nmcli` handler, configure your Additional IP. Replace `vRack` and oth
 - Add the IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.addresses 46.105.135.97/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Set the vRack to not be the default route
+- Prevent the vRack connection from becoming the default route
 
 ```sh
 sudo nmcli connection modify vRack ipv4.never-default yes
@@ -427,7 +428,7 @@ sudo nmcli connection modify vRack ipv4.never-default yes
 - Change the configuration from **auto** to **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Make the configuration persistent
@@ -449,7 +450,7 @@ echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Set the connection for the configured IP to pass through the vRack
+- Route this connection's traffic through the vRack table
 
 ```sh
 sudo nmcli connection modify vRack ipv4.route-table 1

--- a/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/es/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
-title: Configurar un bloque de Additional IP en un vRack
-description: Descubra cómo configurar un bloque de direcciones IP públicas en el vRack.
-lastUpdated: 2026-09-08
+title: Configurar un bloque Additional IP en un vRack
+description: "Descubra cómo configurar un bloque de direcciones IP públicas para su uso con el vRack"
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -15,22 +15,22 @@ Además del direccionamiento IP privado, el [vRack](https://www.ovhcloud.com/es-
 **Esta guía le muestra cómo configurar un bloque de direcciones IP públicas para su uso con el vRack.**
 
 :::info
-El vRack admite tanto el enrutamiento público IPv4 como IPv6 con bloques de direcciones Additional IP. Puede encontrar las instrucciones sobre cómo configurar bloques IPv6 en esta guía: "[Configurar un bloque IPv6 en un vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)".
+El vRack admite tanto el enrutamiento público IPv4 como IPv6 con bloques de direcciones Additional IP. Puede encontrar las instrucciones sobre cómo configurar bloques IPv6 en esta guía: «[Configurar un bloque Additional IPv6 en un vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)».
 
 :::
 
 
 :::info
-Este artículo se centra en la configuración de Additional IP sobre una red vRack. Si busca orientación sobre la configuración de Additional IP junto con la IP primaria (en la interfaz de red pública), consulte los siguientes artículos:
+Este artículo detalla la configuración de direcciones Additional IP en una red vRack. Si busca instrucciones sobre la configuración de direcciones Additional IP con una dirección IP principal (en la interfaz de red pública), consulte los siguientes artículos:
 
 - IPv4:
-    - [Configurar el aliasing de IP en servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
-    - [Configurar el aliasing de IP en un VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
+    - [Configurar una dirección IP en alias en un servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
+    - [Configurar una dirección IP en alias en un servidor VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
 
 - IPv6:
-    - [Configurar IPv6 en servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
-    - [Configurar IPv6 en un VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
-    - [Configurar IPv6 en una instancia de Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
+    - [Configurar IPv6 en un servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
+    - [Configurar IPv6 en un servidor VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
+    - [Configurar IPv6 en una instancia Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
 
 :::
 
@@ -54,7 +54,7 @@ Este artículo se centra en la configuración de Additional IP sobre una red vRa
 {/* CP-NAV-END:network-vrack */}
 
 :::warning
-Es posible que esta funcionalidad no esté disponible o esté limitada en los [servidores dedicados de la línea de productos **Eco**](https://eco.ovhcloud.com/es-es/about/).
+Es posible que esta funcionalidad no esté disponible o esté limitada en los servidores de la [línea de productos **Eco**](https://eco.ovhcloud.com/es-es/about/).
 
 Para más información, visite nuestra [página de comparación](https://eco.ovhcloud.com/es-es/compare/).
 
@@ -64,9 +64,9 @@ Para más información, visite nuestra [página de comparación](https://eco.ovh
 ## Procedimiento
 
 :::info
-A modo de ejemplo, utilizaremos un bloque de IP de 46.105.135.96/28 y eth1 para la interfaz de red secundaria, que está dedicada al vRack.
+A modo de ejemplo, utilizaremos un bloque de IP de 46.105.135.96/28 y `eth1` para la interfaz de red secundaria, dedicada al vRack.
 
-También a modo de ejemplo, el archivo de configuración de red al que hacemos referencia se encuentra en `/etc/network/interfaces`. El archivo equivalente en su servidor puede estar ubicado en otro lugar, dependiendo de su sistema operativo. El contenido del archivo también puede ser diferente. Si tiene alguna dificultad, consulte la documentación oficial de su distribución.
+El archivo de configuración de red al que hacemos referencia se encuentra en `/etc/network/interfaces`. El archivo equivalente en su servidor puede estar ubicado en otro lugar, dependiendo de su sistema operativo. El contenido del archivo también puede ser diferente. Si tiene alguna dificultad, consulte la documentación oficial de su distribución.
 
 :::
 
@@ -76,39 +76,39 @@ También a modo de ejemplo, el archivo de configuración de red al que hacemos r
 :::warning
 Una vez que se añade un bloque de IP al vRack, ya no está asociado a un servidor físico.
 
-Esta configuración le permite configurar IPs del mismo bloque en varios servidores, siempre que todos estos servidores estén en el mismo vRack que el bloque de IP. El bloque de IP debe tener al menos 2 IPs utilizables o más para que esto sea posible.
+Esta configuración permite configurar IPs de un mismo bloque en varios servidores, siempre que todos estos servidores estén en el mismo vRack que el bloque de IP. El bloque de IP debe disponer de al menos 2 IPs utilizables para que esto sea posible.
 
 :::
 
 
-Seleccione su vRack de la lista para mostrar la lista de servicios elegibles. Haga clic en el bloque de IP que desea añadir al vRack y luego haga clic en el botón <code className="action">Añadir</code>.
+Seleccione su vRack en la lista para mostrar la lista de servicios elegibles. Haga clic en el bloque de IP que desea añadir al vRack y, a continuación, haga clic en el botón <code className="action">Añadir</code>.
 
 <img className="thumbnail" alt="Añadir un bloque de IP al vRack" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/addIPblock.png" loading="lazy" />
 
-### Gestionar el ancho de banda de IP pública en el vRack
+### Gestionar el ancho de banda de las IP públicas en el vRack
 
-De forma predeterminada, los bloques de Additional IP enrutados a través de un vRack se benefician de un ancho de banda público estándar de 5 Gbps en Europa y América del Norte, o de 100 Mbps en las regiones APAC. Para más detalles sobre las opciones disponibles, consulte las opciones de enrutamiento público en nuestra [página del producto vRack](https://www.ovhcloud.com/es-es/network/vrack/).
+De forma predeterminada, los bloques de Additional IP enrutados a través de un vRack se benefician de un ancho de banda público estándar de 5 Gbps en Europa, Canadá y Estados Unidos, y de 100 Mbps en las regiones APAC. Para obtener una visión detallada de la disponibilidad, consulte las opciones de enrutamiento público en nuestra [página del producto vRack](https://www.ovhcloud.com/es-es/network/vrack/).
 
-Para responder a las crecientes necesidades de las infraestructuras y a los requisitos de los servicios de alto tráfico, OVHcloud ofrece ahora a sus clientes opciones de ancho de banda de pago. Tenga en cuenta que estas opciones se aplican **por vRack y por región**. Dado que las direcciones Additional IP están vinculadas a una región precisa, cualquier modificación del ancho de banda afectará al conjunto de las direcciones (IPv4 e IPv6) enrutadas a ese vRack en la región correspondiente.
+A medida que aumentan las necesidades de infraestructura, algunos usuarios pueden necesitar un ancho de banda mayor para dar soporte a servicios públicos de alto tráfico, para lo cual OVHcloud ofrece opciones de ancho de banda de pago. Estas opciones se aplican **por vRack y por región**. Dado que las direcciones Additional IP están vinculadas a una región, cualquier modificación del ancho de banda afectará a todas las direcciones IP (IPv4 e IPv6) enrutadas hacia ese vRack dentro de esa región.
 
 <details>
 
-<summary>Durante el proceso de pedido de Additional IP</summary>
+<summary>Al pedir una Additional IP</summary>
 
 
-#### Elegir el ancho de banda público durante el pedido
+#### Elegir el ancho de banda público al pedir una Additional IP
 
-Puede modificar el ancho de banda predeterminado al pedir un nuevo bloque de Additional IP, siempre que se seleccione una red vRack como servicio backend.
+Puede modificar el ancho de banda público predeterminado al pedir un nuevo bloque de Additional IP con una red vRack como servicio backend.
 
 Para pedir un nuevo bloque de Additional IP:
 
-- En la barra lateral izquierda, acceda a la sección <code className="action">Network</code>.
-- Seleccione <code className="action">Direcciones IP públicas</code>.
-- Haga clic en el botón <code className="action">Pedir IPs</code> en la parte superior de la página.
-- Elija la versión de IP y, a continuación, el vRack al que se asociará la Additional IP.
-- Seleccione la región de su Additional IP.
-- Elija el ancho de banda público que desea aplicar a su vRack para esa región.
-- Configure las demás opciones según sus necesidades y, a continuación, finalice el pedido.
+- Abra la sección <code className="action">Network</code> en la barra lateral izquierda.
+- Seleccione <code className="action">Direcciones IP Públicas</code>.
+- Haga clic en el botón <code className="action">Pedir IPs</code>, en la parte superior de la página.
+- Seleccione la versión de la IP y, a continuación, el vRack al que desea asociar su Additional IP.
+- Seleccione la región en la que desea que se encuentre su Additional IP.
+- Elija el ancho de banda público que desea aplicar a su vRack para esa región específica.
+- Complete las demás opciones si es necesario y, a continuación, finalice su pedido.
 
 </details>
 
@@ -118,34 +118,34 @@ Para pedir un nuevo bloque de Additional IP:
 <summary>Desde la página de gestión del vRack</summary>
 
 
-#### Modificar el ancho de banda público desde la página de gestión
+#### Modificar el ancho de banda público del vRack desde la página de gestión
 
-Para los bloques de Additional IP ya asociados a un vRack, el ancho de banda se gestiona directamente desde la página de configuración del servicio.
+Para los bloques de Additional IP ya asociados a un vRack, puede gestionar el ancho de banda directamente desde la página de configuración del servicio.
 
 Para acceder a la interfaz de gestión:
 
 - En la columna "Dirección IP pública y ancho de banda", haga clic en el botón <code className="action">Gestionar</code> correspondiente al vRack deseado.
 
-La interfaz de gestión se divide en dos pestañas:
+La página de gestión está organizada en dos pestañas:
 
-- **All attached services**: Actualmente redirige a la página de gestión clásica del vRack. Próximamente, esta pestaña listará de forma optimizada todos los productos (servidores, proyectos Cloud, etc.) vinculados al vRack.
-- **Conectividad IP pública**: Permite gestionar las opciones de enrutamiento público de su vRack, incluido el ancho de banda.
+- **Todos los servicios asociados**: por el momento, esta pestaña redirige a la página de gestión clásica del vRack. Próximamente, listará de forma optimizada todos los productos (servidores, proyectos Cloud, etc.) actualmente vinculados al vRack.
+- **Conectividad IP pública**: permite gestionar las opciones de enrutamiento público de su vRack, incluido el ancho de banda.
 
-Para modificar el ancho de banda:
+Para modificar el ancho de banda público:
 
-- Vaya a la pestaña <code className="action">Conectividad IP pública</code>.
-- La interfaz muestra ventanas de gestión por región (p. ej., `eu-west-par`) asociadas al vRack, con la lista de las IPs asociadas.
-- En el recuadro de la región correspondiente, haga clic en <code className="action">Modificar ancho de banda</code>.
-- Seleccione la opción deseada en el panel de la derecha y, a continuación, haga clic en <code className="action">Contratar</code> para validar.
-- Una vez realizado el pago, el nuevo ancho de banda estará activo en su vRack en la región elegida después de unos minutos.
+- Acceda a la pestaña <code className="action">Conectividad IP pública</code>.
+- La interfaz muestra ventanas de gestión individuales para cada región (por ejemplo, `eu-west-par`) asociada al vRack, con la lista de todas las direcciones IP asociadas a esa región específica.
+- En la ventana de la región correspondiente, haga clic en el botón <code className="action">Modificar el ancho de banda</code>.
+- Seleccione la opción de ancho de banda deseada en el panel que aparece a la derecha y, a continuación, haga clic en <code className="action">Contratar</code> para validar el pedido.
+- Una vez pagado el pedido, el ancho de banda seleccionado debería estar disponible en su vRack, en la región elegida, transcurridos unos minutos.
 
 :::info
-El primer mes suscrito se factura de forma proporcional a los días restantes. La tarifa completa se aplicará en el siguiente ciclo de facturación.
+Los gastos del primer mes se calculan de forma prorrateada según los días restantes; la tarifa completa se aplicará a partir del siguiente ciclo de facturación.
 
 :::
 
 
-El aumento de ancho de banda se aplicará a todas las direcciones IP de esa región para el vRack seleccionado.
+La actualización de ancho de banda seleccionada se aplicará a todas las direcciones IP de esa región para el vRack elegido.
 
 </details>
 
@@ -174,7 +174,7 @@ Para activar el modo 3-AZ en los bloques de IP enrutados a través del vRack en 
 
 Cuando un vRack se asocia por primera vez a una región 3-AZ, OVHcloud asigna aleatoriamente un orden de prioridad a sus zonas de disponibilidad. Las zonas **principal, secundaria y de último recurso** se muestran en este orden en el recuadro correspondiente a la región dentro de la pestaña <code className="action">Conectividad IP pública</code>, en la subsección `Prioridades de failover 3-AZ`, justo encima del botón <code className="action">Configurar</code>.
 
-Puede modificar esta asignación aleatoria en cualquier momento, por ejemplo, para alinear las prioridades de failover con la disposición AZ de otros componentes asociados a su infraestructura.
+Puede modificar esta asignación en cualquier momento, por ejemplo, para alinear las prioridades de failover con la disposición AZ de otros componentes asociados a su infraestructura.
 
 <details>
 
@@ -183,7 +183,7 @@ Puede modificar esta asignación aleatoria en cualquier momento, por ejemplo, pa
 
 Para ajustar las prioridades de failover de una región 3-AZ:
 
-- En la barra lateral izquierda del área de cliente, acceda a <code className="action">Network</code>.
+- En la barra lateral izquierda de su área de cliente, acceda a <code className="action">Network</code>.
 - Seleccione <code className="action">Red privada vRack</code>.
 - En la columna "Dirección IP pública y ancho de banda", haga clic en el botón <code className="action">Gestionar</code> correspondiente al vRack deseado.
 - Vaya a la pestaña <code className="action">Conectividad IP pública</code>.
@@ -202,11 +202,11 @@ Los cambios de prioridad se aplican a todos los bloques de Additional IP enrutad
 
 ### Configurar una dirección IP utilizable
 
-Para los propósitos del vRack, la primera, penúltima y última dirección de cualquier bloque de IP dado están siempre reservadas para la dirección de red, la puerta de enlace de red y la difusión de red respectivamente. Esto significa que la primera dirección utilizable es la segunda dirección del bloque, como se muestra a continuación:
+En el caso del vRack, la primera, la penúltima y la última dirección de un bloque de IP determinado están siempre reservadas, respectivamente, a la dirección de red, la puerta de enlace de red y la difusión de red. Esto significa que la primera dirección utilizable es la segunda dirección del bloque, como se indica a continuación:
 
 ```sh
-46.105.135.96   # Reservada: Dirección de red
-46.105.135.97   # Primera IP utilizable
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,81 +218,27 @@ Para los propósitos del vRack, la primera, penúltima y última dirección de c
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109  # Última IP utilizable
-46.105.135.110  # Reservada: Puerta de enlace de red
-46.105.135.111  # Reservada: Difusión de red
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Para configurar la primera dirección IP utilizable, necesitamos editar el archivo de configuración de red, como se muestra a continuación. En este ejemplo, necesitamos usar una máscara de subred de *255.255.255.240*.
+Para configurar la primera dirección IP utilizable, debemos editar el archivo de configuración de red, como se indica a continuación. En este ejemplo, debemos utilizar una máscara de subred de **255.255.255.240**.
 
 :::info
-La máscara de subred que hemos utilizado en nuestro ejemplo es apropiada para nuestro bloque de IP. Su máscara de subred puede variar dependiendo del tamaño de su bloque. Cuando compre su bloque de IP, recibirá un correo electrónico que le indicará qué máscara de subred debe usar.
+La máscara de subred utilizada en este ejemplo es adecuada para nuestro bloque de IP. Su máscara de subred puede variar según el tamaño de su bloque. Al comprar su bloque de IP, recibirá un correo electrónico que le indicará qué máscara de subred debe utilizar.
 
 :::
 
 
 ### Descargar el paquete `iproute2`
 
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-### Crear una nueva tabla de enrutamiento IP
-
-En primer lugar, necesitamos descargar e instalar iproute2, que es un paquete que nos permitirá configurar manualmente el enrutamiento IP en el servidor.
+Antes de empezar, descargue e instale **iproute2**, un paquete que permite configurar manualmente el enrutamiento IP. Es posible que este paquete ya esté disponible en su servidor; en ese caso, pase directamente al siguiente paso.
 
 Establezca una conexión SSH con su servidor y ejecute el siguiente comando desde la línea de comandos. Esto descargará e instalará iproute2.
 
 ```sh
-# apt-get install iproute2
-```
-
-A continuación, necesitamos crear una nueva ruta IP para el vRack. Añadiremos una nueva regla de tráfico modificando el archivo, como se muestra a continuación:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valores reservados
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Modificar el archivo de configuración de red
-
-:::info
-A modo de ejemplo, el archivo de configuración de red al que hacemos referencia se encuentra en /etc/network/interfaces. El archivo equivalente en su servidor puede estar ubicado en otro lugar, dependiendo de su sistema operativo.
-
-:::
-
-
-Finalmente, necesitamos modificar el archivo de configuración de red para tener en cuenta la nueva regla de tráfico y enrutar el tráfico del vRack a través de la dirección de puerta de enlace de red **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -301,98 +247,13 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Crear el archivo para la interfaz de red secundaria
-
-En primer lugar, podemos copiar y usar la configuración que se utiliza para la interfaz de red primaria y ajustarla según nuestras necesidades:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Luego accedemos al nuevo archivo:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Y definimos la configuración de IP:
-```sh
-# Creado automáticamente por cloud-init al arrancar la instancia, no editar.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Crear una nueva tabla de enrutamiento IP
-
-A continuación, necesitamos crear una nueva ruta IP para el vRack. Añadiremos una nueva regla de tráfico modificando el archivo, como se muestra a continuación:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valores reservados
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-A continuación, cree el archivo necesario para aplicar las nuevas reglas:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-Y pegue el siguiente contenido (recuerde reemplazar nuestras variables con sus propios valores):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Modificar el archivo de configuración de red
-
-Finalmente, necesitamos modificar el archivo de configuración de red para tener en cuenta la nueva regla de tráfico y enrutar el tráfico del vRack a través de la dirección de puerta de enlace de red **46.105.135.110**.
-
-Podemos lograrlo editando el siguiente archivo para añadir rutas persistentes y estáticas:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Establezca una conexión SSH con su servidor y ejecute el siguiente comando para descargar e instalar iproute2:
-
-```sh
-sudo apt-get install iproute2
-```
-
-Ahora reinicie su servidor para aplicar los cambios o, alternativamente, habilite simplemente la nueva interfaz de red:
-
-```sh
-ip link set eth1 up
-```
-
 #### Configuraciones GNU/Linux
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux y Rocky Linux (8/9)">
+<Tab label="AlmaLinux y Rocky Linux (8/9)">
 **Crear el archivo para la interfaz de red secundaria**
 
-Copie la configuración de la interfaz de red primaria y ajústela según sus necesidades:
+Comience copiando la configuración de la interfaz de red principal y, a continuación, adáptela según sus necesidades:
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
@@ -404,7 +265,7 @@ A continuación, abra el nuevo archivo:
 sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
 ```
 
-- Defina la configuración de IP:
+- Defina los parámetros IP:
 
 ```sh
 # Created by cloud-init on instance boot automatically, do not edit.
@@ -423,7 +284,7 @@ ARP=yes
 
 **Crear una nueva tabla de enrutamiento IP**
 
-A continuación, cree una nueva ruta IP para el vRack. Añada una nueva regla de tráfico modificando el archivo como se muestra a continuación:
+A continuación, debemos crear una nueva ruta IP para el vRack. Añadiremos una nueva regla de tráfico modificando el archivo, como se indica a continuación:
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -441,13 +302,13 @@ sudo nano /etc/iproute2/rt_tables
 1 vrack
 ```
 
-Cree a continuación el archivo necesario para aplicar las nuevas reglas:
+A continuación, cree el archivo necesario para aplicar las nuevas reglas:
 
 ```sh
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Pegue el siguiente contenido (recuerde reemplazar las variables con sus propios valores):
+Y pegue en él el siguiente contenido (recuerde sustituir nuestras variables por sus propios valores):
 
 ```sh
 from 46.105.135.96/28 table vrack
@@ -456,59 +317,72 @@ to 46.105.135.96/28 table vrack
 
 **Modificar el archivo de configuración de red**
 
-Por último, modifique el archivo de configuración de red para tener en cuenta la nueva regla de tráfico y enrutar el tráfico del vRack a través de la dirección de puerta de enlace de red **46.105.135.110**.
+Para terminar, debemos modificar el archivo de configuración de red para tener en cuenta la nueva regla de tráfico y encaminar el tráfico del vRack a través de la dirección de puerta de enlace de red **46.105.135.110**.
 
-Edite el siguiente archivo para añadir rutas persistentes y estáticas:
+Modifique el siguiente archivo para añadir rutas persistentes y estáticas:
 
 ```sh
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Pegue el siguiente contenido (recuerde reemplazar las variables con sus propios valores):
+Pegue el siguiente contenido (recuerde sustituir nuestras variables por sus propios valores):
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Reinicie el servidor para aplicar los cambios o habilite simplemente la nueva interfaz de red:
+Reinicie su servidor para aplicar los cambios, o simplemente active la nueva interfaz de red:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
 <Tab label="Ubuntu y Debian 12+">
+
 - Configurar la Additional IP
 
-Abra el archivo de configuración de red ubicado en `/etc/netplan` con el editor de texto de su elección. Aquí el archivo se llama `50-cloud-init.yaml`.
+Con un editor de texto de su elección, abra el archivo de configuración de red situado en `/etc/netplan`. Aquí el archivo se llama `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Defina la configuración de IP con las siguientes variables:
+- Defina los parámetros IP con las siguientes variables y añádalos a su configuración existente:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Por defecto, el tráfico destinado a su Additional IP puede no utilizar la interfaz vRack para la ruta de retorno. Esto puede provocar un enrutamiento asimétrico, y algunas redes pueden rechazar ese tráfico. La ruta `table: 1`, combinada con la regla `routing-policy` que se muestra a continuación, garantiza que las respuestas procedentes de la Additional IP se enruten correctamente a través de la interfaz vRack. El identificador `1` se utiliza aquí para coincidir con las demás pestañas de esta guía; puede utilizar el número que prefiera, siempre que lo use de forma coherente.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Ejemplo**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
 Aplique la configuración con el siguiente comando:
@@ -518,7 +392,7 @@ sudo netplan apply
 ```
 </Tab>
 <Tab label="Fedora 43+, AlmaLinux y Rocky Linux (10)">
-En primer lugar, compruebe que su interfaz vRack está en estado `connected` o `connecting`. En nuestro ejemplo, la interfaz se llama `eno2`.
+Compruebe primero el nombre de su interfaz vRack. En nuestro ejemplo, la interfaz se llama `eno2`:
 
 ```sh
 nmcli device status
@@ -526,79 +400,87 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-A continuación, obtenga el nombre del archivo de configuración ubicado en `/etc/NetworkManager/system-connections`. Aquí el archivo se llama `vRack.nmconnection`.
+Si su interfaz vRack ya está en estado `connected` o `connecting`, puede proceder a añadir la IP.
+
+En nuestro ejemplo, el estado es `disconnected`, por lo que creamos la interfaz con el siguiente comando. La hemos denominado `vRack` para distinguirla de las demás interfaces.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
-Configure su Additional IP mediante el gestor `nmcli`. Reemplace `vRack` y los demás parámetros con sus propios valores.
+Con el gestor `nmcli`, configure su Additional IP. Sustituya `vRack` y los demás parámetros por sus propios valores.
 
 - Añadir la IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Añadir la puerta de enlace
+- Evitar que la conexión vRack se convierta en la ruta predeterminada
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
 - Cambiar la configuración de **auto** a **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
-- Hacer la configuración persistente
+- Hacer que la configuración sea persistente
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Crear una nueva tabla de enrutamiento IP**
+:::info
+Por defecto, el tráfico destinado a su IP vRack puede no utilizar la interfaz vRack para la ruta de retorno. Esto puede provocar un enrutamiento asimétrico, y algunas redes pueden rechazar ese tráfico. Los siguientes pasos configuran una tabla de enrutamiento independiente para el tráfico vRack, garantizando que las respuestas procedentes de la IP vRack se enruten correctamente a través de la interfaz vRack.
+:::
 
-A continuación, cree una nueva ruta IP para el vRack. Añada una nueva regla de tráfico (`1 vrack`) modificando el archivo como se muestra a continuación:
+- Crear la tabla de enrutamiento del vRack
 
+En nuestro ejemplo, utilizamos 1 como identificador, pero puede elegir el número que prefiera. Los comandos siguientes hacen referencia a la tabla por su identificador (`table=1`); el nombre `vrack` solo sirve para facilitar la lectura posteriormente, por ejemplo con `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Añadir la ruta
+- Enrutar el tráfico de esta conexión a través de la tabla vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Añadir la ruta a través de la puerta de enlace
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 En nuestro ejemplo
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Reinicie su red con el siguiente comando:
+- Añadir una regla para que el tráfico vRack utilice esta tabla
+
+Este paso indica concretamente a su servidor que utilice la tabla 1 para todo lo que se envíe desde su IP vRack. Sin él, las rutas que acaba de añadir se ignorarían.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Aplique los cambios:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>
@@ -606,29 +488,29 @@ sudo systemctl restart NetworkManager
 
 ### Windows Server
 
-#### Paso 1: Verificar y configurar la interfaz de red secundaria
+#### Paso 1: verificar y configurar la interfaz de red secundaria
 
-Compruebe la información de la nueva interfaz de red:
+Compruebe primero la información de la nueva interfaz de red:
 
-<img className="thumbnail" alt="verificación de la interfaz de red secundaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
+<img className="thumbnail" alt="verificación de la segunda interfaz de red" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
 
 A continuación, compruebe las propiedades:
 
-<img className="thumbnail" alt="propiedades de la interfaz de red secundaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
+<img className="thumbnail" alt="propiedades de la segunda interfaz de red" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
 
-<img className="thumbnail" alt="propiedades de la interfaz de red secundaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
+<img className="thumbnail" alt="propiedades de la segunda interfaz de red" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
 
-#### Paso 2: Configuración de IP
+#### Paso 2: configuración IP
 
 Seleccione la opción <code className="action">Use the following IP address</code>:
 
-<img className="thumbnail" alt="configuración de IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-4.png" loading="lazy" />
+<img className="thumbnail" alt="configuración IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-4.png" loading="lazy" />
 
-Defina la información de IP:
+Defina la información IP:
 
-<img className="thumbnail" alt="configuración de IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-5b.png" loading="lazy" />
+<img className="thumbnail" alt="configuración IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-5b.png" loading="lazy" />
 
-#### Paso 3: Reiniciar la interfaz de red
+#### Paso 3: reinicio de la interfaz de red
 
 En primer lugar, desactive la interfaz.
 
@@ -640,15 +522,15 @@ A continuación, actívela.
 
 ### Resolución de problemas
 
-Si no puede establecer una conexión desde su VM o servidor a la red privada, abra un ticket de soporte desde su área de cliente con la siguiente información:
+Si no puede establecer una conexión entre su VM o servidor y la red privada, envíenos un ticket desde su área de cliente indicando lo siguiente:
 
 - IP de origen e IP de destino
-- Resultado de `ifconfig -a` o `ipconfig /all` de ambos servidores o VMs (configuración de la interfaz de red)
-- Ping en ambas direcciones
+- Resultado de `ifconfig -a` o `ipconfig /all` en ambos servidores o VM (configuración de la interfaz de red)
+- Resultado del ping en ambos sentidos
 - Resultado de `arp -a`
 - Tabla de enrutamiento
 
-Incluya los resultados anteriores en su ticket.
+Adjunte los resultados anteriores a su ticket.
 
 ## Más información
 
@@ -656,6 +538,6 @@ Incluya los resultados anteriores en su ticket.
 
 [Crear múltiples VLANs en un vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
 
-[Configurar el vRack entre la Public Cloud y un servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
+[Configurar el vRack entre Public Cloud y un servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/fr/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
-title: Configurer un bloc Additional IP dans le vRack
-description: "Découvrez comment configurer un bloc d'adresses IP publiques dans le vRack"
-lastUpdated: 2026-09-08
+title: Configurer un bloc Additional IP dans un vRack
+description: "Découvrez comment configurer un bloc d'adresses IP publiques à utiliser avec le vRack"
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -10,7 +10,7 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objectif
 
-En plus de l'adressage IP privé, le [vRack](https://www.ovhcloud.com/fr/network/vrack/) vous permet de diriger le trafic IP public via le port vRack de votre serveur à l'aide d'un bloc d'adresses IP publiques.
+En plus de l'adressage IP privé, le [vRack](https://www.ovhcloud.com/fr/network/vrack/) vous permet également d'acheminer le trafic IP public via le port vRack de votre serveur à l'aide d'un bloc d'adresses IP publiques.
 
 **Ce guide vous explique comment configurer un bloc d'adresses IP publiques à utiliser avec le vRack.**
 
@@ -23,11 +23,11 @@ Le vRack prend en charge le routage public IPv4 et IPv6 avec des blocs d'adresse
 :::info
 Cet article détaille la configuration d'adresses Additional IP sur un réseau vRack. Si vous cherchez des instructions sur la configuration d'adresses Additional IP avec une adresse IP principale (sur l'interface réseau publique), consultez les articles suivants :
 
-- IPv4:
+- IPv4 :
     - [Configurer une adresse IP en alias sur un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
     - [Configurer une adresse IP en alias sur un serveur VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
 
-- IPv6:
+- IPv6 :
     - [Configurer IPv6 sur un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
     - [Configurer IPv6 sur un serveur VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
     - [Configurer IPv6 sur une instance Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
@@ -37,10 +37,10 @@ Cet article détaille la configuration d'adresses Additional IP sur un réseau v
 
 ## Prérequis
 
-- Avoir réservé un bloc public d'adresses IP dans votre compte, avec un minimum de quatre adresses.
-- Préparer votre plage d'adresses IP privées choisies.
-- Posséder un [serveur compatible vRack](https://www.ovhcloud.com/fr/bare-metal/).
-- Activer un service [vRack](https://www.ovhcloud.com/fr/network/vrack/).
+- Un bloc public d'adresses IP dans votre compte, avec un minimum de quatre adresses
+- La plage d'adresses IP privées de votre choix
+- Un [serveur compatible vRack](https://www.ovhcloud.com/fr/bare-metal/)
+- Un service [vRack](https://www.ovhcloud.com/fr/network/vrack/) activé dans votre compte
 
 {/* CP-NAV-START:network-vrack */}
 ---
@@ -54,9 +54,9 @@ Cet article détaille la configuration d'adresses Additional IP sur un réseau v
 {/* CP-NAV-END:network-vrack */}
 
 :::warning
-Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+Cette fonctionnalité peut être indisponible ou limitée sur les serveurs de [la gamme **Eco**](https://eco.ovhcloud.com/fr/about/).
 
-Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d'informations.
+Consultez notre [page de comparaison](https://eco.ovhcloud.com/fr/compare/) pour plus d'informations.
 
 :::
 
@@ -64,9 +64,9 @@ Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d'i
 ## En pratique
 
 :::info
-À titre d'exemple, nous utiliserons un bloc IP de 46.105.135.96/28 et `eth1` pour l'interface réseau secondaire, qui est dédiée au vRack.
+À titre d'exemple, nous utiliserons un bloc IP de 46.105.135.96/28 et `eth1` pour l'interface réseau secondaire, dédiée au vRack.
 
-À titre d'exemple également, le fichier de configuration réseau auquel nous faisons référence se trouve dans `/etc/network/interfaces`. En fonction du système d'exploitation utilisé, le fichier équivalent peut être situé ailleurs. Le contenu du fichier peut également être différent. En cas de difficultés, n'hésitez pas à vous référer à la documentation officielle de votre distribution.
+Le fichier de configuration réseau auquel nous faisons référence se trouve dans `/etc/network/interfaces`. Le fichier équivalent sur votre serveur peut se trouver ailleurs, selon votre système d'exploitation. Le contenu du fichier peut également être différent. En cas de difficultés, reportez-vous à la documentation officielle de votre distribution.
 
 :::
 
@@ -74,41 +74,41 @@ Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d'i
 ### Ajouter le bloc IP au vRack
 
 :::warning
-Lorsqu'un bloc IP est ajouté au vRack, il n'est plus rattaché à un serveur physique.
+Une fois qu'un bloc IP est ajouté au vRack, il n'est plus rattaché à un serveur physique.
 
-Cette configuration permet de configurer des IP d'un même bloc sur plusieurs serveurs, à condition que ces serveurs soient tous dans le même vRack que le bloc IP. Le bloc IP doit avoir au moins 2 adresses IPs utilisables ou plus pour que cela soit possible.
+Cette configuration permet de configurer des IP d'un même bloc sur plusieurs serveurs, à condition que ces serveurs soient tous dans le même vRack que le bloc IP. Le bloc IP doit disposer d'au moins 2 IP utilisables pour que cela soit possible.
 
 :::
 
 
-Sélectionnez votre vRack dans la liste pour afficher la liste des services éligibles. Cliquez sur le bloc IP que vous souhaitez ajouter au vRack et cliquez sur le bouton <code className="action">Ajouter</code>.
+Sélectionnez votre vRack dans la liste pour afficher la liste des services éligibles. Cliquez sur le bloc IP que vous souhaitez ajouter au vRack, puis cliquez sur le bouton <code className="action">Ajouter</code>.
 
 <img className="thumbnail" alt="Ajout d'un bloc IP au vRack" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/addIPblock.png" loading="lazy" />
 
 ### Gérer la bande passante des IP publiques sur le vRack
 
-Par défaut, les blocs d'Additional IP routés via un vRack bénéficient d'une bande passante publique standard de 5 Gbps en Europe et en Amérique du Nord, ou de 100 Mbps dans les régions APAC. Pour plus de détails sur les offres disponibles, consultez les options de routage public sur notre [page produit vRack](https://www.ovhcloud.com/fr/network/vrack/).
+Par défaut, les blocs d'Additional IP routés via un vRack bénéficient d'une bande passante publique standard de 5 Gbps en Europe, au Canada et aux États-Unis, et de 100 Mbps dans les régions APAC. Pour un aperçu détaillé de la disponibilité, consultez les options de routage public sur notre [page produit vRack](https://www.ovhcloud.com/fr/network/vrack/).
 
-Pour répondre à la montée en charge des infrastructures et aux besoins des services à fort trafic, OVHcloud propose maintenant à ses clients des options de bande passante payantes. Notez que ces options s'appliquent **par vRack et par région**. Comme les Additional IP sont liées à une région précise, toute modification de la bande passante impactera l'ensemble des adresses (IPv4 et IPv6) routées vers ce vRack dans la région concernée.
+À mesure que les besoins en infrastructure augmentent, certains utilisateurs peuvent nécessiter une bande passante plus large pour prendre en charge des services publics à fort trafic, pour lesquels OVHcloud propose des options de bande passante payantes. Ces options s'appliquent **par vRack et par région**. Comme les adresses Additional IP sont liées à une région, toute modification de la bande passante affectera l'ensemble des adresses IP (IPv4 et IPv6) routées vers ce vRack au sein de cette région.
 
 <details>
 
 <summary>Lors de la commande d'une Additional IP</summary>
 
 
-#### Choisir la bande passante publique lors de la commande
+#### Choisir la bande passante publique lors de la commande d'une Additional IP
 
-Vous pouvez modifier la bande passante par défaut au moment de commander un nouveau bloc d'Additional IP, dès lors qu'un réseau vRack est sélectionné comme service backend.
+Vous pouvez modifier la bande passante publique par défaut lors de la commande d'un nouveau bloc d'Additional IP avec un réseau vRack comme service backend.
 
 Pour commander un nouveau bloc d'Additional IP :
 
-- Dans la barre latérale gauche, accédez à la section <code className="action">Network</code>.
+- Ouvrez la section <code className="action">Network</code> dans la barre latérale gauche.
 - Sélectionnez <code className="action">Adresses IP Publiques</code>.
-- Cliquez sur le bouton <code className="action">Commander des IPs</code> en haut de la page.
-- Choisissez la version de l'IP, puis le vRack auquel l'Additional IP sera rattachée.
-- Sélectionnez la région de votre Additional IP.
-- Choisissez la bande passante publique à appliquer à votre vRack pour cette région.
-- Configurez les autres options selon vos besoins, puis finalisez la commande.
+- Cliquez sur le bouton <code className="action">Commander des IPs</code>, en haut de la page.
+- Sélectionnez la version de l'IP, puis le vRack auquel vous souhaitez rattacher votre Additional IP.
+- Sélectionnez la région dans laquelle vous souhaitez que votre Additional IP se trouve.
+- Choisissez la bande passante publique à appliquer à votre vRack pour cette région spécifique.
+- Renseignez les autres options si nécessaire, puis finalisez votre commande.
 
 </details>
 
@@ -118,34 +118,34 @@ Pour commander un nouveau bloc d'Additional IP :
 <summary>Depuis la page de gestion du vRack</summary>
 
 
-#### Modifier la bande passante publique depuis la page de gestion
+#### Modifier la bande passante publique du vRack depuis la page de gestion
 
-Pour les blocs d'Additional IP déjà rattachés à un vRack, la bande passante se gère directement depuis la page de configuration du service.
+Pour les blocs d'Additional IP déjà rattachés à un vRack, vous pouvez gérer la bande passante directement depuis la page de configuration du service.
 
 Pour accéder à l'interface de gestion :
 
 - Dans la colonne « Adresse IP publique et bande passante », cliquez sur le bouton <code className="action">Gérer</code> correspondant au vRack souhaité.
 
-L'interface de gestion se divise en deux onglets :
+La page de gestion est organisée en deux onglets :
 
-- **Tous les services attachés** : Redirige actuellement vers la page de gestion classique du vRack. Prochainement, cet onglet listera de façon optimisée tous les produits (serveurs, projets Cloud, etc.) liés au vRack.
-- **Connectivité IP publique** : Permet de gérer les options de routage public de votre vRack, y compris la bande passante.
+- **Tous les services attachés** : pour le moment, cet onglet redirige vers la page de gestion classique du vRack. Prochainement, il listera, de façon optimisée, tous les produits (serveurs, projets Cloud, etc.) actuellement liés au vRack.
+- **Connectivité IP publique** : permet de gérer les options de routage public de votre vRack, y compris la bande passante.
 
-Pour modifier la bande passante :
+Pour modifier la bande passante publique :
 
-- Allez dans l'onglet <code className="action">Connectivité IP publique</code>.
-- L'interface affiche des fenêtres de gestion par région (ex : `eu-west-par`) associées au vRack, avec la liste des IP rattachées.
-- Dans l'encadré de la région concernée, cliquez sur <code className="action">Modifier la bande passante</code>.
-- Sélectionnez l'option souhaitée dans le panneau de droite, puis cliquez sur <code className="action">Commander</code> pour valider.
-- Une fois le paiement effectué, la nouvelle bande passante sera effective sur votre vRack dans la région choisie après quelques minutes.
+- Accédez à l'onglet <code className="action">Connectivité IP publique</code>.
+- L'interface affiche des fenêtres de gestion individuelles pour chaque région (par exemple `eu-west-par`) associée au vRack, avec la liste de toutes les adresses IP rattachées à cette région spécifique.
+- Dans la fenêtre de la région concernée, cliquez sur le bouton <code className="action">Modifier la bande passante</code>.
+- Sélectionnez l'option de bande passante souhaitée dans le panneau qui apparaît à droite, puis cliquez sur <code className="action">Commander</code> pour valider la commande.
+- Une fois la commande payée, la bande passante sélectionnée devrait être disponible sur votre vRack, dans la région choisie, après quelques minutes.
 
 :::info
-Le premier mois souscrit est facturé au prorata des jours restants. Le tarif complet s'appliquera lors du cycle de facturation suivant.
+Les frais du premier mois sont calculés au prorata des jours restants ; le tarif complet s'appliquera dès le cycle de facturation suivant.
 
 :::
 
 
-L'augmentation de bande passante s'appliquera à toutes les adresses IP de cette région pour le vRack sélectionné.
+La mise à niveau de bande passante sélectionnée s'appliquera à toutes les adresses IP de cette région pour le vRack choisi.
 
 </details>
 
@@ -157,7 +157,7 @@ Certaines régions OVHcloud s'étendent sur trois zones de disponibilité (AZ) h
 :::info
 Si une région est passée en mode 3-AZ alors que vous aviez déjà des adresses IP routées via le vRack dans cette région, ces IP resteront en mode 1-AZ et ne bénéficieront pas automatiquement de la configuration de routage 3-AZ.
 
-Pour activer le mode 3-AZ pour les blocs d'adresses IP routés via le vRack dans ces régions, vous devez retirer le bloc IP du vRack, puis le réajouter.
+Pour activer le mode 3-AZ pour les blocs d'adresses IP routés via le vRack dans ces régions, retirez le bloc IP du vRack, puis réajoutez-le.
 
 **Les blocs d'adresses IP qui sont toujours routés en mode 1-AZ sont identifiés par un badge gris `1-AZ`.**
 
@@ -187,9 +187,9 @@ Pour ajuster les priorités de basculement d'une région 3-AZ :
 - Sélectionnez <code className="action">Réseau Privé vRack</code>.
 - Dans la colonne « Adresse IP publique et bande passante », cliquez sur le bouton <code className="action">Gérer</code> correspondant au vRack souhaité.
 - Ouvrez l'onglet <code className="action">Connectivité IP publique</code>.
-- Dans la tuile de la région 3-AZ à configurer, localisez la sous-section `Priorités de basculement 3-AZ`, puis cliquez sur <code className="action">Configurer</code>.
+- Repérez la tuile de la région 3-AZ que vous souhaitez configurer, puis la sous-section `Priorités de basculement 3-AZ`, et cliquez sur <code className="action">Configurer</code>.
 - Dans le panneau qui s'ouvre à droite, attribuez chaque zone de disponibilité à l'un des trois emplacements : **Zone principale**, **Zone secondaire** et **Zone de dernier recours**.
-- Validez votre sélection.
+- Confirmez votre sélection.
 
 :::info
 Les modifications de priorité s'appliquent à tous les blocs d'Additional IP routés vers la région 3-AZ correspondante pour le vRack sélectionné, quelle que soit leur version d'IP.
@@ -202,11 +202,11 @@ Les modifications de priorité s'appliquent à tous les blocs d'Additional IP ro
 
 ### Configurer une adresse IP utilisable
 
-Dans le cas du vRack, la première, l'avant-dernière et la dernière adresse d'un bloc d'IP donné sont toujours réservées respectivement à l'adresse réseau, la passerelle réseau et au *broadcast* du réseau. Cela signifie que la première adresse utilisable est la deuxième adresse du bloc, comme indiqué ci-dessous :
+Dans le cas du vRack, la première, l'avant-dernière et la dernière adresse d'un bloc IP donné sont toujours réservées respectivement à l'adresse réseau, la passerelle réseau et au broadcast réseau. Cela signifie que la première adresse utilisable est la deuxième adresse du bloc, comme indiqué ci-dessous :
 
 ```sh
-46.105.135.96   # Réservée : adresse réseau
-46.105.135.97   # Première IP utilisable
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,82 +218,27 @@ Dans le cas du vRack, la première, l'avant-dernière et la dernière adresse d'
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109   # Dernière IP utilisable
-46.105.135.110   # Réservée : passerelle réseau
-46.105.135.111   # Réservée : broadcast réseau
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Pour configurer la première adresse IP utilisable, vous devez éditer le fichier de configuration réseau comme indiqué ci-dessous. Dans cet exemple, utilisez un masque de sous-réseau de **255.255.255.240**.
+Pour configurer la première adresse IP utilisable, nous devons éditer le fichier de configuration réseau, comme indiqué ci-dessous. Dans cet exemple, nous devons utiliser un masque de sous-réseau de **255.255.255.240**.
 
 :::info
-Le masque de sous-réseau utilisé dans cet exemple est approprié pour notre bloc IP. Votre masque de sous-réseau peut différer en fonction de la taille de votre bloc. Lorsque vous achetez votre bloc d'IP, vous recevez un e-mail vous indiquant le masque de sous-réseau à utiliser.
+Le masque de sous-réseau utilisé dans cet exemple est approprié pour notre bloc IP. Votre masque de sous-réseau peut différer en fonction de la taille de votre bloc. Lorsque vous achetez votre bloc IP, vous recevez un e-mail vous indiquant le masque de sous-réseau à utiliser.
 
 :::
 
 
 ### Télécharger le paquet `iproute2`
 
-```sh
-/etc/network/interfaces
+Avant de commencer, téléchargez et installez **iproute2**, un paquet permettant de configurer manuellement le routage IP. Ce paquet est peut-être déjà disponible sur votre serveur ; le cas échéant, passez directement à l'étape suivante.
 
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-
-### Créer une nouvelle table de routage IP
-
-Avant tout, il convient de télécharger et installer « iproute2 », un paquet qui permettra de configurer manuellement le routage IP sur le serveur.
-
-Ouvrez ensuite une connexion SSH à votre serveur et utilisez la commande suivante pour télécharger et installer le paquet :
+Établissez une connexion SSH à votre serveur et exécutez la commande suivante depuis la ligne de commande. Celle-ci téléchargera et installera iproute2.
 
 ```sh
-apt-get install iproute2
-```
-
-Ensuite, vous devez créer une nouvelle route IP pour le vRack. Pour cela, il convient d'ajouter une nouvelle règle de trafic en modifiant le fichier comme indiqué ci-dessous :
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Modifier le fichier de configuration réseau
-
-:::info
-À titre d'exemple, le fichier de configuration réseau auquel nous faisons référence se trouve dans /etc/network/interfaces. En fonction du système d'exploitation utilisé, le fichier équivalent peut être situé ailleurs.
-
-:::
-
-
-Pour finir, il reste à modifier le fichier de configuration réseau pour prendre en compte la nouvelle règle de trafic et acheminer le trafic vRack via l'adresse de passerelle réseau **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -302,102 +247,13 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Créer le fichier pour l'interface réseau secondaire
-
-Tout d'abord, copiez et utilisez la configuration de l'interface réseau principale, puis adaptez-la selon vos besoins :
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-
-Accédez ensuite au nouveau fichier :
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-
-Définissez les paramètres IP :
-
-```sh
-# Created by cloud-init on instance boot automatically, do not edit.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Créer une nouvelle table de routage IP
-
-Ensuite, créez une nouvelle route IP pour le vRack. Ajoutez une nouvelle règle de trafic en modifiant le fichier comme indiqué ci-dessous :
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Créez ensuite le fichier nécessaire pour appliquer les nouvelles règles :
-
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-Établissez une connexion SSH à votre serveur et exécutez la commande suivante pour télécharger et installer iproute2 :
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Modifier le fichier de configuration réseau
-
-Pour finir, modifiez le fichier de configuration réseau pour prendre en compte la nouvelle règle de trafic et acheminer le trafic vRack via l'adresse de passerelle réseau **46.105.135.110**.
-
-Modifiez le fichier suivant afin d'ajouter des routes persistantes et statiques :
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Collez le contenu suivant (pensez à remplacer les variables par vos propres valeurs) :
-
-```sh
-sudo apt-get install iproute2
-```
-
-Redémarrez le serveur pour appliquer les modifications effectuées. Vous pouvez également activer simplement la nouvelle interface réseau :
-
-```sh
-ip link set eth1 up
-```
-
 #### Configurations GNU/Linux
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux et Rocky Linux (8/9)">
+<Tab label="AlmaLinux and Rocky Linux (8/9)">
 **Créer le fichier pour l'interface réseau secondaire**
 
-Copiez la configuration de l'interface réseau principale et adaptez-la selon vos besoins :
+Commencez par copier la configuration de l'interface réseau principale, puis adaptez-la selon vos besoins :
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
@@ -428,7 +284,7 @@ ARP=yes
 
 **Créer une nouvelle table de routage IP**
 
-Ensuite, créez une nouvelle route IP pour le vRack. Ajoutez une nouvelle règle de trafic en modifiant le fichier comme indiqué ci-dessous :
+Ensuite, nous devons créer une nouvelle route IP pour le vRack. Nous allons ajouter une nouvelle règle de trafic en modifiant le fichier, comme indiqué ci-dessous :
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -446,13 +302,13 @@ sudo nano /etc/iproute2/rt_tables
 1 vrack
 ```
 
-Créez ensuite le fichier nécessaire pour appliquer les nouvelles règles :
+Créez ensuite le fichier nécessaire à l'application des nouvelles règles :
 
 ```sh
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Collez le contenu suivant (pensez à remplacer les variables par vos propres valeurs) :
+Et collez-y le contenu suivant (pensez à remplacer nos variables par vos propres valeurs) :
 
 ```sh
 from 46.105.135.96/28 table vrack
@@ -461,7 +317,7 @@ to 46.105.135.96/28 table vrack
 
 **Modifier le fichier de configuration réseau**
 
-Pour finir, modifiez le fichier de configuration réseau pour prendre en compte la nouvelle règle de trafic et acheminer le trafic vRack via l'adresse de passerelle réseau **46.105.135.110**.
+Pour finir, nous devons modifier le fichier de configuration réseau afin de prendre en compte la nouvelle règle de trafic et d'acheminer le trafic du vRack via l'adresse de passerelle réseau **46.105.135.110**.
 
 Modifiez le fichier suivant afin d'ajouter des routes persistantes et statiques :
 
@@ -469,61 +325,74 @@ Modifiez le fichier suivant afin d'ajouter des routes persistantes et statiques 
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Collez le contenu suivant (pensez à remplacer les variables par vos propres valeurs) :
+Collez le contenu suivant (pensez à remplacer nos variables par vos propres valeurs) :
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Redémarrez le serveur pour appliquer les modifications ou activez simplement la nouvelle interface réseau :
+Redémarrez votre serveur pour appliquer les modifications, ou activez simplement la nouvelle interface réseau :
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="Ubuntu et Debian 12+">
+<Tab label="Ubuntu & Debian 12+">
+
 - Configurer l'Additional IP
 
-Ouvrez le fichier de configuration réseau situé dans `/etc/netplan` avec un éditeur de texte de votre choix. Ici, le fichier s'appelle `50-cloud-init.yaml`.
+À l'aide d'un éditeur de texte de votre choix, ouvrez le fichier de configuration réseau situé dans `/etc/netplan`. Ici, le fichier s'appelle `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Définissez les paramètres IP avec les variables suivantes :
+- Définissez les paramètres IP à l'aide des variables suivantes, puis ajoutez-les à votre configuration existante :
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Par défaut, le trafic à destination de votre Additional IP peut ne pas emprunter l'interface vRack pour le chemin de retour. Cela peut entraîner un routage asymétrique, et certains réseaux peuvent rejeter ce trafic. La route `table: 1`, combinée à la règle `routing-policy` ci-dessous, garantit que les réponses provenant de l'Additional IP sont bien routées via l'interface vRack. L'identifiant `1` est utilisé ici pour correspondre aux autres onglets de ce guide ; libre à vous d'utiliser le numéro de votre choix, à condition de l'utiliser de manière cohérente.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Exemple**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
-Appliquez la configuration avec la commande suivante :
+Appliquez la configuration à l'aide de la commande suivante :
 
 ```bash
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora 43+, AlmaLinux et Rocky Linux (10)">
-Vérifiez d'abord que votre interface vRack est à l'état `connected` ou `connecting`. Dans notre exemple, l'interface s'appelle `eno2`.
+<Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
+Vérifiez d'abord le nom de votre interface vRack. Dans notre exemple, l'interface s'appelle `eno2` :
 
 ```sh
 nmcli device status
@@ -531,79 +400,87 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Récupérez ensuite le nom du fichier de configuration situé dans `/etc/NetworkManager/system-connections`. Ici, le fichier s'appelle `vRack.nmconnection`.
+Si votre interface vRack est déjà à l'état `connected` ou `connecting`, vous pouvez procéder à l'ajout de l'IP.
+
+Dans notre exemple, l'état est `disconnected` : nous créons donc l'interface avec la commande suivante. Nous l'avons nommée `vRack` pour la distinguer des autres interfaces.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
-Configurez votre Additional IP à l'aide du gestionnaire `nmcli`. Remplacez `vRack` et les autres paramètres par vos propres valeurs.
+À l'aide du gestionnaire `nmcli`, configurez votre Additional IP. Remplacez `vRack` et les autres paramètres par vos propres valeurs.
 
 - Ajouter l'IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Ajouter la passerelle
+- Empêcher la connexion vRack de devenir la route par défaut
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
-- Changer la configuration de **auto** à **manual** :
+- Faire passer la configuration de **auto** à **manual** :
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Rendre la configuration persistante
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Créer une nouvelle table de routage IP**
+:::info
+Par défaut, le trafic à destination de votre IP vRack peut ne pas emprunter l'interface vRack pour le chemin de retour. Cela peut entraîner un routage asymétrique, et certains réseaux peuvent rejeter ce trafic. Les étapes ci-dessous configurent une table de routage distincte pour le trafic vRack, garantissant que les réponses provenant de l'IP vRack sont bien routées via l'interface vRack.
+:::
 
-Ensuite, créez une nouvelle route IP pour le vRack. Ajoutez une nouvelle règle de trafic (`1 vrack`) en modifiant le fichier comme indiqué ci-dessous :
+- Créer la table de routage du vRack
 
+Dans notre exemple, nous utilisons 1 comme identifiant, mais vous pouvez choisir le numéro de votre choix. Les commandes ci-dessous font référence à la table par son identifiant (`table=1`) ; le nom `vrack` sert uniquement à faciliter la lecture par la suite, par exemple avec `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Ajouter la route
+- Router le trafic de cette connexion via la table vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Ajouter la route via la passerelle
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 Dans notre exemple
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Redémarrez votre réseau avec la commande suivante :
+- Ajouter une règle pour que le trafic vRack utilise cette table
+
+Cette étape indique concrètement à votre serveur d'utiliser la table 1 pour tout ce qui est envoyé depuis votre IP vRack. Sans elle, les routes que vous venez d'ajouter seraient ignorées.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Appliquez les modifications :
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>
@@ -611,21 +488,21 @@ sudo systemctl restart NetworkManager
 
 ### Windows Server
 
-#### Étape 1 : Vérifier et configurer l'interface réseau secondaire
+#### Étape 1 : vérifier et configurer l'interface réseau secondaire
 
-Vérifiez les informations de la nouvelle interface réseau :
+Vérifiez d'abord les informations de la nouvelle interface réseau :
 
-<img className="thumbnail" alt="vérification de l'interface réseau secondaire" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
+<img className="thumbnail" alt="vérification de la seconde interface réseau" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
 
 Vérifiez ensuite les propriétés :
 
-<img className="thumbnail" alt="propriétés de l'interface réseau secondaire" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
+<img className="thumbnail" alt="propriétés de la seconde interface réseau" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
 
-<img className="thumbnail" alt="propriétés de l'interface réseau secondaire" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
+<img className="thumbnail" alt="propriétés de la seconde interface réseau" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
 
-#### Étape 2 : Configuration IP
+#### Étape 2 : configuration IP
 
-Sélectionnez l'option `Utiliser l'adresse IP suivante` :
+Sélectionnez l'option <code className="action">Utiliser l'adresse IP suivante</code> :
 
 <img className="thumbnail" alt="configuration IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-4.png" loading="lazy" />
 
@@ -633,34 +510,34 @@ Définissez les informations IP :
 
 <img className="thumbnail" alt="configuration IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-5b.png" loading="lazy" />
 
-#### Étape 3 : Redémarrage de l'interface réseau
+#### Étape 3 : redémarrage de l'interface réseau
 
 Commencez par désactiver l'interface.
 
 <img className="thumbnail" alt="désactivation du réseau" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-6.png" loading="lazy" />
 
-Puis activez-la.
+Activez-la ensuite.
 
 <img className="thumbnail" alt="activation du réseau" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-7.png" loading="lazy" />
 
 ### Résolution des problèmes
 
-Si vous ne parvenez pas à établir une connexion depuis votre VM ou serveur vers le réseau privé, ouvrez un ticket d'assistance depuis votre espace client en fournissant les informations suivantes :
+Si vous ne parvenez pas à établir une connexion entre votre VM ou serveur et le réseau privé, envoyez-nous un ticket depuis votre espace client en précisant les éléments suivants :
 
 - IP source et IP de destination
-- Résultat de la commande `ifconfig -a` ou `ipconfig /all` sur les deux serveurs ou VMs (configuration de l'interface réseau)
+- Résultat de `ifconfig -a` ou `ipconfig /all` sur les deux serveurs ou VM (configuration de l'interface réseau)
 - Résultat du ping dans les deux sens
-- Résultat de la commande `arp -a`
+- Résultat de `arp -a`
 - Table de routage
 
-Joignez les résultats des commandes ci-dessus à votre ticket.
+Joignez les résultats ci-dessus à votre ticket.
 
 ## Aller plus loin
 
-[Configurer plusieurs serveurs dédiés dans le vRack](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
+[Configurer le vRack sur vos serveurs dédiés](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
 
-[Créer plusieurs réseaux locaux virtuels dans un vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
+[Créer plusieurs vLAN dans un vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
 
-[Configurer un vRack entre une instance Public Cloud et un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
+[Configurer le vRack entre Public Cloud et un serveur dédié](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
 
-Échangez avec notre [communauté d’utilisateurs](/links/community).
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/it/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configurare un blocco Additional IP in un vRack
-description: Scopri come configurare un blocco di indirizzi IP pubblici nel vRack.
-lastUpdated: 2026-09-08
+description: "Scopri come configurare un blocco di indirizzi IP pubblici da utilizzare con il vRack"
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -10,25 +10,25 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Obiettivo
 
-Oltre all'indirizzamento IP privato, il [vRack](https://www.ovhcloud.com/it/network/vrack/) consente anche di instradare il traffico IP pubblico attraverso la porta vRack del server utilizzando un blocco di indirizzi IP pubblici.
+Oltre all'indirizzamento IP privato, il [vRack](https://www.ovhcloud.com/it/network/vrack/) ti consente anche di instradare il traffico IP pubblico attraverso la porta vRack del tuo server utilizzando un blocco di indirizzi IP pubblici.
 
-**Questa guida mostra come configurare un blocco di indirizzi IP pubblici per l'utilizzo con il vRack.**
+**Questa guida ti mostra come configurare un blocco di indirizzi IP pubblici da utilizzare con il vRack.**
 
 :::info
-Il vRack supporta sia il routing pubblico IPv4 che IPv6 con blocchi di indirizzi Additional IP. Le istruzioni su come configurare i blocchi IPv6 sono disponibili in questa guida: "[Configurare un blocco IPv6 in un vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)".
+Il vRack supporta il routing pubblico IPv4 e IPv6 con blocchi di indirizzi Additional IP. Trovi le istruzioni su come configurare i blocchi IPv6 in questa guida: "[Configurare un blocco Additional IPv6 in un vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)".
 
 :::
 
 
 :::info
-Questo articolo è incentrato sulla configurazione di Additional IP su una rete vRack. Se si cercano indicazioni sulla configurazione di Additional IP insieme all'IP primario (sull'interfaccia di rete pubblica), consultare i seguenti articoli:
+Questo articolo descrive la configurazione degli indirizzi Additional IP su una rete vRack. Se stai cercando istruzioni per configurare indirizzi Additional IP con un indirizzo IP principale (sull'interfaccia di rete pubblica), consulta i seguenti articoli:
 
 - IPv4:
-    - [Configurare l'IP aliasing sui server dedicati](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
-    - [Configurare l'IP aliasing su un VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
+    - [Configurare un indirizzo IP in alias su un server dedicato](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
+    - [Configurare un indirizzo IP in alias su un VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
 
 - IPv6:
-    - [Configurare IPv6 sui server dedicati](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
+    - [Configurare IPv6 su un server dedicato](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
     - [Configurare IPv6 su un VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
     - [Configurare IPv6 su un'istanza Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
 
@@ -37,10 +37,10 @@ Questo articolo è incentrato sulla configurazione di Additional IP su una rete 
 
 ## Prerequisiti
 
-- Un blocco pubblico di indirizzi IP nel proprio account, con un minimo di quattro indirizzi
-- L'intervallo di indirizzi IP privati scelto
+- Un blocco pubblico di indirizzi IP nel tuo account, con un minimo di quattro indirizzi
+- L'intervallo di indirizzi IP privati di tua scelta
 - Un [server compatibile con vRack](https://www.ovhcloud.com/it/bare-metal/)
-- Un servizio [vRack](https://www.ovhcloud.com/it/network/vrack/) attivato nel proprio account
+- Un servizio [vRack](https://www.ovhcloud.com/it/network/vrack/) attivo nel tuo account
 
 {/* CP-NAV-START:network-vrack */}
 ---
@@ -54,9 +54,9 @@ Questo articolo è incentrato sulla configurazione di Additional IP su una rete 
 {/* CP-NAV-END:network-vrack */}
 
 :::warning
-Questa funzionalità potrebbe non essere disponibile o potrebbe essere limitata sui [server dedicati della linea di prodotti **Eco**](https://eco.ovhcloud.com/it/about/).
+Questa funzionalità potrebbe non essere disponibile o essere limitata sui server della [gamma **Eco**](https://eco.ovhcloud.com/it/about/).
 
-Per ulteriori informazioni, visitare la nostra [pagina di confronto](https://eco.ovhcloud.com/it/compare/).
+Consulta la nostra [pagina di confronto](https://eco.ovhcloud.com/it/compare/) per ulteriori informazioni.
 
 :::
 
@@ -64,9 +64,9 @@ Per ulteriori informazioni, visitare la nostra [pagina di confronto](https://eco
 ## Procedura
 
 :::info
-A titolo di esempio utilizzeremo un blocco IP di 46.105.135.96/28 ed eth1 per l'interfaccia di rete secondaria, dedicata al vRack.
+A titolo di esempio, utilizzeremo un blocco IP 46.105.135.96/28 e `eth1` per l'interfaccia di rete secondaria, dedicata al vRack.
 
-Sempre a titolo di esempio, il file di configurazione di rete a cui facciamo riferimento si trova in `/etc/network/interfaces`. Il file equivalente sul server potrebbe trovarsi altrove, a seconda del sistema operativo. Il contenuto del file potrebbe essere diverso. In caso di difficoltà, fare riferimento alla documentazione ufficiale della propria distribuzione.
+Il file di configurazione di rete a cui facciamo riferimento si trova in `/etc/network/interfaces`. Il file equivalente sul tuo server potrebbe trovarsi altrove, a seconda del sistema operativo. Anche il contenuto del file potrebbe essere diverso. In caso di difficoltà, fai riferimento alla documentazione ufficiale della tua distribuzione.
 
 :::
 
@@ -74,41 +74,41 @@ Sempre a titolo di esempio, il file di configurazione di rete a cui facciamo rif
 ### Aggiungere il blocco IP al vRack
 
 :::warning
-Una volta aggiunto un blocco IP al vRack, non è più collegato a un server fisico.
+Una volta aggiunto un blocco IP al vRack, questo non è più collegato a un server fisico.
 
-Questa configurazione consente di configurare gli IP dello stesso blocco su più server, a condizione che tutti questi server si trovino nello stesso vRack del blocco IP. Il blocco IP deve avere almeno 2 IP utilizzabili o più affinché ciò sia possibile.
+Questa configurazione consente di configurare gli IP dello stesso blocco su più server, a condizione che tali server si trovino tutti nello stesso vRack del blocco IP. Il blocco IP deve disporre di almeno 2 IP utilizzabili affinché ciò sia possibile.
 
 :::
 
 
-Selezionare il proprio vRack dall'elenco per visualizzare l'elenco dei servizi idonei. Cliccare sul blocco IP da aggiungere al vRack e poi sul pulsante <code className="action">Aggiungi</code>.
+Seleziona il tuo vRack dall'elenco per visualizzare l'elenco dei servizi idonei. Clicca sul blocco IP che desideri aggiungere al vRack, quindi clicca sul pulsante <code className="action">Aggiungi</code>.
 
 <img className="thumbnail" alt="Aggiunta di un blocco IP al vRack" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/addIPblock.png" loading="lazy" />
 
-### Gestire la larghezza di banda IP pubblica nel vRack
+### Gestire la larghezza di banda IP pubblica sul vRack
 
-Per impostazione predefinita, i blocchi Additional IP instradati tramite un vRack beneficiano di una larghezza di banda pubblica standard di 5 Gbps in Europa e Nord America, o di 100 Mbps nelle regioni APAC. Per ulteriori dettagli sulle opzioni disponibili, fare riferimento alle opzioni di routing pubblico sulla nostra [pagina del prodotto vRack](https://www.ovhcloud.com/it/network/vrack/).
+Per impostazione predefinita, i blocchi di Additional IP instradati tramite un vRack beneficiano di una larghezza di banda pubblica standard di 5 Gbps in Europa, Canada e Stati Uniti, e di 100 Mbps nelle regioni APAC. Per una panoramica dettagliata della disponibilità, consulta le opzioni di routing pubblico sulla nostra [pagina del prodotto vRack](https://www.ovhcloud.com/it/network/vrack/).
 
-Per rispondere alle crescenti esigenze delle infrastrutture e ai requisiti dei servizi ad alto traffico, OVHcloud propone ora ai propri clienti opzioni di larghezza di banda a pagamento. Si noti che queste opzioni si applicano **per vRack e per regione**. Poiché gli indirizzi Additional IP sono collegati a una regione precisa, qualsiasi modifica della larghezza di banda influirà sull'insieme degli indirizzi (IPv4 e IPv6) instradati verso quel vRack nella regione corrispondente.
+Con la crescita delle esigenze infrastrutturali, alcuni utenti potrebbero avere bisogno di una larghezza di banda maggiore per supportare servizi pubblici ad alto traffico, per i quali OVHcloud propone opzioni di larghezza di banda a pagamento. Queste opzioni si applicano **per vRack e per regione**. Poiché gli indirizzi Additional IP sono legati a una regione, qualsiasi modifica della larghezza di banda influirà su tutti gli indirizzi IP (IPv4 e IPv6) instradati verso quel vRack all'interno di quella regione.
 
 <details>
 
-<summary>Durante il processo di ordine di Additional IP</summary>
+<summary>Al momento dell'ordine di un Additional IP</summary>
 
 
-#### Scelta della larghezza di banda pubblica durante il processo di ordine
+#### Scegliere la larghezza di banda pubblica al momento dell'ordine di un Additional IP
 
-È possibile modificare la larghezza di banda predefinita al momento di ordinare un nuovo blocco Additional IP, non appena viene selezionata una rete vRack come servizio backend.
+Puoi modificare la larghezza di banda pubblica predefinita al momento di ordinare un nuovo blocco di Additional IP con una rete vRack come servizio backend.
 
-Per ordinare un nuovo blocco Additional IP:
+Per ordinare un nuovo blocco di Additional IP:
 
-- Nella barra laterale sinistra, accedere alla sezione <code className="action">Network</code>.
-- Selezionare <code className="action">Indirizzi IP pubblici</code>.
-- Cliccare sul pulsante <code className="action">Ordina IP</code> in cima alla pagina.
-- Scegliere la versione IP, quindi il vRack a cui sarà associato l'Additional IP.
-- Selezionare la regione del proprio Additional IP.
-- Scegliere la larghezza di banda pubblica da applicare al proprio vRack per quella regione.
-- Configurare le altre opzioni secondo le proprie esigenze e, successivamente, finalizzare l'ordine.
+- Apri la sezione <code className="action">Network</code> nella barra laterale sinistra.
+- Seleziona <code className="action">Indirizzi IP pubblici</code>.
+- Clicca sul pulsante <code className="action">Ordina degli IP</code>, in cima alla pagina.
+- Seleziona la versione IP, quindi il vRack a cui vuoi collegare il tuo Additional IP.
+- Seleziona la regione in cui vuoi che si trovi il tuo Additional IP.
+- Scegli la larghezza di banda pubblica da applicare al tuo vRack per questa regione specifica.
+- Compila le altre opzioni se necessario, quindi finalizza il tuo ordine.
 
 </details>
 
@@ -118,34 +118,34 @@ Per ordinare un nuovo blocco Additional IP:
 <summary>Dalla pagina di gestione del vRack</summary>
 
 
-#### Modifica della larghezza di banda pubblica dalla pagina di gestione
+#### Modificare la larghezza di banda pubblica del vRack dalla pagina di gestione
 
-Per i blocchi Additional IP già collegati a un vRack, la larghezza di banda viene gestita direttamente dalla pagina di configurazione del servizio.
+Per i blocchi di Additional IP già collegati a un vRack, puoi gestire la larghezza di banda direttamente dalla pagina di configurazione del servizio.
 
 Per accedere all'interfaccia di gestione:
 
-- Nella colonna "Indirizzo IP pubblico e larghezza di banda", cliccare sul pulsante <code className="action">Gestisci</code> corrispondente al vRack desiderato.
+- Nella colonna "Indirizzo IP pubblico e larghezza di banda", clicca sul pulsante <code className="action">Gestisci</code> corrispondente al vRack desiderato.
 
-L'interfaccia di gestione si divide in due schede:
+La pagina di gestione è organizzata in due schede:
 
-- **All attached services**: Attualmente reindirizza alla pagina di gestione classica del vRack. Prossimamente, questa scheda elencherà in modo ottimizzato tutti i prodotti (server, progetti Cloud, ecc.) collegati al vRack.
-- **Connettività IP pubblica**: Consente di gestire le opzioni di routing pubblico del proprio vRack, inclusa la larghezza di banda.
+- **Tutti i servizi collegati**: al momento, questa scheda reindirizza alla pagina di gestione classica del vRack. Prossimamente, elencherà in modo ottimizzato tutti i prodotti (server, progetti Cloud, ecc.) attualmente collegati al vRack.
+- **Connettività IP pubblica**: consente di gestire le opzioni di routing pubblico del tuo vRack, inclusa la larghezza di banda.
 
-Per modificare la larghezza di banda:
+Per modificare la larghezza di banda pubblica:
 
-- Andare alla scheda <code className="action">Connettività IP pubblica</code>.
-- L'interfaccia mostra finestre di gestione per regione (ad es. `eu-west-par`) associate al vRack, con la lista degli IP associati.
-- Nel riquadro della regione corrispondente, cliccare su <code className="action">Modifica larghezza di banda</code>.
-- Selezionare l'opzione desiderata nel pannello di destra, quindi cliccare su <code className="action">Ordina</code> per convalidare.
-- Una volta effettuato il pagamento, la nuova larghezza di banda sarà attiva sul proprio vRack nella regione scelta dopo alcuni minuti.
+- Vai alla scheda <code className="action">Connettività IP pubblica</code>.
+- L'interfaccia mostra finestre di gestione individuali per ogni regione (ad esempio `eu-west-par`) associata al vRack, con l'elenco di tutti gli indirizzi IP collegati a quella regione specifica.
+- Nella finestra della regione interessata, clicca sul pulsante <code className="action">Modifica la larghezza di banda</code>.
+- Seleziona l'opzione di larghezza di banda desiderata nel pannello che appare a destra, quindi clicca su <code className="action">Ordina</code> per confermare l'ordine.
+- Una volta pagato l'ordine, la larghezza di banda selezionata dovrebbe essere disponibile sul tuo vRack, nella regione scelta, dopo qualche minuto.
 
 :::info
-Il primo mese sottoscritto viene fatturato in modo proporzionale ai giorni rimanenti. La tariffa completa verrà applicata nel ciclo di fatturazione successivo.
+Le spese del primo mese vengono calcolate in proporzione ai giorni rimanenti; la tariffa completa si applicherà a partire dal ciclo di fatturazione successivo.
 
 :::
 
 
-L'aumento di larghezza di banda si applicherà a tutti gli indirizzi IP di quella regione per il vRack selezionato.
+L'aggiornamento della larghezza di banda selezionato si applicherà a tutti gli indirizzi IP di quella regione per il vRack scelto.
 
 </details>
 
@@ -202,11 +202,11 @@ Le modifiche di priorità si applicano a tutti i blocchi di Additional IP indiri
 
 ### Configurare un indirizzo IP utilizzabile
 
-Per i fini del vRack, il primo, il penultimo e l'ultimo indirizzo in qualsiasi blocco IP sono sempre riservati rispettivamente per l'indirizzo di rete, il gateway di rete e il broadcast di rete. Ciò significa che il primo indirizzo utilizzabile è il secondo indirizzo nel blocco, come mostrato di seguito:
+Nel caso del vRack, il primo, il penultimo e l'ultimo indirizzo di un dato blocco IP sono sempre riservati rispettivamente all'indirizzo di rete, al gateway di rete e al broadcast di rete. Ciò significa che il primo indirizzo utilizzabile è il secondo indirizzo del blocco, come indicato di seguito:
 
 ```sh
-46.105.135.96   # Riservato: Indirizzo di rete
-46.105.135.97   # Primo IP utilizzabile
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,81 +218,27 @@ Per i fini del vRack, il primo, il penultimo e l'ultimo indirizzo in qualsiasi b
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109  # Ultimo IP utilizzabile
-46.105.135.110  # Riservato: Gateway di rete
-46.105.135.111  # Riservato: Broadcast di rete
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Per configurare il primo indirizzo IP utilizzabile, è necessario modificare il file di configurazione di rete, come mostrato di seguito. In questo esempio, è necessario utilizzare una subnet mask di *255.255.255.240*.
+Per configurare il primo indirizzo IP utilizzabile, dobbiamo modificare il file di configurazione di rete, come indicato di seguito. In questo esempio, dobbiamo utilizzare una subnet mask di **255.255.255.240**.
 
 :::info
-La subnet mask utilizzata nel nostro esempio è appropriata per il nostro blocco IP. La subnet mask potrebbe variare a seconda della dimensione del blocco. Quando si acquista il blocco IP, si riceverà un'e-mail che indicherà quale subnet mask utilizzare.
+La subnet mask utilizzata in questo esempio è adatta al nostro blocco IP. La tua subnet mask potrebbe essere diversa a seconda delle dimensioni del tuo blocco. Quando acquisti il tuo blocco IP, ricevi un'e-mail che ti indica quale subnet mask utilizzare.
 
 :::
 
 
 ### Scaricare il pacchetto `iproute2`
 
-```sh
-/etc/network/interfaces
+Prima di iniziare, scarica e installa **iproute2**, un pacchetto che consente di configurare manualmente il routing IP. Questo pacchetto potrebbe essere già disponibile sul tuo server; in tal caso, passa direttamente al passaggio successivo.
 
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-### Creare una nuova tabella di routing IP
-
-Per prima cosa, è necessario scaricare e installare iproute2, un pacchetto che ci permetterà di configurare manualmente il routing IP sul server.
-
-Stabilire una connessione SSH al server ed eseguire il seguente comando dalla riga di comando. Questo scaricherà e installerà iproute2.
+Stabilisci una connessione SSH al tuo server ed esegui il seguente comando dalla riga di comando. Questo scaricherà e installerà iproute2.
 
 ```sh
-# apt-get install iproute2
-```
-
-Successivamente, è necessario creare una nuova route IP per il vRack. Aggiungeremo una nuova regola di traffico modificando il file, come mostrato di seguito:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valori riservati
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# locale
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Modificare il file di configurazione di rete
-
-:::info
-A titolo di esempio, il file di configurazione di rete a cui facciamo riferimento si trova in /etc/network/interfaces. Il file equivalente sul server potrebbe trovarsi altrove, a seconda del sistema operativo.
-
-:::
-
-
-Infine, è necessario modificare il file di configurazione di rete per tenere conto della nuova regola di traffico e instradare il traffico del vRack attraverso l'indirizzo del gateway di rete **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -301,110 +247,25 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Creare il file per l'interfaccia di rete secondaria
-
-Per prima cosa, è possibile copiare e utilizzare la configurazione utilizzata per l'interfaccia di rete primaria e adattarla alle proprie esigenze:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Poi accediamo al nuovo file:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-E definiamo le impostazioni IP:
-```sh
-# Creato automaticamente da cloud-init all'avvio dell'istanza, non modificare.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Creare una nuova tabella di routing IP
-
-Successivamente, è necessario creare una nuova route IP per il vRack. Aggiungeremo una nuova regola di traffico modificando il file, come mostrato di seguito:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valori riservati
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# locale
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Successivamente, creare il file necessario per applicare le nuove regole:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-E incollare il seguente contenuto (ricordare di sostituire le variabili con i propri valori):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Modificare il file di configurazione di rete
-
-Infine, è necessario modificare il file di configurazione di rete per tenere conto della nuova regola di traffico e instradare il traffico del vRack attraverso l'indirizzo del gateway di rete **46.105.135.110**.
-
-È possibile farlo modificando il seguente file per aggiungere route persistenti e statiche:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Stabilire una connessione SSH al server ed eseguire il seguente comando per scaricare e installare iproute2:
-
-```sh
-sudo apt-get install iproute2
-```
-
-Riavviare il server per applicare le modifiche oppure abilitare semplicemente la nuova interfaccia di rete:
-
-```sh
-ip link set eth1 up
-```
-
 #### Configurazioni GNU/Linux
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
+<Tab label="AlmaLinux and Rocky Linux (8/9)">
 **Creare il file per l'interfaccia di rete secondaria**
 
-Copiare la configurazione dell'interfaccia di rete primaria e adattarla alle proprie esigenze:
+Inizia copiando la configurazione dell'interfaccia di rete principale, quindi adattala in base alle tue esigenze:
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
 ```
 
-Aprire poi il nuovo file:
+Apri quindi il nuovo file:
 
 ```sh
 sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
 ```
 
-- Definire le impostazioni IP:
+- Definisci i parametri IP:
 
 ```sh
 # Created by cloud-init on instance boot automatically, do not edit.
@@ -423,7 +284,7 @@ ARP=yes
 
 **Creare una nuova tabella di routing IP**
 
-Successivamente, creare una nuova route IP per il vRack. Aggiungere una nuova regola di traffico modificando il file come mostrato di seguito:
+Successivamente, dobbiamo creare una nuova route IP per il vRack. Aggiungeremo una nuova regola di traffico modificando il file, come indicato di seguito:
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -441,13 +302,13 @@ sudo nano /etc/iproute2/rt_tables
 1 vrack
 ```
 
-Creare poi il file necessario per applicare le nuove regole:
+Crea quindi il file necessario per applicare le nuove regole:
 
 ```sh
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Incollare il seguente contenuto (ricordare di sostituire le variabili con i propri valori):
+E incolla il seguente contenuto (ricorda di sostituire le nostre variabili con i tuoi valori):
 
 ```sh
 from 46.105.135.96/28 table vrack
@@ -456,69 +317,82 @@ to 46.105.135.96/28 table vrack
 
 **Modificare il file di configurazione di rete**
 
-Infine, modificare il file di configurazione di rete per tenere conto della nuova regola di traffico e instradare il traffico del vRack attraverso l'indirizzo del gateway di rete **46.105.135.110**.
+Per concludere, dobbiamo modificare il file di configurazione di rete per tenere conto della nuova regola di traffico e instradare il traffico del vRack tramite l'indirizzo del gateway di rete **46.105.135.110**.
 
-Modificare il seguente file per aggiungere route persistenti e statiche:
+Modifica il seguente file per aggiungere route persistenti e statiche:
 
 ```sh
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Incollare il seguente contenuto (ricordare di sostituire le variabili con i propri valori):
+Incolla il seguente contenuto (ricorda di sostituire le nostre variabili con i tuoi valori):
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Riavviare il server per applicare le modifiche oppure abilitare semplicemente la nuova interfaccia di rete:
+Riavvia il tuo server per applicare le modifiche, oppure attiva semplicemente la nuova interfaccia di rete:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
-<Tab label="Ubuntu e Debian 12+">
+<Tab label="Ubuntu & Debian 12+">
+
 - Configurare l'Additional IP
 
-Aprire il file di configurazione di rete situato in `/etc/netplan` con un editor di testo a scelta. Qui il file si chiama `50-cloud-init.yaml`.
+Utilizzando un editor di testo a tua scelta, apri il file di configurazione di rete situato in `/etc/netplan`. Qui il file si chiama `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Definire le impostazioni IP con le seguenti variabili:
+- Definisci i parametri IP utilizzando le seguenti variabili, quindi aggiungili alla tua configurazione esistente:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Per impostazione predefinita, il traffico destinato al tuo Additional IP potrebbe non utilizzare l'interfaccia vRack per il percorso di ritorno. Questo può causare un routing asimmetrico, e alcune reti potrebbero rifiutare tale traffico. La route `table: 1`, combinata con la regola `routing-policy` riportata di seguito, garantisce che le risposte provenienti dall'Additional IP vengano instradate correttamente tramite l'interfaccia vRack. L'identificativo `1` viene utilizzato qui per corrispondere alle altre schede di questa guida; sei libero di utilizzare il numero che preferisci, a condizione di utilizzarlo in modo coerente.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Esempio**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
-Applicare la configurazione con il seguente comando:
+Applica la configurazione con il seguente comando:
 
 ```bash
 sudo netplan apply
 ```
 </Tab>
-<Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
-Per prima cosa, verificare che l'interfaccia vRack sia nello stato `connected` o `connecting`. Nel nostro esempio, l'interfaccia si chiama `eno2`.
+<Tab label="Fedora 43+, AlmaLinux and Rocky Linux (10)">
+Verifica innanzitutto il nome della tua interfaccia vRack. Nel nostro esempio, l'interfaccia si chiama `eno2`:
 
 ```sh
 nmcli device status
@@ -526,79 +400,87 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Successivamente, ottenere il nome del file di configurazione situato in `/etc/NetworkManager/system-connections`. Qui il file si chiama `vRack.nmconnection`.
+Se la tua interfaccia vRack è già nello stato `connected` o `connecting`, puoi procedere con l'aggiunta dell'IP.
+
+Nel nostro esempio, lo stato è `disconnected`: creiamo quindi l'interfaccia con il seguente comando. L'abbiamo chiamata `vRack` per distinguerla dalle altre interfacce.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
-Configurare l'Additional IP tramite il gestore `nmcli`. Sostituire `vRack` e gli altri parametri con i propri valori.
+Utilizzando il gestore `nmcli`, configura il tuo Additional IP. Sostituisci `vRack` e gli altri parametri con i tuoi valori.
 
 - Aggiungere l'IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Aggiungere il gateway
+- Impedire che la connessione vRack diventi la route predefinita
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
-- Cambiare la configurazione da **auto** a **manual**:
+- Passare la configurazione da **auto** a **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Rendere la configurazione persistente
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Creare una nuova tabella di routing IP**
+:::info
+Per impostazione predefinita, il traffico destinato al tuo IP vRack potrebbe non utilizzare l'interfaccia vRack per il percorso di ritorno. Questo può causare un routing asimmetrico, e alcune reti potrebbero rifiutare tale traffico. I passaggi seguenti configurano una tabella di routing separata per il traffico vRack, garantendo che le risposte provenienti dall'IP vRack vengano instradate correttamente tramite l'interfaccia vRack.
+:::
 
-Successivamente, creare una nuova route IP per il vRack. Aggiungere una nuova regola di traffico (`1 vrack`) modificando il file come mostrato di seguito:
+- Creare la tabella di routing del vRack
 
+Nel nostro esempio, utilizziamo 1 come identificativo, ma puoi scegliere il numero che preferisci. I comandi seguenti fanno riferimento alla tabella tramite il suo identificativo (`table=1`); il nome `vrack` serve solo a facilitarne la lettura in seguito, ad esempio con `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Aggiungere la route
+- Instradare il traffico di questa connessione tramite la tabella vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Aggiungere la route tramite il gateway
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 Nel nostro esempio
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Riavviare la rete con il seguente comando:
+- Aggiungere una regola affinché il traffico vRack utilizzi questa tabella
+
+Questo passaggio indica concretamente al tuo server di utilizzare la tabella 1 per tutto ciò che viene inviato dal tuo IP vRack. Senza di essa, le route che hai appena aggiunto verrebbero ignorate.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Applica le modifiche:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>
@@ -606,56 +488,56 @@ sudo systemctl restart NetworkManager
 
 ### Windows Server
 
-#### Step 1: Verifica e configurazione dell'interfaccia di rete secondaria
+#### Passaggio 1: verifica e configurazione dell'interfaccia di rete secondaria
 
-Verificare le informazioni della nuova interfaccia di rete:
+Verifica innanzitutto le informazioni della nuova interfaccia di rete:
 
-<img className="thumbnail" alt="verifica dell'interfaccia di rete secondaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
+<img className="thumbnail" alt="verifica della seconda interfaccia di rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
 
-Verificare poi le proprietà:
+Verifica quindi le proprietà:
 
-<img className="thumbnail" alt="proprietà dell'interfaccia di rete secondaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
+<img className="thumbnail" alt="proprietà della seconda interfaccia di rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
 
-<img className="thumbnail" alt="proprietà dell'interfaccia di rete secondaria" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
+<img className="thumbnail" alt="proprietà della seconda interfaccia di rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
 
-#### Step 2: Configurazione IP
+#### Passaggio 2: configurazione IP
 
-Selezionare l'opzione <code className="action">Use the following IP address</code>:
+Seleziona l'opzione <code className="action">Utilizza il seguente indirizzo IP</code>:
 
 <img className="thumbnail" alt="configurazione IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-4.png" loading="lazy" />
 
-Definire le informazioni IP:
+Definisci le informazioni IP:
 
 <img className="thumbnail" alt="configurazione IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-5b.png" loading="lazy" />
 
-#### Step 3: Riavvio dell'interfaccia di rete
+#### Passaggio 3: riavvio dell'interfaccia di rete
 
-Per prima cosa, disabilitare l'interfaccia.
+Inizia disattivando l'interfaccia.
 
-<img className="thumbnail" alt="disabilitazione rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-6.png" loading="lazy" />
+<img className="thumbnail" alt="disattivazione della rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-6.png" loading="lazy" />
 
-Poi abilitarla.
+Attivala quindi.
 
-<img className="thumbnail" alt="abilitazione rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-7.png" loading="lazy" />
+<img className="thumbnail" alt="attivazione della rete" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-7.png" loading="lazy" />
 
 ### Risoluzione dei problemi
 
-Se non si riesce a stabilire una connessione dalla propria VM o server alla rete privata, aprire un ticket di supporto dal proprio Spazio Cliente con le seguenti informazioni:
+Se non riesci a stabilire una connessione tra la tua VM o server e la rete privata, inviaci un ticket dal tuo Spazio Cliente specificando i seguenti elementi:
 
-- IP sorgente e IP destinazione
-- Risultato di `ifconfig -a` o `ipconfig /all` da entrambi i server o VM (configurazione dell'interfaccia di rete)
-- Ping in entrambe le direzioni
+- IP di origine e IP di destinazione
+- Risultato di `ifconfig -a` o `ipconfig /all` su entrambi i server o VM (configurazione dell'interfaccia di rete)
+- Risultato del ping in entrambe le direzioni
 - Risultato di `arp -a`
 - Tabella di routing
 
-Includere i risultati sopra indicati nel ticket.
+Allega i risultati sopra indicati al tuo ticket.
 
 ## Per saperne di più
 
-[Configurare il vRack sui server dedicati](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
+[Configurare il vRack sui tuoi server dedicati](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
 
-[Creare più VLAN in un vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
+[Creare più vLAN in un vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
 
-[Configurare il vRack tra il Public Cloud e un server dedicato](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
+[Configurare il vRack tra Public Cloud e un server dedicato](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pl/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
 title: Konfiguracja bloku Additional IP w sieci vRack
-description: Ten przewodnik pokazuje, jak skonfigurować blok publicznych adresów IP do użytku z siecią vRack.
-lastUpdated: 2026-09-08
+description: Ten przewodnik pokazuje, jak skonfigurować blok publicznych adresów IP do użytku z siecią vRack
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -66,7 +66,7 @@ Więcej informacji znajdziesz na naszej [stronie porównawczej](https://eco.ovhc
 :::info
 Dla celów przykładowych będziemy używać bloku IP 46.105.135.96/28 i eth1 dla dodatkowego interfejsu sieciowego, który jest dedykowany sieci vRack.
 
-Również dla celów przykładowych, plik konfiguracji sieci, do którego się odwołujemy, znajduje się w `/etc/network/interfaces`. Odpowiedni plik na Twoim serwerze może znajdować się w innym miejscu, w zależności od systemu operacyjnego. Zawartość pliku może być również inna. W przypadku trudności zapoznaj się z oficjalną dokumentacją swojej dystrybucji.
+Plik konfiguracji sieci, do którego się odwołujemy, znajduje się w `/etc/network/interfaces`. Odpowiedni plik na Twoim serwerze może znajdować się w innym miejscu, w zależności od systemu operacyjnego. Zawartość pliku może być również inna. W przypadku trudności zapoznaj się z oficjalną dokumentacją swojej dystrybucji.
 
 :::
 
@@ -89,7 +89,7 @@ Wybierz swój vRack z listy, aby wyświetlić listę kwalifikujących się usłu
 
 Domyślnie bloki Additional IP kierowane przez sieć vRack korzystają ze standardowej publicznej przepustowości 5 Gbps w Europie/Kanadzie/USA i 100 Mbps w regionach APAC. Szczegółowe informacje o dostępności można znaleźć w opcjach routingu publicznego na naszej [stronie produktu vRack](https://www.ovhcloud.com/pl/network/vrack/).
 
-Wraz ze wzrostem wymagań infrastrukturalnych użytkownicy mogą potrzebować większej przepustowości do obsługi publicznych usług o dużym natężeniu ruchu, dla których OVHcloud oferuje płatne opcje przepustowości. Należy pamiętać, że opcje przepustowości są stosowane **per vRack i per region**. Ponieważ adresy Additional IP są powiązane z regionem, każda modyfikacja przepustowości wpłynie na wszystkie adresy IP (zarówno IPv4, jak i IPv6) kierowane do konkretnego vRack w tym określonym regionie.
+Wraz ze wzrostem wymagań infrastrukturalnych użytkownicy mogą potrzebować większej przepustowości do obsługi publicznych usług o dużym natężeniu ruchu, dla których OVHcloud oferuje płatne opcje przepustowości. Opcje przepustowości są stosowane **per vRack i per region**. Ponieważ adresy Additional IP są powiązane z regionem, każda modyfikacja przepustowości wpłynie na wszystkie adresy IP (zarówno IPv4, jak i IPv6) kierowane do konkretnego vRack w tym określonym regionie.
 
 <details>
 
@@ -102,7 +102,7 @@ Domyślną publiczną przepustowość można zmienić podczas zamawiania nowego 
 
 Aby zamówić nowy blok Additional IP:
 
-- Otwórz sekcję <code className="action">Sieć</code> na lewym pasku bocznym.
+- Otwórz sekcję <code className="action">Network</code> na lewym pasku bocznym.
 - Wybierz <code className="action">Publiczne adresy IP</code>.
 - Kliknij przycisk <code className="action">Zamów IP</code> w pobliżu górnej części strony.
 - Wybierz wersję IP, a następnie vRack, do którego chcesz przypisać swój Additional IP.
@@ -124,7 +124,7 @@ W przypadku bloków Additional IP już przypisanych do sieci vRack przepustowoś
 
 Aby uzyskać dostęp do interfejsu zarządzania:
 
-- W kolumnie "Public IP & bandwidth" kliknij przycisk <code className="action">Zarządzaj</code> dla odpowiedniego vRack.
+- W kolumnie "Publiczny adres IP i przepustowość" kliknij przycisk <code className="action">Zarządzaj</code> dla odpowiedniego vRack.
 
 Strona zarządzania jest podzielona na dwie zakładki:
 
@@ -205,8 +205,8 @@ Zmiany priorytetów są stosowane do wszystkich bloków Additional IP routowanyc
 W sieci vRack pierwszy, przedostatni i ostatni adres w dowolnym bloku IP są zawsze zarezerwowane odpowiednio dla adresu sieci, bramki sieciowej i rozgłoszenia sieciowego. Oznacza to, że pierwszy użyteczny adres to drugi adres w bloku, jak pokazano poniżej:
 
 ```sh
-46.105.135.96   # Zarezerwowany: Adres sieci
-46.105.135.97   # Pierwszy użyteczny adres IP
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,12 +218,12 @@ W sieci vRack pierwszy, przedostatni i ostatni adres w dowolnym bloku IP są zaw
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109  # Ostatni użyteczny adres IP
-46.105.135.110  # Zarezerwowany: Bramka sieciowa
-46.105.135.111  # Zarezerwowany: Rozgłoszenie sieciowe
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Aby skonfigurować pierwszy użyteczny adres IP, należy edytować plik konfiguracji sieci, jak pokazano poniżej. W tym przykładzie musimy użyć maski podsieci *255.255.255.240*.
+Aby skonfigurować pierwszy użyteczny adres IP, należy edytować plik konfiguracji sieci, jak pokazano poniżej. W tym przykładzie musimy użyć maski podsieci **255.255.255.240**.
 
 :::info
 Maska podsieci użyta w naszym przykładzie jest odpowiednia dla naszego bloku IP. Twoja maska podsieci może się różnić w zależności od rozmiaru bloku. Po zakupie bloku IP otrzymasz e-mail z informacją, której maski podsieci należy użyć.
@@ -233,66 +233,12 @@ Maska podsieci użyta w naszym przykładzie jest odpowiednia dla naszego bloku I
 
 ### Pobieranie pakietu `iproute2`
 
-```sh
-/etc/network/interfaces
+Zanim zaczniesz, pobierz i zainstaluj pakiet **iproute2**, który umożliwia ręczną konfigurację routingu IP. Pakiet ten może być już dostępny na Twoim serwerze — jeśli tak, przejdź do kolejnego kroku.
 
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-### Tworzenie nowej tabeli routingu IP
-
-Najpierw musimy pobrać i zainstalować iproute2, czyli pakiet, który umożliwi nam ręczną konfigurację routingu IP na serwerze.
-
-Nawiąż połączenie SSH z serwerem i uruchom następujące polecenie z wiersza poleceń. Spowoduje to pobranie i zainstalowanie iproute2.
+Nawiąż połączenie SSH z serwerem i uruchom z wiersza poleceń poniższe polecenie. Spowoduje to pobranie i zainstalowanie pakietu iproute2.
 
 ```sh
-# apt-get install iproute2
-```
-
-Następnie musimy utworzyć nową trasę IP dla sieci vRack. Dodamy nową regułę ruchu, modyfikując plik w następujący sposób:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# zarezerwowane wartości
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# lokalne
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Modyfikacja pliku konfiguracji sieci
-
-:::info
-Dla celów przykładowych plik konfiguracji sieci, do którego się odwołujemy, znajduje się w /etc/network/interfaces. Odpowiedni plik na Twoim serwerze może znajdować się w innym miejscu, w zależności od systemu operacyjnego.
-
-:::
-
-
-Na koniec musimy zmodyfikować plik konfiguracji sieci, aby uwzględnić nową regułę ruchu i skierować ruch vRack przez adres bramki sieciowej **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -301,98 +247,13 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Tworzenie pliku dla dodatkowego interfejsu sieciowego
-
-Najpierw możemy skopiować i użyć konfiguracji stosowanej dla głównego interfejsu sieciowego i dostosować ją do naszych potrzeb:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Następnie otwieramy nowy plik:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-I definiujemy ustawienia IP:
-```sh
-# Automatycznie utworzone przez cloud-init podczas uruchamiania instancji, nie edytować.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Tworzenie nowej tabeli routingu IP
-
-Następnie musimy utworzyć nową trasę IP dla sieci vRack. Dodamy nową regułę ruchu, modyfikując plik w następujący sposób:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# zarezerwowane wartości
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# lokalne
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Następnie utwórz plik potrzebny do zastosowania nowych reguł:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-I wklej następującą zawartość (pamiętaj, aby zastąpić nasze zmienne własnymi wartościami):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Modyfikacja pliku konfiguracji sieci
-
-Na koniec musimy zmodyfikować plik konfiguracji sieci, aby uwzględnić nową regułę ruchu i skierować ruch vRack przez adres bramki sieciowej **46.105.135.110**.
-
-Możemy to osiągnąć, edytując następujący plik w celu dodania trwałych i statycznych tras:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Nawiąż połączenie SSH z serwerem i uruchom następujące polecenie, aby pobrać i zainstalować iproute2:
-
-```sh
-sudo apt-get install iproute2
-```
-
-Teraz uruchom ponownie serwer, aby zastosować zmiany, lub alternatywnie włącz po prostu nowy interfejs sieciowy:
-
-```sh
-ip link set eth1 up
-```
-
 #### Konfiguracje GNU/Linux
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux i Rocky Linux (8/9)">
-**Tworzenie pliku dla dodatkowego interfejsu sieciowego**
+<Tab label="AlmaLinux i Rocky Linux (8/9)">
+**Utwórz plik dla dodatkowego interfejsu sieciowego**
 
-Skopiuj konfigurację głównego interfejsu sieciowego i dostosuj ją do swoich potrzeb:
+Najpierw skopiuj konfigurację głównego interfejsu sieciowego i dostosuj ją do własnych potrzeb:
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
@@ -421,9 +282,9 @@ IPADDR=46.105.135.97
 ARP=yes
 ```
 
-**Tworzenie nowej tabeli routingu IP**
+**Utwórz nową tabelę routingu IP**
 
-Następnie utwórz nową trasę IP dla sieci vRack. Dodaj nową regułę ruchu, modyfikując plik w następujący sposób:
+Następnie musisz utworzyć nową trasę IP dla sieci vRack. Dodasz nową regułę ruchu, modyfikując plik w sposób pokazany poniżej:
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -447,68 +308,81 @@ Następnie utwórz plik potrzebny do zastosowania nowych reguł:
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Wklej następującą zawartość (pamiętaj, aby zastąpić zmienne własnymi wartościami):
+I wklej poniższą zawartość (pamiętaj, aby zastąpić nasze zmienne własnymi wartościami):
 
 ```sh
 from 46.105.135.96/28 table vrack
 to 46.105.135.96/28 table vrack
 ```
 
-**Modyfikacja pliku konfiguracji sieci**
+**Zmodyfikuj plik konfiguracji sieci**
 
-Na koniec zmodyfikuj plik konfiguracji sieci, aby uwzględnić nową regułę ruchu i skierować ruch vRack przez adres bramki sieciowej **46.105.135.110**.
+Na koniec musisz zmodyfikować plik konfiguracji sieci, aby uwzględnić nową regułę ruchu i skierować ruch sieci vRack przez adres bramki sieciowej **46.105.135.110**.
 
-Edytuj następujący plik, aby dodać trwałe i statyczne trasy:
+Edytuj poniższy plik, aby dodać trwałe i statyczne trasy:
 
 ```sh
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Wklej następującą zawartość (pamiętaj, aby zastąpić zmienne własnymi wartościami):
+Wklej poniższą zawartość (pamiętaj, aby zastąpić nasze zmienne własnymi wartościami):
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Uruchom ponownie serwer, aby zastosować zmiany, lub włącz po prostu nowy interfejs sieciowy:
+Uruchom teraz ponownie serwer, aby zastosować zmiany, lub po prostu włącz nowy interfejs sieciowy:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
 <Tab label="Ubuntu i Debian 12+">
-- Konfiguracja Additional IP
 
-Otwórz plik konfiguracji sieci znajdujący się w `/etc/netplan` za pomocą wybranego edytora tekstu. Tutaj plik nazywa się `50-cloud-init.yaml`.
+- Skonfiguruj Additional IP
+
+Za pomocą wybranego edytora tekstu otwórz do edycji plik konfiguracji sieci znajdujący się w `/etc/netplan`. W naszym przykładzie plik nazywa się `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Zdefiniuj ustawienia IP za pomocą następujących zmiennych:
+- Zdefiniuj ustawienia IP za pomocą poniższych zmiennych i dodaj je do istniejącej konfiguracji:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Domyślnie ruch kierowany do Twojego adresu Additional IP może nie korzystać z interfejsu vRack w drodze powrotnej. Może to powodować asymetryczny routing, który niektóre sieci mogą odrzucać. Trasa `table: 1` w połączeniu z regułą `routing-policy` poniżej zapewnia, że odpowiedzi z adresu Additional IP są kierowane z powrotem przez interfejs vRack. Identyfikator `1` jest tu używany, aby zachować zgodność z pozostałymi zakładkami tego przewodnika; możesz swobodnie użyć dowolnego innego numeru, o ile stosujesz go konsekwentnie.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Przykład**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
 Zastosuj konfigurację za pomocą następującego polecenia:
@@ -518,7 +392,7 @@ sudo netplan apply
 ```
 </Tab>
 <Tab label="Fedora 43+, AlmaLinux i Rocky Linux (10)">
-Najpierw sprawdź, czy interfejs vRack ma status `connected` lub `connecting`. W naszym przykładzie interfejs nazywa się `eno2`.
+Najpierw sprawdź nazwę swojego interfejsu vRack. W naszym przykładzie interfejs nazywa się `eno2`:
 
 ```sh
 nmcli device status
@@ -526,79 +400,87 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Następnie pobierz nazwę pliku konfiguracyjnego znajdującego się w `/etc/NetworkManager/system-connections`. Tutaj plik nazywa się `vRack.nmconnection`.
+Jeśli Twój interfejs vRack jest już w stanie `connected` lub `connecting`, możesz przejść od razu do dodawania adresu IP.
+
+W naszym przykładzie stan to `disconnected`, dlatego tworzymy interfejs za pomocą poniższego polecenia. Nazwaliśmy go `vRack`, aby odróżnić go od pozostałych interfejsów.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
-Skonfiguruj Additional IP za pomocą handlera `nmcli`. Zastąp `vRack` i inne parametry własnymi wartościami.
+Za pomocą narzędzia `nmcli` skonfiguruj swój Additional IP. Zastąp `vRack` i pozostałe parametry własnymi wartościami.
 
-- Dodaj IP
+- Dodaj adres IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Dodaj bramkę
+- Zapobiegnij temu, aby połączenie vRack stało się trasą domyślną
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
 - Zmień konfigurację z **auto** na **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Ustaw konfigurację jako trwałą
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Tworzenie nowej tabeli routingu IP**
+:::info
+Domyślnie ruch kierowany do Twojego adresu IP w sieci vRack może nie korzystać z interfejsu vRack w drodze powrotnej. Może to powodować asymetryczny routing, który niektóre sieci mogą odrzucać. Poniższe kroki konfigurują osobną tabelę routingu dla ruchu vRack, zapewniając, że odpowiedzi z adresu IP w sieci vRack są kierowane z powrotem przez interfejs vRack.
+:::
 
-Następnie utwórz nową trasę IP dla sieci vRack. Dodaj nową regułę ruchu (`1 vrack`), modyfikując plik w następujący sposób:
+- Utwórz tabelę routingu dla vRack
 
+W naszym przykładzie jako identyfikatora używamy 1, ale możesz swobodnie wybrać dowolny inny numer. Poniższe polecenia odwołują się do tabeli po jej identyfikatorze (`table=1`); nazwa `vrack` służy jedynie do łatwiejszego odczytu później, na przykład za pomocą polecenia `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Dodaj trasę
+- Skieruj ruch tego połączenia przez tabelę vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Dodaj trasę przez bramkę
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 W naszym przykładzie
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Uruchom ponownie sieć za pomocą następującego polecenia:
+- Dodaj regułę, aby ruch vRack korzystał z tej tabeli
+
+To ten krok faktycznie informuje serwer, aby używał tabeli 1 dla wszystkiego, co jest wysyłane z Twojego adresu IP w sieci vRack. Bez niego dodane wcześniej trasy zostałyby zignorowane.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Zastosuj zmiany:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>

--- a/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
+++ b/docs/pt/guides/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack.mdx
@@ -1,7 +1,7 @@
 ---
-title: Configurar um bloco de Additional IP num vRack
-description: Saiba como configurar um bloco de endereços IP públicos num vRack.
-lastUpdated: 2026-09-08
+title: Configurar um bloco Additional IP num vRack
+description: Saiba como configurar um bloco de endereços IP públicos para utilização com o vRack
+lastUpdated: 2026-09-16
 ---
 import { Tab, Tabs } from '@rspress/core/theme';
 
@@ -10,27 +10,27 @@ import { Tab, Tabs } from '@rspress/core/theme';
 
 ## Objetivo
 
-Para além do endereçamento IP privado, o [vRack](https://www.ovhcloud.com/pt/network/vrack/) permite também encaminhar o tráfego IP público através da porta vRack do servidor utilizando um bloco de endereços IP públicos.
+Para além do endereçamento IP privado, o [vRack](https://www.ovhcloud.com/pt/network/vrack/) permite também encaminhar o tráfego IP público através da porta vRack do servidor, utilizando um bloco de endereços IP públicos.
 
-**Este guia mostra como configurar um bloco de endereços IP públicos para utilização com o vRack.**
+**Este guia explica como configurar um bloco de endereços IP públicos para utilização com o vRack.**
 
 :::info
-O vRack suporta tanto o routing público IPv4 como IPv6 com blocos de endereços Additional IP. Pode encontrar as instruções sobre como configurar blocos IPv6 neste guia: "[Configurar um bloco IPv6 num vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)".
+O vRack suporta o roteamento público IPv4 e IPv6 com blocos de endereços Additional IP. Encontre as instruções sobre a configuração de blocos IPv6 neste guia: "[Configurar um bloco Additional IPv6 num vRack](/guides/bare-metal-cloud/dedicated-servers/configure-ipv6-in-vrack)".
 
 :::
 
 
 :::info
-Este artigo foca-se na configuração de Additional IP numa rede vRack. Se procura orientações sobre a configuração de Additional IP em conjunto com o IP principal (na interface de rede pública), consulte os seguintes artigos:
+Este artigo detalha a configuração de endereços Additional IP numa rede vRack. Se procura instruções sobre a configuração de endereços Additional IP com um endereço IP principal (na interface de rede pública), consulte os seguintes artigos:
 
 - IPv4:
-    - [Configurar o IP aliasing em servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
-    - [Configurar o IP aliasing num VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
+    - [Configurar um endereço IP em alias num servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/network-ipaliasing).
+    - [Configurar um endereço IP em alias num VPS](/guides/bare-metal-cloud/virtual-private-servers/configuring-ip-aliasing).
 
 - IPv6:
-    - [Configurar o IPv6 em servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
-    - [Configurar o IPv6 num VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
-    - [Configurar o IPv6 numa instância Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
+    - [Configurar IPv6 num servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/network-ipv6).
+    - [Configurar IPv6 num VPS](/guides/bare-metal-cloud/virtual-private-servers/configure-ipv6).
+    - [Configurar IPv6 numa instância Public Cloud](/guides/public-cloud/network-services/ipv6-configuration).
 
 :::
 
@@ -38,7 +38,7 @@ Este artigo foca-se na configuração de Additional IP numa rede vRack. Se procu
 ## Requisitos
 
 - Um bloco público de endereços IP na sua conta, com um mínimo de quatro endereços
-- O intervalo de endereços IP privados escolhido
+- O intervalo de endereços IP privados à sua escolha
 - Um [servidor compatível com vRack](https://www.ovhcloud.com/pt/bare-metal/)
 - Um serviço [vRack](https://www.ovhcloud.com/pt/network/vrack/) ativado na sua conta
 
@@ -54,9 +54,9 @@ Este artigo foca-se na configuração de Additional IP numa rede vRack. Se procu
 {/* CP-NAV-END:network-vrack */}
 
 :::warning
-Esta funcionalidade pode não estar disponível ou pode estar limitada nos [servidores dedicados da linha de produtos **Eco**](https://eco.ovhcloud.com/pt/about/).
+Esta funcionalidade pode estar indisponível ou limitada nos servidores da [gama **Eco**](https://eco.ovhcloud.com/pt/about/).
 
-Visite a nossa [página de comparação](https://eco.ovhcloud.com/pt/compare/) para mais informações.
+Consulte a nossa [página de comparação](https://eco.ovhcloud.com/pt/compare/) para mais informações.
 
 :::
 
@@ -64,9 +64,9 @@ Visite a nossa [página de comparação](https://eco.ovhcloud.com/pt/compare/) p
 ## Instruções
 
 :::info
-A título de exemplo, utilizaremos um bloco IP de 46.105.135.96/28 e eth1 para a interface de rede secundária, dedicada ao vRack.
+A título de exemplo, utilizaremos um bloco IP de 46.105.135.96/28 e `eth1` para a interface de rede secundária, dedicada ao vRack.
 
-Também a título de exemplo, o ficheiro de configuração de rede ao qual nos referimos encontra-se em `/etc/network/interfaces`. O ficheiro equivalente no seu servidor pode estar noutro local, dependendo do sistema operativo. O conteúdo do ficheiro também pode ser diferente. Se tiver dificuldades, consulte a documentação oficial da sua distribuição.
+O ficheiro de configuração de rede ao qual nos referimos encontra-se em `/etc/network/interfaces`. O ficheiro equivalente no seu servidor pode estar noutro local, dependendo do seu sistema operativo. O conteúdo do ficheiro também pode ser diferente. Em caso de dificuldades, consulte a documentação oficial da sua distribuição.
 
 :::
 
@@ -76,39 +76,39 @@ Também a título de exemplo, o ficheiro de configuração de rede ao qual nos r
 :::warning
 Assim que um bloco IP é adicionado ao vRack, deixa de estar associado a um servidor físico.
 
-Esta configuração permite-lhe configurar IPs do mesmo bloco em vários servidores, desde que todos esses servidores estejam no mesmo vRack que o bloco IP. O bloco IP deve ter pelo menos 2 IPs utilizáveis ou mais para que isso seja possível.
+Esta configuração permite configurar IPs do mesmo bloco em vários servidores, desde que esses servidores estejam todos no mesmo vRack que o bloco IP. O bloco IP deve dispor de, pelo menos, 2 IPs utilizáveis para que isso seja possível.
 
 :::
 
 
-Selecione o seu vRack na lista para exibir a lista de serviços elegíveis. Clique no bloco IP que deseja adicionar ao vRack e clique no botão <code className="action">Adicionar</code>.
+Selecione o seu vRack na lista para exibir a lista de serviços elegíveis. Clique no bloco IP que pretende adicionar ao vRack e, em seguida, clique no botão <code className="action">Adicionar</code>.
 
-<img className="thumbnail" alt="Adicionar um bloco IP ao vRack" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/addIPblock.png" loading="lazy" />
+<img className="thumbnail" alt="Adição de um bloco IP ao vRack" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/addIPblock.png" loading="lazy" />
 
-### Gerir a largura de banda IP pública no vRack
+### Gerir a largura de banda dos IPs públicos no vRack
 
-Por predefinição, os blocos Additional IP encaminhados através de um vRack beneficiam de uma largura de banda pública padrão de 5 Gbps na Europa e na América do Norte, ou de 100 Mbps nas regiões APAC. Para mais detalhes sobre as opções disponíveis, consulte as opções de routing público na nossa [página do produto vRack](https://www.ovhcloud.com/pt/network/vrack/).
+Por predefinição, os blocos de Additional IP encaminhados através de um vRack beneficiam de uma largura de banda pública padrão de 5 Gbps na Europa, no Canadá e nos Estados Unidos, e de 100 Mbps nas regiões APAC. Para uma visão geral detalhada da disponibilidade, consulte as opções de roteamento público na nossa [página do produto vRack](https://www.ovhcloud.com/pt/network/vrack/).
 
-Para responder às crescentes necessidades das infraestruturas e aos requisitos dos serviços de alto tráfego, a OVHcloud oferece agora aos seus clientes opções de largura de banda pagas. Tenha em atenção que estas opções se aplicam **por vRack e por região**. Uma vez que os endereços Additional IP estão associados a uma região precisa, qualquer modificação da largura de banda afetará o conjunto dos endereços (IPv4 e IPv6) encaminhados para esse vRack na região correspondente.
+À medida que as necessidades de infraestrutura aumentam, alguns utilizadores podem precisar de uma largura de banda mais ampla para suportar serviços públicos com tráfego elevado, para os quais a OVHcloud disponibiliza opções de largura de banda pagas. Estas opções aplicam-se **por vRack e por região**. Uma vez que os endereços Additional IP estão associados a uma região, qualquer alteração da largura de banda afetará todos os endereços IP (IPv4 e IPv6) encaminhados para esse vRack dentro dessa região.
 
 <details>
 
-<summary>Durante o processo de encomenda de Additional IP</summary>
+<summary>Durante a encomenda de uma Additional IP</summary>
 
 
-#### Escolha da largura de banda pública durante o processo de encomenda
+#### Escolher a largura de banda pública durante a encomenda de uma Additional IP
 
-É possível modificar a largura de banda predefinida no momento de encomendar um novo bloco Additional IP, desde que seja selecionada uma rede vRack como serviço backend.
+Pode alterar a largura de banda pública predefinida ao encomendar um novo bloco de Additional IP com uma rede vRack como serviço backend.
 
-Para encomendar um novo bloco Additional IP:
+Para encomendar um novo bloco de Additional IP:
 
-- Na barra lateral esquerda, aceda à secção <code className="action">Network</code>.
-- Selecione <code className="action">Endereços IP públicos</code>.
-- Clique no botão <code className="action">Encomendar IPs</code> no topo da página.
-- Escolha a versão IP e, em seguida, o vRack ao qual o Additional IP será associado.
-- Selecione a região do seu Additional IP.
-- Escolha a largura de banda pública a aplicar ao seu vRack para essa região.
-- Configure as outras opções de acordo com as suas necessidades e, em seguida, finalize a encomenda.
+- Abra a secção <code className="action">Network</code> na barra lateral esquerda.
+- Selecione <code className="action">Endereços IP Públicos</code>.
+- Clique no botão <code className="action">Encomendar IPs</code>, no topo da página.
+- Selecione a versão do IP e, em seguida, o vRack ao qual pretende associar o seu Additional IP.
+- Selecione a região onde pretende que o seu Additional IP se encontre.
+- Escolha a largura de banda pública a aplicar ao seu vRack para essa região específica.
+- Preencha as outras opções, se necessário, e finalize a sua encomenda.
 
 </details>
 
@@ -118,63 +118,63 @@ Para encomendar um novo bloco Additional IP:
 <summary>A partir da página de gestão do vRack</summary>
 
 
-#### Modificação da largura de banda pública a partir da página de gestão
+#### Modificar a largura de banda pública do vRack a partir da página de gestão
 
-Para os blocos Additional IP já associados a um vRack, a largura de banda é gerida diretamente a partir da página de configuração do serviço.
+Para os blocos de Additional IP já associados a um vRack, pode gerir a largura de banda diretamente a partir da página de configuração do serviço.
 
 Para aceder à interface de gestão:
 
 - Na coluna "Endereço IP público e largura de banda", clique no botão <code className="action">Gerir</code> correspondente ao vRack pretendido.
 
-A interface de gestão divide-se em dois separadores:
+A página de gestão está organizada em dois separadores:
 
-- **All attached services**: Atualmente redireciona para a página clássica de gestão do vRack. Em breve, este separador listará de forma otimizada todos os produtos (servidores, projetos Cloud, etc.) associados ao vRack.
-- **Conectividade IP pública**: Permite gerir as opções de routing público do seu vRack, incluindo a largura de banda.
+- **Todos os serviços associados**: por agora, este separador redireciona para a página de gestão clássica do vRack. Em breve, listará, de forma otimizada, todos os produtos (servidores, projetos Cloud, etc.) atualmente associados ao vRack.
+- **Conectividade IP pública**: permite gerir as opções de roteamento público do seu vRack, incluindo a largura de banda.
 
-Para modificar a largura de banda:
+Para modificar a largura de banda pública:
 
-- Vá ao separador <code className="action">Conectividade IP pública</code>.
-- A interface apresenta janelas de gestão por região (por exemplo, `eu-west-par`) associadas ao vRack, com a lista dos IPs associados.
-- No bloco da região correspondente, clique em <code className="action">Modificar largura de banda</code>.
-- Selecione a opção pretendida no painel da direita e, em seguida, clique em <code className="action">Encomendar</code> para validar.
-- Após o pagamento, a nova largura de banda estará ativa no seu vRack na região escolhida após alguns minutos.
+- Aceda ao separador <code className="action">Conectividade IP pública</code>.
+- A interface apresenta janelas de gestão individuais para cada região (por exemplo, `eu-west-par`) associada ao vRack, com a lista de todos os endereços IP associados a essa região específica.
+- Na janela da região em causa, clique no botão <code className="action">Modificar a largura de banda</code>.
+- Selecione a opção de largura de banda pretendida no painel que aparece à direita e, em seguida, clique em <code className="action">Encomendar</code> para validar a encomenda.
+- Assim que a encomenda for paga, a largura de banda selecionada deverá estar disponível no seu vRack, na região escolhida, ao fim de alguns minutos.
 
 :::info
-O primeiro mês subscrito é faturado de forma proporcional aos dias restantes. A tarifa completa será aplicada no próximo ciclo de faturação.
+Os custos do primeiro mês são calculados proporcionalmente aos dias restantes; a tarifa completa aplicar-se-á a partir do ciclo de faturação seguinte.
 
 :::
 
 
-O aumento de largura de banda será aplicado a todos os endereços IP dessa região para o vRack selecionado.
+A atualização de largura de banda selecionada aplicar-se-á a todos os endereços IP dessa região para o vRack escolhido.
 
 </details>
 
 
 ### Gerir as prioridades de failover 3-AZ
 
-Algumas regiões OVHcloud estendem-se por três zonas de disponibilidade (AZ) alojadas em locais fisicamente independentes dentro da mesma região. Quando uma região deste tipo intervém no encaminhamento dos IP públicos do seu vRack, é identificada na área de cliente OVHcloud através de uma etiqueta **3-AZ** apresentada junto ao nome da região no separador <code className="action">Conectividade IP pública</code>.
+Algumas regiões OVHcloud estendem-se por três zonas de disponibilidade (AZ) alojadas em localizações fisicamente independentes dentro da mesma região. Quando uma região deste tipo é utilizada para o roteamento dos IPs públicos do seu vRack, é identificada na Área de Cliente OVHcloud através de um badge **3-AZ** apresentado junto ao nome da região no separador <code className="action">Conectividade IP pública</code>.
 
 :::info
-Se uma região passou para o modo 3-AZ enquanto já tinha endereços IP encaminhados através do vRack nessa região, esses IP permanecerão no modo 1-AZ e não beneficiarão automaticamente da configuração de encaminhamento 3-AZ.
+Se uma região passou para o modo 3-AZ quando já tinha endereços IP encaminhados através do vRack nessa região, esses IPs permanecerão no modo 1-AZ e não beneficiarão automaticamente da configuração de roteamento 3-AZ.
 
-Para ativar o modo 3-AZ nos blocos de IP encaminhados através do vRack nessas regiões, deve retirar o bloco IP do vRack e, em seguida, voltar a adicioná-lo.
+Para ativar o modo 3-AZ para os blocos de endereços IP encaminhados através do vRack nessas regiões, retire o bloco IP do vRack e volte a adicioná-lo.
 
-**Os blocos de IP que continuam a ser encaminhados no modo 1-AZ são identificados por uma etiqueta cinzenta `1-AZ`.**
+**Os blocos de endereços IP que continuam a ser encaminhados no modo 1-AZ são identificados por um badge cinzento `1-AZ`.**
 
 :::
 
 
 #### Vantagens
 
-- **Resiliência integrada**: o tráfego IP público encaminhado através do vRack permanece disponível se uma zona de disponibilidade ficar indisponível, uma vez que o encaminhamento comuta automaticamente para a AZ seguinte na ordem de prioridade.
-- **Comportamento de failover previsível**: cada região 3-AZ atribui ao seu vRack uma zona de disponibilidade principal e duas posições de failover ordenadas, tornando determinista a sequência de failover.
-- **Alinhamento com a carga de trabalho**: quando outros serviços OVHcloud estão implementados na mesma região 3-AZ, as prioridades podem ser alinhadas para que a AZ ativa do vRack corresponda à AZ que aloja os seus serviços. Desta forma, o seu tráfego público mantém-se na mesma AZ que a sua carga de trabalho durante o funcionamento normal.
+- **Resiliência integrada**: o tráfego IP público encaminhado através do vRack permanece disponível se uma zona de disponibilidade ficar indisponível, uma vez que o roteamento passa automaticamente para a AZ seguinte na ordem de prioridade.
+- **Comportamento de failover previsível**: cada região 3-AZ atribui ao seu vRack uma zona de disponibilidade principal e duas posições de failover ordenadas, o que torna a sequência de failover determinista.
+- **Alinhamento com a carga de trabalho**: quando outros serviços OVHcloud são implementados na mesma região 3-AZ, as prioridades podem ser alinhadas para que a AZ ativa do vRack corresponda à AZ que aloja os seus serviços. Assim, o seu tráfego público mantém-se na mesma AZ que a sua carga de trabalho em funcionamento normal.
 
 #### Mecânica e gestão das prioridades
 
-Quando um vRack é associado pela primeira vez a uma região 3-AZ, a OVHcloud atribui aleatoriamente uma ordem de prioridade às suas zonas de disponibilidade. As zonas **principal, secundária e de último recurso** são apresentadas por esta ordem no bloco da região correspondente no separador <code className="action">Conectividade IP pública</code>, dentro da subsecção `Prioridades de failover 3-AZ`, mesmo por cima do botão <code className="action">Configurar</code>.
+Quando um vRack é associado pela primeira vez a uma região 3-AZ, a OVHcloud atribui aleatoriamente uma ordem de prioridade às suas zonas de disponibilidade. As **zonas principal, secundária e de último recurso** são apresentadas por esta ordem no separador <code className="action">Conectividade IP pública</code>, na área correspondente à região 3-AZ, na subsecção `Prioridades de failover 3-AZ`, mesmo por cima do botão <code className="action">Configurar</code>.
 
-Pode alterar esta atribuição aleatória a qualquer momento, por exemplo para alinhar as prioridades de failover com a disposição AZ de outros componentes associados à sua infraestrutura.
+Pode alterar esta atribuição a qualquer momento, por exemplo, para alinhar as prioridades de failover com a disposição AZ dos outros componentes da sua infraestrutura.
 
 <details>
 
@@ -183,16 +183,16 @@ Pode alterar esta atribuição aleatória a qualquer momento, por exemplo para a
 
 Para ajustar as prioridades de failover de uma região 3-AZ:
 
-- Na barra lateral esquerda da área de cliente, abra <code className="action">Network</code>.
+- Na barra lateral esquerda da sua Área de Cliente, abra <code className="action">Network</code>.
 - Selecione <code className="action">Rede privada vRack</code>.
 - Na coluna "Endereço IP público e largura de banda", clique no botão <code className="action">Gerir</code> correspondente ao vRack pretendido.
-- Vá ao separador <code className="action">Conectividade IP pública</code>.
-- No bloco da região 3-AZ que pretende configurar, localize a subsecção `Prioridades de failover 3-AZ` e clique em <code className="action">Configurar</code>.
-- No painel apresentado, atribua cada zona de disponibilidade a uma das três posições: **Zona principal**, **Zona secundária** e **Zona de último recurso**.
+- Abra o separador <code className="action">Conectividade IP pública</code>.
+- Localize a área da região 3-AZ que pretende configurar e, em seguida, a subsecção `Prioridades de failover 3-AZ`, e clique em <code className="action">Configurar</code>.
+- No painel que se abre à direita, atribua cada zona de disponibilidade a uma das três posições: **Zona principal**, **Zona secundária** e **Zona de último recurso**.
 - Confirme a sua seleção.
 
 :::info
-As alterações de prioridade aplicam-se a todos os blocos de Additional IP encaminhados para a região 3-AZ correspondente para o vRack selecionado, independentemente da sua versão de IP.
+As alterações de prioridade aplicam-se a todos os blocos de Additional IP encaminhados para a região 3-AZ correspondente do vRack selecionado, independentemente da sua versão de IP.
 
 :::
 
@@ -202,11 +202,11 @@ As alterações de prioridade aplicam-se a todos os blocos de Additional IP enca
 
 ### Configurar um endereço IP utilizável
 
-Para fins do vRack, o primeiro, o penúltimo e o último endereço em qualquer bloco IP são sempre reservados para o endereço de rede, o gateway de rede e o broadcast de rede, respetivamente. Isto significa que o primeiro endereço utilizável é o segundo endereço no bloco, como se mostra abaixo:
+No caso do vRack, o primeiro, o penúltimo e o último endereço de um determinado bloco IP são sempre reservados, respetivamente, ao endereço de rede, ao gateway de rede e ao broadcast de rede. Isto significa que o primeiro endereço utilizável é o segundo endereço do bloco, como se indica abaixo:
 
 ```sh
-46.105.135.96   # Reservado: Endereço de rede
-46.105.135.97   # Primeiro IP utilizável
+46.105.135.96   Reserved: Network address
+46.105.135.97   First usable IP
 46.105.135.98
 46.105.135.99
 46.105.135.100
@@ -218,81 +218,27 @@ Para fins do vRack, o primeiro, o penúltimo e o último endereço em qualquer b
 46.105.135.106
 46.105.135.107
 46.105.135.108
-46.105.135.109  # Último IP utilizável
-46.105.135.110  # Reservado: Gateway de rede
-46.105.135.111  # Reservado: Broadcast de rede
+46.105.135.109  Last usable IP
+46.105.135.110  Reserved: Network gateway
+46.105.135.111  Reserved: Network broadcast
 ```
 
-Para configurar o primeiro endereço IP utilizável, é necessário editar o ficheiro de configuração de rede, como se mostra abaixo. Neste exemplo, precisamos de utilizar uma máscara de sub-rede de *255.255.255.240*.
+Para configurar o primeiro endereço IP utilizável, temos de editar o ficheiro de configuração de rede, como se indica abaixo. Neste exemplo, temos de utilizar uma máscara de sub-rede de **255.255.255.240**.
 
 :::info
-A máscara de sub-rede utilizada no nosso exemplo é adequada para o nosso bloco IP. A sua máscara de sub-rede pode variar consoante o tamanho do seu bloco. Quando adquirir o seu bloco IP, receberá um e-mail que lhe indicará qual a máscara de sub-rede a utilizar.
+A máscara de sub-rede utilizada neste exemplo é adequada ao nosso bloco IP. A sua máscara de sub-rede pode variar consoante o tamanho do seu bloco. Quando adquire o seu bloco IP, recebe um e-mail a indicar qual a máscara de sub-rede a utilizar.
 
 :::
 
 
 ### Descarregar o pacote `iproute2`
 
-```sh
-/etc/network/interfaces
+Antes de começar, descarregue e instale o **iproute2**, um pacote que permite configurar manualmente o roteamento IP. Este pacote pode já estar disponível no seu servidor; nesse caso, avance diretamente para o passo seguinte.
 
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-```
-### Criar uma nova tabela de routing IP
-
-Em primeiro lugar, precisamos de descarregar e instalar o iproute2, que é um pacote que nos permitirá configurar manualmente o routing IP no servidor.
-
-Estabeleça uma ligação SSH ao servidor e execute o seguinte comando a partir da linha de comandos. Isto irá descarregar e instalar o iproute2.
+Estabeleça uma ligação SSH ao seu servidor e execute o seguinte comando a partir da linha de comandos. Este irá descarregar e instalar o iproute2.
 
 ```sh
-# apt-get install iproute2
-```
-
-Em seguida, precisamos de criar uma nova rota IP para o vRack. Adicionaremos uma nova regra de tráfego modificando o ficheiro, como se mostra abaixo:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valores reservados
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-### Modificar o ficheiro de configuração de rede
-
-:::info
-A título de exemplo, o ficheiro de configuração de rede ao qual nos referimos encontra-se em /etc/network/interfaces. O ficheiro equivalente no seu servidor pode estar noutro local, dependendo do sistema operativo.
-
-:::
-
-
-Por último, precisamos de modificar o ficheiro de configuração de rede para ter em conta a nova regra de tráfego e encaminhar o tráfego do vRack através do endereço do gateway de rede **46.105.135.110**.
-
-```sh
-/etc/network/interfaces
-
-auto eth1
-iface eth1 inet static
-address 46.105.135.97
-netmask 255.255.255.240
-broadcast 46.105.135.111
-post-up ip route add 46.105.135.96/28 dev eth1 table vrack
-post-up ip route add default via 46.105.135.110 dev eth1 table vrack
-post-up ip rule add from 46.105.135.96/28 table vrack
-post-up ip rule add to 46.105.135.96/28 table vrack
+sudo apt-get install iproute2
 ```
 
 **Fedora**
@@ -301,98 +247,13 @@ post-up ip rule add to 46.105.135.96/28 table vrack
 sudo dnf install iproute
 ```
 
-### CentOS 6/7
-
-#### Criar o ficheiro para a interface de rede secundária
-
-Em primeiro lugar, podemos copiar e utilizar a configuração utilizada para a interface de rede primária e ajustá-la de acordo com as nossas necessidades:
-
-```sh
-sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-Em seguida, acedemos ao novo ficheiro:
-
-```sh
-sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
-```
-E definimos as configurações de IP:
-```sh
-# Criado automaticamente pelo cloud-init no arranque da instância, não editar.
-#
-DEVICE=eth1
-BOOTPROTO=static
-ONBOOT=yes
-USERCTL=no
-IPV6INIT=no
-PEERDNS=yes
-TYPE=Ethernet
-NETMASK=255.255.255.240
-IPADDR=46.105.135.97
-ARP=yes
-```
-
-### Criar uma nova tabela de routing IP
-
-Em seguida, precisamos de criar uma nova rota IP para o vRack. Adicionaremos uma nova regra de tráfego modificando o ficheiro, como se mostra abaixo:
-
-```sh
-/etc/iproute2/rt_tables
-
-#
-# valores reservados
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
-1 vrack
-```
-
-Em seguida, crie o ficheiro necessário para aplicar as novas regras:
-```sh
-nano /etc/sysconfig/network-scripts/rule-eth1
-```
-
-E cole o seguinte conteúdo (lembre-se de substituir as nossas variáveis pelos seus próprios valores):
-
-```sh
-from 46.105.135.96/28 table vrack
-to 46.105.135.96/28 table vrack
-```
-
-### Modificar o ficheiro de configuração de rede
-
-Por último, precisamos de modificar o ficheiro de configuração de rede para ter em conta a nova regra de tráfego e encaminhar o tráfego do vRack através do endereço do gateway de rede **46.105.135.110**.
-
-Podemos fazê-lo editando o seguinte ficheiro para adicionar rotas persistentes e estáticas:
-
-```sh
-nano /etc/sysconfig/network-scripts/route-eth1
-```
-
-Estabeleça uma ligação SSH ao servidor e execute o seguinte comando para descarregar e instalar o iproute2:
-
-```sh
-sudo apt-get install iproute2
-```
-
-Reinicie agora o servidor para aplicar as alterações ou, em alternativa, ative simplesmente a nova interface de rede:
-
-```sh
-ip link set eth1 up
-```
-
 #### Configurações GNU/Linux
 
 <Tabs>
-<Tab label="CentOS, AlmaLinux e Rocky Linux (8/9)">
+<Tab label="AlmaLinux e Rocky Linux (8/9)">
 **Criar o ficheiro para a interface de rede secundária**
 
-Copie a configuração da interface de rede primária e ajuste-a de acordo com as suas necessidades:
+Comece por copiar a configuração da interface de rede principal e adapte-a às suas necessidades:
 
 ```sh
 sudo cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-eth1
@@ -404,7 +265,7 @@ Em seguida, abra o novo ficheiro:
 sudo nano /etc/sysconfig/network-scripts/ifcfg-eth1
 ```
 
-- Defina as configurações de IP:
+- Defina os parâmetros IP:
 
 ```sh
 # Created by cloud-init on instance boot automatically, do not edit.
@@ -421,9 +282,9 @@ IPADDR=46.105.135.97
 ARP=yes
 ```
 
-**Criar uma nova tabela de routing IP**
+**Criar uma nova tabela de roteamento IP**
 
-Em seguida, crie uma nova rota IP para o vRack. Adicione uma nova regra de tráfego modificando o ficheiro como indicado abaixo:
+Em seguida, temos de criar uma nova rota IP para o vRack. Vamos adicionar uma nova regra de tráfego modificando o ficheiro, como se indica abaixo:
 
 ```sh
 sudo nano /etc/iproute2/rt_tables
@@ -447,7 +308,7 @@ Em seguida, crie o ficheiro necessário para aplicar as novas regras:
 nano /etc/sysconfig/network-scripts/rule-eth1
 ```
 
-Cole o seguinte conteúdo (lembre-se de substituir as variáveis pelos seus próprios valores):
+E cole o seguinte conteúdo (lembre-se de substituir as nossas variáveis pelos seus próprios valores):
 
 ```sh
 from 46.105.135.96/28 table vrack
@@ -456,59 +317,72 @@ to 46.105.135.96/28 table vrack
 
 **Modificar o ficheiro de configuração de rede**
 
-Por último, modifique o ficheiro de configuração de rede para ter em conta a nova regra de tráfego e encaminhar o tráfego do vRack através do endereço do gateway de rede **46.105.135.110**.
+Por fim, temos de modificar o ficheiro de configuração de rede para ter em conta a nova regra de tráfego e encaminhar o tráfego do vRack através do endereço do gateway de rede **46.105.135.110**.
 
-Edite o seguinte ficheiro para adicionar rotas persistentes e estáticas:
+Modifique o seguinte ficheiro para adicionar rotas persistentes e estáticas:
 
 ```sh
 nano /etc/sysconfig/network-scripts/route-eth1
 ```
 
-Cole o seguinte conteúdo (lembre-se de substituir as variáveis pelos seus próprios valores):
+Cole o seguinte conteúdo (lembre-se de substituir as nossas variáveis pelos seus próprios valores):
 
 ```sh
 46.105.135.96/28 dev eth1 table vrack
 default via 46.105.135.110 dev eth1 table vrack
 ```
 
-Reinicie o servidor para aplicar as alterações ou ative simplesmente a nova interface de rede:
+Reinicie o servidor para aplicar as alterações ou, em alternativa, ative simplesmente a nova interface de rede:
 
 ```sh
 ip link set eth1 up
 ```
 </Tab>
 <Tab label="Ubuntu e Debian 12+">
+
 - Configurar o Additional IP
 
-Abra o ficheiro de configuração de rede situado em `/etc/netplan` com um editor de texto à sua escolha. Aqui, o ficheiro chama-se `50-cloud-init.yaml`.
+Com um editor de texto à sua escolha, abra o ficheiro de configuração de rede situado em `/etc/netplan`. Aqui, o ficheiro chama-se `50-cloud-init.yaml`.
 
 
 ```sh
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-- Defina as configurações de IP com as seguintes variáveis:
+- Defina os parâmetros IP com as seguintes variáveis e adicione-os à sua configuração existente:
 
-```sh
-NETWORK_INTERFACE:
-dhcp4: false
-addresses:
-- ADDITIONAL_IP/PREFIX
-routes:
-- to: NETWORK_IP/PREFIX
-  via: GATEWAY_IP
+:::info
+Por predefinição, o tráfego destinado ao seu Additional IP pode não utilizar a interface vRack para o caminho de retorno. Isto pode causar um roteamento assimétrico, e algumas redes podem rejeitar esse tráfego. A rota `table: 1`, combinada com a regra `routing-policy` abaixo, garante que as respostas provenientes do Additional IP são encaminhadas de volta através da interface vRack. O identificador `1` é utilizado aqui para corresponder aos outros separadores deste guia; é livre de utilizar o número que preferir, desde que o utilize de forma consistente.
+:::
+
+```yaml
+    NETWORK_INTERFACE:
+        dhcp4: false
+        addresses:
+          - ADDITIONAL_IP/PREFIX
+        routes:
+          - to: 0.0.0.0/0
+            via: GATEWAY_IP
+            table: 1
+        routing-policy:
+          - from: ADDITIONAL_IP/32
+            table: 1
 ```
 
 **Exemplo**
 
-```sh
-eno2:
-dhcp4: false
-addresses:
-- 46.105.135.97/28
-routes:
-- to: 46.105.135.96/28
-  via: 46.105.135.110
+```yaml
+    eno2:
+        dhcp4: false
+        addresses:
+          - 46.105.135.97/28
+        routes:
+          - to: 0.0.0.0/0
+            via: 46.105.135.110
+            table: 1
+        routing-policy:
+          - from: 46.105.135.97/32
+            table: 1
 ```
 
 Aplique a configuração com o seguinte comando:
@@ -518,7 +392,7 @@ sudo netplan apply
 ```
 </Tab>
 <Tab label="Fedora 43+, AlmaLinux e Rocky Linux (10)">
-Em primeiro lugar, verifique que a sua interface vRack está no estado `connected` ou `connecting`. No nosso exemplo, a interface chama-se `eno2`.
+Primeiro, verifique o nome da sua interface vRack. No nosso exemplo, a interface chama-se `eno2`:
 
 ```sh
 nmcli device status
@@ -526,79 +400,87 @@ nmcli device status
 DEVICE           TYPE      STATE                   CONNECTION
 eno1             ethernet  connected               cloud-init eno1
 lo               loopback  connected (externally)  lo
-eno2             ethernet   connecting (getting IP configuration)               vRack
+eno2             ethernet  disconnected            --
 ```
 
-Em seguida, obtenha o nome do ficheiro de configuração situado em `/etc/NetworkManager/system-connections`. Aqui, o ficheiro chama-se `vRack.nmconnection`.
+Se a sua interface vRack já estiver no estado `connected` ou `connecting`, pode avançar para a adição do IP.
+
+No nosso exemplo, o estado é `disconnected`: criamos, por isso, a interface com o seguinte comando. Demos-lhe o nome `vRack` para a distinguir das outras interfaces.
 
 ```sh
-[user@server ~]$ cd /etc/NetworkManager/system-connections
-cloud-init-eno1.nmconnection vRack.nmconnection
+sudo nmcli connection add type ethernet ifname eno2 con-name vRack
 ```
 
-Configure o seu Additional IP através do gestor `nmcli`. Substitua `vRack` e os outros parâmetros pelos seus próprios valores.
+Com o gestor `nmcli`, configure o seu Additional IP. Substitua `vRack` e os outros parâmetros pelos seus próprios valores.
 
 - Adicionar o IP
 
 ```sh
-sudo nmcli connection modify vRack IPv4.address 46.105.135.96/28
+sudo nmcli connection modify vRack ipv4.addresses 46.105.135.97/28
 ```
 
-- Adicionar o gateway
+- Impedir que a ligação vRack se torne a rota predefinida
 
 ```sh
-sudo nmcli connection modify vRack IPv4.gateway 46.105.135.110
+sudo nmcli connection modify vRack ipv4.never-default yes
 ```
 
 - Alterar a configuração de **auto** para **manual**:
 
 ```sh
-sudo nmcli connection modify vRack IPv4.method manual
+sudo nmcli connection modify vRack ipv4.method manual
 ```
 
 - Tornar a configuração persistente
 
 ```sh
-sudo nmcli con mod 'vRack' connection.autoconnect true
+sudo nmcli connection modify 'vRack' connection.autoconnect yes
 ```
 
-**Criar uma nova tabela de routing IP**
+:::info
+Por predefinição, o tráfego destinado ao seu IP vRack pode não utilizar a interface vRack para o caminho de retorno. Isto pode causar um roteamento assimétrico, e algumas redes podem rejeitar esse tráfego. Os passos abaixo configuram uma tabela de roteamento distinta para o tráfego vRack, garantindo que as respostas provenientes do IP vRack são encaminhadas de volta através da interface vRack.
+:::
 
-Em seguida, crie uma nova rota IP para o vRack. Adicione uma nova regra de tráfego (`1 vrack`) modificando o ficheiro como indicado abaixo:
+- Criar a tabela de roteamento do vRack
 
+No nosso exemplo, utilizamos 1 como identificador, mas pode escolher o número que preferir. Os comandos abaixo referem-se à tabela pelo seu identificador (`table=1`); o nome `vrack` serve apenas para facilitar a leitura mais tarde, por exemplo com `ip route show table vrack`.
 
 ```sh
-sudo nano /usr/share/iproute2/rt_tables
-#
-# reserved values
-#
-255	local
-254	main
-253	default
-0	unspec
-#
-# local
-#
-#1	inr.ruhep
+echo "1 vrack" | sudo tee -a /etc/iproute2/rt_tables
 1 vrack
 ```
 
-- Adicionar a rota
+- Encaminhar o tráfego desta ligação através da tabela vRack
 
 ```sh
-sudo ip route add <network_ip>/<prefix> via <gateway> dev <interface>
+sudo nmcli connection modify vRack ipv4.route-table 1
+```
+
+- Adicionar a rota através da gateway
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 <gateway_ip>"
 ```
 
 No nosso exemplo
 
 ```sh
-sudo ip route add 46.105.135.96/28 via 46.105.135.110 dev eno2
+sudo nmcli connection modify vRack +ipv4.routes "0.0.0.0/0 46.105.135.110"
 ```
 
-Reinicie a rede com o seguinte comando:
+- Adicionar uma regra para que o tráfego vRack utilize esta tabela
+
+Este passo indica concretamente ao seu servidor para utilizar a tabela 1 para tudo o que for enviado a partir do seu IP vRack. Sem ela, as rotas que acabou de adicionar seriam ignoradas.
+
+```sh
+sudo nmcli connection modify vRack +ipv4.routing-rules "priority 1 from 46.105.135.97/32 table 1"
+```
+
+Aplique as alterações:
 
 ```bash
-sudo systemctl restart NetworkManager
+sudo nmcli connection down vRack
+sudo nmcli connection up vRack
 ```
 </Tab>
 </Tabs>
@@ -606,21 +488,21 @@ sudo systemctl restart NetworkManager
 
 ### Windows Server
 
-#### Passo 1: Verificar e configurar a interface de rede secundária
+#### Passo 1: verificar e configurar a interface de rede secundária
 
-Verifique as informações da nova interface de rede:
+Verifique primeiro as informações da nova interface de rede:
 
-<img className="thumbnail" alt="verificação da interface de rede secundária" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
+<img className="thumbnail" alt="verificação da segunda interface de rede" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-1.png" loading="lazy" />
 
 Em seguida, verifique as propriedades:
 
-<img className="thumbnail" alt="propriedades da interface de rede secundária" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
+<img className="thumbnail" alt="propriedades da segunda interface de rede" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-2.png" loading="lazy" />
 
-<img className="thumbnail" alt="propriedades da interface de rede secundária" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
+<img className="thumbnail" alt="propriedades da segunda interface de rede" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-3.png" loading="lazy" />
 
-#### Passo 2: Configuração de IP
+#### Passo 2: configuração de IP
 
-Selecione a opção <code className="action">Use the following IP address</code>:
+Selecione a opção <code className="action">Utilizar o seguinte endereço IP</code>:
 
 <img className="thumbnail" alt="configuração de IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-4.png" loading="lazy" />
 
@@ -628,9 +510,9 @@ Defina as informações de IP:
 
 <img className="thumbnail" alt="configuração de IP" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-5b.png" loading="lazy" />
 
-#### Passo 3: Reiniciar a interface de rede
+#### Passo 3: reiniciar a interface de rede
 
-Em primeiro lugar, desative a interface.
+Comece por desativar a interface.
 
 <img className="thumbnail" alt="desativação da rede" src="/images/bare-metal-cloud/dedicated-servers/configuring-an-ip-block-in-a-vrack/win-ip-vrack-6.png" loading="lazy" />
 
@@ -640,22 +522,22 @@ Em seguida, ative-a.
 
 ### Resolução de problemas
 
-Se não conseguir estabelecer uma ligação a partir da sua VM ou servidor para a rede privada, abra um ticket de suporte a partir da sua Área de Cliente com as seguintes informações:
+Se não conseguir estabelecer uma ligação entre a sua VM ou servidor e a rede privada, envie-nos um ticket a partir da sua Área de Cliente, indicando os seguintes elementos:
 
 - IP de origem e IP de destino
-- Resultado de `ifconfig -a` ou `ipconfig /all` de ambos os servidores ou VMs (configuração da interface de rede)
-- Ping em ambas as direções
+- Resultado de `ifconfig -a` ou `ipconfig /all` em ambos os servidores ou VM (configuração da interface de rede)
+- Resultado do ping em ambos os sentidos
 - Resultado de `arp -a`
-- Tabela de routing
+- Tabela de roteamento
 
-Inclua os resultados acima no seu ticket.
+Anexe os resultados acima ao seu ticket.
 
 ## Quer saber mais?
 
-[Configurar o vRack nos servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
+[Configurar o vRack nos seus servidores dedicados](/guides/bare-metal-cloud/dedicated-servers/vrack-configuring-on-dedicated-server)
 
-[Criar múltiplas VLANs num vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
+[Criar múltiplas vLAN num vRack](/guides/bare-metal-cloud/dedicated-servers/creating-multiple-vlans-in-a-vrack)
 
 [Configurar o vRack entre o Public Cloud e um servidor dedicado](/guides/bare-metal-cloud/dedicated-servers/configuring-the-vrack-between-the-public-cloud-and-a-dedicated-server)
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
- Fixes and modernizes the "Configuring an Additional IP block in a vRack" guide across all 7 locales.

### Content/technical fixes:

**Fedora tab:** 
- Fixed a routing bug where a custom policy-routing table was created but never actually used by any route or rule

**Ubuntu & Debian 12+ tab:** 
- Corrected invalid netplan YAML indentation and added the missing routing policy needed to avoid asymmetric routing
- General wording and clarity improvements (proofread pass)

**Translations:**
- Fully re-translated the guide into FR, DE, ES, IT, PL, PT, replacing outdated content that predated the current tabbed OS structure