### PR TITLE
docs(domains): document the three DNS server options in the incoming …

### DIFF
--- a/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/de/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domainnamen zu OVHcloud transferieren
 description: Erfahren Sie hier, wie Sie Ihren Domainnamen zu OVHcloud transferieren
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -121,17 +121,31 @@ Wir empfehlen Ihnen, während des gesamten Bestellvorgangs folgende Punkte zu be
 
 - **Angaben zum Inhaber des Domainnamens.** Vor allem seit Inkrafttreten der DSGVO ist es wichtig, dass Sie sicherstellen, dass die Angaben zum Inhaber mit denen übereinstimmen, die von Ihrem bisherigen Registrar gespeichert wurden. So wird verhindert, dass Sie der unbefugten Aneignung des Domainnamens verdächtigt werden.
 
-- **Eingabe der DNS-Server für Ihren Domainnamen.** Wenn Sie Ihren Domainnamen derzeit verwenden, um eine Website oder einen E-Mail-Dienst bereitzustellen, sollten Sie deren DNS-Server angeben, um Dienstunterbrechungen zu vermeiden.
+- **Konfiguration der DNS-Server für Ihren Domainnamen.** Wenn Sie Ihren Domainnamen derzeit verwenden, um eine Website oder einen E-Mail-Dienst bereitzustellen, wählen Sie, ob Sie die bestehenden DNS-Server beibehalten oder anpassen möchten, um Dienstunterbrechungen zu vermeiden.
 
 :::
 
 #### Konfiguration der Inhaber- und DNS-Informationen
 
-- Wenn Sie in diesem Schritt auf <code className="action">Konfiguration ändern</code> klicken, können Sie die Namen der DNS-Server eingeben, die der Domainname derzeit verwendet. Auf diese Weise wird der Domainname in der OVHcloud-Konfiguration unmittelbar diesen DNS-Servern zugewiesen.
+Wenn Sie in diesem Schritt auf <code className="action">Konfiguration ändern</code> klicken, wählen Sie die DNS-Konfiguration aus, die nach Abschluss des Transfers auf Ihren Domainnamen angewendet wird. Es stehen drei Optionen zur Verfügung:
 
-- Wenn Sie fortfahren, ohne diese Operation durchzuführen, wird der Domainname mit einer neuen DNS-Zone auf den OVHcloud DNS-Servern konfiguriert. In diesem Fall kann eine [manuelle Bearbeitung der DNS-Zone](/guides/web-cloud/domains/dns-zone-edit) erforderlich werden.
+|Option|Beschreibung|
+|---|---|
+|<code className="action">Standard-DNS-Server</code>|Der Domainname wird den DNS-Servern von OVHcloud zugewiesen und es wird eine neue DNS-Zone erstellt. Ihre aktuelle DNS-Konfiguration wird nicht übernommen: Eine [manuelle Bearbeitung der DNS-Zone](/guides/web-cloud/domains/dns-zone-edit) kann dann erforderlich werden, um Ihre Dienste wiederherzustellen.|
+|<code className="action">Bestehende DNS-Server beibehalten</code>|Die DNS-Server, die derzeit bei Ihrem Registrar für den Domainnamen eingetragen sind, werden nach dem Transfer unverändert beibehalten. Ihre Dienste bleiben ohne Ihr Zutun erreichbar, solange diese DNS-Server aktiv bleiben.|
+|<code className="action">DNS-Server anpassen</code>|Sie geben die Namen der DNS-Server, die dem Domainnamen zugewiesen werden sollen, selbst ein. Verwenden Sie diese Option, wenn Sie im Rahmen des Transfers eine andere DNS-Konfiguration anwenden möchten.|
 
