### PR TITLE
docs: add a TLS note on redis and valkey database servers

### DIFF
--- a/docs/de/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/de/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit Web Cloud Databases
 description: Erfahren Sie, wie Sie mit der Lösung Web Cloud Databases starten
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Um diese Informationen abzurufen, klicken Sie auf die unten stehenden Tabs, um d
 Das Feld <code className="action">Port</code> ist möglicherweise in der Konfiguration Ihrer Website nicht vorhanden. Sie müssen dieses Feld nach dem Hostnamen Ihres Servers hinzufügen, getrennt durch ein *:*.
 
 Zum Beispiel müssten Sie für den Hostnamen `aaXXXXX-XXX.eu.clouddb.ovh.net` mit dem SQL-Port `12345` im Bereich "Host" / "Hostname" `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` eingeben.
+
+:::
+
+:::info
+OVHcloud bietet keinen TLS-verschlüsselten Port für Redis- und Valkey-Datenbankserver an. Die Kommunikation darf ausschließlich über den standardmäßigen, unverschlüsselten Port erfolgen.
 
 :::
 

--- a/docs/en/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/en/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with the Web Cloud Databases service
 description: Find out how to get started with the Web Cloud Databases service
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ To find them, click on the tabs below to view each of the **2** steps.
 The <code className="action">port</code> field may not be available in your website's configuration. You must add this field after the server hostname, separated by a *:*.
 
 For example, for the hostname `aaXXXXX-XXX.eu.clouddb.ovh.net` with SQL port `12345`, you would enter `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` in the "Host" / "Hostname" section.
+
+:::
+
+:::info
+OVHcloud does not offer a TLS-encrypted port on Redis and Valkey database servers. Communications must use the default, unencrypted port only.
 
 :::
 

--- a/docs/es/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/es/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Primeros pasos con Web Cloud Databases
 description: Descubra cómo empezar a utilizar la solución Web Cloud Databases
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Para obtener esta información, haga clic en las pestañas de abajo para ver cad
 Es posible que el campo <code className="action">puerto</code> no esté disponible en la configuración de su sitio web. Debe añadir este campo después del nombre de host de su servidor, separándolos con *:*.
 
 Por ejemplo, para el nombre de host `aaXXXXX-XXX.eu.clouddb.ovh.net` con el puerto SQL `12345`, deberá indicar `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` en el apartado "Host" / "Nombre de host".
+
+:::
+
+:::info
+OVHcloud no ofrece ningún puerto cifrado mediante TLS en los servidores de bases de datos Redis y Valkey. Las comunicaciones deben realizarse únicamente a través del puerto por defecto, sin cifrar.
 
 :::
 

--- a/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/fr/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Premiers pas avec le service Web Cloud Databases
 description: Découvrez comment bien débuter avec la solution Web Cloud Databases
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Pour les retrouver, cliquez sur les onglets ci-dessous pour afficher successivem
 Le champ <code className="action">port</code> peut ne pas être proposé dans la configuration de votre site web. Vous devez ajouter ce champ après le nom d’hôte de votre serveur en les séparant par un *:* .
 
 Par exemple, pour le nom d’hôte `aaXXXXX-XXX.eu.clouddb.ovh.net` avec comme port SQL `12345`, vous devrez renseigner `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` dans la partie « Hôte » / « Nom d’hôte ».
+
+:::
+
+:::info
+OVHcloud ne propose pas de port chiffré via TLS sur les serveurs de bases de données Redis et Valkey. Les communications doivent passer uniquement par le port par défaut, non chiffré.
 
 :::
 

--- a/docs/it/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/it/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare Web Cloud Databases
 description: Scopri come iniziare a utilizzare la soluzione Web Cloud Databases
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Per recuperare queste informazioni, clicca sulle schede qui sotto per visualizza
 Il campo <code className="action">porta</code> potrebbe non essere disponibile nella configurazione del sito Web. È necessario aggiungere questo campo dopo l'hostname del server, separandoli con *:*.
 
 Ad esempio, per l'hostname `aaXXXXX-XXX.eu.clouddb.ovh.net` con la porta SQL `12345`, sarà necessario inserire `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` nella sezione "Host" / "Hostname".
