### PR TITLE
FIX - theme - Add vertical spacing inside tab panels

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -609,6 +609,35 @@ details.support[open] > summary::before {
   background-color: transparent;
 }
 
+/* Tab panels ship with horizontal padding only (`0 16px`), so the first
+   heading sits against the tab bar and — more visibly — a trailing image
+   touches the bottom border of the panel. Add vertical breathing room and
+   make sure the last child never hugs the edge. */
+.rp-doc .rp-tabs__content__item {
+  padding-top: 4px;
+  padding-bottom: 20px;
+}
+
+.rp-doc .rp-tabs__content__item > :first-child {
+  margin-top: 8px;
+}
+
+.rp-doc .rp-tabs__content__item > :last-child {
+  margin-bottom: 0;
+}
+
+/* Images inside a tab carry no margin of their own: give them the same
+   rhythm they have in the flow of a guide. */
+.rp-doc .rp-tabs__content__item img.thumbnail {
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
+/* Callouts sitting at the end of a tab need the panel padding to breathe. */
+.rp-doc .rp-tabs__content__item > .rp-callout:last-child {
+  margin-bottom: 4px;
+}
+
 /* Print styles for PDF export */
 @media print {
   .rp-nav,


### PR DESCRIPTION
## What this does

Tab panels (`.rp-tabs__content__item`) ship from the Rspress default theme with horizontal padding only (`0 16px`). Two visible consequences in every guide that uses `<Tabs>`:

- the first heading of a panel sits directly against the tab bar;
- a trailing image or callout touches the bottom border of the panel.

This adds vertical breathing room to the panels and makes sure the last child never hugs the edge. Images inside a tab get the same rhythm they have in the normal flow of a guide.

## Scope

`styles/index.css` only, +29 lines, no markup change. Selectors are scoped to `.rp-doc` so the docs content is the only thing affected.

This is a theme-wide change: it touches every guide using `<Tabs>` (~316 EN guides on `develop`, plus their locales). That is why it is shipped on its own rather than inside a content PR.

## Origin

Split out of #750 (SK-2757, Exchange S/MIME guide), where the issue was first noticed on the Outlook and OWA tabs. No JIRA ticket, hence the `FIX` prefix.

## How to check

Open any guide with tabs on the staging deploy, e.g. `microsoft-exchange/how-to-configure-outlook-2016`, and compare the spacing above the first heading and below the last image of a panel with `develop`.