-- In einigen Fällen kann der Transfer zusätzliche Informationen zum Inhaber des Domainnamens erfordern. Um diese Informationen hinzuzufügen, klicken Sie auf die Option <code className="action">Kontakte/Inhaber verwalten</code>.
+:::warning
+Wenn Sie <code className="action">Bestehende DNS-Server beibehalten</code> wählen, kann Ihr bisheriger Registrar seine DNS-Server nach dem Transfer deaktivieren, wodurch Ihr Domainname nicht mehr erreichbar wäre. Stellen Sie sicher, dass Ihre DNS-Server unabhängig gehostet werden.
+
+:::
+
+:::info
+Wenn Sie Ihren Domainnamen derzeit für eine Website oder einen E-Mail-Dienst verwenden, wählen Sie <code className="action">Bestehende DNS-Server beibehalten</code> oder <code className="action">DNS-Server anpassen</code>, um Betriebsunterbrechungen zu vermeiden. Die Option <code className="action">Standard-DNS-Server</code> ist für Domainnamen vorgesehen, deren Dienste bei OVHcloud gehostet werden (oder künftig gehostet werden sollen).
+
+:::
+
+In einigen Fällen kann der Transfer zusätzliche Informationen zum Inhaber des Domainnamens erfordern. Um diese Informationen hinzuzufügen, klicken Sie auf die Option <code className="action">Kontakte/Inhaber verwalten</code>.
 
 <img className="thumbnail" alt="Domain" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/en/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferring a domain name to OVHcloud
 description: Find out how to transfer a generic domain name to OVHcloud
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -121,17 +121,31 @@ Throughout the order process, we advise taking special care with regard to the f
 
 - **Data on the domain name holder.** Especially since GDPR legislation is in effect, please ensure that all information on the domain name holder matches the information stored by your current domain name registrar. Doing this will ensure that you will not be suspected of domain name theft.
 
-- **Entering the DNS servers for your domain name.** If you are currently using your domain name to keep a website or email service online, you will need to specify their DNS servers in order to avoid any service interruptions.  
+- **Configuring the DNS servers for your domain name.** If you are currently using your domain name to keep a website or email service online, choose to keep the existing DNS servers or to customise them in order to avoid any service interruptions.  
 
 :::
 
 #### Managing holder and DNS servers details
 
-- Clicking on <code className="action">Change the configuration</code> in this step allows you to enter the names of the DNS servers the domain name is currently using. This way, the domain name will be already associated with those DNS servers in the OVHcloud configuration.
+Clicking on <code className="action">Change the configuration</code> in this step allows you to choose the DNS configuration that will be applied to your domain name once the transfer is complete. Three options are available:
 
-- If you proceed without doing this, the domain name will provided with a new DNS zone on OVHcloud DNS servers. A manual [modification of the DNS zone](/guides/web-cloud/domains/dns-zone-edit) might then become necessary.
+|Option|Description|
+|---|---|
+|<code className="action">Default DNS servers</code>|The domain name is associated with the OVHcloud DNS servers and a new DNS zone is created. Your current DNS configuration is not carried over: a manual [modification of the DNS zone](/guides/web-cloud/domains/dns-zone-edit) might then become necessary to restore your services.|
+|<code className="action">Keep the existing DNS servers</code>|The DNS servers currently declared on the domain name at your registrar are kept identical after the transfer. Your services remain reachable without any action on your part, as long as those DNS servers stay active.|
+|<code className="action">Custom DNS servers</code>|You enter the names of the DNS servers to associate with the domain name yourself. Use this option if you want to apply a different DNS configuration as part of the transfer.|
 
-- In some cases, the transfer process may require additional information regarding the domain name holder. To add this information, click on the option <code className="action">Manage contacts/holders</code>.
+:::warning
+If you choose <code className="action">Keep the existing DNS servers</code>, your previous registrar may deactivate its DNS servers after the transfer, which would make your domain name unreachable. Make sure your DNS servers are hosted independently.
+
+:::
+
+:::info
+If you are currently using your domain name for a website or an email service, choose <code className="action">Keep the existing DNS servers</code> or <code className="action">Custom DNS servers</code> to avoid any service interruption. The <code className="action">Default DNS servers</code> option should be reserved for domain names whose services are (or will be) hosted at OVHcloud.
+
+:::
+
+In some cases, the transfer process may require additional information regarding the domain name holder. To add this information, click on the option <code className="action">Manage contacts/holders</code>.
 
 <img className="thumbnail" alt="domain" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/es/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir un nombre de dominio a OVHcloud
 description: Descubra cómo realizar la transferencia de un nombre de dominio a OVHcloud
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -123,17 +123,31 @@ Durante el proceso de contratación, le recomendamos que tenga en cuenta los sig
 
 - **datos sobre el titular del nombre de dominio.** Particularmente desde la entrada en vigor del RGPD, es fundamental asegurarse de que la información sobre el titular del nombre de dominio se corresponde con la almacenada por su actual agente registrador. Para evitar cualquier sospecha de robo de nombres de dominio.
 
