### PR TITLE
chore(links): centralise Public Cloud URLs and fix the valkey routes

### DIFF
--- a/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/de/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/de/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/de/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/de/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/de/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -49,7 +49,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/de/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -37,7 +37,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/de/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/advanced-configuration.mdx
@@ -26,7 +26,7 @@ Advanced configuration is available for the following Analytics engines :
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An analytics service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement)
 - Access to your <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/en-gb/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/en-gb/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/handling-disk-full.mdx
@@ -13,7 +13,7 @@ No matter the Analytics technology, when no more physical disk space is availabl
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/en-gb/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/en-gb/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/en/guides/public-cloud/data-analytics/analytics/pricing.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/pricing.mdx
@@ -65,7 +65,7 @@ This evolution provides better visibility into how costs are distributed between
 
 ### Website pricing page
 
-The [pricing page on the OVHcloud website](https://www.ovhcloud.com/en-gb/public-cloud/prices/) provides a high-level overview of analytics service costs. It displays hourly and estimated monthly prices, allowing users to compare different plans and configurations.
+The [pricing page on the OVHcloud website](/links/public-cloud/prices) provides a high-level overview of analytics service costs. It displays hourly and estimated monthly prices, allowing users to compare different plans and configurations.
 
 ### OVHcloud Control Panel – Order page
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -53,7 +53,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/en-gb/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/service-metrics-with-prometheus.mdx
@@ -15,7 +15,7 @@ Analytics services allow you to export service metrics using Prometheus.
 
 ## Requirements
 
-- An [Analytics service](https://www.ovhcloud.com/en-gb/public-cloud/cloud-analytics/) up and running,
+- An [Analytics service](/links/public-cloud/analytics) up and running,
 - Access to the <ApiLink>OVHcloud API</ApiLink>,
 - A [Prometheus](https://prometheus.io) server to collect metrics.
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -39,7 +39,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/en/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 

--- a/docs/en/guides/public-cloud/databases/advanced-configuration.mdx
+++ b/docs/en/guides/public-cloud/databases/advanced-configuration.mdx
@@ -148,7 +148,7 @@ Open the following API call and paste the corresponding inputs (serviceName, clu
     <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
 </Tabs>
 
@@ -171,7 +171,7 @@ Open the following API call and paste the corresponding inputs (serviceName, clu
     <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/capabilities/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/capabilities/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/capabilities/advancedConfiguration"} />
   </Tab>
 </Tabs>
 
@@ -202,7 +202,7 @@ Open the following API call and paste the corresponding inputs (serviceName, clu
     <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
 </Tabs>
 

--- a/docs/en/guides/public-cloud/databases/redis-update-acls.mdx
+++ b/docs/en/guides/public-cloud/databases/redis-update-acls.mdx
@@ -74,7 +74,7 @@ Open the following API call and do the following steps:
 - paste the cluster ID into the **clusterId** input field
 - click <code className="action">Execute</code>
 
-<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user"} />
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user"} />
 
 
 From the resulting list, find and select the desired **user**.
@@ -96,7 +96,7 @@ To get more details on a user, open the following API call and do the following 
 - the cluster ID into the **clusterId** input field
 - click <code className="action">Execute</code>
 
-<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user/\{userId\}"} />
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user/\{userId\}"} />
 
 
 Example:
@@ -127,7 +127,7 @@ You can follow the official Redis® documentation about users and ACL: [https://
 
 Open the following API call and paste the corresponding inputs (**serviceName**, **clusterId**, **user**).
 
-<Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user/\{userId\}"} />
+<Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user/\{userId\}"} />
 
 
 Now, according to the strategy you chose, set the different values into the string arrays of the *request body*, such as in the example below:

--- a/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/es/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/es/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/es/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/es-es/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/es/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -49,7 +49,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/es-es/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -37,7 +37,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/es/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 

--- a/docs/fr/guides/public-cloud/data-analytics/analytics/pricing.mdx
+++ b/docs/fr/guides/public-cloud/data-analytics/analytics/pricing.mdx
@@ -65,7 +65,7 @@ Cette évolution offre une meilleure visibilité sur la répartition des coûts 
 
 ### Page de prix sur le site web
 
-La [page de prix du site web d’OVHcloud](https://www.ovhcloud.com/fr/public-cloud/prices/) fournit un aperçu général des coûts des services Analytics. Elle affiche les prix horaires et les prix mensuels estimés, permettant de comparer différentes offres et configurations.
+La [page de prix du site web d’OVHcloud](/links/public-cloud/prices) fournit un aperçu général des coûts des services Analytics. Elle affiche les prix horaires et les prix mensuels estimés, permettant de comparer différentes offres et configurations.
 
 ### Espace client OVHcloud – Page de commande
 

--- a/docs/fr/guides/public-cloud/databases/advanced-configuration.mdx
+++ b/docs/fr/guides/public-cloud/databases/advanced-configuration.mdx
@@ -148,7 +148,7 @@ Ouvrez l'appel API suivant, renseignez les champs correspondants (serviceName, c
     <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
 </Tabs>
 
@@ -171,7 +171,7 @@ Ouvrez l'appel API suivant, renseignez les champs correspondants (serviceName, c
     <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/capabilities/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/capabilities/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/capabilities/advancedConfiguration"} />
   </Tab>
 </Tabs>
 
@@ -202,7 +202,7 @@ Ouvrez l'appel API suivant et renseignez les champs correspondants (serviceName,
     <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/postgresql/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
   <Tab label="Valkey">
-    <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/redis/\\{clusterId\\}/advancedConfiguration"} />
+    <Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\\{serviceName\\}/database/valkey/\\{clusterId\\}/advancedConfiguration"} />
   </Tab>
 </Tabs>
 

--- a/docs/fr/guides/public-cloud/databases/redis-update-acls.mdx
+++ b/docs/fr/guides/public-cloud/databases/redis-update-acls.mdx
@@ -74,7 +74,7 @@ Ouvrez l'appel API suivant et effectuez les étapes suivantes :
 - collez l'identifiant du cluster dans le champ **clusterId**
 - cliquez sur <code className="action">Execute</code>
 
-<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user"} />
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user"} />
 
 
 Dans la liste de résultats, recherchez et sélectionnez l'**utilisateur** souhaité.
@@ -96,7 +96,7 @@ Pour obtenir plus de détails sur un utilisateur, ouvrez l'appel API suivant et 
 - l'identifiant du cluster dans le champ **clusterId**
 - cliquez sur <code className="action">Execute</code>
 
-<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user/\{userId\}"} />
+<Api version="v1" section="/cloud" method="GET" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user/\{userId\}"} />
 
 
 Exemple :
@@ -127,7 +127,7 @@ Vous pouvez consulter la documentation officielle de Redis® sur les utilisateur
 
 Ouvrez l'appel API suivant et collez les entrées correspondantes (**serviceName**, **clusterId**, **user**).
 
-<Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/database/redis/\{clusterId\}/user/\{userId\}"} />
+<Api version="v1" section="/cloud" method="PUT" route={"/cloud/project/\{serviceName\}/database/valkey/\{clusterId\}/user/\{userId\}"} />
 
 
 Ensuite, selon la stratégie choisie, définissez les différentes valeurs dans les tableaux de chaînes du *corps de la requête*, comme dans l'exemple ci-dessous :

--- a/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/it/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/it/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/it/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/it/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/it/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -49,7 +49,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/it/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -37,7 +37,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/it/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/pl/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/pl/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/pl/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -49,7 +49,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/pl/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -37,7 +37,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/pl/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/analytics-regions-comparison.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2025-06-11
 
 ## Objective
 
-OVHcloud offers two deployment modes for its [Analytics](https://www.ovhcloud.com/pt/public-cloud/cloud-analytics/) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
+OVHcloud offers two deployment modes for its [Analytics](/links/public-cloud/analytics) service, each tailored to specific needs regarding resilience, availability, performance, and latency. This document provides a detailed explanation of the characteristics of each deployment mode, followed by a comprehensive comparison to help users choose the best option for their requirements.
 
 ## Concepts
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-cluster-cli.mdx
@@ -14,7 +14,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud and accepting incoming connections.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-connect-tabix.mdx
@@ -12,7 +12,7 @@ Analytics engines let you focus on building and analyzing data while OVHcloud ha
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help you to meet this requirement).
 - A ClickHouse instance configured to accept incoming connections.
 - A stable version of Tabix installed and public network connectivity (Internet). This guide was created using Tabix version 22.05.25.

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-create-cluster.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 
 {/* CP-NAV-START:publiccloud-projects */}
 ---

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-getting-started.mdx
@@ -10,7 +10,7 @@ ClickHouse on OVHcloud is a fully managed, high-performance analytical column-st
 
 ### Product page
 
-Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](https://www.ovhcloud.com/pt/public-cloud/clickhouse/).
+Discover how OVHcloud’s Managed ClickHouse service enables you to deploy and operate fully managed, high-performance analytical clusters in the Public Cloud, complete with distributed storage, column-oriented processing, real-time ingestion, advanced compression, and effortless scalability. Benefit from built-in high availability, seamless integration with OVHcloud networking options, Terraform support for automated provisioning, and competitive pay-as-you-go pricing. Learn more on the [ClickHouse product page](/links/public-cloud/analytics-clickhouse).
 
 ### Pricing
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-incoming-connections.mdx
@@ -12,7 +12,7 @@ ClickHouse is an open-source, columnar analytical database system designed for r
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse cluster running on OVHcloud Public Cloud.
 
 {/* CP-NAV-START:publiccloud-projects */}

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/clickhouse-integration-with-kafka.mdx
@@ -12,7 +12,7 @@ This guide explains how to integrate ClickHouse with Kafka using Aiven: setting 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account.
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account.
 - A ClickHouse service running on your OVHcloud Analytics ([this guide](/guides/public-cloud/data-analytics/analytics/getting-started) can help).
 - A ClickHouse instance configured to accept incoming connections.
 - An [active Kafka cluster integrated via Aiven](https://aiven.io/docs/products/clickhouse/howto/data-service-integration#create-apache-kafka-integrations) or a managed Kafka cluster.

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/logs-to-customers.mdx
@@ -16,7 +16,7 @@ Analytics services allow you to send logs of your service to your own Logs Data 
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/pt/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 - Access to the <ApiLink>OVHcloud API</ApiLink>
 - A Logs Data Platform account within this OVHcloud account with at least one destination stream configured
     - If you are not familiar with all the LDP *Stream* configuration possibilities, simply create a new one with the default options (indexing & websocket enabled, long-term storage disabled) for the purpose of this guide.

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/resize-cluster-storage.mdx
@@ -32,7 +32,7 @@ When changing the storage space of your service, the system checks that at least
 #### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 
@@ -49,7 +49,7 @@ Click <code className="action">Edit additional storage</code> and adjust the sto
 #### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 #### Instructions
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/restore-backup.mdx
@@ -15,7 +15,7 @@ We continuously improve our offers. You can follow and submit ideas to add to ou
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink>
-- An [Analytics service](https://www.ovhcloud.com/pt/public-cloud/cloud-analytics/) up and running
+- An [Analytics service](/links/public-cloud/analytics) up and running
 
 ## Instructions
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-flavor.mdx
@@ -18,7 +18,7 @@ This option is available through the OVHcloud <ApiLink>API</ApiLink> and the <Ma
 ### Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 
@@ -37,7 +37,7 @@ This option is currently available via the OVHcloud <ApiLink>API</ApiLink>.
 ### Requirements
 
 - Access to the OVHcloud <ApiLink>API</ApiLink> (create your credentials by consulting [this guide](/guides/manage-and-operate/api/first-steps))
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ### Instructions
 

--- a/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
+++ b/docs/pt/guides/public-cloud/data-analytics/analytics/update-cluster-plan.mdx
@@ -20,7 +20,7 @@ Once you have upgraded your solution, you will not be able to downgrade to a low
 ## Requirements
 
 - Access to the <ManagerLink to="/">OVHcloud Control Panel</ManagerLink> or to the <ApiLink>OVHcloud API</ApiLink>
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 
 ## Instructions
 


### PR DESCRIPTION
- replace 89 hardcoded https://www.ovhcloud.com/{locale}/public-cloud/ URLs with their /links/ keys across the data-analytics guides, in the 7 locales
- fix 12 <Api> routes from database/redis/ to database/valkey/: the redis routes exist in neither zone schema while the valkey ones do, so those console deep links were silently broken