### PR TITLE
Update Fail2ban documentation link

### DIFF
--- a/docs/fr/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
+++ b/docs/fr/guides/bare-metal-cloud/virtual-private-servers/secure-your-vps.mdx
@@ -324,7 +324,7 @@ sudo service fail2ban restart
 
 Fail2ban dispose de nombreux paramètres et filtres de personnalisation ainsi que d’options prédéfinies, par exemple lorsque vous souhaitez ajouter une couche de protection à un serveur web Nginx.
 
-Pour toute information complémentaire et pour des recommandations concernant Fail2ban, n'hésitez pas à consulter [la documentation officielle](https://www.fail2ban.org/wiki/index.php/Main_Page) de cet outil.
+Pour toute information complémentaire et pour des recommandations concernant Fail2ban, n'hésitez pas à consulter [la documentation officielle](https://github.com/fail2ban/fail2ban/wiki) de cet outil.
 
 ### Configurer le Network Firewall OVHcloud <a name="networkfirewall"></a>
 


### PR DESCRIPTION
Updated the link to the official Fail2ban documentation from the old URL to the new GitHub wiki link.