-- **introduciendo los servidores DNS para su nombre de dominio.** Si está utilizando su nombre de dominio para mantener un sitio web o un servicio de correo en internet, deberá indicar sus servidores DNS para evitar interrupciones del servicio.
+- **configurando los servidores DNS para su nombre de dominio.** Si está utilizando su nombre de dominio para mantener un sitio web o un servicio de correo en internet, elija mantener los servidores DNS existentes o personalizarlos para evitar interrupciones del servicio.
 
 :::
 
 #### Gestión del titular y detalles de los servidores DNS
 
-- Al hacer clic en <code className="action">Cambiar la configuración</code>, puede introducir los nombres de los servidores DNS que el nombre de dominio utiliza actualmente. De este modo, el nombre de dominio ya estará asociado a estos servidores DNS en la configuración de OVHcloud.
+Al hacer clic en <code className="action">Cambiar la configuración</code>, puede elegir la configuración DNS que se aplicará a su nombre de dominio una vez finalizada la transferencia. Dispone de tres opciones:
 
-- Si continúa sin realizar esta operación, el nombre de dominio se añadirá a los servidores DNS de OVHcloud con una nueva zona DNS. En ese caso, puede ser necesario [modificar manualmente la zona DNS](/guides/web-cloud/domains/dns-zone-edit).
+|Opción|Descripción|
+|---|---|
+|<code className="action">Servidores DNS por defecto</code>|El nombre de dominio se asocia a los servidores DNS de OVHcloud y se crea una nueva zona DNS. Su configuración DNS actual no se conserva: en ese caso, puede ser necesario [modificar manualmente la zona DNS](/guides/web-cloud/domains/dns-zone-edit) para restablecer sus servicios.|
+|<code className="action">Mantener los servidores DNS existentes</code>|Los servidores DNS declarados actualmente en el nombre de dominio en su agente registrador se mantienen sin cambios tras la transferencia. Sus servicios siguen siendo accesibles sin ninguna intervención por su parte, siempre que esos servidores DNS sigan activos.|
+|<code className="action">Personalizar los servidores DNS</code>|Usted mismo introduce los nombres de los servidores DNS que desea asociar al nombre de dominio. Utilice esta opción si quiere aplicar una configuración DNS diferente con motivo de la transferencia.|
 
-- En algunos casos, es posible que sea necesario disponer de información adicional sobre el titular del nombre de dominio. Para añadir esta información, haga clic en la opción <code className="action">Gestionar los contactos o el titular</code>.
+:::warning
+Si elige <code className="action">Mantener los servidores DNS existentes</code>, su anterior agente registrador puede desactivar sus servidores DNS después de la transferencia, lo que haría que su nombre de dominio dejara de ser accesible. Asegúrese de que sus servidores DNS estén alojados de forma independiente.
+
+:::
+
+:::info
+Si actualmente utiliza su nombre de dominio para un sitio web o un servicio de correo electrónico, elija <code className="action">Mantener los servidores DNS existentes</code> o <code className="action">Personalizar los servidores DNS</code> para evitar cualquier interrupción del servicio. La opción <code className="action">Servidores DNS por defecto</code> está reservada a los nombres de dominio cuyos servicios estén (o vayan a estar) alojados en OVHcloud.
+
+:::
+
+En algunos casos, es posible que sea necesario disponer de información adicional sobre el titular del nombre de dominio. Para añadir esta información, haga clic en la opción <code className="action">Gestionar los contactos o el titular</code>.
 
 <img className="thumbnail" alt="dominio" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/fr/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transférer son nom de domaine vers OVHcloud
 description: "Découvrez comment réaliser le transfert d’un nom de domaine vers OVHcloud"
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -122,17 +122,31 @@ Tout au long du processus de commande, nous vous conseillons de prendre en compt
 
 - **données sur le titulaire du nom de domaine.** Particulièrement depuis l’entrée en vigueur du RGPD, il est essentiel de vous assurer que les informations sur le titulaire du nom de domaine correspondent à celles stockées par votre bureau d’enregistrement actuel. Cela vous évitera d’être soupçonné de vol de nom de domaine ;
 
