### PR TITLE
feat(opcp): add documentation for controller backup

### DIFF
--- a/config/sidebar/index.md
+++ b/config/sidebar/index.md
@@ -613,6 +613,7 @@
             + [How the Ironic to NetBox synchronisation works](hosted-private-cloud/opcp/netbox-ironic-synchronisation)
             + [How to use Terraform](hosted-private-cloud/opcp/use-terraform)
             + [How to update the backup S3 buckets](hosted-private-cloud/opcp/how-to-update-backup-s3-buckets)
+            + [Creating a backup](hosted-private-cloud/opcp/how-to-create-a-backup)
             + [How to upgrade OPCP](hosted-private-cloud/opcp/how-to-upgrade-opcp)
         + [Security](hosted-private-cloud-hosted-private-cloud-opcp-security)
             + [IAM rights management](hosted-private-cloud/opcp/iam-rights-management)

--- a/docs/en/guides/hosted-private-cloud/opcp/how-to-create-a-backup.mdx
+++ b/docs/en/guides/hosted-private-cloud/opcp/how-to-create-a-backup.mdx
@@ -1,0 +1,92 @@
+---
+title: "Creating a backup"
+excerpt: "Discover the steps required to make a backup of the OPCP"
+lastUpdated: 2026-09-11
+---
+
+# Creating a backup
+
+## Introduction
+
+Backups in OPCP are automatically scheduled hourly for databases, PVs, KMS autounsealer shares and tfstate. Database backups are done with the kubernetes resource `ScheduledBackups`, PVs, KMS autounsealer shares and tfstate is done using [velero](https://velero.io/).
+
+## Prerequisites
+
+Make sure your data is backed up somewhere outside of the cluster. Do so by checking `opcp-cli config edit`. Make sure, that `backups.endpoint.url` is pointing outside of the cluster. Also `backups.endpoint.region` must be set accordingly. The bucket names, configured in `backups.db.bucket` and `backups.pv.bucket` must be exist.
+
+Credentials must also be set correctly with `opcp-cli secrets passwords --edit`. The keys `stringData.backup_access_key_id` and `stringData.backup_secret_access_key` must be set with the secrets provided by the S3 provider. Make sure the user has access to all the buckets.
+
+## Instructions
+
+It is possible to schedule backups from the terminal.
+
+### tl;dr
+
+Run the following lines as `root` (using `sudo -i`) on the OPCP controller node.
+
+```bash
+kubectl get cluster -A -o jsonpath='{range .items[*]}kubectl cnpg backup {.metadata.name} -n {.metadata.namespace}{"\n"}{end}' | bash
+velero get schedule -o json | jq -r '.items[] | .metadata.name as $name | {cmd: ("velero backup create --from-schedule " + $name)} | .cmd' | bash
+```
+
+Verify by running the following on the OPCP controller node.
+
+```bash
+kubectl get backup -A
+velero backup get
+```
+
+### Databases
+
+To list all database, run `kubectl get cluster -A`. Do a backup by running `kubectl cnpg backup {db-name} -n {namespace}`. Replace `{name}` with the database cluster name and `{namespace}` with the corresponding namespace.
+
+There is a shortcut to trigger backups of all the databse clusters: `kubectl get cluster -A -o jsonpath='{range .items[*]}kubectl cnpg backup {.metadata.name} -n {.metadata.namespace}{"\n"}{end}' | bash`.
+
+### KMS autounsealer shares
+
+Create a backup of `kms-autounsealer-shares-backup`:
+
+```bash
+velero backup create --from-schedule kms-autounsealer-shares-backup
+```
+
+### PVs
+
+Create a backup of the PVs:
+
+```bash
+velero backup create --from-schedule pvs-backup
+```
+
+### tfstate
+
+OPCP relies on [opentofu](https://opentofu.org/) during setup. We need to store the state. Backups are created by running
+
+```bash
+velero backup create --from-schedule tfstate-backup
+```
+
+### Verification
+
+Verify db backups are done by typing `kubectl get backup -A`. There are all the database backups, that are available listed.
+
+To verify PV, KMS autounsealer shares and tfstate backups are present, type `velero get schedule`.
+
+You should also check your S3 buckets. If there is no data in there, something went wrong when configuring the backups. You can do so by using [s3cmd](https://s3tools.org/s3cmd). First configure `s3cmd` to read from your bucket:
+
+```bash
+cat << EOF > ~/.s3cfg
+[default]
+access_key = ${ACCESS_KEY_ID}
+secret_key = ${SECRET_ACCESS_KEY}
+bucket_location = ${REGION}
+host_base = s3.gra.io.cloud.ovh.net
+host_bucket = %(bucket)s.s3.gra.io.cloud.ovh.net
+EOF
+```
+
+Adjust the values as you need it. Then you can do a `s3cmd ls s3://bucket-name` to see if there is any data in there.
+
+## Go further
+
+For more information about how to configure your backups, read [the documentation about how to update backup S3 buckets](/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets).

--- a/docs/fr/guides/hosted-private-cloud/opcp/how-to-create-a-backup.mdx
+++ b/docs/fr/guides/hosted-private-cloud/opcp/how-to-create-a-backup.mdx
@@ -1,0 +1,92 @@
+---
+title: "Créer un backup"
+excerpt: "Découvrez les étapes nécessaires pour effectuer une sauvegarde de l'OPCP"
+lastUpdated: 2026-09-11
+---
+
+# Créer une sauvegarde
+
+## Introduction
+
+Les sauvegardes dans OPCP sont automatiquement planifiées toutes les heures pour les bases de données, les PVs, les partages KMS autounsealer et tfstate. Les sauvegardes de base de données sont effectuées avec la ressource kubernetes `ScheduledBackups`, les PVs, les partages KMS autounsealer et tfstate sont effectués en utilisant [velero](https://velero.io/).
+
+## Prérequis
+
+Assurez-vous que vos données sont sauvegardées quelque part en dehors du cluster. Pour ce faire, vérifiez `opcp-cli config edit`. Assurez-vous que `backups.endpoint.url` pointe en dehors du cluster. De plus, `backups.endpoint.region` doit être défini en conséquence. Les noms de compartiment configurés dans `backups.db.bucket` et `backups.pv.bucket` doivent exister.
+
+Les identifiants doivent également être définis correctement avec `opcp-cli secrets passwords --edit`. Les clés `stringData.backup_access_key_id` et `stringData.backup_secret_access_key` doivent être définies avec les secrets fournis par le fournisseur S3. Assurez-vous que l'utilisateur a accès à tous les compartiments.
+
+## Instructions
+
+Il est possible de planifier des sauvegardes depuis le terminal.
+
+### tl;dr
+
+Exécutez les lignes suivantes en tant que `root` (en utilisant `sudo -i`) sur le nœud contrôleur OPCP.
+
+```bash
+kubectl get cluster -A -o jsonpath='{range .items[*]}kubectl cnpg backup {.metadata.name} -n {.metadata.namespace}{"\n"}{end}' | bash
+velero get schedule -o json | jq -r '.items[] | .metadata.name as $name | {cmd: ("velero backup create --from-schedule " + $name)} | .cmd' | bash
+```
+
+Vérifiez en exécutant ce qui suit sur le nœud contrôleur OPCP.
+
+```bash
+kubectl get backup -A
+velero backup get
+```
+
+### Bases de données
+
+Pour lister toutes les bases de données, exécutez `kubectl get cluster -A`. Effectuez une sauvegarde en exécutant `kubectl cnpg backup {db-name} -n {namespace}`. Remplacez `{name}` par le nom du cluster de bases de données et `{namespace}` par l'espace de noms correspondant.
+
+Il existe un raccourci pour déclencher les sauvegardes de tous les clusters de base de données : `kubectl get cluster -A -o jsonpath='{range .items[*]}kubectl cnpg backup {.metadata.name} -n {.metadata.namespace}{"\n"}{end}' | bash`.
+
+### Partages KMS autounsealer
+
+Créer une sauvegarde de `kms-autounsealer-shares-backup` :
+
+```bash
+velero backup create --from-schedule kms-autounsealer-shares-backup
+```
+
+### PVs
+
+Créer une sauvegarde des PVs :
+
+```bash
+velero backup create --from-schedule pvs-backup
+```
+
+### tfstate
+
+OPCP s'appuie sur [opentofu](https://opentofu.org/) lors de la configuration. Nous devons stocker l'état. Les sauvegardes sont créées en exécutant
+
+```bash
+velero backup create --from-schedule tfstate-backup
+```
+
+### Vérification
+
+Vérifiez que les sauvegardes de la base de données sont terminées en tapant `kubectl get backup -A`. Tous les sauvegardes de base de données disponibles sont répertoriés.
+
+Pour vérifier que les sauvegardes des PVs, des partages KMS autounsealer et de tfstate sont présentes, tapez `velero get schedule`.
+
+Vous devriez également vérifier vos compartiments S3. S'il n'y a pas de données, quelque chose s'est mal passé lors de la configuration des sauvegardes. Vous pouvez le faire en utilisant [s3cmd](https://s3tools.org/s3cmd). Configurez d'abord `s3cmd` pour lire depuis votre compartiment :
+
+```bash
+cat << EOF > ~/.s3cfg
+[default]
+access_key = ${ACCESS_KEY_ID}
+secret_key = ${SECRET_ACCESS_KEY}
+bucket_location = ${REGION}
+host_base = s3.gra.io.cloud.ovh.net
+host_bucket = %(bucket)s.s3.gra.io.cloud.ovh.net
+EOF
+```
+
+Ajustez les valeurs selon vos besoins. Vous pouvez alors faire un `s3cmd ls s3://bucket-name` pour voir s'il y a des données.
+
+## Aller plus loin
+
+Pour plus d'informations sur la configuration de vos sauvegardes, consultez [la documentation sur la mise à jour des compartiments S3 de sauvegarde](/guides/hosted-private-cloud/opcp/how-to-update-backup-s3-buckets).

--- a/i18n.json
+++ b/i18n.json
@@ -8261,6 +8261,15 @@
     "pl": "Private Cloud",
     "pt": "Private Cloud"
   },
+  "sidebar.privateCloud.howToCreateABackup": {
+    "fr": "Créer un backup",
+    "en": "Creating a backup",
+    "de": "Creating a backup",
+    "es": "Creating a backup",
+    "it": "Creating a backup",
+    "pl": "Creating a backup",
+    "pt": "Creating a backup"
+  },
   "sidebar.gen.publicCloud": {
     "fr": "Public Cloud",
     "en": "Public Cloud",


### PR DESCRIPTION
Users can trigger manual backups of the OPCP controller node(s). This is the manual how to trigger a backup.