+
+:::
+
+:::info
+OVHcloud non offre una porta cifrata tramite TLS sui server di database Redis e Valkey. Le comunicazioni devono avvenire esclusivamente attraverso la porta predefinita, non cifrata.
 
 :::
 

--- a/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pl/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pierwsze kroki z usługą Web Cloud Databases
 description: Dowiedz się, jak rozpocząć korzystanie z rozwiązania Web Cloud Databases
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Aby je znaleźć, kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 Pole <code className="action">port</code> może nie być dostępne w konfiguracji Twojej strony WWW. Należy dodać to pole po nazwie hosta serwera, oddzielając je znakiem *:*.
 
 Na przykład, dla nazwy hosta `aaXXXXX-XXX.eu.clouddb.ovh.net` z portem SQL `12345` należy wpisać `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` w polu "Host" / "Nazwa hosta".
+
+:::
+
+:::info
+OVHcloud nie udostępnia portu szyfrowanego TLS dla serwerów baz danych Redis i Valkey. Komunikacja musi odbywać się wyłącznie przez domyślny, nieszyfrowany port.
 
 :::
 

--- a/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
+++ b/docs/pt/guides/web-cloud/databases/db-getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Web Cloud Databases - Primeira utilização
 description: Saiba como começar a utilizar a solução Web Cloud Databases
-lastUpdated: 2026-08-26
+lastUpdated: 2026-09-11
 ---
 
 import { Tab, Tabs } from '@rspress/core/theme';
@@ -273,6 +273,11 @@ Para as obter, clique nos separadores abaixo para ver cada um dos **2** passos.
 O campo <code className="action">porta</code> pode não estar disponível na configuração do seu website. Deve adicionar este campo após o nome de host do servidor, separando-os com *:*.
 
 Por exemplo, para o nome de host `aaXXXXX-XXX.eu.clouddb.ovh.net` com a porta SQL `12345`, deverá introduzir `aaXXXXX-XXX.eu.clouddb.ovh.net:12345` na secção "Host" / "Nome de host".
+
+:::
+
+:::info
+A OVHcloud não disponibiliza nenhuma porta encriptada através de TLS nos servidores de bases de dados Redis e Valkey. As comunicações devem efetuar-se unicamente através da porta predefinida, não encriptada.
 
 :::
 


### PR DESCRIPTION
## What

Adds an informational callout to the Web Cloud Databases getting-started guide
stating that OVHcloud does not offer a TLS-encrypted port on Redis and Valkey
database servers, and that connections must use the default, unencrypted port.

Ticket: SK2791

## Where

`docs/<locale>/guides/web-cloud/databases/db-getting-started.mdx`, at the end of
the *Linking your website to the database* section — right after the existing
warning about the `port` field, which is the only place in the product where the
connection port is documented.

This guide is also the only WCDB guide (besides `db-eos-eol`) that already
addresses Redis/Valkey readers, through the two existing "this step does not
apply to the Redis database system" callouts.

`:::info` rather than `:::warning`: this is a product limitation to be aware of,
not a configuration pitfall, and it avoids stacking two red blocks in a row.

## Locales

All 7 locales updated, `lastUpdated` bumped to 2026-09-11.

Translation routing per the house rules: FR → en, es, it, pt; then EN → de, pl.
Terminology aligned with each locale's existing corpus rather than translated
freehand — `database server` (en), `servidor de bases de datos` (es),
`server di database` (it, the form used in this very guide),
`servidor de bases de dados` / `encriptada` (pt-PT), `Datenbankserver` (de),
`serwer baz danych` (pl). `Redis` is invariant across all 7 columns of the
terminology reference; `Valkey` is a proper noun and stays untranslated.

## Checks

- MDX compiles on all 7 files
- `/proofread` pre-pass: 0 ERROR, 0 WARN on the changed block
- DE quality pass: `Infrastrukturintegrität` avoided (compound over 21 chars)
- PT quality pass: pt-PT only, no pt-BR markers
- `pnpm lint`: clean