-- **saisie des serveurs DNS pour votre nom de domaine.** Si vous utilisez actuellement votre nom de domaine pour maintenir un site Internet ou un service de messagerie en ligne, vous devrez spécifier leurs serveurs DNS afin d’éviter toute interruption de service.
+- **configuration des serveurs DNS de votre nom de domaine.** Si vous utilisez actuellement votre nom de domaine pour maintenir un site Internet ou un service de messagerie en ligne, choisissez de garder les serveurs DNS existants ou de les personnaliser afin d’éviter toute interruption de service.
 
 :::
 
 #### Gestion du titulaire et détails des serveurs DNS
 
-- En cliquant sur <code className="action">Modifier la configuration</code> dans cette étape, vous pouvez entrer les noms des serveurs DNS que le nom de domaine utilise actuellement. De cette manière, le nom de domaine sera déjà associé à ces serveurs DNS dans la configuration OVHcloud.
+En cliquant sur <code className="action">Modifier la configuration</code> dans cette étape, vous choisissez la configuration DNS qui sera appliquée à votre nom de domaine une fois le transfert terminé. Trois options sont proposées :
 
-- Si vous continuez sans effectuer cette opération, le nom de domaine sera fourni avec une nouvelle zone DNS sur les serveurs DNS OVHcloud. Une [modification manuelle de la zone DNS](/guides/web-cloud/domains/dns-zone-edit) peut alors devenir nécessaire.
+|Option|Description|
+|---|---|
+|<code className="action">Serveurs DNS par défaut</code>|Le nom de domaine est associé aux serveurs DNS d’OVHcloud et une nouvelle zone DNS est créée. Votre configuration DNS actuelle n’est pas reprise : une [modification manuelle de la zone DNS](/guides/web-cloud/domains/dns-zone-edit) peut alors devenir nécessaire pour rétablir vos services.|
+|<code className="action">Garder les DNS existants</code>|Les serveurs DNS actuellement déclarés sur le nom de domaine chez votre bureau d’enregistrement sont conservés à l’identique après le transfert. Vos services restent joignables sans intervention de votre part, tant que ces serveurs DNS restent actifs.|
+|<code className="action">Personnaliser les serveurs DNS</code>|Vous saisissez vous-même les noms des serveurs DNS à associer au nom de domaine. Utilisez cette option si vous souhaitez appliquer une configuration DNS différente à l’occasion du transfert.|
 
-- Dans certains cas, le processus de transfert peut nécessiter des informations supplémentaires concernant le titulaire du nom de domaine. Pour ajouter ces informations, cliquez sur l’option <code className="action">Gérer les contacts/le titulaire</code>.
+:::warning
+Si vous choisissez <code className="action">Garder les DNS existants</code>, votre ancien bureau d’enregistrement peut désactiver ses serveurs DNS après le transfert, ce qui rendrait votre nom de domaine inaccessible. Assurez-vous que vos serveurs DNS sont hébergés de manière indépendante.
+
+:::
+
+:::info
+Si vous utilisez actuellement votre nom de domaine pour un site internet ou un service de messagerie, choisissez <code className="action">Garder les DNS existants</code> ou <code className="action">Personnaliser les serveurs DNS</code> afin d’éviter toute interruption de service. L’option <code className="action">Serveurs DNS par défaut</code> est à réserver aux noms de domaine dont vous hébergez (ou allez héberger) les services chez OVHcloud.
+
+:::
+
+Dans certains cas, le processus de transfert peut nécessiter des informations supplémentaires concernant le titulaire du nom de domaine. Pour ajouter ces informations, cliquez sur l’option <code className="action">Gérer les contacts/le titulaire</code>.
 
 <img className="thumbnail" alt="domaine" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/it/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Trasferire un nome di dominio in OVHcloud
 description: Questa guida ti mostra come avviare la procedura di trasferimento di un nome di dominio generico verso OVHcloud
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -122,17 +122,31 @@ Durante il processo di ordine, ti consigliamo di considerare questi aspetti:
 
 - **dati sull'intestatario del nome di dominio.** In particolare dall'entrata in vigore del GDPR, è essenziale assicurarsi che le informazioni sull'intestatario del nome di dominio corrispondano a quelle archiviate dal tuo attuale Registrar. Per evitare sospetti di furto di nomi di dominio;
 
-- **inserimento dei server DNS per il tuo nome di dominio.** Se utilizzi il tuo nome di dominio per mantenere un sito Internet o un servizio di posta online, è necessario specificare i server DNS per evitare interruzioni di servizio.
+- **configurazione dei server DNS per il tuo nome di dominio.** Se utilizzi il tuo nome di dominio per mantenere un sito Internet o un servizio di posta online, scegli di mantenere i server DNS esistenti o di personalizzarli per evitare interruzioni di servizio.
 
 :::
 
 #### Gestione dell'intestatario e dettagli dei server DNS
 
-- Cliccando su <code className="action">Modifica la configurazione</code> in questo step, puoi inserire i nomi dei server DNS che il nome di dominio sta utilizzando. In questo modo, il nome di dominio sarà già associato a questi server DNS nella configurazione OVHcloud.
+Cliccando su <code className="action">Modifica la configurazione</code> in questo step, scegli la configurazione DNS che sarà applicata al tuo nome di dominio una volta completato il trasferimento. Sono disponibili tre opzioni:
 
-- Se continui senza effettuare questa operazione, il nome di dominio verrà fornito sui server DNS OVHcloud con una nuova zona DNS. Una [modifica manuale della zona DNS](/guides/web-cloud/domains/dns-zone-edit) può rendersi necessaria.
+|Opzione|Descrizione|
+|---|---|
+|<code className="action">Server DNS predefiniti</code>|Il nome di dominio viene associato ai server DNS OVHcloud e viene creata una nuova zona DNS. La tua configurazione DNS attuale non viene mantenuta: una [modifica manuale della zona DNS](/guides/web-cloud/domains/dns-zone-edit) può rendersi necessaria per ripristinare i tuoi servizi.|
+|<code className="action">Mantieni i server DNS esistenti</code>|I server DNS attualmente dichiarati sul nome di dominio presso il tuo registrar vengono mantenuti identici dopo il trasferimento. I tuoi servizi restano raggiungibili senza alcun intervento da parte tua, a condizione che questi server DNS restino attivi.|
+|<code className="action">Personalizza i server DNS</code>|Inserisci personalmente i nomi dei server DNS da associare al nome di dominio. Utilizza questa opzione se desideri applicare una configurazione DNS diversa in occasione del trasferimento.|
 
-- In alcuni casi, la procedura di trasferimento può richiedere informazioni aggiuntive sull'intestatario del nome di dominio. Per aggiungere queste informazioni, clicca sull'opzione <code className="action">Gestisci i contatti/l'intestatario</code>.
+:::warning
+Se scegli <code className="action">Mantieni i server DNS esistenti</code>, il tuo precedente registrar può disattivare i suoi server DNS dopo il trasferimento, rendendo il tuo nome di dominio irraggiungibile. Assicurati che i tuoi server DNS siano ospitati in modo indipendente.
+
+:::
+
+:::info
+Se attualmente utilizzi il tuo nome di dominio per un sito Internet o un servizio di posta elettronica, scegli <code className="action">Mantieni i server DNS esistenti</code> o <code className="action">Personalizza i server DNS</code> per evitare interruzioni di servizio. L'opzione <code className="action">Server DNS predefiniti</code> è da riservare ai nomi di dominio i cui servizi sono (o saranno) ospitati su OVHcloud.
+
+:::
+
+In alcuni casi, la procedura di trasferimento può richiedere informazioni aggiuntive sull'intestatario del nome di dominio. Per aggiungere queste informazioni, clicca sull'opzione <code className="action">Gestisci i contatti/l'intestatario</code>.
 
 <img className="thumbnail" alt="dominio" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pl/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transfer nazwy domeny do OVHcloud
 description: Dowiedz się, jak wykonać transfer nazwy domeny do OVHcloud
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -122,17 +122,31 @@ Podczas składania zamówienia radzimy uwzględnić następujące kwestie:
 
 - **dane dotyczące abonenta nazwy domeny.** Szczególnie od czasu wejścia w życie rozporządzenia RODO należy upewnić się, czy dane abonenta nazwy domeny odpowiadają informacjom przechowywanym przez aktualnego operatora. Pozwoli to uniknąć podejrzenia kradzieży nazwy domeny;
 
-- **wprowadzenie serwerów DNS dla Twojej nazwy domeny** Jeśli używasz aktualnie Twojej nazwy domeny do utrzymania strony WWW lub usługi poczty elektronicznej, określ Twoje serwery DNS, aby uniknąć przerw w dostępie do usługi.
+- **konfiguracja serwerów DNS dla Twojej nazwy domeny** Jeśli używasz aktualnie Twojej nazwy domeny do utrzymania strony WWW lub usługi poczty elektronicznej, wybierz zachowanie istniejących serwerów DNS lub ich dostosowanie, aby uniknąć przerw w dostępie do usługi.
 
 :::
 
 #### Zarządzanie abonentem i szczegóły dotyczące serwerów DNS
 
-- Po kliknięciu <code className="action">Zmień konfigurację</code> w tym etapie możesz wprowadzić nazwy serwerów DNS, których nazwa domeny używa obecnie. W ten sposób nazwa domeny będzie już powiązana z tymi serwerami DNS w konfiguracji OVHcloud.
+Po kliknięciu <code className="action">Zmień konfigurację</code> w tym etapie wybierasz konfigurację DNS, która zostanie zastosowana do Twojej nazwy domeny po zakończeniu transferu. Dostępne są trzy opcje:
 
-- Jeśli nie przeprowadzasz tej operacji, nazwa domeny zostanie dostarczona wraz z nową strefą DNS na serwerach DNS OVHcloud. Może zaistnieć konieczność ręcznej [modyfikacji strefy DNS](/guides/web-cloud/domains/dns-zone-edit).
+|Opcja|Opis|
+|---|---|
+|<code className="action">Domyślne serwery DNS</code>|Nazwa domeny zostaje powiązana z serwerami DNS OVHcloud i tworzona jest nowa strefa DNS. Twoja obecna konfiguracja DNS nie zostaje zachowana: może zaistnieć konieczność ręcznej [modyfikacji strefy DNS](/guides/web-cloud/domains/dns-zone-edit), aby przywrócić działanie Twoich usług.|
+|<code className="action">Zachowaj istniejące serwery DNS</code>|Serwery DNS zadeklarowane obecnie dla nazwy domeny u Twojego operatora zostają zachowane bez zmian po transferze. Twoje usługi pozostają dostępne bez żadnych działań z Twojej strony, o ile te serwery DNS pozostaną aktywne.|
+|<code className="action">Dostosuj serwery DNS</code>|Samodzielnie wprowadzasz nazwy serwerów DNS, które mają zostać powiązane z nazwą domeny. Wybierz tę opcję, jeśli przy okazji transferu chcesz zastosować inną konfigurację DNS.|
 
-- W niektórych przypadkach proces transferu może wymagać dodatkowych informacji o abonencie nazwy domeny. Aby dodać te informacje, kliknij opcję <code className="action">Zarządzanie kontaktami/abonentem</code>.
+:::warning
+Jeśli wybierzesz opcję <code className="action">Zachowaj istniejące serwery DNS</code>, Twój poprzedni operator może wyłączyć swoje serwery DNS po transferze, co spowoduje, że Twoja nazwa domeny stanie się niedostępna. Upewnij się, że Twoje serwery DNS są hostowane niezależnie.
+
+:::
+
+:::info
+Jeśli używasz obecnie swojej nazwy domeny do obsługi strony internetowej lub poczty elektronicznej, wybierz <code className="action">Zachowaj istniejące serwery DNS</code> lub <code className="action">Dostosuj serwery DNS</code>, aby uniknąć przerwy w działaniu usług. Opcja <code className="action">Domyślne serwery DNS</code> jest przeznaczona dla nazw domen, których usługi są (lub będą) hostowane w OVHcloud.
+
+:::
+
+W niektórych przypadkach proces transferu może wymagać dodatkowych informacji o abonencie nazwy domeny. Aby dodać te informacje, kliknij opcję <code className="action">Zarządzanie kontaktami/abonentem</code>.
 
 <img className="thumbnail" alt="nazwa domeny" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 

--- a/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
+++ b/docs/pt/guides/web-cloud/domains/transfer-incoming-generic-domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transferir o nome de domínio para a OVHcloud
 description: Descubra como transferir um nome de domínio para a OVHcloud
-lastUpdated: 2026-08-24
+lastUpdated: 2026-09-11
 availableIn: [eu, ca, apac]
 ---
 
@@ -122,17 +122,31 @@ Durante o processo de encomenda, sugerimos que tenha em conta os seguintes aspet
 
 - **dados sobre o titular do nome de domínio.** Especialmente após a entrada em vigor do RGPD, é essencial assegurar-se de que as informações sobre o titular do nome de domínio correspondam às armazenadas pelo seu agente de registo atual. Isto irá evitar suspeitas de roubo de um nome de domínio;
 
-- **introduzir os servidores DNS para o seu nome de domínio.** Se atualmente utiliza o seu nome de domínio para manter um website ou um serviço de e-mail online, deverá especificar os seus servidores DNS para evitar qualquer interrupção do serviço.
+- **configurar os servidores DNS para o seu nome de domínio.** Se atualmente utiliza o seu nome de domínio para manter um website ou um serviço de e-mail online, escolha manter os servidores DNS existentes ou personalizá-los para evitar qualquer interrupção do serviço.
 
 :::
 
 #### Gestão do titular e detalhes dos servidores DNS
 
-- Ao clicar em <code className="action">Alterar a configuração</code> nesta etapa, pode introduzir os nomes dos servidores DNS que o nome de domínio utiliza atualmente. Desta forma, o nome de domínio ficará associado a estes servidores DNS na configuração da OVHcloud.
+Ao clicar em <code className="action">Alterar a configuração</code> nesta etapa, escolhe a configuração DNS que será aplicada ao seu nome de domínio depois de concluída a transferência. Estão disponíveis três opções:
 
-- Se continuar sem efetuar esta operação, o nome de domínio será fornecido com uma nova zona DNS nos servidores DNS da OVHcloud. A [alteração manual da zona DNS](/guides/web-cloud/domains/dns-zone-edit) pode ser necessária.
+|Opção|Descrição|
+|---|---|
+|<code className="action">Servidores DNS por defeito</code>|O nome de domínio é associado aos servidores DNS da OVHcloud e é criada uma nova zona DNS. A sua configuração DNS atual não é mantida: a [alteração manual da zona DNS](/guides/web-cloud/domains/dns-zone-edit) pode ser necessária para repor os seus serviços.|
+|<code className="action">Manter os servidores DNS existentes</code>|Os servidores DNS atualmente declarados no nome de domínio junto do seu agente registador são mantidos tal como estão após a transferência. Os seus serviços continuam acessíveis sem qualquer intervenção da sua parte, desde que esses servidores DNS se mantenham ativos.|
+|<code className="action">Personalizar os servidores DNS</code>|Introduz você mesmo os nomes dos servidores DNS a associar ao nome de domínio. Utilize esta opção se pretender aplicar uma configuração DNS diferente aquando da transferência.|
 
-- Em alguns casos, o processo de transferência pode requerer informações adicionais sobre o titular do nome de domínio. Para adicionar estas informações, clique na opção <code className="action">Gerir os contactos/o titular</code>.
+:::warning
+Se escolher <code className="action">Manter os servidores DNS existentes</code>, o seu anterior agente registador pode desativar os seus servidores DNS após a transferência, o que tornaria o seu nome de domínio inacessível. Certifique-se de que os seus servidores DNS estão alojados de forma independente.
+
+:::
+
+:::info
+Se utiliza atualmente o seu nome de domínio para um site ou um serviço de email, escolha <code className="action">Manter os servidores DNS existentes</code> ou <code className="action">Personalizar os servidores DNS</code> para evitar qualquer interrupção de serviço. A opção <code className="action">Servidores DNS por defeito</code> destina-se aos nomes de domínio cujos serviços estão (ou estarão) alojados na OVHcloud.
+
+:::
+
+Em alguns casos, o processo de transferência pode requerer informações adicionais sobre o titular do nome de domínio. Para adicionar estas informações, clique na opção <code className="action">Gerir os contactos/o titular</code>.
 
 <img className="thumbnail" alt="nome de domínio" src="/images/assets/screens/website/order/order-summary.png" loading="lazy" />
 


### PR DESCRIPTION
…transfer guide

The order funnel used to offer two choices only; it now offers three, so the section lists them in a table: default DNS servers, which create a new DNS zone and drop the current configuration; keep the existing DNS servers; and custom DNS servers, entered by the customer.

D2I-6414